### PR TITLE
Add LeetCode problem-list refs to cheatsheets

### DIFF
--- a/doc/cheatsheet/00_template.md
+++ b/doc/cheatsheet/00_template.md
@@ -1,5 +1,12 @@
 # cheatsheet template 
 
+## LeetCode Problem Lists
+
+<!-- One bullet per relevant LC topic tag, most relevant first.
+     Slugs must be real LC topic tags — verify with:
+       python3 script/add_lc_problem_lists.py --verify -->
+- [Topic Name](https://leetcode.com/problem-list/topic-slug/)
+
 ## 0) Concept
 
 ### 0-1) Types

--- a/doc/cheatsheet/2_pointers.md
+++ b/doc/cheatsheet/2_pointers.md
@@ -3,6 +3,12 @@
 - Ref
     - [fucking-algorithm : 2 pointers](https://labuladong.online/algo/essential-technique/array-two-pointers-summary/#%E5%8E%9F%E5%9C%B0%E4%BF%AE%E6%94%B9)
 
+## LeetCode Problem Lists
+
+- [Two Pointers](https://leetcode.com/problem-list/two-pointers/)
+- [Sliding Window](https://leetcode.com/problem-list/sliding-window/)
+- [Array](https://leetcode.com/problem-list/array/)
+
 ## 0) Concept  
 
 ### 0-1) Types

--- a/doc/cheatsheet/2_pointers_linkedlist.md
+++ b/doc/cheatsheet/2_pointers_linkedlist.md
@@ -3,6 +3,11 @@
 - Ref
     - [fucking-algorithm : 2 pointers Linkedlist](https://labuladong.online/algo/essential-technique/linked-list-skills-summary/)
 
+## LeetCode Problem Lists
+
+- [Two Pointers](https://leetcode.com/problem-list/two-pointers/)
+- [Linked List](https://leetcode.com/problem-list/linked-list/)
+
 ### 0-1) Types
 
 - Pointer types

--- a/doc/cheatsheet/Bellman-Ford.md
+++ b/doc/cheatsheet/Bellman-Ford.md
@@ -1,5 +1,11 @@
 # Bellman-Ford Algorithm
 
+## LeetCode Problem Lists
+
+- [Shortest Path](https://leetcode.com/problem-list/shortest-path/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+
 ## Overview
 **Bellman-Ford algorithm** is a single-source shortest path algorithm that can handle graphs with negative edge weights. Unlike Dijkstra's algorithm, it can detect negative cycles and is guaranteed to find the shortest path if no negative cycles exist.
 

--- a/doc/cheatsheet/Collection.md
+++ b/doc/cheatsheet/Collection.md
@@ -1,5 +1,12 @@
 # Collection 
 
+## LeetCode Problem Lists
+
+- [Array](https://leetcode.com/problem-list/array/)
+- [Hash Table](https://leetcode.com/problem-list/hash-table/)
+- [Linked List](https://leetcode.com/problem-list/linked-list/)
+- [Heap (Priority Queue)](https://leetcode.com/problem-list/heap-priority-queue/)
+
 ## 0) Concept  
 
 ### 0-1) Types

--- a/doc/cheatsheet/Dijkstra.md
+++ b/doc/cheatsheet/Dijkstra.md
@@ -1,5 +1,11 @@
 # Dijkstra's Algorithm
 
+## LeetCode Problem Lists
+
+- [Shortest Path](https://leetcode.com/problem-list/shortest-path/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+- [Heap (Priority Queue)](https://leetcode.com/problem-list/heap-priority-queue/)
+
 ## Overview
 **Dijkstra's algorithm** is a greedy algorithm that solves the single-source shortest path problem for a graph with `NON-NEGATIVE` edge weights. It finds the shortest path from a starting node (source) to all other nodes in the graph.
 

--- a/doc/cheatsheet/Floyd-Warshall.md
+++ b/doc/cheatsheet/Floyd-Warshall.md
@@ -1,5 +1,11 @@
 # Floyd-Warshall Algorithm
 
+## LeetCode Problem Lists
+
+- [Shortest Path](https://leetcode.com/problem-list/shortest-path/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+
 ## Overview
 **Floyd-Warshall algorithm** is a dynamic programming algorithm that solves the all-pairs shortest path problem. It finds the shortest paths between all pairs of vertices in a weighted graph, even with negative edge weights (but no negative cycles).
 

--- a/doc/cheatsheet/add_x_sum.md
+++ b/doc/cheatsheet/add_x_sum.md
@@ -19,6 +19,11 @@
     - LC 002 : Add Two Numbers.
     - LC 445 : Add Two Numbers II.
 
+## LeetCode Problem Lists
+
+- [Math](https://leetcode.com/problem-list/math/)
+- [String](https://leetcode.com/problem-list/string/)
+- [Bit Manipulation](https://leetcode.com/problem-list/bit-manipulation/)
 
 ## 2) LC Example
 

--- a/doc/cheatsheet/advanced_divide_and_conquer.md
+++ b/doc/cheatsheet/advanced_divide_and_conquer.md
@@ -1,5 +1,11 @@
 # Advanced Divide and Conquer
 
+## LeetCode Problem Lists
+
+- [Divide and Conquer](https://leetcode.com/problem-list/divide-and-conquer/)
+- [Merge Sort](https://leetcode.com/problem-list/merge-sort/)
+- [Quickselect](https://leetcode.com/problem-list/quickselect/)
+
 ## Overview
 **Divide and Conquer** is a powerful algorithmic paradigm that breaks complex problems into smaller subproblems, solves them recursively, and combines the results. This approach is particularly effective for inversion counting, range queries, and merge-based operations.
 

--- a/doc/cheatsheet/advanced_simulation.md
+++ b/doc/cheatsheet/advanced_simulation.md
@@ -1,5 +1,10 @@
 # Advanced Simulation
 
+## LeetCode Problem Lists
+
+- [Simulation](https://leetcode.com/problem-list/simulation/)
+- [Design](https://leetcode.com/problem-list/design/)
+
 ## Overview
 **Simulation** problems require step-by-step execution of a process, following specific rules and state transitions. These problems test your ability to model real-world scenarios, manage complex state, and implement precise logic flow.
 

--- a/doc/cheatsheet/advanced_string_algorithms.md
+++ b/doc/cheatsheet/advanced_string_algorithms.md
@@ -1,5 +1,12 @@
 # Advanced String Algorithms
 
+## LeetCode Problem Lists
+
+- [String](https://leetcode.com/problem-list/string/)
+- [String Matching](https://leetcode.com/problem-list/string-matching/)
+- [Rolling Hash](https://leetcode.com/problem-list/rolling-hash/)
+- [Suffix Array](https://leetcode.com/problem-list/suffix-array/)
+
 ## Overview
 **Advanced String Algorithms** encompass sophisticated techniques for string processing beyond basic operations. These algorithms provide optimal solutions for pattern matching, palindrome detection, and complex string manipulations with theoretical guarantees.
 

--- a/doc/cheatsheet/array.md
+++ b/doc/cheatsheet/array.md
@@ -1,6 +1,10 @@
 # Array
 > Basic linear data structure
 
+## LeetCode Problem Lists
+
+- [Array](https://leetcode.com/problem-list/array/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/array_overlap_explaination.md
+++ b/doc/cheatsheet/array_overlap_explaination.md
@@ -10,6 +10,12 @@ if (start < date.get(1) && end > date.get(0)) {
 }
 ```
 
+## LeetCode Problem Lists
+
+- [Design](https://leetcode.com/problem-list/design/)
+- [Ordered Set](https://leetcode.com/problem-list/ordered-set/)
+- [Segment Tree](https://leetcode.com/problem-list/segment-tree/)
+
 ## Purpose
 The purpose of this logic is to check whether a new booking overlaps with an existing booking in the calendar. If the new booking overlaps with an existing booking, the function will return `false`, indicating that the booking cannot be made.
 

--- a/doc/cheatsheet/backtrack.md
+++ b/doc/cheatsheet/backtrack.md
@@ -1,5 +1,10 @@
 # Backtracking
 
+## LeetCode Problem Lists
+
+- [Backtracking](https://leetcode.com/problem-list/backtracking/)
+- [Recursion](https://leetcode.com/problem-list/recursion/)
+
 ## Overview
 
 Backtracking is a **brute-force search over a decision tree**: at each step we make a

--- a/doc/cheatsheet/bfs.md
+++ b/doc/cheatsheet/bfs.md
@@ -1,5 +1,10 @@
 # BFS (Breadth-First Search)
 
+## LeetCode Problem Lists
+
+- [Breadth-First Search](https://leetcode.com/problem-list/breadth-first-search/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+
 ## Overview
 Breadth-First Search is a graph traversal algorithm that explores nodes level by level, visiting all nodes at the current depth before moving to nodes at the next depth.
 

--- a/doc/cheatsheet/binary_indexed_tree.md
+++ b/doc/cheatsheet/binary_indexed_tree.md
@@ -1,5 +1,10 @@
 # Binary Indexed Tree (Fenwick Tree)
 
+## LeetCode Problem Lists
+
+- [Binary Indexed Tree](https://leetcode.com/problem-list/binary-indexed-tree/)
+- [Segment Tree](https://leetcode.com/problem-list/segment-tree/)
+
 ## Overview
 
 A Binary Indexed Tree (BIT), also known as a Fenwick Tree, is a data structure that efficiently supports both:

--- a/doc/cheatsheet/binary_search.md
+++ b/doc/cheatsheet/binary_search.md
@@ -1,5 +1,9 @@
 # Binary Search
 
+## LeetCode Problem Lists
+
+- [Binary Search](https://leetcode.com/problem-list/binary-search/)
+
 ## Overview
 
 **Binary Search** is an efficient algorithm to find a target value in a **sorted search space** using two pointers.

--- a/doc/cheatsheet/binary_tree.md
+++ b/doc/cheatsheet/binary_tree.md
@@ -1,5 +1,10 @@
 # Binary Tree
 
+## LeetCode Problem Lists
+
+- [Binary Tree](https://leetcode.com/problem-list/binary-tree/)
+- [Tree](https://leetcode.com/problem-list/tree/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/bit_manipulation.md
+++ b/doc/cheatsheet/bit_manipulation.md
@@ -1,5 +1,10 @@
 # Bit Manipulation
 
+## LeetCode Problem Lists
+
+- [Bit Manipulation](https://leetcode.com/problem-list/bit-manipulation/)
+- [Bitmask](https://leetcode.com/problem-list/bitmask/)
+
 ## Overview
 
 Bit manipulation operates directly on the **binary representation** of integers. Because

--- a/doc/cheatsheet/bst.md
+++ b/doc/cheatsheet/bst.md
@@ -1,5 +1,10 @@
 # BST (Binary Search Tree)
 
+## LeetCode Problem Lists
+
+- [Binary Search Tree](https://leetcode.com/problem-list/binary-search-tree/)
+- [Binary Tree](https://leetcode.com/problem-list/binary-tree/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/combinatorics_math_patterns.md
+++ b/doc/cheatsheet/combinatorics_math_patterns.md
@@ -1,5 +1,11 @@
 # Combinatorics & Math Patterns
 
+## LeetCode Problem Lists
+
+- [Combinatorics](https://leetcode.com/problem-list/combinatorics/)
+- [Math](https://leetcode.com/problem-list/math/)
+- [Number Theory](https://leetcode.com/problem-list/number-theory/)
+
 ## Overview
 Google interviews frequently test math/combinatorics reasoning — more than other FAANGs. This covers number theory, counting, geometry, and probability patterns common in coding interviews.
 

--- a/doc/cheatsheet/concurrency_patterns.md
+++ b/doc/cheatsheet/concurrency_patterns.md
@@ -1,5 +1,9 @@
 # Concurrency Patterns (Java)
 
+## LeetCode Problem Lists
+
+- [Concurrency](https://leetcode.com/problem-list/concurrency/)
+
 ## Overview
 Google sometimes asks concurrency/threading problems at L4+. These test understanding of synchronization, thread safety, and concurrent data structure design.
 

--- a/doc/cheatsheet/design.md
+++ b/doc/cheatsheet/design.md
@@ -1,5 +1,10 @@
 # Design
 
+## LeetCode Problem Lists
+
+- [Design](https://leetcode.com/problem-list/design/)
+- [Data Stream](https://leetcode.com/problem-list/data-stream/)
+
 ## 0) Concept
 
 ### 0-1) Types

--- a/doc/cheatsheet/dfs.md
+++ b/doc/cheatsheet/dfs.md
@@ -1,5 +1,10 @@
 # DFS (Depth-First Search)
 
+## LeetCode Problem Lists
+
+- [Depth-First Search](https://leetcode.com/problem-list/depth-first-search/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+
 ## Overview
 **Depth-First Search (DFS)** is a graph/tree traversal algorithm that explores as far as possible along each branch before backtracking. It uses recursion or a stack to maintain the traversal path.
 

--- a/doc/cheatsheet/diff_toposort_quickunion.md
+++ b/doc/cheatsheet/diff_toposort_quickunion.md
@@ -13,6 +13,11 @@
 
 ---
 
+## LeetCode Problem Lists
+
+- [Topological Sort](https://leetcode.com/problem-list/topological-sort/)
+- [Union-Find](https://leetcode.com/problem-list/union-find/)
+
 ## 🏩 Conceptual Difference
 
 | | Topological Sort | Quick Union |

--- a/doc/cheatsheet/difference_array.md
+++ b/doc/cheatsheet/difference_array.md
@@ -1,5 +1,10 @@
 # Difference Array
 
+## LeetCode Problem Lists
+
+- [Prefix Sum](https://leetcode.com/problem-list/prefix-sum/)
+- [Array](https://leetcode.com/problem-list/array/)
+
 ## Overview
 **Difference Array** is a technique for efficiently performing range update operations on an array. Instead of updating each element individually (O(n) per update), we can perform range updates in O(1) time and reconstruct the final array in O(n) time.
 

--- a/doc/cheatsheet/dp.md
+++ b/doc/cheatsheet/dp.md
@@ -1,5 +1,10 @@
 # Dynamic Programming (DP)
 
+## LeetCode Problem Lists
+
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+- [Memoization](https://leetcode.com/problem-list/memoization/)
+
 ## Overview
 **Dynamic Programming** is an algorithmic paradigm that solves complex problems by breaking them down into simpler subproblems and storing their solutions to avoid redundant computations.
 

--- a/doc/cheatsheet/dp_pattern.md
+++ b/doc/cheatsheet/dp_pattern.md
@@ -2,7 +2,9 @@
 
 - https://leetcode.com/discuss/study-guide/1308617/Dynamic-Programming-Patterns
 
+## LeetCode Problem Lists
 
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
 
 ## 1. Kadane's Algorithm (Maximum Subarray)
 

--- a/doc/cheatsheet/graph.md
+++ b/doc/cheatsheet/graph.md
@@ -1,5 +1,9 @@
 # Graph Algorithms
 
+## LeetCode Problem Lists
+
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+
 ## Overview
 **Graph algorithms** are techniques for solving problems on graph data structures consisting of vertices (nodes) and edges (connections between nodes).
 

--- a/doc/cheatsheet/greedy.md
+++ b/doc/cheatsheet/greedy.md
@@ -1,5 +1,9 @@
 # Greedy Algorithms
 
+## LeetCode Problem Lists
+
+- [Greedy](https://leetcode.com/problem-list/greedy/)
+
 ## Overview
 **Greedy algorithms** make locally optimal choices at each step with the hope of finding a global optimum. They work by selecting the best available option at each decision point without reconsidering previous choices.
 

--- a/doc/cheatsheet/hash_map.md
+++ b/doc/cheatsheet/hash_map.md
@@ -1,5 +1,9 @@
 # Hash Map Cheatsheet
 
+## LeetCode Problem Lists
+
+- [Hash Table](https://leetcode.com/problem-list/hash-table/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/hashing.md
+++ b/doc/cheatsheet/hashing.md
@@ -1,5 +1,11 @@
 # Hashing & Counting
 
+## LeetCode Problem Lists
+
+- [Hash Table](https://leetcode.com/problem-list/hash-table/)
+- [Counting](https://leetcode.com/problem-list/counting/)
+- [Hash Function](https://leetcode.com/problem-list/hash-function/)
+
 ## Overview
 **Hashing & Counting** techniques use hash tables and frequency maps to solve problems involving counting, grouping, and fast lookups.
 

--- a/doc/cheatsheet/heap.md
+++ b/doc/cheatsheet/heap.md
@@ -1,5 +1,9 @@
 # Heap Data Structure
 
+## LeetCode Problem Lists
+
+- [Heap (Priority Queue)](https://leetcode.com/problem-list/heap-priority-queue/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/intervals.md
+++ b/doc/cheatsheet/intervals.md
@@ -1,5 +1,11 @@
 # Intervals
 
+## LeetCode Problem Lists
+
+- [Sorting](https://leetcode.com/problem-list/sorting/)
+- [Greedy](https://leetcode.com/problem-list/greedy/)
+- [Sweep Line](https://leetcode.com/problem-list/sweep-line/)
+
 ## Overview
 
 **Intervals** are problems involving ranges of values, typically represented as `[start, end]` pairs, requiring operations like merging overlapping ranges, finding intersections, or scheduling non-overlapping events.

--- a/doc/cheatsheet/iterator.md
+++ b/doc/cheatsheet/iterator.md
@@ -1,5 +1,10 @@
 # Iterator
 
+## LeetCode Problem Lists
+
+- [Iterator](https://leetcode.com/problem-list/iterator/)
+- [Design](https://leetcode.com/problem-list/design/)
+
 ## 0) Concept
 
 An **iterator** exposes sequential access to a collection via `hasNext()` / `next()`

--- a/doc/cheatsheet/kadane_algorithm.md
+++ b/doc/cheatsheet/kadane_algorithm.md
@@ -9,6 +9,11 @@
 **Time Complexity:** O(n) - single pass
 **Space Complexity:** O(1) - only need few variables
 
+## LeetCode Problem Lists
+
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+- [Array](https://leetcode.com/problem-list/array/)
+
 ## 0) Concept
 
 ### 0-0) Core Principle

--- a/doc/cheatsheet/linked_list.md
+++ b/doc/cheatsheet/linked_list.md
@@ -1,5 +1,10 @@
 # Linked List 
 
+## LeetCode Problem Lists
+
+- [Linked List](https://leetcode.com/problem-list/linked-list/)
+- [Doubly-Linked List](https://leetcode.com/problem-list/doubly-linked-list/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/math.md
+++ b/doc/cheatsheet/math.md
@@ -1,5 +1,10 @@
 # Math
 
+## LeetCode Problem Lists
+
+- [Math](https://leetcode.com/problem-list/math/)
+- [Number Theory](https://leetcode.com/problem-list/number-theory/)
+
 ## 1) General form
 
 ### 1-1) Basic OP

--- a/doc/cheatsheet/matrix.md
+++ b/doc/cheatsheet/matrix.md
@@ -1,5 +1,9 @@
 # Matrix Data Structure
 
+## LeetCode Problem Lists
+
+- [Matrix](https://leetcode.com/problem-list/matrix/)
+
 ## Overview
 
 **Matrix** is a 2-dimensional array data structure that stores elements in rows and columns. It's fundamental for solving problems involving grids, images, game boards, and mathematical computations.

--- a/doc/cheatsheet/monotonic_queue.md
+++ b/doc/cheatsheet/monotonic_queue.md
@@ -1,5 +1,11 @@
 # Monotonic Queue (Deque)
 
+## LeetCode Problem Lists
+
+- [Monotonic Queue](https://leetcode.com/problem-list/monotonic-queue/)
+- [Sliding Window](https://leetcode.com/problem-list/sliding-window/)
+- [Queue](https://leetcode.com/problem-list/queue/)
+
 ## Overview
 **Monotonic Queue** is a double-ended queue (deque) that maintains elements in monotonic order (increasing or decreasing). Unlike monotonic stack which only removes from one end, monotonic queue can remove from **both ends** — enabling efficient sliding window min/max queries.
 

--- a/doc/cheatsheet/monotonic_stack.md
+++ b/doc/cheatsheet/monotonic_stack.md
@@ -1,5 +1,10 @@
 # Monotonic Stack Data Structure
 
+## LeetCode Problem Lists
+
+- [Monotonic Stack](https://leetcode.com/problem-list/monotonic-stack/)
+- [Stack](https://leetcode.com/problem-list/stack/)
+
 ## Overview
 **Monotonic Stack** is a specialized stack data structure that maintains a monotonic (either strictly increasing or strictly decreasing) order of elements. It efficiently solves problems related to finding next greater/smaller elements, histogram areas, and sequence optimization problems.
 

--- a/doc/cheatsheet/n_sum.md
+++ b/doc/cheatsheet/n_sum.md
@@ -1,5 +1,11 @@
 # N Sum
 
+## LeetCode Problem Lists
+
+- [Two Pointers](https://leetcode.com/problem-list/two-pointers/)
+- [Hash Table](https://leetcode.com/problem-list/hash-table/)
+- [Sorting](https://leetcode.com/problem-list/sorting/)
+
 ## 0) Concept  
 
 ### 0-1) Types

--- a/doc/cheatsheet/ood_design.md
+++ b/doc/cheatsheet/ood_design.md
@@ -1,5 +1,9 @@
 # Object-Oriented Design (OOD / Low-Level Design)
 
+## LeetCode Problem Lists
+
+- [Design](https://leetcode.com/problem-list/design/)
+
 ## Overview
 
 **OOD (Object-Oriented Design)**, also called **LLD (Low-Level Design)**, tests your ability to translate a real-world problem into a clean set of **classes, interfaces, and relationships**. You are graded less on a working end-to-end program and more on **modeling, responsibility separation, extensibility, and use of design patterns**.

--- a/doc/cheatsheet/palindrome.md
+++ b/doc/cheatsheet/palindrome.md
@@ -1,5 +1,11 @@
 # Palindrome (回文)
 
+## LeetCode Problem Lists
+
+- [String](https://leetcode.com/problem-list/string/)
+- [Two Pointers](https://leetcode.com/problem-list/two-pointers/)
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+
 ## Overview
 **Palindrome** is a sequence that reads the same forward and backward. It's a fundamental concept in string manipulation and array processing, commonly appearing in coding interviews.
 

--- a/doc/cheatsheet/prefix_sum.md
+++ b/doc/cheatsheet/prefix_sum.md
@@ -2,6 +2,10 @@
 
 <p align="center"><img src="../pic/prefix_sum.png"></p>
 
+## LeetCode Problem Lists
+
+- [Prefix Sum](https://leetcode.com/problem-list/prefix-sum/)
+
 ## Overview
 
 **Prefix Sum** is a preprocessing technique that allows us to compute the sum of any subarray in O(1) time after O(n) preprocessing. The core idea is to precompute cumulative sums from the beginning of the array to each position.

--- a/doc/cheatsheet/priority_queue.md
+++ b/doc/cheatsheet/priority_queue.md
@@ -1,5 +1,9 @@
 # Priority Queue (PQ) Data Structure 
 
+## LeetCode Problem Lists
+
+- [Heap (Priority Queue)](https://leetcode.com/problem-list/heap-priority-queue/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/python_gotchas.md
+++ b/doc/cheatsheet/python_gotchas.md
@@ -1,5 +1,9 @@
 # Python Gotchas & Concurrency
 
+## LeetCode Problem Lists
+
+- [Concurrency](https://leetcode.com/problem-list/concurrency/)
+
 ## Overview
 
 Interviewers rarely ask *"list Python gotchas"* directly. Instead, these traps surface **inside** a normal coding problem — you initialize a grid with `[[0]]*n`, you use a mutable default argument, you `pop(0)` in a hot loop — and a strong candidate spots and explains them on the fly.

--- a/doc/cheatsheet/queue.md
+++ b/doc/cheatsheet/queue.md
@@ -1,5 +1,9 @@
 # Queue Data Structure
 
+## LeetCode Problem Lists
+
+- [Queue](https://leetcode.com/problem-list/queue/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/recursion.md
+++ b/doc/cheatsheet/recursion.md
@@ -1,5 +1,9 @@
 # Recursion
 
+## LeetCode Problem Lists
+
+- [Recursion](https://leetcode.com/problem-list/recursion/)
+
 ## 0) Quick Reference
 
 **When should I use recursion?**

--- a/doc/cheatsheet/recursion_to_dp.md
+++ b/doc/cheatsheet/recursion_to_dp.md
@@ -14,6 +14,12 @@
 
 ---
 
+## LeetCode Problem Lists
+
+- [Recursion](https://leetcode.com/problem-list/recursion/)
+- [Memoization](https://leetcode.com/problem-list/memoization/)
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+
 ## 0) Concept
 
 ### 0-0) When to Convert Recursion to DP

--- a/doc/cheatsheet/scanning_line.md
+++ b/doc/cheatsheet/scanning_line.md
@@ -1,5 +1,11 @@
 # Scanning Line (Line Sweep) Algorithm
 
+## LeetCode Problem Lists
+
+- [Sweep Line](https://leetcode.com/problem-list/sweep-line/)
+- [Sorting](https://leetcode.com/problem-list/sorting/)
+- [Prefix Sum](https://leetcode.com/problem-list/prefix-sum/)
+
 ## Overview
 **Scanning Line** (also known as Line Sweep or Sweep Line) is an algorithmic paradigm that processes geometric objects by imagining a vertical line sweeping across the plane from left to right, processing events as they occur.
 

--- a/doc/cheatsheet/segment_tree.md
+++ b/doc/cheatsheet/segment_tree.md
@@ -1,5 +1,10 @@
 # Segment Tree & Binary Indexed Tree (Fenwick Tree)
 
+## LeetCode Problem Lists
+
+- [Segment Tree](https://leetcode.com/problem-list/segment-tree/)
+- [Binary Indexed Tree](https://leetcode.com/problem-list/binary-indexed-tree/)
+
 ## Overview
 **Segment Trees** and **Binary Indexed Trees (BIT/Fenwick Tree)** are advanced data structures for efficiently handling range queries and updates on arrays.
 

--- a/doc/cheatsheet/set.md
+++ b/doc/cheatsheet/set.md
@@ -1,5 +1,10 @@
 # Set
 
+## LeetCode Problem Lists
+
+- [Hash Table](https://leetcode.com/problem-list/hash-table/)
+- [Ordered Set](https://leetcode.com/problem-list/ordered-set/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/shortest_path_comparison.md
+++ b/doc/cheatsheet/shortest_path_comparison.md
@@ -1,5 +1,10 @@
 # Shortest Path Algorithms — When to Use Which
 
+## LeetCode Problem Lists
+
+- [Shortest Path](https://leetcode.com/problem-list/shortest-path/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+
 ## Quick Decision Table
 
 | Question | Answer → Algorithm |

--- a/doc/cheatsheet/sliding_window.md
+++ b/doc/cheatsheet/sliding_window.md
@@ -1,5 +1,10 @@
 # Sliding Window
 
+## LeetCode Problem Lists
+
+- [Sliding Window](https://leetcode.com/problem-list/sliding-window/)
+- [Two Pointers](https://leetcode.com/problem-list/two-pointers/)
+
 ## Overview
 
 **Sliding Window** is a technique that uses two pointers to maintain a "window" over arrays or strings, expanding and contracting to find optimal solutions efficiently.

--- a/doc/cheatsheet/sort.md
+++ b/doc/cheatsheet/sort.md
@@ -2,6 +2,15 @@
 
 <p align="center"><img src="../pic/sort_cheatsheet.png"></p>
 
+## LeetCode Problem Lists
+
+- [Sorting](https://leetcode.com/problem-list/sorting/)
+- [Merge Sort](https://leetcode.com/problem-list/merge-sort/)
+- [Counting Sort](https://leetcode.com/problem-list/counting-sort/)
+- [Bucket Sort](https://leetcode.com/problem-list/bucket-sort/)
+- [Radix Sort](https://leetcode.com/problem-list/radix-sort/)
+- [Quickselect](https://leetcode.com/problem-list/quickselect/)
+
 ## Overview
 **Sorting** is the process of arranging elements in a specific order (ascending or descending). It's fundamental to many algorithms and data structures, enabling efficient searching, data analysis, and problem-solving.
 

--- a/doc/cheatsheet/stack.md
+++ b/doc/cheatsheet/stack.md
@@ -1,5 +1,10 @@
 # Stack
 
+## LeetCode Problem Lists
+
+- [Stack](https://leetcode.com/problem-list/stack/)
+- [Monotonic Stack](https://leetcode.com/problem-list/monotonic-stack/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/stock_trading.md
+++ b/doc/cheatsheet/stock_trading.md
@@ -1,6 +1,12 @@
 # Best Time to Buy and Sell Stock
 > Dynamic Programming approach to stock trading problems
 
+## LeetCode Problem Lists
+
+- [Dynamic Programming](https://leetcode.com/problem-list/dynamic-programming/)
+- [Array](https://leetcode.com/problem-list/array/)
+- [Greedy](https://leetcode.com/problem-list/greedy/)
+
 ## 0) Concept
 
 ### 0-1) Types

--- a/doc/cheatsheet/streaming_algorithms.md
+++ b/doc/cheatsheet/streaming_algorithms.md
@@ -9,6 +9,12 @@
 **Time Complexity:** O(1) per element processed (streaming)
 **Space Complexity:** O(k) or O(log n) typically, independent of stream size
 
+## LeetCode Problem Lists
+
+- [Data Stream](https://leetcode.com/problem-list/data-stream/)
+- [Heap (Priority Queue)](https://leetcode.com/problem-list/heap-priority-queue/)
+- [Reservoir Sampling](https://leetcode.com/problem-list/reservoir-sampling/)
+
 ## 0) Concept
 
 ### 0-0) Why Streaming Algorithms?

--- a/doc/cheatsheet/string.md
+++ b/doc/cheatsheet/string.md
@@ -1,5 +1,9 @@
 # String Algorithms & Manipulation
 
+## LeetCode Problem Lists
+
+- [String](https://leetcode.com/problem-list/string/)
+
 ## Overview
 **String algorithms** encompass techniques for processing, searching, and manipulating text data. These are fundamental in text processing, pattern matching, parsing, and many coding interview problems.
 

--- a/doc/cheatsheet/string_matching_kmp_rolling_hash.md
+++ b/doc/cheatsheet/string_matching_kmp_rolling_hash.md
@@ -1,5 +1,11 @@
 # String Matching (KMP, Rolling Hash)
 
+## LeetCode Problem Lists
+
+- [String Matching](https://leetcode.com/problem-list/string-matching/)
+- [Rolling Hash](https://leetcode.com/problem-list/rolling-hash/)
+- [Hash Function](https://leetcode.com/problem-list/hash-function/)
+
 ## 0) Concept
 
 ### 0-1) Types

--- a/doc/cheatsheet/topology_sorting.md
+++ b/doc/cheatsheet/topology_sorting.md
@@ -1,5 +1,10 @@
 # Topological Sorting - Complete Guide
 
+## LeetCode Problem Lists
+
+- [Topological Sort](https://leetcode.com/problem-list/topological-sort/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+
 ## Overview
 
 Topological sorting is a linear ordering of vertices in a Directed Acyclic Graph (DAG) such that for every directed edge (u, v), vertex u comes before v in the ordering.

--- a/doc/cheatsheet/tree.md
+++ b/doc/cheatsheet/tree.md
@@ -1,5 +1,11 @@
 # Tree Data Structure - Concepts & Patterns
 
+## LeetCode Problem Lists
+
+- [Tree](https://leetcode.com/problem-list/tree/)
+- [Binary Tree](https://leetcode.com/problem-list/binary-tree/)
+- [Depth-First Search](https://leetcode.com/problem-list/depth-first-search/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/tree2.md
+++ b/doc/cheatsheet/tree2.md
@@ -2,6 +2,12 @@
 
 > **Note:** This file contains detailed traversal templates and implementation code. For tree concepts, types, and algorithm patterns, see [tree.md](./tree.md).
 
+## LeetCode Problem Lists
+
+- [Tree](https://leetcode.com/problem-list/tree/)
+- [Binary Tree](https://leetcode.com/problem-list/binary-tree/)
+- [Depth-First Search](https://leetcode.com/problem-list/depth-first-search/)
+
 ## Overview
 
 This document provides detailed templates for all tree problem patterns, organized by categories with example code, explanations, and corresponding LeetCode problems.

--- a/doc/cheatsheet/tree_backtrack.md
+++ b/doc/cheatsheet/tree_backtrack.md
@@ -11,6 +11,12 @@ I'll show the **universal template**, then how each problem plugs into it.
 
 ---
 
+## LeetCode Problem Lists
+
+- [Tree](https://leetcode.com/problem-list/tree/)
+- [Backtracking](https://leetcode.com/problem-list/backtracking/)
+- [Depth-First Search](https://leetcode.com/problem-list/depth-first-search/)
+
 ## 1️⃣ Universal Tree Backtracking Template
 
 ```java

--- a/doc/cheatsheet/trie.md
+++ b/doc/cheatsheet/trie.md
@@ -2,6 +2,11 @@
 > Whenever we come across questions with multiple strings, it is best to think if Trie can help us.
 - https://leetcode.com/problems/search-suggestions-system/solution/
 
+## LeetCode Problem Lists
+
+- [Trie](https://leetcode.com/problem-list/trie/)
+- [String](https://leetcode.com/problem-list/string/)
+
 ## Time Complexity
 
 | Data structure | Search   | Insert   | Delete   | Min/Max  |

--- a/doc/cheatsheet/union_find.md
+++ b/doc/cheatsheet/union_find.md
@@ -8,6 +8,11 @@
 
 **Time Complexity:** Nearly O(1) per operation with optimizations
 
+## LeetCode Problem Lists
+
+- [Union-Find](https://leetcode.com/problem-list/union-find/)
+- [Graph Theory](https://leetcode.com/problem-list/graph/)
+
 ## 0) Concept
 
 ### 0-0) Union-Find Variants

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -18,7 +18,7 @@ Output: `data/LC_Practice_{year_start}_{year_end}_By_Category.md` — table of c
 
 ## add_lc_problem_lists.py
 
-Maintains the `## LeetCode Problem Lists` section in every cheatsheet under `doc/cheatsheet/`, linking each doc to the matching LeetCode topic problem lists (`https://leetcode.com/problem-list/<tag>/`).
+Maintains the `## LeetCode Problem Lists` section in every mapped cheatsheet under `doc/cheatsheet/`, linking each doc to the matching LeetCode topic problem lists (`https://leetcode.com/problem-list/<tag>/`).
 
 ```bash
 # Apply (idempotent — rewrites the block in place, never duplicates it)

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -16,6 +16,25 @@ python3 script/categorize_lc_by_type.py 2024 2025
 
 Output: `data/LC_Practice_{year_start}_{year_end}_By_Category.md` — table of contents, problem counts per category, summary statistics. Categorizes ~80%+ of problems.
 
+## add_lc_problem_lists.py
+
+Maintains the `## LeetCode Problem Lists` section in every cheatsheet under `doc/cheatsheet/`, linking each doc to the matching LeetCode topic problem lists (`https://leetcode.com/problem-list/<tag>/`).
+
+```bash
+# Apply (idempotent — rewrites the block in place, never duplicates it)
+python3 script/add_lc_problem_lists.py
+
+# Preview which files would change
+python3 script/add_lc_problem_lists.py --dry-run
+
+# Check every slug/label against LeetCode (network)
+python3 script/add_lc_problem_lists.py --verify
+```
+
+The doc → tag mapping lives in `DOC_TAGS` inside the script; edit it there rather than hand-editing the generated sections. Docs with no meaningful LC topic tag (language tricks, complexity theory, pattern indexes) are listed in `SKIP`.
+
+`--verify` uses LeetCode's public GraphQL endpoint (`topicTag(slug:)`) because leetcode.com returns HTTP 403 to non-browser clients for HTML pages. It also confirms each link label matches LeetCode's canonical tag name.
+
 ## Other Scripts
 
 | Script | Purpose |

--- a/script/add_lc_problem_lists.py
+++ b/script/add_lc_problem_lists.py
@@ -179,15 +179,6 @@ SKIP = {
     "time_space_complexity.md",
 }
 
-# Matches a previously inserted block: its heading plus the lines under it, stopping
-# at the next heading of ANY level (stopping only at `## ` would swallow a following
-# `### ` section on re-run).
-BLOCK_RE = re.compile(
-    r"^## " + re.escape(SECTION_TITLE) + r"\n(?:(?!#{1,6} )[^\n]*\n)*",
-    re.MULTILINE,
-)
-
-
 def build_block(tags):
     lines = ["## " + SECTION_TITLE, ""]
     for tag in tags:
@@ -196,8 +187,55 @@ def build_block(tags):
     return "\n".join(lines)
 
 
-FENCE_RE = re.compile(r"^\s*(```|~~~)")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 SUBHEADING_RE = re.compile(r"^#{2,6} ")
+HEADING_RE = re.compile(r"^#{1,6} ")
+SECTION_RE = re.compile(r"^## " + re.escape(SECTION_TITLE) + r"\s*$")
+
+
+def code_line_flags(lines):
+    """Flag every line that belongs to a fenced code block (fence lines included).
+
+    A fence closes only on the same character with a marker at least as long as
+    the one that opened it, so a ``` example nested inside a ```` block doesn't
+    end the outer block early.
+    """
+    flags = []
+    fence = None  # (char, length) of the currently open fence
+    for line in lines:
+        match = FENCE_RE.match(line)
+        if match:
+            marker = match.group(1)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            flags.append(True)
+        else:
+            flags.append(fence is not None)
+    return flags
+
+
+def strip_block(lines):
+    """Drop a previously inserted block: its heading plus the lines under it.
+
+    Stops at the next heading of ANY level (stopping only at `## ` would swallow
+    a following `### ` section on re-run). Only headings outside fenced code
+    count, so a markdown example of the section inside a fence stays intact.
+    """
+    in_code = code_line_flags(lines)
+    kept = []
+    dropping = False
+    for i, line in enumerate(lines):
+        if dropping:
+            if in_code[i] or not HEADING_RE.match(line):
+                continue
+            dropping = False
+        if not in_code[i] and SECTION_RE.match(line):
+            dropping = True
+            continue
+        kept.append(line)
+    return kept
 
 
 def insert_block(text, block):
@@ -207,16 +245,12 @@ def insert_block(text, block):
     image, ref bullets), so the block becomes the doc's first real section.
     Headings inside fenced code blocks don't count.
     """
-    text = BLOCK_RE.sub("", text)
-    lines = text.split("\n")
+    lines = strip_block(text.split("\n"))
+    in_code = code_line_flags(lines)
 
     insert_at = None
-    in_fence = False
     for i, line in enumerate(lines):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if not in_fence and SUBHEADING_RE.match(line):
+        if not in_code[i] and SUBHEADING_RE.match(line):
             insert_at = i
             break
 

--- a/script/add_lc_problem_lists.py
+++ b/script/add_lc_problem_lists.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Insert a "LeetCode Problem Lists" section into every cheatsheet under doc/cheatsheet/.
+
+Each doc gets links to the LeetCode problem lists (https://leetcode.com/problem-list/<tag>/)
+for the LC topic tags that match the doc's pattern, e.g.
+
+    ## LeetCode Problem Lists
+    - [Monotonic Stack](https://leetcode.com/problem-list/monotonic-stack/)
+    - [Stack](https://leetcode.com/problem-list/stack/)
+
+Placement: as the first `##` section of the doc (right before the existing first `##`
+heading), so the links show up at the top of the page and in the generated site TOC.
+
+The script is idempotent: re-running it rewrites the block in place instead of
+appending a second copy.
+
+Usage:
+    python3 script/add_lc_problem_lists.py           # apply
+    python3 script/add_lc_problem_lists.py --dry-run # report only
+    python3 script/add_lc_problem_lists.py --verify  # check slugs/names against LeetCode
+
+Note on --verify: leetcode.com serves 403 to non-browser clients for HTML pages, so
+slugs are validated through the public GraphQL endpoint (`topicTag(slug:)`) instead,
+which also gives the canonical display name for each tag.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+SECTION_TITLE = "LeetCode Problem Lists"
+
+# LC topic tag slug -> display name (as LeetCode labels them)
+TAG_NAMES = {
+    "array": "Array",
+    "backtracking": "Backtracking",
+    "binary-indexed-tree": "Binary Indexed Tree",
+    "binary-search": "Binary Search",
+    "binary-search-tree": "Binary Search Tree",
+    "binary-tree": "Binary Tree",
+    "bit-manipulation": "Bit Manipulation",
+    "bitmask": "Bitmask",
+    "breadth-first-search": "Breadth-First Search",
+    "bucket-sort": "Bucket Sort",
+    "combinatorics": "Combinatorics",
+    "concurrency": "Concurrency",
+    "counting": "Counting",
+    "counting-sort": "Counting Sort",
+    "data-stream": "Data Stream",
+    "depth-first-search": "Depth-First Search",
+    "design": "Design",
+    "divide-and-conquer": "Divide and Conquer",
+    "doubly-linked-list": "Doubly-Linked List",
+    "dynamic-programming": "Dynamic Programming",
+    "graph": "Graph Theory",
+    "greedy": "Greedy",
+    "hash-function": "Hash Function",
+    "hash-table": "Hash Table",
+    "heap-priority-queue": "Heap (Priority Queue)",
+    "iterator": "Iterator",
+    "linked-list": "Linked List",
+    "math": "Math",
+    "matrix": "Matrix",
+    "memoization": "Memoization",
+    "merge-sort": "Merge Sort",
+    "monotonic-queue": "Monotonic Queue",
+    "monotonic-stack": "Monotonic Stack",
+    "number-theory": "Number Theory",
+    "ordered-set": "Ordered Set",
+    "prefix-sum": "Prefix Sum",
+    "queue": "Queue",
+    "quickselect": "Quickselect",
+    "radix-sort": "Radix Sort",
+    "recursion": "Recursion",
+    "reservoir-sampling": "Reservoir Sampling",
+    "rolling-hash": "Rolling Hash",
+    "segment-tree": "Segment Tree",
+    "shortest-path": "Shortest Path",
+    "simulation": "Simulation",
+    "sliding-window": "Sliding Window",
+    "sorting": "Sorting",
+    "stack": "Stack",
+    "string": "String",
+    "string-matching": "String Matching",
+    "suffix-array": "Suffix Array",
+    "sweep-line": "Sweep Line",
+    "topological-sort": "Topological Sort",
+    "tree": "Tree",
+    "trie": "Trie",
+    "two-pointers": "Two Pointers",
+    "union-find": "Union-Find",
+}
+
+# cheatsheet file -> LC topic tags (most relevant first)
+DOC_TAGS = {
+    "2_pointers.md": ["two-pointers", "sliding-window", "array"],
+    "2_pointers_linkedlist.md": ["two-pointers", "linked-list"],
+    "add_x_sum.md": ["math", "string", "bit-manipulation"],
+    "advanced_divide_and_conquer.md": ["divide-and-conquer", "merge-sort", "quickselect"],
+    "advanced_simulation.md": ["simulation", "design"],
+    "advanced_string_algorithms.md": ["string", "string-matching", "rolling-hash", "suffix-array"],
+    "array.md": ["array"],
+    "array_overlap_explaination.md": ["design", "ordered-set", "segment-tree"],
+    "backtrack.md": ["backtracking", "recursion"],
+    "Bellman-Ford.md": ["shortest-path", "graph", "dynamic-programming"],
+    "bfs.md": ["breadth-first-search", "graph"],
+    "binary_indexed_tree.md": ["binary-indexed-tree", "segment-tree"],
+    "binary_search.md": ["binary-search"],
+    "binary_tree.md": ["binary-tree", "tree"],
+    "bit_manipulation.md": ["bit-manipulation", "bitmask"],
+    "bst.md": ["binary-search-tree", "binary-tree"],
+    "Collection.md": ["array", "hash-table", "linked-list", "heap-priority-queue"],
+    "combinatorics_math_patterns.md": ["combinatorics", "math", "number-theory"],
+    "concurrency_patterns.md": ["concurrency"],
+    "design.md": ["design", "data-stream"],
+    "dfs.md": ["depth-first-search", "graph"],
+    "diff_toposort_quickunion.md": ["topological-sort", "union-find"],
+    "difference_array.md": ["prefix-sum", "array"],
+    "Dijkstra.md": ["shortest-path", "graph", "heap-priority-queue"],
+    "dp.md": ["dynamic-programming", "memoization"],
+    "dp_pattern.md": ["dynamic-programming"],
+    "Floyd-Warshall.md": ["shortest-path", "graph", "dynamic-programming"],
+    "graph.md": ["graph"],
+    "greedy.md": ["greedy"],
+    "hash_map.md": ["hash-table"],
+    "hashing.md": ["hash-table", "counting", "hash-function"],
+    "heap.md": ["heap-priority-queue"],
+    "intervals.md": ["sorting", "greedy", "sweep-line"],
+    "iterator.md": ["iterator", "design"],
+    "kadane_algorithm.md": ["dynamic-programming", "array"],
+    "linked_list.md": ["linked-list", "doubly-linked-list"],
+    "math.md": ["math", "number-theory"],
+    "matrix.md": ["matrix"],
+    "monotonic_queue.md": ["monotonic-queue", "sliding-window", "queue"],
+    "monotonic_stack.md": ["monotonic-stack", "stack"],
+    "n_sum.md": ["two-pointers", "hash-table", "sorting"],
+    "ood_design.md": ["design"],
+    "palindrome.md": ["string", "two-pointers", "dynamic-programming"],
+    "prefix_sum.md": ["prefix-sum"],
+    "priority_queue.md": ["heap-priority-queue"],
+    "python_gotchas.md": ["concurrency"],
+    "queue.md": ["queue"],
+    "recursion.md": ["recursion"],
+    "recursion_to_dp.md": ["recursion", "memoization", "dynamic-programming"],
+    "scanning_line.md": ["sweep-line", "sorting", "prefix-sum"],
+    "segment_tree.md": ["segment-tree", "binary-indexed-tree"],
+    "set.md": ["hash-table", "ordered-set"],
+    "shortest_path_comparison.md": ["shortest-path", "graph"],
+    "sliding_window.md": ["sliding-window", "two-pointers"],
+    "sort.md": ["sorting", "merge-sort", "counting-sort", "bucket-sort", "radix-sort", "quickselect"],
+    "stack.md": ["stack", "monotonic-stack"],
+    "stock_trading.md": ["dynamic-programming", "array", "greedy"],
+    "streaming_algorithms.md": ["data-stream", "heap-priority-queue", "reservoir-sampling"],
+    "string.md": ["string"],
+    "string_matching_kmp_rolling_hash.md": ["string-matching", "rolling-hash", "hash-function"],
+    "topology_sorting.md": ["topological-sort", "graph"],
+    "tree.md": ["tree", "binary-tree", "depth-first-search"],
+    "tree2.md": ["tree", "binary-tree", "depth-first-search"],
+    "tree_backtrack.md": ["tree", "backtracking", "depth-first-search"],
+    "trie.md": ["trie", "string"],
+    "union_find.md": ["union-find", "graph"],
+}
+
+# Docs with no meaningful LC topic tag (language tricks, complexity theory,
+# pattern indexes). Listed explicitly so nothing is silently missed.
+SKIP = {
+    "00_template.md",
+    "code_interview_general_cheatsheet.md",
+    "complexity_cheatsheet.md",
+    "complexity_drills.md",
+    "java_trick.md",
+    "lc_category.md",
+    "lc_pattern.md",
+    "python_trick.md",
+    "time_space_complexity.md",
+}
+
+# Matches a previously inserted block: its heading plus the lines under it, stopping
+# at the next heading of ANY level (stopping only at `## ` would swallow a following
+# `### ` section on re-run).
+BLOCK_RE = re.compile(
+    r"^## " + re.escape(SECTION_TITLE) + r"\n(?:(?!#{1,6} )[^\n]*\n)*",
+    re.MULTILINE,
+)
+
+
+def build_block(tags):
+    lines = ["## " + SECTION_TITLE, ""]
+    for tag in tags:
+        lines.append(f"- [{TAG_NAMES[tag]}](https://leetcode.com/problem-list/{tag}/)")
+    lines.append("")
+    return "\n".join(lines)
+
+
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+SUBHEADING_RE = re.compile(r"^#{2,6} ")
+
+
+def insert_block(text, block):
+    """Put block right after the doc's intro, before its first sub-heading.
+
+    Anything above the first `##`/`###`/... heading is the doc's intro (subtitle,
+    image, ref bullets), so the block becomes the doc's first real section.
+    Headings inside fenced code blocks don't count.
+    """
+    text = BLOCK_RE.sub("", text)
+    lines = text.split("\n")
+
+    insert_at = None
+    in_fence = False
+    for i, line in enumerate(lines):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence and SUBHEADING_RE.match(line):
+            insert_at = i
+            break
+
+    if insert_at is None:
+        # No sub-heading anywhere: place after the H1 plus any immediately
+        # following subtitle / image lines.
+        insert_at = 0
+        for i, line in enumerate(lines):
+            if line.startswith("# "):
+                insert_at = i + 1
+                break
+        while insert_at < len(lines):
+            stripped = lines[insert_at].strip()
+            if stripped and not stripped.startswith((">", "<p", "<img")):
+                break
+            insert_at += 1
+
+    head = "\n".join(lines[:insert_at]).rstrip("\n")
+    tail = "\n".join(lines[insert_at:]).lstrip("\n")
+    return f"{head}\n\n{block}\n{tail}"
+
+
+GRAPHQL_URL = "https://leetcode.com/graphql/"
+BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+
+def fetch_tag(slug):
+    """Return LeetCode's display name for a topic tag slug, or None if it doesn't exist."""
+    payload = json.dumps(
+        {
+            "query": "query t($slug:String!){topicTag(slug:$slug){name slug}}",
+            "variables": {"slug": slug},
+        }
+    ).encode()
+    req = urllib.request.Request(
+        GRAPHQL_URL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": BROWSER_UA,
+            "Origin": "https://leetcode.com",
+            "Referer": "https://leetcode.com/problemset/",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            tag = json.load(resp)["data"]["topicTag"]
+    except (urllib.error.URLError, KeyError, TypeError, ValueError) as exc:
+        print(f"  {slug}: request failed ({exc})", file=sys.stderr)
+        return None
+    return tag["name"] if tag else None
+
+
+def verify():
+    used = sorted({t for tags in DOC_TAGS.values() for t in tags})
+    problems = []
+    for slug in used:
+        official = fetch_tag(slug)
+        if official is None:
+            problems.append(f"{slug}: not a LeetCode topic tag")
+        elif official != TAG_NAMES[slug]:
+            problems.append(f"{slug}: label {TAG_NAMES[slug]!r} != LeetCode {official!r}")
+    for line in problems:
+        print(f"FAIL {line}")
+    print(f"\n{len(used) - len(problems)}/{len(used)} tag(s) verified")
+    return 1 if problems else 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verify", action="store_true", help="validate slugs against LeetCode, don't edit files")
+    parser.add_argument(
+        "--dir",
+        default=os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "doc", "cheatsheet"),
+    )
+    args = parser.parse_args()
+
+    if args.verify:
+        return verify()
+
+    present = {f for f in os.listdir(args.dir) if f.endswith(".md")}
+    unmapped = present - set(DOC_TAGS) - SKIP
+    missing = (set(DOC_TAGS) | SKIP) - present
+    if unmapped:
+        print(f"warning: no tag mapping for: {sorted(unmapped)}", file=sys.stderr)
+    if missing:
+        print(f"warning: mapped file not found: {sorted(missing)}", file=sys.stderr)
+
+    changed = 0
+    for name in sorted(DOC_TAGS):
+        path = os.path.join(args.dir, name)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding="utf-8") as fh:
+            original = fh.read()
+        updated = insert_block(original, build_block(DOC_TAGS[name]))
+        if updated == original:
+            continue
+        changed += 1
+        if args.dry_run:
+            print(f"would update {name}: {', '.join(DOC_TAGS[name])}")
+        else:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(updated)
+            print(f"updated {name}: {', '.join(DOC_TAGS[name])}")
+
+    print(f"\n{changed} file(s) {'to change' if args.dry_run else 'changed'}; {len(SKIP)} skipped (no LC topic tag)")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)


### PR DESCRIPTION
Add a "## LeetCode Problem Lists" section to 66 cheatsheets under doc/cheatsheet/, linking each doc to the matching LeetCode topic problem lists (https://leetcode.com/problem-list/<tag>/). The section is placed after the doc intro and before the first sub-heading, so it renders as the first section and picks up a TOC entry on the generated site.

Tag slugs and labels are validated against LeetCode's public GraphQL endpoint (topicTag(slug:)), since leetcode.com returns HTTP 403 to non-browser clients for HTML pages. That check caught:

- `line-sweep` is not a real tag; the correct slug is `sweep-line` (affected intervals.md and scanning_line.md)
- `graph` is labelled "Graph Theory", not "Graph"
- `union-find` is labelled "Union-Find", not "Union Find"

All 57 slugs in use now verify, labels included.

script/add_lc_problem_lists.py owns the doc -> tag mapping and is idempotent, with --dry-run and --verify modes. 9 docs are explicitly skipped (language tricks, complexity theory, pattern indexes) as no LC topic tag applies. 00_template.md documents the convention for new cheatsheets.

_site/ is intentionally not rebuilt here: deploy-pages.yml regenerates it from source on push to master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LeetCode problem-list links across algorithm and data-structure cheatsheets.
  * Added guidance for adding and verifying problem-list links in the cheatsheet template.
  * Added a command-line tool to insert, preview, and validate problem-list sections.

* **Documentation**
  * Documented the new tool’s commands, validation behavior, configuration, and usage considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->