### PR TITLE
error return value is ignored

### DIFF
--- a/ref_code/leetcode/go/0093-restore-ip-addresses.go
+++ b/ref_code/leetcode/go/0093-restore-ip-addresses.go
@@ -25,8 +25,11 @@ func restoreIpAddresses(s string) []string {
 
 
 		for j := i; j < min(i+3, len(s)); j++ {
-			val, _ := strconv.Atoi(s[i:j+1])
-			if  val < 256 && (i == j || s[i] != '0') {
+			val, err := strconv.Atoi(s[i:j+1])
+			if err != nil {
+				break
+			}
+			if val < 256 && (i == j || s[i] != '0') {
 				backtrack(j+1 , dots + 1, currentIP + s[i:j+1] + ".")
 			}
 		}


### PR DESCRIPTION
I think 0093-restore-ip-addresses might be doing a bit more work than it needs to here, but I could be wrong. Ignoring the returned error makes failures invisible at the call site. This patch tightens the code around that spot.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.