### PR TITLE
site: simplify navbar to 7 items, move the rest behind a "more" dropdown

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -57,8 +57,12 @@ jobs:
         mkdir -p _site/faqs
         node site/build-site.js
 
-    - name: Copy CSS
-      run: cp site/style.css _site/style.css
+    - name: Copy shared CSS + JS
+      run: |
+        cp site/style.css _site/style.css
+        cp site/nav.css _site/nav.css
+        cp site/nav.js _site/nav.js
+        cp site/site.js _site/site.js
 
     - name: Bundle vendor assets (highlight.js + fonts)
       run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Cache npm dependencies
       uses: actions/cache@v4

--- a/.github/workflows/validate-pages.yml
+++ b/.github/workflows/validate-pages.yml
@@ -11,6 +11,10 @@ on:
       - 'algo_demo/**'
       - 'site/build-*.js'
       - 'site/ensure-nav-pages.js'
+      - 'site/nav.js'
+      - 'site/nav.css'
+      - 'site/site.js'
+      - 'site/test/**'
       - 'site/package.json'
       - 'site/package-lock.json'
       - 'site/style.css'
@@ -25,6 +29,10 @@ on:
       - 'algo_demo/**'
       - 'site/build-*.js'
       - 'site/ensure-nav-pages.js'
+      - 'site/nav.js'
+      - 'site/nav.css'
+      - 'site/site.js'
+      - 'site/test/**'
       - 'site/package.json'
       - 'site/package-lock.json'
       - 'site/style.css'
@@ -62,6 +70,10 @@ jobs:
         mkdir -p _site/faqs
         node site/build-site.js
         cp site/style.css _site/style.css
+        cp site/nav.css _site/nav.css
+        cp site/nav.js _site/nav.js
+        cp site/site.js _site/site.js
+        cp -r algo_demo _site/algo_demo
         mkdir -p _site/vendor/highlight
         cp site/node_modules/highlight.js/styles/atom-one-dark.min.css _site/vendor/highlight/atom-one-dark.min.css
         cp vendor/fonts.css _site/vendor/fonts.css
@@ -69,6 +81,9 @@ jobs:
           -o _site/vendor/inter.woff2
         curl -sSfL "https://fonts.gstatic.com/s/jetbrainsmono/v24/tDbv2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKwBNntkaToggR7BYRbKPxDcwgknk-4.woff2" \
           -o _site/vendor/jetbrains-mono.woff2
+
+    - name: Run JS unit tests
+      run: npm test --prefix site
 
     - name: Validate generated HTML files
       run: |
@@ -93,7 +108,10 @@ jobs:
           '_site/cheatsheets.html',
           '_site/faqs.html',
           '_site/patterns.html',
-          '_site/style.css'
+          '_site/style.css',
+          '_site/nav.css',
+          '_site/nav.js',
+          '_site/site.js'
         ];
 
         for (const file of requiredFiles) {
@@ -177,20 +195,18 @@ jobs:
             error(`${relPath}: Empty or undefined title`);
           }
 
-          // Check navbar
-          if (!html.includes('class="navbar"') && !html.includes("class='navbar'")) {
-            error(`${relPath}: Missing navbar`);
+          // Check the shared navbar is wired up (nav.js renders the markup)
+          if (!html.includes('id="site-nav"')) {
+            error(`${relPath}: Missing #site-nav mount point`);
           }
-          if (!html.includes('nav-links')) {
-            error(`${relPath}: Missing nav-links`);
+          if (!html.includes('CSNav.mount()')) {
+            error(`${relPath}: Missing CSNav.mount() call`);
           }
-
-          // Check navigation links exist
-          if (!html.includes('index.html')) {
-            warn(`${relPath}: Missing Home link`);
+          if (!/<script src="[^"]*nav\.js"><\/script>/.test(html)) {
+            error(`${relPath}: Missing nav.js include`);
           }
-          if (!html.includes('cheatsheets.html')) {
-            warn(`${relPath}: Missing Cheat Sheets link`);
+          if (!/<link rel="stylesheet" href="[^"]*nav\.css">/.test(html)) {
+            error(`${relPath}: Missing nav.css include`);
           }
 
           // Check footer
@@ -263,7 +279,30 @@ jobs:
         }
 
         // ──────────────────────────────────────────────
-        // 5. Validate internal link consistency
+        // 5. Navbar entries resolve to real pages
+        // ──────────────────────────────────────────────
+        // The nav used to be inlined into every page, so its links were covered
+        // by the internal-link scan below. Now that they live in one module,
+        // check that module's targets directly.
+        info('=== Checking navbar entries ===');
+        {
+          const CSNav = require(path.resolve('site/nav.js'));
+          const entries = [...CSNav.PRIMARY, ...CSNav.MORE];
+          if (entries.length === 0) error('nav.js exposes no entries');
+          for (const entry of entries) {
+            if (entry.external) continue;
+            if (!fs.existsSync(path.join('_site', entry.href))) {
+              error(`nav.js entry "${entry.id}" points at a missing page: ${entry.href}`);
+            }
+          }
+          const navMarkup = CSNav.navHTML({ currentPage: 'home' });
+          if (!navMarkup.includes('class="navbar"')) error('nav.js does not render a .navbar');
+          if (!navMarkup.includes('nav-links')) error('nav.js does not render .nav-links');
+          info(`Checked ${entries.length} navbar entries`);
+        }
+
+        // ──────────────────────────────────────────────
+        // 6. Validate internal link consistency
         // ──────────────────────────────────────────────
         info('=== Checking internal links ===');
 

--- a/.github/workflows/validate-pages.yml
+++ b/.github/workflows/validate-pages.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Cache npm dependencies
       uses: actions/cache@v4

--- a/_site/cheatsheets.html
+++ b/_site/cheatsheets.html
@@ -11,108 +11,17 @@
   <title>Cheat Sheets — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="nav.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <script src="site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="index.html" class="">home</a>
-        <a href="search.html" class="">search</a>
-        <a href="cheatsheets.html" class="active">cheatsheets</a>
-        <a href="faqs.html" class="">faqs</a>
-        <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-random-picker.html" class="">random</a>
-        <a href="algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html" class="">patterns</a>
-            <a href="lc-similar.html" class="">similar</a>
-            <a href="lc-review-plan.html" class="">review</a>
-            <a href="resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base=""></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets.html
+++ b/_site/cheatsheets.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="index.html" class="">home</a>
         <a href="search.html" class="">search</a>
         <a href="cheatsheets.html" class="active">cheatsheets</a>
-        <a href="patterns.html" class="">patterns</a>
         <a href="faqs.html" class="">faqs</a>
         <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-similar.html" class="">similar</a>
         <a href="lc-random-picker.html" class="">random</a>
-        <a href="lc-review-plan.html" class="">review</a>
         <a href="algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html" class="">patterns</a>
+            <a href="lc-similar.html" class="">similar</a>
+            <a href="lc-review-plan.html" class="">review</a>
+            <a href="resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/2_pointers.html
+++ b/_site/cheatsheets/2_pointers.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/2_pointers.html
+++ b/_site/cheatsheets/2_pointers.html
@@ -11,108 +11,17 @@
   <title>2 Pointers — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/2_pointers_linkedlist.html
+++ b/_site/cheatsheets/2_pointers_linkedlist.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/2_pointers_linkedlist.html
+++ b/_site/cheatsheets/2_pointers_linkedlist.html
@@ -11,108 +11,17 @@
   <title>2 Pointers Linkedlist — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/Bellman-Ford.html
+++ b/_site/cheatsheets/Bellman-Ford.html
@@ -11,108 +11,17 @@
   <title>Bellman-Ford — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/Bellman-Ford.html
+++ b/_site/cheatsheets/Bellman-Ford.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/Collection.html
+++ b/_site/cheatsheets/Collection.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/Collection.html
+++ b/_site/cheatsheets/Collection.html
@@ -11,108 +11,17 @@
   <title>Collection — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/Dijkstra.html
+++ b/_site/cheatsheets/Dijkstra.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/Dijkstra.html
+++ b/_site/cheatsheets/Dijkstra.html
@@ -11,108 +11,17 @@
   <title>Dijkstra — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/Floyd-Warshall.html
+++ b/_site/cheatsheets/Floyd-Warshall.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/Floyd-Warshall.html
+++ b/_site/cheatsheets/Floyd-Warshall.html
@@ -11,108 +11,17 @@
   <title>Floyd-Warshall — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/add_x_sum.html
+++ b/_site/cheatsheets/add_x_sum.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/add_x_sum.html
+++ b/_site/cheatsheets/add_x_sum.html
@@ -11,108 +11,17 @@
   <title>Add X Sum — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/advanced_divide_and_conquer.html
+++ b/_site/cheatsheets/advanced_divide_and_conquer.html
@@ -11,108 +11,17 @@
   <title>Advanced Divide And Conquer — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/advanced_divide_and_conquer.html
+++ b/_site/cheatsheets/advanced_divide_and_conquer.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/advanced_simulation.html
+++ b/_site/cheatsheets/advanced_simulation.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/advanced_simulation.html
+++ b/_site/cheatsheets/advanced_simulation.html
@@ -11,108 +11,17 @@
   <title>Advanced Simulation — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/advanced_string_algorithms.html
+++ b/_site/cheatsheets/advanced_string_algorithms.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/advanced_string_algorithms.html
+++ b/_site/cheatsheets/advanced_string_algorithms.html
@@ -11,108 +11,17 @@
   <title>Advanced String Algorithms — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/array.html
+++ b/_site/cheatsheets/array.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/array.html
+++ b/_site/cheatsheets/array.html
@@ -11,108 +11,17 @@
   <title>Array — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/array_overlap_explaination.html
+++ b/_site/cheatsheets/array_overlap_explaination.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/array_overlap_explaination.html
+++ b/_site/cheatsheets/array_overlap_explaination.html
@@ -11,108 +11,17 @@
   <title>Array Overlap Explaination — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/backtrack.html
+++ b/_site/cheatsheets/backtrack.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/backtrack.html
+++ b/_site/cheatsheets/backtrack.html
@@ -11,108 +11,17 @@
   <title>Backtrack — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/bfs.html
+++ b/_site/cheatsheets/bfs.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/bfs.html
+++ b/_site/cheatsheets/bfs.html
@@ -11,108 +11,17 @@
   <title>Bfs — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/binary_indexed_tree.html
+++ b/_site/cheatsheets/binary_indexed_tree.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/binary_indexed_tree.html
+++ b/_site/cheatsheets/binary_indexed_tree.html
@@ -11,108 +11,17 @@
   <title>Binary Indexed Tree — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/binary_search.html
+++ b/_site/cheatsheets/binary_search.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/binary_search.html
+++ b/_site/cheatsheets/binary_search.html
@@ -11,108 +11,17 @@
   <title>Binary Search — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/binary_tree.html
+++ b/_site/cheatsheets/binary_tree.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/binary_tree.html
+++ b/_site/cheatsheets/binary_tree.html
@@ -11,108 +11,17 @@
   <title>Binary Tree — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/bit_manipulation.html
+++ b/_site/cheatsheets/bit_manipulation.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/bit_manipulation.html
+++ b/_site/cheatsheets/bit_manipulation.html
@@ -11,108 +11,17 @@
   <title>Bit Manipulation — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/bst.html
+++ b/_site/cheatsheets/bst.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/bst.html
+++ b/_site/cheatsheets/bst.html
@@ -11,108 +11,17 @@
   <title>Bst — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/code_interview_general_cheatsheet.html
+++ b/_site/cheatsheets/code_interview_general_cheatsheet.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/code_interview_general_cheatsheet.html
+++ b/_site/cheatsheets/code_interview_general_cheatsheet.html
@@ -11,108 +11,17 @@
   <title>Code Interview General Cheatsheet — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/combinatorics_math_patterns.html
+++ b/_site/cheatsheets/combinatorics_math_patterns.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/combinatorics_math_patterns.html
+++ b/_site/cheatsheets/combinatorics_math_patterns.html
@@ -11,108 +11,17 @@
   <title>Combinatorics Math Patterns — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/complexity_cheatsheet.html
+++ b/_site/cheatsheets/complexity_cheatsheet.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/complexity_cheatsheet.html
+++ b/_site/cheatsheets/complexity_cheatsheet.html
@@ -11,108 +11,17 @@
   <title>Complexity Cheatsheet — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/complexity_drills.html
+++ b/_site/cheatsheets/complexity_drills.html
@@ -11,108 +11,17 @@
   <title>Complexity Drills — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/complexity_drills.html
+++ b/_site/cheatsheets/complexity_drills.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/concurrency_patterns.html
+++ b/_site/cheatsheets/concurrency_patterns.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/concurrency_patterns.html
+++ b/_site/cheatsheets/concurrency_patterns.html
@@ -11,108 +11,17 @@
   <title>Concurrency Patterns — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/design.html
+++ b/_site/cheatsheets/design.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/design.html
+++ b/_site/cheatsheets/design.html
@@ -11,108 +11,17 @@
   <title>Design — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/dfs.html
+++ b/_site/cheatsheets/dfs.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/dfs.html
+++ b/_site/cheatsheets/dfs.html
@@ -11,108 +11,17 @@
   <title>Dfs — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/diff_toposort_quickunion.html
+++ b/_site/cheatsheets/diff_toposort_quickunion.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/diff_toposort_quickunion.html
+++ b/_site/cheatsheets/diff_toposort_quickunion.html
@@ -11,108 +11,17 @@
   <title>Diff Toposort Quickunion — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/difference_array.html
+++ b/_site/cheatsheets/difference_array.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/difference_array.html
+++ b/_site/cheatsheets/difference_array.html
@@ -11,108 +11,17 @@
   <title>Difference Array — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/dp.html
+++ b/_site/cheatsheets/dp.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/dp.html
+++ b/_site/cheatsheets/dp.html
@@ -11,108 +11,17 @@
   <title>Dp — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/dp_pattern.html
+++ b/_site/cheatsheets/dp_pattern.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/dp_pattern.html
+++ b/_site/cheatsheets/dp_pattern.html
@@ -11,108 +11,17 @@
   <title>Dp Pattern — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/graph.html
+++ b/_site/cheatsheets/graph.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/graph.html
+++ b/_site/cheatsheets/graph.html
@@ -11,108 +11,17 @@
   <title>Graph — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/greedy.html
+++ b/_site/cheatsheets/greedy.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/greedy.html
+++ b/_site/cheatsheets/greedy.html
@@ -11,108 +11,17 @@
   <title>Greedy — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/hash_map.html
+++ b/_site/cheatsheets/hash_map.html
@@ -11,108 +11,17 @@
   <title>Hash Map — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/hash_map.html
+++ b/_site/cheatsheets/hash_map.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/hashing.html
+++ b/_site/cheatsheets/hashing.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/hashing.html
+++ b/_site/cheatsheets/hashing.html
@@ -11,108 +11,17 @@
   <title>Hashing — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/heap.html
+++ b/_site/cheatsheets/heap.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/heap.html
+++ b/_site/cheatsheets/heap.html
@@ -11,108 +11,17 @@
   <title>Heap — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/intervals.html
+++ b/_site/cheatsheets/intervals.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/intervals.html
+++ b/_site/cheatsheets/intervals.html
@@ -11,108 +11,17 @@
   <title>Intervals — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/iterator.html
+++ b/_site/cheatsheets/iterator.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/iterator.html
+++ b/_site/cheatsheets/iterator.html
@@ -11,108 +11,17 @@
   <title>Iterator — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/java_trick.html
+++ b/_site/cheatsheets/java_trick.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/java_trick.html
+++ b/_site/cheatsheets/java_trick.html
@@ -11,108 +11,17 @@
   <title>Java Trick — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/kadane_algorithm.html
+++ b/_site/cheatsheets/kadane_algorithm.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/kadane_algorithm.html
+++ b/_site/cheatsheets/kadane_algorithm.html
@@ -11,108 +11,17 @@
   <title>Kadane Algorithm — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/lc_category.html
+++ b/_site/cheatsheets/lc_category.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/lc_category.html
+++ b/_site/cheatsheets/lc_category.html
@@ -11,108 +11,17 @@
   <title>Lc Category — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/lc_pattern.html
+++ b/_site/cheatsheets/lc_pattern.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/lc_pattern.html
+++ b/_site/cheatsheets/lc_pattern.html
@@ -11,108 +11,17 @@
   <title>Lc Pattern — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/linked_list.html
+++ b/_site/cheatsheets/linked_list.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/linked_list.html
+++ b/_site/cheatsheets/linked_list.html
@@ -11,108 +11,17 @@
   <title>Linked List — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/math.html
+++ b/_site/cheatsheets/math.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/math.html
+++ b/_site/cheatsheets/math.html
@@ -11,108 +11,17 @@
   <title>Math — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/matrix.html
+++ b/_site/cheatsheets/matrix.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/matrix.html
+++ b/_site/cheatsheets/matrix.html
@@ -11,108 +11,17 @@
   <title>Matrix — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/monotonic_queue.html
+++ b/_site/cheatsheets/monotonic_queue.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/monotonic_queue.html
+++ b/_site/cheatsheets/monotonic_queue.html
@@ -11,108 +11,17 @@
   <title>Monotonic Queue — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/monotonic_stack.html
+++ b/_site/cheatsheets/monotonic_stack.html
@@ -11,108 +11,17 @@
   <title>Monotonic Stack — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/monotonic_stack.html
+++ b/_site/cheatsheets/monotonic_stack.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/n_sum.html
+++ b/_site/cheatsheets/n_sum.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/n_sum.html
+++ b/_site/cheatsheets/n_sum.html
@@ -11,108 +11,17 @@
   <title>N Sum — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/ood_design.html
+++ b/_site/cheatsheets/ood_design.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/ood_design.html
+++ b/_site/cheatsheets/ood_design.html
@@ -11,108 +11,17 @@
   <title>Ood Design — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/palindrome.html
+++ b/_site/cheatsheets/palindrome.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/palindrome.html
+++ b/_site/cheatsheets/palindrome.html
@@ -11,108 +11,17 @@
   <title>Palindrome — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/prefix_sum.html
+++ b/_site/cheatsheets/prefix_sum.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/prefix_sum.html
+++ b/_site/cheatsheets/prefix_sum.html
@@ -11,108 +11,17 @@
   <title>Prefix Sum — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/priority_queue.html
+++ b/_site/cheatsheets/priority_queue.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/priority_queue.html
+++ b/_site/cheatsheets/priority_queue.html
@@ -11,108 +11,17 @@
   <title>Priority Queue — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/python_gotchas.html
+++ b/_site/cheatsheets/python_gotchas.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/python_gotchas.html
+++ b/_site/cheatsheets/python_gotchas.html
@@ -11,108 +11,17 @@
   <title>Python Gotchas — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/python_trick.html
+++ b/_site/cheatsheets/python_trick.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/python_trick.html
+++ b/_site/cheatsheets/python_trick.html
@@ -11,108 +11,17 @@
   <title>Python Trick — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/queue.html
+++ b/_site/cheatsheets/queue.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/queue.html
+++ b/_site/cheatsheets/queue.html
@@ -11,108 +11,17 @@
   <title>Queue — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/recursion.html
+++ b/_site/cheatsheets/recursion.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/recursion.html
+++ b/_site/cheatsheets/recursion.html
@@ -11,108 +11,17 @@
   <title>Recursion — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/recursion_to_dp.html
+++ b/_site/cheatsheets/recursion_to_dp.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/recursion_to_dp.html
+++ b/_site/cheatsheets/recursion_to_dp.html
@@ -11,108 +11,17 @@
   <title>Recursion To Dp — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/scanning_line.html
+++ b/_site/cheatsheets/scanning_line.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/scanning_line.html
+++ b/_site/cheatsheets/scanning_line.html
@@ -11,108 +11,17 @@
   <title>Scanning Line — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/segment_tree.html
+++ b/_site/cheatsheets/segment_tree.html
@@ -11,108 +11,17 @@
   <title>Segment Tree — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/segment_tree.html
+++ b/_site/cheatsheets/segment_tree.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/set.html
+++ b/_site/cheatsheets/set.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/set.html
+++ b/_site/cheatsheets/set.html
@@ -11,108 +11,17 @@
   <title>Set — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/shortest_path_comparison.html
+++ b/_site/cheatsheets/shortest_path_comparison.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/shortest_path_comparison.html
+++ b/_site/cheatsheets/shortest_path_comparison.html
@@ -11,108 +11,17 @@
   <title>Shortest Path Comparison — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/sliding_window.html
+++ b/_site/cheatsheets/sliding_window.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/sliding_window.html
+++ b/_site/cheatsheets/sliding_window.html
@@ -11,108 +11,17 @@
   <title>Sliding Window — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/sort.html
+++ b/_site/cheatsheets/sort.html
@@ -11,108 +11,17 @@
   <title>Sort — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/sort.html
+++ b/_site/cheatsheets/sort.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/stack.html
+++ b/_site/cheatsheets/stack.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/stack.html
+++ b/_site/cheatsheets/stack.html
@@ -11,108 +11,17 @@
   <title>Stack — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/stock_trading.html
+++ b/_site/cheatsheets/stock_trading.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/stock_trading.html
+++ b/_site/cheatsheets/stock_trading.html
@@ -11,108 +11,17 @@
   <title>Stock Trading — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/streaming_algorithms.html
+++ b/_site/cheatsheets/streaming_algorithms.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/streaming_algorithms.html
+++ b/_site/cheatsheets/streaming_algorithms.html
@@ -11,108 +11,17 @@
   <title>Streaming Algorithms — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/string.html
+++ b/_site/cheatsheets/string.html
@@ -11,108 +11,17 @@
   <title>String — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/string.html
+++ b/_site/cheatsheets/string.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/string_matching_kmp_rolling_hash.html
+++ b/_site/cheatsheets/string_matching_kmp_rolling_hash.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/string_matching_kmp_rolling_hash.html
+++ b/_site/cheatsheets/string_matching_kmp_rolling_hash.html
@@ -11,108 +11,17 @@
   <title>String Matching Kmp Rolling Hash — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/time_space_complexity.html
+++ b/_site/cheatsheets/time_space_complexity.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/time_space_complexity.html
+++ b/_site/cheatsheets/time_space_complexity.html
@@ -11,108 +11,17 @@
   <title>Time Space Complexity — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/topology_sorting.html
+++ b/_site/cheatsheets/topology_sorting.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/topology_sorting.html
+++ b/_site/cheatsheets/topology_sorting.html
@@ -11,108 +11,17 @@
   <title>Topology Sorting — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/tree.html
+++ b/_site/cheatsheets/tree.html
@@ -11,108 +11,17 @@
   <title>Tree — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/tree.html
+++ b/_site/cheatsheets/tree.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/tree2.html
+++ b/_site/cheatsheets/tree2.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/tree2.html
+++ b/_site/cheatsheets/tree2.html
@@ -11,108 +11,17 @@
   <title>Tree2 — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/tree_backtrack.html
+++ b/_site/cheatsheets/tree_backtrack.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/tree_backtrack.html
+++ b/_site/cheatsheets/tree_backtrack.html
@@ -11,108 +11,17 @@
   <title>Tree Backtrack — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/trie.html
+++ b/_site/cheatsheets/trie.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/cheatsheets/trie.html
+++ b/_site/cheatsheets/trie.html
@@ -11,108 +11,17 @@
   <title>Trie — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/union_find.html
+++ b/_site/cheatsheets/union_find.html
@@ -11,108 +11,17 @@
   <title>Union Find — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../faqs.html" class="">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/cheatsheets/union_find.html
+++ b/_site/cheatsheets/union_find.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="active">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs.html
+++ b/_site/faqs.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="index.html" class="">home</a>
         <a href="search.html" class="">search</a>
         <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="patterns.html" class="">patterns</a>
         <a href="faqs.html" class="active">faqs</a>
         <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-similar.html" class="">similar</a>
         <a href="lc-random-picker.html" class="">random</a>
-        <a href="lc-review-plan.html" class="">review</a>
         <a href="algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html" class="">patterns</a>
+            <a href="lc-similar.html" class="">similar</a>
+            <a href="lc-review-plan.html" class="">review</a>
+            <a href="resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs.html
+++ b/_site/faqs.html
@@ -11,108 +11,17 @@
   <title>FAQs — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="nav.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <script src="site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="index.html" class="">home</a>
-        <a href="search.html" class="">search</a>
-        <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="faqs.html" class="active">faqs</a>
-        <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-random-picker.html" class="">random</a>
-        <a href="algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html" class="">patterns</a>
-            <a href="lc-similar.html" class="">similar</a>
-            <a href="lc-review-plan.html" class="">review</a>
-            <a href="resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base=""></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_authentication.html
+++ b/_site/faqs/backend_authentication.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_authentication.html
+++ b/_site/faqs/backend_authentication.html
@@ -11,108 +11,17 @@
   <title>Authentication — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_be_programming_notes.html
+++ b/_site/faqs/backend_be_programming_notes.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_be_programming_notes.html
+++ b/_site/faqs/backend_be_programming_notes.html
@@ -11,108 +11,17 @@
   <title>Be Programming Notes — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_be_programming_notes_pt2.html
+++ b/_site/faqs/backend_be_programming_notes_pt2.html
@@ -11,108 +11,17 @@
   <title>Be Programming Notes Pt2 — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_be_programming_notes_pt2.html
+++ b/_site/faqs/backend_be_programming_notes_pt2.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_be_programming_notes_pt3.html
+++ b/_site/faqs/backend_be_programming_notes_pt3.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_be_programming_notes_pt3.html
+++ b/_site/faqs/backend_be_programming_notes_pt3.html
@@ -11,108 +11,17 @@
   <title>Be Programming Notes Pt3 — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_db_isolation_demo_mysql.html
+++ b/_site/faqs/backend_db_isolation_demo_mysql.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_db_isolation_demo_mysql.html
+++ b/_site/faqs/backend_db_isolation_demo_mysql.html
@@ -11,108 +11,17 @@
   <title>Db Isolation Demo Mysql — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_overbooking_prevention.html
+++ b/_site/faqs/backend_overbooking_prevention.html
@@ -11,108 +11,17 @@
   <title>Overbooking Prevention — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_overbooking_prevention.html
+++ b/_site/faqs/backend_overbooking_prevention.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_web_long_connections.html
+++ b/_site/faqs/backend_web_long_connections.html
@@ -11,108 +11,17 @@
   <title>Web Long Connections — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/backend_web_long_connections.html
+++ b/_site/faqs/backend_web_long_connections.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_後端面試題總整理.html
+++ b/_site/faqs/backend_後端面試題總整理.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/backend_後端面試題總整理.html
+++ b/_site/faqs/backend_後端面試題總整理.html
@@ -11,108 +11,17 @@
   <title>後端面試題總整理 — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/cs_basic.html
+++ b/_site/faqs/cs_basic.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/cs_basic.html
+++ b/_site/faqs/cs_basic.html
@@ -11,108 +11,17 @@
   <title>Cs Basic — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/db_faq_DB_DW.html
+++ b/_site/faqs/db_faq_DB_DW.html
@@ -11,108 +11,17 @@
   <title>Faq DB DW — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/db_faq_DB_DW.html
+++ b/_site/faqs/db_faq_DB_DW.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/db_faq_redshift.html
+++ b/_site/faqs/db_faq_redshift.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/db_faq_redshift.html
+++ b/_site/faqs/db_faq_redshift.html
@@ -11,108 +11,17 @@
   <title>Faq Redshift — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/db_postgre.html
+++ b/_site/faqs/db_postgre.html
@@ -11,108 +11,17 @@
   <title>Postgre — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/db_postgre.html
+++ b/_site/faqs/db_postgre.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_Airflow.html
+++ b/_site/faqs/faq_Airflow.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_Airflow.html
+++ b/_site/faqs/faq_Airflow.html
@@ -11,108 +11,17 @@
   <title>Faq Airflow — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_DE.html
+++ b/_site/faqs/faq_DE.html
@@ -11,108 +11,17 @@
   <title>Faq DE — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_DE.html
+++ b/_site/faqs/faq_DE.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_ML.html
+++ b/_site/faqs/faq_ML.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_ML.html
+++ b/_site/faqs/faq_ML.html
@@ -11,108 +11,17 @@
   <title>Faq ML — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_data_model.html
+++ b/_site/faqs/faq_data_model.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_data_model.html
+++ b/_site/faqs/faq_data_model.html
@@ -11,108 +11,17 @@
   <title>Faq Data Model — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_dev_interview.html
+++ b/_site/faqs/faq_dev_interview.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_dev_interview.html
+++ b/_site/faqs/faq_dev_interview.html
@@ -11,108 +11,17 @@
   <title>Faq Dev Interview — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_devops.html
+++ b/_site/faqs/faq_devops.html
@@ -11,108 +11,17 @@
   <title>Faq Devops — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_devops.html
+++ b/_site/faqs/faq_devops.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_performance_tune.html
+++ b/_site/faqs/faq_performance_tune.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_performance_tune.html
+++ b/_site/faqs/faq_performance_tune.html
@@ -11,108 +11,17 @@
   <title>Faq Performance Tune — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_python.html
+++ b/_site/faqs/faq_python.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_python.html
+++ b/_site/faqs/faq_python.html
@@ -11,108 +11,17 @@
   <title>Faq Python — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/faq_software_runtime.html
+++ b/_site/faqs/faq_software_runtime.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/faq_software_runtime.html
+++ b/_site/faqs/faq_software_runtime.html
@@ -11,108 +11,17 @@
   <title>Faq Software Runtime — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/flink_faq_flink.html
+++ b/_site/faqs/flink_faq_flink.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/flink_faq_flink.html
+++ b/_site/faqs/flink_faq_flink.html
@@ -11,108 +11,17 @@
   <title>Faq Flink — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_cqrs.html
+++ b/_site/faqs/java_cqrs.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_cqrs.html
+++ b/_site/faqs/java_cqrs.html
@@ -11,108 +11,17 @@
   <title>Cqrs — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_faq_OOP.html
+++ b/_site/faqs/java_faq_OOP.html
@@ -11,108 +11,17 @@
   <title>Faq OOP — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_faq_OOP.html
+++ b/_site/faqs/java_faq_OOP.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_basic.html
+++ b/_site/faqs/java_java_basic.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_basic.html
+++ b/_site/faqs/java_java_basic.html
@@ -11,108 +11,17 @@
   <title>Java Basic — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_java_collection.html
+++ b/_site/faqs/java_java_collection.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_collection.html
+++ b/_site/faqs/java_java_collection.html
@@ -11,108 +11,17 @@
   <title>Java Collection — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_java_design_pattern.html
+++ b/_site/faqs/java_java_design_pattern.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_design_pattern.html
+++ b/_site/faqs/java_java_design_pattern.html
@@ -11,108 +11,17 @@
   <title>Java Design Pattern — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_java_multi_thread.html
+++ b/_site/faqs/java_java_multi_thread.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_multi_thread.html
+++ b/_site/faqs/java_java_multi_thread.html
@@ -11,108 +11,17 @@
   <title>Java Multi Thread — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_java_spring.html
+++ b/_site/faqs/java_java_spring.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_spring.html
+++ b/_site/faqs/java_java_spring.html
@@ -11,108 +11,17 @@
   <title>Java Spring — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_java_tdd.html
+++ b/_site/faqs/java_java_tdd.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_java_tdd.html
+++ b/_site/faqs/java_java_tdd.html
@@ -11,108 +11,17 @@
   <title>Java Tdd — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_jmm.html
+++ b/_site/faqs/java_jmm.html
@@ -11,108 +11,17 @@
   <title>Jmm — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/java_jmm.html
+++ b/_site/faqs/java_jmm.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_jvm.html
+++ b/_site/faqs/java_jvm.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/java_jvm.html
+++ b/_site/faqs/java_jvm.html
@@ -11,108 +11,17 @@
   <title>Jvm — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/kafka_faq_kafka.html
+++ b/_site/faqs/kafka_faq_kafka.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/kafka_faq_kafka.html
+++ b/_site/faqs/kafka_faq_kafka.html
@@ -11,108 +11,17 @@
   <title>Faq Kafka — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/redis_redis_backend.html
+++ b/_site/faqs/redis_redis_backend.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/redis_redis_backend.html
+++ b/_site/faqs/redis_redis_backend.html
@@ -11,108 +11,17 @@
   <title>Redis Backend — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/redis_redis_info.html
+++ b/_site/faqs/redis_redis_info.html
@@ -11,108 +11,17 @@
   <title>Redis Info — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/redis_redis_info.html
+++ b/_site/faqs/redis_redis_info.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/redis_redis_leaderboard.html
+++ b/_site/faqs/redis_redis_leaderboard.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/redis_redis_leaderboard.html
+++ b/_site/faqs/redis_redis_leaderboard.html
@@ -11,108 +11,17 @@
   <title>Redis Leaderboard — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/spark_faq_hadoop.html
+++ b/_site/faqs/spark_faq_hadoop.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/spark_faq_hadoop.html
+++ b/_site/faqs/spark_faq_hadoop.html
@@ -11,108 +11,17 @@
   <title>Faq Hadoop — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/spark_faq_mapreduce.html
+++ b/_site/faqs/spark_faq_mapreduce.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/spark_faq_mapreduce.html
+++ b/_site/faqs/spark_faq_mapreduce.html
@@ -11,108 +11,17 @@
   <title>Faq Mapreduce — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/spark_faq_spark_hadoop.html
+++ b/_site/faqs/spark_faq_spark_hadoop.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/spark_faq_spark_hadoop.html
+++ b/_site/faqs/spark_faq_spark_hadoop.html
@@ -11,108 +11,17 @@
   <title>Faq Spark Hadoop — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/sql_faq_mysql.html
+++ b/_site/faqs/sql_faq_mysql.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/sql_faq_mysql.html
+++ b/_site/faqs/sql_faq_mysql.html
@@ -11,108 +11,17 @@
   <title>Faq Mysql — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/sql_faq_sql.html
+++ b/_site/faqs/sql_faq_sql.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/sql_faq_sql.html
+++ b/_site/faqs/sql_faq_sql.html
@@ -11,108 +11,17 @@
   <title>Faq Sql — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/faqs/stream_faq_stream.html
+++ b/_site/faqs/stream_faq_stream.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="../index.html" class="">home</a>
         <a href="../search.html" class="">search</a>
         <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../patterns.html" class="">patterns</a>
         <a href="../faqs.html" class="active">faqs</a>
         <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-similar.html" class="">similar</a>
         <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../lc-review-plan.html" class="">review</a>
         <a href="../algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html" class="">patterns</a>
+            <a href="../lc-similar.html" class="">similar</a>
+            <a href="../lc-review-plan.html" class="">review</a>
+            <a href="../resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/faqs/stream_faq_stream.html
+++ b/_site/faqs/stream_faq_stream.html
@@ -11,108 +11,17 @@
   <title>Faq Stream — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="../vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
+  <script src="../site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="../index.html" class="">home</a>
-        <a href="../search.html" class="">search</a>
-        <a href="../cheatsheets.html" class="">cheatsheets</a>
-        <a href="../faqs.html" class="active">faqs</a>
-        <a href="../lc-explorer.html" class="">lc-explorer</a>
-        <a href="../lc-random-picker.html" class="">random</a>
-        <a href="../algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html" class="">patterns</a>
-            <a href="../lc-similar.html" class="">similar</a>
-            <a href="../lc-review-plan.html" class="">review</a>
-            <a href="../resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="faqs" data-base="../"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/index.html
+++ b/_site/index.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="index.html" class="active">home</a>
         <a href="search.html" class="">search</a>
         <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="patterns.html" class="">patterns</a>
         <a href="faqs.html" class="">faqs</a>
         <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-similar.html" class="">similar</a>
         <a href="lc-random-picker.html" class="">random</a>
-        <a href="lc-review-plan.html" class="">review</a>
         <a href="algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html" class="">patterns</a>
+            <a href="lc-similar.html" class="">similar</a>
+            <a href="lc-review-plan.html" class="">review</a>
+            <a href="resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/index.html
+++ b/_site/index.html
@@ -11,108 +11,17 @@
   <title>Home — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="nav.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <script src="site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="index.html" class="active">home</a>
-        <a href="search.html" class="">search</a>
-        <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="faqs.html" class="">faqs</a>
-        <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-random-picker.html" class="">random</a>
-        <a href="algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html" class="">patterns</a>
-            <a href="lc-similar.html" class="">similar</a>
-            <a href="lc-review-plan.html" class="">review</a>
-            <a href="resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="home" data-base=""></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/lc-explorer.html
+++ b/_site/lc-explorer.html
@@ -9,6 +9,9 @@
   <title>LeetCode Explorer - CS Basics</title>
   <meta name="description" content="Explore LeetCode problems by difficulty and tags">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💻</text></svg>">
+  <link rel="stylesheet" href="nav.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
   <style>
     * { box-sizing: border-box; }
     :root {
@@ -29,53 +32,13 @@
       background: var(--bg); color: var(--text);
       transition: background 0.2s, color 0.2s; font-size: 13px;
     }
-    .navbar {
-      background: var(--surface);
-      border-bottom: 1px solid var(--border);
-      padding: 1rem 2rem;
-      position: sticky;
-      top: 0;
-      z-index: 100;
-    }
-    .nav-content {
-      max-width: 1200px;
-      margin: 0 auto;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-    .nav-links {
-      display: flex;
-      gap: 1rem;
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
-    .nav-links a {
-      color: var(--text-light);
-      text-decoration: none;
-      font-size: 0.9rem;
-      padding: 0.3rem 0;
-      border-bottom: 2px solid transparent;
-      transition: all 0.2s;
-    }
-    .nav-links a:hover, .nav-links a.active {
-      color: var(--text);
-      border-bottom-color: var(--text);
-    }
-    .logo {
-      font-size: 1.1rem;
-      font-weight: 700;
-      color: var(--text);
-      text-decoration: none;
-    }
-    .theme-btn {
-      background: none;
-      border: none;
-      font-size: 1.2rem;
-      cursor: pointer;
-      padding: 0.5rem;
-    }
+
+
+
+
+
+
+
     .container {
       max-width: 1200px;
       margin: 2rem auto;
@@ -418,17 +381,17 @@
     /* ── Terminal-core overrides ── */
     *, *::before, *::after { border-radius: 0 !important; box-shadow: none !important; }
     body { font-family: 'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,'Menlo',monospace !important; font-size: 15px !important; }
-    .navbar { background: var(--bg) !important; border-bottom: 1px solid var(--border) !important; padding: 10px 32px !important; }
-    .nav-content { max-width: 100% !important; }
-    .logo { font-size: 13px !important; font-weight: 700 !important; text-transform: uppercase; letter-spacing: .08em; margin-right: 24px; }
-    .nav-links { gap: 0 !important; list-style: none !important; flex-wrap: nowrap !important; }
-    .nav-links li { display: inline-flex; }
-    .nav-links a { font-size: 13px !important; color: var(--text-light) !important; text-decoration: none !important; border-bottom: 1px solid transparent !important; white-space: nowrap; padding: 2px 10px !important; }
-    .nav-links a.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-links li + li > a { border-left: 1px solid var(--border) !important; }
-    .nav-links a:hover { color: var(--text) !important; }
-    .theme-btn { background: none !important; border: none !important; border-left: 1px solid var(--border) !important; font-size: 13px !important; color: var(--text-light) !important; cursor: pointer; font-family: inherit !important; padding: 2px 10px !important; white-space: nowrap; }
-    input, select, button:not(.theme-btn) { border-radius: 0 !important; font-family: inherit !important; }
+
+
+
+
+
+
+
+
+
+
+
     pre, .code-block-wrapper pre { background: #0d1117 !important; border-color: #30363d !important; }
     .hljs { background: #0d1117 !important; }
     .card, .filter-section, .filter-bar, .results-section { border-radius: 0 !important; box-shadow: none !important; }
@@ -436,13 +399,13 @@
     html { -webkit-text-size-adjust:100%; -webkit-tap-highlight-color:transparent; }
     a, button { touch-action:manipulation; }
     @media(max-width:768px) {
-      .navbar { padding: 0 !important; }
-      .nav-content { padding: 8px 14px !important; flex-wrap: wrap; gap: 6px; }
-      .nav-links { flex-wrap: wrap !important; gap: 2px !important; }
-      .nav-links li { display: inline-flex; }
-      .nav-links a { font-size: 14px !important; padding: 8px 8px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-links li+li>a { border-left: none !important; }
-      .theme-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+
+
+
+
+
+
+
       .controls { grid-template-columns: 1fr !important; }
       .problem-header, .problem-row { grid-template-columns: 3.5rem 1fr auto !important; }
       .container { margin: 1rem auto !important; padding: 0 12px !important; }
@@ -453,73 +416,23 @@
       .problem-header { display: none !important; }
       .problem-row { grid-template-columns: 3rem 1fr !important; gap: 6px !important; }
     }
-    @supports(padding:env(safe-area-inset-left)) {
-      .navbar { padding-left: env(safe-area-inset-left) !important; padding-right: env(safe-area-inset-right) !important; }
-    }
   
-    /* ── "more" nav dropdown — secondary entries ── */
-    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
-    .nav-more-btn {
-      background: none !important; border: none !important;
-      border-left: 1px solid var(--border) !important;
-      border-bottom: 1px solid transparent !important;
-      font-family: inherit !important; font-size: 13px !important;
-      color: var(--text-light, var(--muted)) !important;
-      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
-      display: inline-flex; align-items: center; gap: 4px;
-    }
-    .nav-more-btn:hover { color: var(--text) !important; }
-    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-more-caret { font-size: .8em; transition: transform .15s; }
-    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
-    .nav-more-menu {
-      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
-      min-width: 150px; flex-direction: column;
-      background: var(--bg); border: 1px solid var(--border);
-    }
-    .nav-more.open .nav-more-menu { display: flex; }
-    .nav-more-menu a {
-      display: block; white-space: nowrap;
-      padding: 9px 14px !important;
-      border-left: none !important;
-      border-bottom: 1px solid var(--border) !important;
-    }
-    .nav-more-menu a:last-child { border-bottom: none !important; }
-    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
-    @media(max-width:768px) {
-      .nav-links li.nav-more { position: static; }
-      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-more-menu { left: 0; right: 0; min-width: 0; }
-      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
-    }
+
+
+
+
+
+
+
+
+
+
+
   </style>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="nav-content">
-      <a href="index.html" class="logo">CS_basics</a>
-      <ul class="nav-links">
-        <li><a href="index.html">home</a></li>
-        <li><a href="search.html">search</a></li>
-        <li><a href="cheatsheets.html">cheatsheets</a></li>
-        <li><a href="faqs.html">faqs</a></li>
-        <li><a href="lc-explorer.html" class="active">lc-explorer</a></li>
-        <li><a href="lc-random-picker.html">random</a></li>
-        <li><a href="algo_demo/index.html">visualizer</a></li>
-        <li class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html">patterns</a>
-            <a href="lc-similar.html">similar</a>
-            <a href="lc-review-plan.html">review</a>
-            <a href="resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </li>
-      </ul>
-      <button class="theme-btn" onclick="toggleTheme()" aria-label="Toggle theme">☀ light</button>
-    </div>
-  </nav>
+<div id="site-nav" data-page="lc-explorer"></div>
+<script>CSNav.mount();</script>
 
   <div class="container">
     <div class="header">
@@ -986,41 +899,7 @@ ${results.map(p =>
       }
     });
 
-    function toggleTheme() {
-      const html = document.documentElement;
-      const isDark = (html.getAttribute('data-theme') || 'dark') === 'dark';
-      const next = isDark ? 'light' : 'dark';
-      html.setAttribute('data-theme', next);
-      localStorage.setItem('theme', next);
-      const btn = document.querySelector('.theme-btn');
-      if (btn) btn.textContent = isDark ? '● dark' : '☀ light';
-    }
-
-    const savedTheme = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', savedTheme);
-    document.addEventListener('DOMContentLoaded', () => {
-      const btn = document.querySelector('.theme-btn');
-      if (btn) btn.textContent = savedTheme === 'dark' ? '☀ light' : '● dark';
-    });
-
     loadData();
   </script>
-<script>
-(function() {
-  var more = document.querySelector('.nav-more');
-  if (!more) return;
-  var btn = more.querySelector('.nav-more-btn');
-  function setOpen(open) {
-    more.classList.toggle('open', open);
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  }
-  btn.addEventListener('click', function(e) {
-    e.stopPropagation();
-    setOpen(!more.classList.contains('open'));
-  });
-  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
-  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
-})();
-</script>
 </body>
 </html>

--- a/_site/lc-explorer.html
+++ b/_site/lc-explorer.html
@@ -456,6 +456,42 @@
     @supports(padding:env(safe-area-inset-left)) {
       .navbar { padding-left: env(safe-area-inset-left) !important; padding-right: env(safe-area-inset-right) !important; }
     }
+  
+    /* ── "more" nav dropdown — secondary entries ── */
+    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
+    .nav-more-btn {
+      background: none !important; border: none !important;
+      border-left: 1px solid var(--border) !important;
+      border-bottom: 1px solid transparent !important;
+      font-family: inherit !important; font-size: 13px !important;
+      color: var(--text-light, var(--muted)) !important;
+      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .nav-more-btn:hover { color: var(--text) !important; }
+    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
+    .nav-more-caret { font-size: .8em; transition: transform .15s; }
+    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
+    .nav-more-menu {
+      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
+      min-width: 150px; flex-direction: column;
+      background: var(--bg); border: 1px solid var(--border);
+    }
+    .nav-more.open .nav-more-menu { display: flex; }
+    .nav-more-menu a {
+      display: block; white-space: nowrap;
+      padding: 9px 14px !important;
+      border-left: none !important;
+      border-bottom: 1px solid var(--border) !important;
+    }
+    .nav-more-menu a:last-child { border-bottom: none !important; }
+    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
+    @media(max-width:768px) {
+      .nav-links li.nav-more { position: static; }
+      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+      .nav-more-menu { left: 0; right: 0; min-width: 0; }
+      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
+    }
   </style>
 </head>
 <body>
@@ -463,11 +499,23 @@
     <div class="nav-content">
       <a href="index.html" class="logo">CS_basics</a>
       <ul class="nav-links">
+        <li><a href="index.html">home</a></li>
         <li><a href="search.html">search</a></li>
+        <li><a href="cheatsheets.html">cheatsheets</a></li>
+        <li><a href="faqs.html">faqs</a></li>
         <li><a href="lc-explorer.html" class="active">lc-explorer</a></li>
-        <li><a href="lc-similar.html">similar</a></li>
         <li><a href="lc-random-picker.html">random</a></li>
-        <li><a href="lc-review-plan.html">review</a></li>
+        <li><a href="algo_demo/index.html">visualizer</a></li>
+        <li class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html">patterns</a>
+            <a href="lc-similar.html">similar</a>
+            <a href="lc-review-plan.html">review</a>
+            <a href="resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </li>
       </ul>
       <button class="theme-btn" onclick="toggleTheme()" aria-label="Toggle theme">☀ light</button>
     </div>
@@ -957,5 +1005,22 @@ ${results.map(p =>
 
     loadData();
   </script>
+<script>
+(function() {
+  var more = document.querySelector('.nav-more');
+  if (!more) return;
+  var btn = more.querySelector('.nav-more-btn');
+  function setOpen(open) {
+    more.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  btn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    setOpen(!more.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
+  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
+})();
+</script>
 </body>
 </html>

--- a/_site/lc-random-picker.html
+++ b/_site/lc-random-picker.html
@@ -229,6 +229,42 @@
       .navbar { padding-left: env(safe-area-inset-left) !important; padding-right: env(safe-area-inset-right) !important; }
       .container { padding-left: max(14px,env(safe-area-inset-left)) !important; padding-right: max(14px,env(safe-area-inset-right)) !important; }
     }
+  
+    /* ── "more" nav dropdown — secondary entries ── */
+    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
+    .nav-more-btn {
+      background: none !important; border: none !important;
+      border-left: 1px solid var(--border) !important;
+      border-bottom: 1px solid transparent !important;
+      font-family: inherit !important; font-size: 13px !important;
+      color: var(--text-light, var(--muted)) !important;
+      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .nav-more-btn:hover { color: var(--text) !important; }
+    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
+    .nav-more-caret { font-size: .8em; transition: transform .15s; }
+    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
+    .nav-more-menu {
+      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
+      min-width: 150px; flex-direction: column;
+      background: var(--bg); border: 1px solid var(--border);
+    }
+    .nav-more.open .nav-more-menu { display: flex; }
+    .nav-more-menu a {
+      display: block; white-space: nowrap;
+      padding: 9px 14px !important;
+      border-left: none !important;
+      border-bottom: 1px solid var(--border) !important;
+    }
+    .nav-more-menu a:last-child { border-bottom: none !important; }
+    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
+    @media(max-width:768px) {
+      .nav-links li.nav-more { position: static; }
+      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+      .nav-more-menu { left: 0; right: 0; min-width: 0; }
+      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
+    }
   </style>
 </head>
 <body>
@@ -236,11 +272,23 @@
     <div class="nav-content">
       <a href="index.html" class="logo">CS_basics</a>
       <ul class="nav-links">
+        <li><a href="index.html">home</a></li>
         <li><a href="search.html">search</a></li>
+        <li><a href="cheatsheets.html">cheatsheets</a></li>
+        <li><a href="faqs.html">faqs</a></li>
         <li><a href="lc-explorer.html">lc-explorer</a></li>
-        <li><a href="lc-similar.html">similar</a></li>
         <li><a href="lc-random-picker.html" class="active">random</a></li>
-        <li><a href="lc-review-plan.html">review</a></li>
+        <li><a href="algo_demo/index.html">visualizer</a></li>
+        <li class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html">patterns</a>
+            <a href="lc-similar.html">similar</a>
+            <a href="lc-review-plan.html">review</a>
+            <a href="resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </li>
       </ul>
       <button class="theme-btn" onclick="toggleTheme()" title="Toggle theme">☀ light</button>
     </div>
@@ -420,5 +468,22 @@
 
     loadData();
   </script>
+<script>
+(function() {
+  var more = document.querySelector('.nav-more');
+  if (!more) return;
+  var btn = more.querySelector('.nav-more-btn');
+  function setOpen(open) {
+    more.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  btn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    setOpen(!more.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
+  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
+})();
+</script>
 </body>
 </html>

--- a/_site/lc-random-picker.html
+++ b/_site/lc-random-picker.html
@@ -8,6 +8,9 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <title>Random LC Picker - CS Basics</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎲</text></svg>">
+  <link rel="stylesheet" href="nav.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
   <style>
     * { box-sizing: border-box; }
     :root {
@@ -25,22 +28,13 @@
       transition: background 0.2s, color 0.2s; font-size: 13px;
     }
 
-    /* ── Navbar ── */
-    .navbar {
-      background: var(--surface);
-      border-bottom: 1px solid var(--border);
-      padding: 1rem 2rem;
-      position: sticky; top: 0; z-index: 100;
-    }
-    .nav-content {
-      max-width: 900px; margin: 0 auto;
-      display: flex; justify-content: space-between; align-items: center;
-    }
-    .logo { font-size: 1.1rem; font-weight: 700; color: var(--text); text-decoration: none; }
-    .nav-links { display: flex; gap: 1rem; list-style: none; margin: 0; padding: 0; }
-    .nav-links a { color: var(--text-light); text-decoration: none; font-size: 0.9rem; padding: 0.3rem 0; border-bottom: 2px solid transparent; transition: all 0.2s; }
-    .nav-links a:hover, .nav-links a.active { color: var(--text); border-bottom-color: var(--text); }
-    .theme-btn { background: none; border: none; font-size: 1.2rem; cursor: pointer; padding: 0.5rem; }
+
+
+
+
+
+
+
 
     /* ── Main layout ── */
     .container { max-width: 900px; margin: 2.5rem auto; padding: 0 1.5rem; }
@@ -193,27 +187,27 @@
     /* ── Terminal-core overrides ── */
     *, *::before, *::after { border-radius: 0 !important; box-shadow: none !important; }
     body { font-family: 'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,'Menlo',monospace !important; font-size: 15px !important; }
-    .navbar { background: var(--bg) !important; border-bottom: 1px solid var(--border) !important; padding: 10px 32px !important; }
-    .nav-content { max-width: 100% !important; }
-    .logo { font-size: 13px !important; font-weight: 700 !important; text-transform: uppercase; letter-spacing: .08em; margin-right: 24px; }
-    .nav-links { gap: 0 !important; flex-wrap: nowrap !important; }
-    .nav-links a { font-size: 13px !important; color: var(--text-light) !important; text-decoration: none !important; border-bottom: 1px solid transparent !important; white-space: nowrap; padding: 2px 10px !important; }
-    .nav-links a.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-links li + li > a { border-left: 1px solid var(--border) !important; }
-    .nav-links a:hover { color: var(--text) !important; }
-    .theme-btn { background: none !important; border: none !important; border-left: 1px solid var(--border) !important; font-size: 13px !important; color: var(--text-light) !important; cursor: pointer; font-family: inherit !important; padding: 2px 10px !important; white-space: nowrap; }
-    input, select, button:not(.theme-btn) { border-radius: 0 !important; font-family: inherit !important; }
+
+
+
+
+
+
+
+
+
+
     .empty-state .emoji { font-size: 2rem !important; }
     /* ── Mobile responsive ── */
     html { -webkit-text-size-adjust:100%; -webkit-tap-highlight-color:transparent; }
     a, button { touch-action:manipulation; }
     @media(max-width:768px) {
-      .navbar { padding: 0 !important; }
-      .nav-content { padding: 8px 14px !important; flex-wrap: wrap; gap: 6px; }
-      .nav-links { flex-wrap: wrap !important; gap: 2px !important; }
-      .nav-links a { font-size: 14px !important; padding: 8px 8px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-links li+li>a { border-left: none !important; }
-      .theme-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+
+
+
+
+
+
       .container { padding: 0 14px !important; }
       .panel { padding: 1.25rem !important; }
       .filters-row { grid-template-columns: 1fr !important; }
@@ -226,73 +220,26 @@
       .card-tags { display: none; }
     }
     @supports(padding:env(safe-area-inset-left)) {
-      .navbar { padding-left: env(safe-area-inset-left) !important; padding-right: env(safe-area-inset-right) !important; }
+
       .container { padding-left: max(14px,env(safe-area-inset-left)) !important; padding-right: max(14px,env(safe-area-inset-right)) !important; }
     }
   
-    /* ── "more" nav dropdown — secondary entries ── */
-    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
-    .nav-more-btn {
-      background: none !important; border: none !important;
-      border-left: 1px solid var(--border) !important;
-      border-bottom: 1px solid transparent !important;
-      font-family: inherit !important; font-size: 13px !important;
-      color: var(--text-light, var(--muted)) !important;
-      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
-      display: inline-flex; align-items: center; gap: 4px;
-    }
-    .nav-more-btn:hover { color: var(--text) !important; }
-    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-more-caret { font-size: .8em; transition: transform .15s; }
-    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
-    .nav-more-menu {
-      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
-      min-width: 150px; flex-direction: column;
-      background: var(--bg); border: 1px solid var(--border);
-    }
-    .nav-more.open .nav-more-menu { display: flex; }
-    .nav-more-menu a {
-      display: block; white-space: nowrap;
-      padding: 9px 14px !important;
-      border-left: none !important;
-      border-bottom: 1px solid var(--border) !important;
-    }
-    .nav-more-menu a:last-child { border-bottom: none !important; }
-    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
-    @media(max-width:768px) {
-      .nav-links li.nav-more { position: static; }
-      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-more-menu { left: 0; right: 0; min-width: 0; }
-      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
-    }
+
+
+
+
+
+
+
+
+
+
+
   </style>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="nav-content">
-      <a href="index.html" class="logo">CS_basics</a>
-      <ul class="nav-links">
-        <li><a href="index.html">home</a></li>
-        <li><a href="search.html">search</a></li>
-        <li><a href="cheatsheets.html">cheatsheets</a></li>
-        <li><a href="faqs.html">faqs</a></li>
-        <li><a href="lc-explorer.html">lc-explorer</a></li>
-        <li><a href="lc-random-picker.html" class="active">random</a></li>
-        <li><a href="algo_demo/index.html">visualizer</a></li>
-        <li class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html">patterns</a>
-            <a href="lc-similar.html">similar</a>
-            <a href="lc-review-plan.html">review</a>
-            <a href="resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </li>
-      </ul>
-      <button class="theme-btn" onclick="toggleTheme()" title="Toggle theme">☀ light</button>
-    </div>
-  </nav>
+<div id="site-nav" data-page="lc-random-picker"></div>
+<script>CSNav.mount();</script>
 
   <div class="container">
     <div class="page-header">
@@ -445,22 +392,6 @@
     }
 
     /* ── Theme ── */
-    function toggleTheme() {
-      const html = document.documentElement;
-      const isDark = html.getAttribute('data-theme') === 'dark';
-      const next = isDark ? 'light' : 'dark';
-      html.setAttribute('data-theme', next);
-      localStorage.setItem('theme', next);
-      const btn = document.querySelector('.theme-btn');
-      if (btn) btn.textContent = isDark ? '● dark' : '☀ light';
-    }
-    const _t = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', _t);
-    document.addEventListener('DOMContentLoaded', () => {
-      const btn = document.querySelector('.theme-btn');
-      if (btn) btn.textContent = _t === 'dark' ? '☀ light' : '● dark';
-    });
-
     /* ── Keyboard ── */
     document.addEventListener('keydown', e => {
       if (e.key === 'Enter' && document.activeElement !== document.getElementById('searchInput')) pick();
@@ -468,22 +399,5 @@
 
     loadData();
   </script>
-<script>
-(function() {
-  var more = document.querySelector('.nav-more');
-  if (!more) return;
-  var btn = more.querySelector('.nav-more-btn');
-  function setOpen(open) {
-    more.classList.toggle('open', open);
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  }
-  btn.addEventListener('click', function(e) {
-    e.stopPropagation();
-    setOpen(!more.classList.contains('open'));
-  });
-  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
-  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
-})();
-</script>
 </body>
 </html>

--- a/_site/lc-review-plan.html
+++ b/_site/lc-review-plan.html
@@ -266,6 +266,42 @@
       .navbar { padding-left:env(safe-area-inset-left); padding-right:env(safe-area-inset-right); }
       .container { padding-left:max(16px,env(safe-area-inset-left)); padding-right:max(16px,env(safe-area-inset-right)); }
     }
+  
+    /* ── "more" nav dropdown — secondary entries ── */
+    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
+    .nav-more-btn {
+      background: none !important; border: none !important;
+      border-left: 1px solid var(--border) !important;
+      border-bottom: 1px solid transparent !important;
+      font-family: inherit !important; font-size: 13px !important;
+      color: var(--text-light, var(--muted)) !important;
+      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .nav-more-btn:hover { color: var(--text) !important; }
+    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
+    .nav-more-caret { font-size: .8em; transition: transform .15s; }
+    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
+    .nav-more-menu {
+      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
+      min-width: 150px; flex-direction: column;
+      background: var(--bg); border: 1px solid var(--border);
+    }
+    .nav-more.open .nav-more-menu { display: flex; }
+    .nav-more-menu a {
+      display: block; white-space: nowrap;
+      padding: 9px 14px !important;
+      border-left: none !important;
+      border-bottom: 1px solid var(--border) !important;
+    }
+    .nav-more-menu a:last-child { border-bottom: none !important; }
+    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
+    @media(max-width:768px) {
+      .nav-links li.nav-more { position: static; }
+      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+      .nav-more-menu { left: 0; right: 0; min-width: 0; }
+      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
+    }
   </style>
 </head>
 <body>
@@ -275,11 +311,23 @@
     <a href="index.html" class="logo">CS_basics</a>
     <div style="display:flex;align-items:center;">
       <ul class="nav-links">
+        <li><a href="index.html">home</a></li>
         <li><a href="search.html">search</a></li>
+        <li><a href="cheatsheets.html">cheatsheets</a></li>
+        <li><a href="faqs.html">faqs</a></li>
         <li><a href="lc-explorer.html">lc-explorer</a></li>
-        <li><a href="lc-similar.html">similar</a></li>
         <li><a href="lc-random-picker.html">random</a></li>
-        <li><a href="lc-review-plan.html" class="active">review</a></li>
+        <li><a href="algo_demo/index.html">visualizer</a></li>
+        <li class="nav-more">
+          <button type="button" class="nav-more-btn active" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html">patterns</a>
+            <a href="lc-similar.html">similar</a>
+            <a href="lc-review-plan.html" class="active">review</a>
+            <a href="resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </li>
       </ul>
       <div class="theme-switch" onclick="toggleTheme()" title="Toggle light/dark">
         <div class="switch-track"><div class="switch-thumb"></div></div>
@@ -896,6 +944,23 @@ renderAllTable();
       <div class="tl-probs">${probs.map(p=>`<span class="tl-tag">#${p}</span>`).join('')}</div>`;
     el.appendChild(div);
   });
+})();
+</script>
+<script>
+(function() {
+  var more = document.querySelector('.nav-more');
+  if (!more) return;
+  var btn = more.querySelector('.nav-more-btn');
+  function setOpen(open) {
+    more.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  btn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    setOpen(!more.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
+  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
 })();
 </script>
 </body>

--- a/_site/lc-review-plan.html
+++ b/_site/lc-review-plan.html
@@ -7,6 +7,9 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <title>Review Plan — CS Basics</title>
+  <link rel="stylesheet" href="nav.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
   <style>
     /* ── tokens ── */
     :root {
@@ -31,40 +34,22 @@
     a { color:var(--text); text-decoration:underline; }
     a:hover { opacity:.6; }
 
-    /* ── Navbar ── */
-    .navbar {
-      background:var(--bg); border-bottom:1px solid var(--border);
-      padding:10px 32px; position:sticky; top:0; z-index:100;
-    }
-    .nav-content { display:flex; justify-content:space-between; align-items:center; }
-    .logo { font-size:13px; font-weight:700; color:var(--text); text-decoration:none;
-            text-transform:uppercase; letter-spacing:.08em; margin-right:24px; }
-    .nav-links { display:flex; gap:0; list-style:none; flex-wrap:nowrap; }
-    .nav-links a { font-size:13px; color:var(--muted); text-decoration:none;
-                   padding:2px 10px; border-bottom:1px solid transparent; white-space:nowrap; }
-    .nav-links li+li>a { border-left:1px solid var(--border); }
-    .nav-links a:hover { color:var(--text); }
-    .nav-links a.active { color:var(--text); border-bottom-color:var(--text); }
 
-    /* ── Theme toggle switch ── */
-    .theme-switch {
-      display:flex; align-items:center; gap:8px;
-      border-left:1px solid var(--border); padding-left:14px; margin-left:4px;
-    }
-    .switch-label { font-size:12px; color:var(--muted); user-select:none; min-width:32px; }
-    .switch-track {
-      width:44px; height:22px; border:1px solid var(--border-s);
-      background:var(--surface2); position:relative; cursor:pointer;
-      transition:background .2s, border-color .2s; flex-shrink:0;
-    }
-    .switch-track:hover { border-color:var(--text); }
-    .switch-thumb {
-      position:absolute; top:3px; left:3px;
-      width:14px; height:14px; background:var(--muted);
-      transition:transform .2s, background .2s;
-    }
-    [data-theme="dark"] .switch-track { background:var(--surface); border-color:var(--border-s); }
-    [data-theme="dark"] .switch-thumb { transform:translateX(22px); background:var(--text); }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     /* ── Container ── */
     .container { max-width:1200px; margin:0 auto; padding:32px 32px; }
@@ -213,13 +198,13 @@
     /* ── Mobile ≤768px ── */
     @media(max-width:768px) {
       body { font-size:15px; }
-      .navbar { padding:0; }
-      .nav-content { padding:10px 16px; flex-wrap:wrap; gap:8px; }
-      .logo { font-size:14px; }
-      .nav-links { flex-wrap:wrap; gap:4px; }
-      .nav-links a { font-size:14px; padding:6px 8px; min-height:44px; display:inline-flex; align-items:center; }
-      .nav-links li+li>a { border-left:none; }
-      .theme-switch { padding-left:8px; }
+
+
+
+
+
+
+
 
       .container { padding:16px; }
       h1 { font-size:20px; }
@@ -263,79 +248,27 @@
     }
     /* ── iOS safe area ── */
     @supports(padding:env(safe-area-inset-left)) {
-      .navbar { padding-left:env(safe-area-inset-left); padding-right:env(safe-area-inset-right); }
+
       .container { padding-left:max(16px,env(safe-area-inset-left)); padding-right:max(16px,env(safe-area-inset-right)); }
     }
   
-    /* ── "more" nav dropdown — secondary entries ── */
-    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
-    .nav-more-btn {
-      background: none !important; border: none !important;
-      border-left: 1px solid var(--border) !important;
-      border-bottom: 1px solid transparent !important;
-      font-family: inherit !important; font-size: 13px !important;
-      color: var(--text-light, var(--muted)) !important;
-      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
-      display: inline-flex; align-items: center; gap: 4px;
-    }
-    .nav-more-btn:hover { color: var(--text) !important; }
-    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-more-caret { font-size: .8em; transition: transform .15s; }
-    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
-    .nav-more-menu {
-      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
-      min-width: 150px; flex-direction: column;
-      background: var(--bg); border: 1px solid var(--border);
-    }
-    .nav-more.open .nav-more-menu { display: flex; }
-    .nav-more-menu a {
-      display: block; white-space: nowrap;
-      padding: 9px 14px !important;
-      border-left: none !important;
-      border-bottom: 1px solid var(--border) !important;
-    }
-    .nav-more-menu a:last-child { border-bottom: none !important; }
-    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
-    @media(max-width:768px) {
-      .nav-links li.nav-more { position: static; }
-      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-more-menu { left: 0; right: 0; min-width: 0; }
-      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
-    }
+
+
+
+
+
+
+
+
+
+
+
   </style>
 </head>
 <body>
 
-<nav class="navbar">
-  <div class="nav-content">
-    <a href="index.html" class="logo">CS_basics</a>
-    <div style="display:flex;align-items:center;">
-      <ul class="nav-links">
-        <li><a href="index.html">home</a></li>
-        <li><a href="search.html">search</a></li>
-        <li><a href="cheatsheets.html">cheatsheets</a></li>
-        <li><a href="faqs.html">faqs</a></li>
-        <li><a href="lc-explorer.html">lc-explorer</a></li>
-        <li><a href="lc-random-picker.html">random</a></li>
-        <li><a href="algo_demo/index.html">visualizer</a></li>
-        <li class="nav-more">
-          <button type="button" class="nav-more-btn active" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html">patterns</a>
-            <a href="lc-similar.html">similar</a>
-            <a href="lc-review-plan.html" class="active">review</a>
-            <a href="resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </li>
-      </ul>
-      <div class="theme-switch" onclick="toggleTheme()" title="Toggle light/dark">
-        <div class="switch-track"><div class="switch-thumb"></div></div>
-        <span class="switch-label" id="theme-label">light</span>
-      </div>
-    </div>
-  </div>
-</nav>
+<div id="site-nav" data-page="lc-review-plan"></div>
+<script>CSNav.mount();</script>
 
 <div class="container">
   <h1>Spaced Repetition Review Plan</h1>
@@ -420,21 +353,6 @@
 
 <script>
 // ── Theme ────────────────────────────────────────────────────────────────
-function toggleTheme() {
-  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-  const next = isDark ? 'light' : 'dark';
-  document.documentElement.setAttribute('data-theme', next);
-  localStorage.setItem('theme', next);
-  document.getElementById('theme-label').textContent = isDark ? 'dark' : 'light';
-}
-(function initTheme() {
-  const t = localStorage.getItem('theme') || 'dark';
-  document.documentElement.setAttribute('data-theme', t);
-  document.addEventListener('DOMContentLoaded', () => {
-    document.getElementById('theme-label').textContent = t === 'dark' ? 'light' : 'dark';
-  });
-})();
-
 // ── Tabs ──────────────────────────────────────────────────────────────────
 function switchTab(name, btn) {
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
@@ -944,23 +862,6 @@ renderAllTable();
       <div class="tl-probs">${probs.map(p=>`<span class="tl-tag">#${p}</span>`).join('')}</div>`;
     el.appendChild(div);
   });
-})();
-</script>
-<script>
-(function() {
-  var more = document.querySelector('.nav-more');
-  if (!more) return;
-  var btn = more.querySelector('.nav-more-btn');
-  function setOpen(open) {
-    more.classList.toggle('open', open);
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  }
-  btn.addEventListener('click', function(e) {
-    e.stopPropagation();
-    setOpen(!more.classList.contains('open'));
-  });
-  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
-  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
 })();
 </script>
 </body>

--- a/_site/lc-similar.html
+++ b/_site/lc-similar.html
@@ -207,6 +207,42 @@
     @supports(padding:env(safe-area-inset-left)) {
       .navbar { padding-left: env(safe-area-inset-left) !important; padding-right: env(safe-area-inset-right) !important; }
     }
+  
+    /* ── "more" nav dropdown — secondary entries ── */
+    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
+    .nav-more-btn {
+      background: none !important; border: none !important;
+      border-left: 1px solid var(--border) !important;
+      border-bottom: 1px solid transparent !important;
+      font-family: inherit !important; font-size: 13px !important;
+      color: var(--text-light, var(--muted)) !important;
+      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .nav-more-btn:hover { color: var(--text) !important; }
+    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
+    .nav-more-caret { font-size: .8em; transition: transform .15s; }
+    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
+    .nav-more-menu {
+      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
+      min-width: 150px; flex-direction: column;
+      background: var(--bg); border: 1px solid var(--border);
+    }
+    .nav-more.open .nav-more-menu { display: flex; }
+    .nav-more-menu a {
+      display: block; white-space: nowrap;
+      padding: 9px 14px !important;
+      border-left: none !important;
+      border-bottom: 1px solid var(--border) !important;
+    }
+    .nav-more-menu a:last-child { border-bottom: none !important; }
+    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
+    @media(max-width:768px) {
+      .nav-links li.nav-more { position: static; }
+      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+      .nav-more-menu { left: 0; right: 0; min-width: 0; }
+      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
+    }
   </style>
 </head>
 <body>
@@ -215,12 +251,24 @@
   <div class="nav-content">
     <a href="index.html" class="logo">CS_basics</a>
     <ul class="nav-links">
+        <li><a href="index.html">home</a></li>
         <li><a href="search.html">search</a></li>
-      <li><a href="lc-explorer.html">lc-explorer</a></li>
-      <li><a href="lc-similar.html" class="active">similar</a></li>
-      <li><a href="lc-random-picker.html">random</a></li>
-      <li><a href="lc-review-plan.html">review</a></li>
-    </ul>
+        <li><a href="cheatsheets.html">cheatsheets</a></li>
+        <li><a href="faqs.html">faqs</a></li>
+        <li><a href="lc-explorer.html">lc-explorer</a></li>
+        <li><a href="lc-random-picker.html">random</a></li>
+        <li><a href="algo_demo/index.html">visualizer</a></li>
+        <li class="nav-more">
+          <button type="button" class="nav-more-btn active" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html">patterns</a>
+            <a href="lc-similar.html" class="active">similar</a>
+            <a href="lc-review-plan.html">review</a>
+            <a href="resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </li>
+      </ul>
     <button class="theme-btn" onclick="toggleTheme()" aria-label="Toggle theme">☀ light</button>
   </div>
 </nav>
@@ -1898,6 +1946,23 @@ function clearTraversal() {
    INIT
 ══════════════════════════════════════════════════════════ */
 loadData();
+</script>
+<script>
+(function() {
+  var more = document.querySelector('.nav-more');
+  if (!more) return;
+  var btn = more.querySelector('.nav-more-btn');
+  function setOpen(open) {
+    more.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  btn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    setOpen(!more.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
+  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
+})();
 </script>
 </body>
 </html>

--- a/_site/lc-similar.html
+++ b/_site/lc-similar.html
@@ -10,6 +10,9 @@
   <meta name="description" content="Explore similar LeetCode problems by topic, pattern, and difficulty">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💻</text></svg>">
   <script src="https://d3js.org/d3.v7.min.js"></script>
+  <link rel="stylesheet" href="nav.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0}
     :root{
@@ -25,17 +28,13 @@
     body{font-family:'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,'Menlo',monospace;
          background:var(--bg);color:var(--text);transition:background .2s,color .2s;font-size:13px}
 
-    /* ── NAV ─────────────────────────────────────────────── */
-    .navbar{background:var(--surface);border-bottom:1px solid var(--border);
-            padding:.8rem 1.5rem;position:sticky;top:0;z-index:100}
-    .nav-content{max-width:1400px;margin:0 auto;display:flex;
-                 justify-content:space-between;align-items:center;gap:1rem}
-    .nav-links{display:flex;gap:.75rem;list-style:none;flex-wrap:wrap}
-    .nav-links a{color:var(--text-light);text-decoration:none;font-size:.85rem;
-                 padding:.25rem 0;border-bottom:2px solid transparent;transition:all .2s}
-    .nav-links a:hover,.nav-links a.active{color:var(--text);border-bottom-color:var(--accent)}
-    .logo{font-size:1.05rem;font-weight:700;color:var(--text);text-decoration:none;white-space:nowrap}
-    .theme-btn{background:none;border:none;font-size:1.2rem;cursor:pointer;padding:.4rem}
+
+
+
+
+
+
+
 
     /* ── PAGE HEADER ────────────────────────────────────── */
     .page-header{text-align:center;padding:1.5rem 1rem .5rem}
@@ -179,99 +178,49 @@
     /* ── Terminal-core overrides ── */
     *, *::before, *::after { border-radius: 0 !important; box-shadow: none !important; }
     body { font-family: 'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,'Menlo',monospace !important; font-size: 15px !important; }
-    .navbar { background: var(--bg) !important; border-bottom: 1px solid var(--border) !important; padding: 10px 32px !important; }
-    .nav-content { max-width: 100% !important; }
-    .logo { font-size: 13px !important; font-weight: 700 !important; text-transform: uppercase; letter-spacing: .08em; margin-right: 24px; }
-    .nav-links { gap: 0 !important; flex-wrap: nowrap !important; }
-    .nav-links a { font-size: 13px !important; color: var(--text-light) !important; text-decoration: none !important; border-bottom: 1px solid transparent !important; white-space: nowrap; padding: 2px 10px !important; }
-    .nav-links a.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-links li + li > a { border-left: 1px solid var(--border) !important; }
-    .nav-links a:hover { color: var(--text) !important; }
-    .theme-btn { background: none !important; border: none !important; border-left: 1px solid var(--border) !important; font-size: 13px !important; color: var(--text-light) !important; cursor: pointer; font-family: inherit !important; padding: 2px 10px !important; white-space: nowrap; }
-    input, select, button:not(.theme-btn) { border-radius: 0 !important; font-family: inherit !important; }
+
+
+
+
+
+
+
+
+
+
     /* ── Mobile responsive ── */
     html { -webkit-text-size-adjust:100%; -webkit-tap-highlight-color:transparent; }
     a, button { touch-action:manipulation; }
     @media(max-width:768px) {
-      .navbar { padding: 0 !important; }
-      .nav-content { padding: 8px 14px !important; flex-wrap: wrap; gap: 6px; }
-      .nav-links { flex-wrap: wrap !important; gap: 2px !important; }
-      .nav-links a { font-size: 14px !important; padding: 8px 8px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-links li+li>a { border-left: none !important; }
-      .theme-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
+
+
+
+
+
+
       .ctrl-bar { flex-direction: column !important; }
       input[type="text"], select { font-size: 16px !important; min-height: 44px; }
       table { font-size: 13px !important; }
       th, td { padding: 8px !important; }
     }
-    @supports(padding:env(safe-area-inset-left)) {
-      .navbar { padding-left: env(safe-area-inset-left) !important; padding-right: env(safe-area-inset-right) !important; }
-    }
   
-    /* ── "more" nav dropdown — secondary entries ── */
-    .nav-links li.nav-more { position: relative; display: inline-flex; align-items: center; }
-    .nav-more-btn {
-      background: none !important; border: none !important;
-      border-left: 1px solid var(--border) !important;
-      border-bottom: 1px solid transparent !important;
-      font-family: inherit !important; font-size: 13px !important;
-      color: var(--text-light, var(--muted)) !important;
-      cursor: pointer; white-space: nowrap; padding: 2px 10px !important; margin: 0;
-      display: inline-flex; align-items: center; gap: 4px;
-    }
-    .nav-more-btn:hover { color: var(--text) !important; }
-    .nav-more-btn.active { color: var(--text) !important; border-bottom-color: var(--text) !important; }
-    .nav-more-caret { font-size: .8em; transition: transform .15s; }
-    .nav-more.open .nav-more-caret { transform: rotate(180deg); }
-    .nav-more-menu {
-      display: none; position: absolute; top: 100%; right: 0; z-index: 300;
-      min-width: 150px; flex-direction: column;
-      background: var(--bg); border: 1px solid var(--border);
-    }
-    .nav-more.open .nav-more-menu { display: flex; }
-    .nav-more-menu a {
-      display: block; white-space: nowrap;
-      padding: 9px 14px !important;
-      border-left: none !important;
-      border-bottom: 1px solid var(--border) !important;
-    }
-    .nav-more-menu a:last-child { border-bottom: none !important; }
-    .nav-more-menu a.active { color: var(--text) !important; font-weight: 700; }
-    @media(max-width:768px) {
-      .nav-links li.nav-more { position: static; }
-      .nav-more-btn { font-size: 14px !important; padding: 8px 10px !important; min-height: 44px !important; border-left: none !important; }
-      .nav-more-menu { left: 0; right: 0; min-width: 0; }
-      .nav-more-menu a { font-size: 14px !important; padding: 12px 14px !important; min-height: 44px !important; display: flex; align-items: center; }
-    }
+
+
+
+
+
+
+
+
+
+
+
   </style>
 </head>
 <body>
 <!-- ── NAV ─────────────────────────────────────────────────── -->
-<nav class="navbar">
-  <div class="nav-content">
-    <a href="index.html" class="logo">CS_basics</a>
-    <ul class="nav-links">
-        <li><a href="index.html">home</a></li>
-        <li><a href="search.html">search</a></li>
-        <li><a href="cheatsheets.html">cheatsheets</a></li>
-        <li><a href="faqs.html">faqs</a></li>
-        <li><a href="lc-explorer.html">lc-explorer</a></li>
-        <li><a href="lc-random-picker.html">random</a></li>
-        <li><a href="algo_demo/index.html">visualizer</a></li>
-        <li class="nav-more">
-          <button type="button" class="nav-more-btn active" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html">patterns</a>
-            <a href="lc-similar.html" class="active">similar</a>
-            <a href="lc-review-plan.html">review</a>
-            <a href="resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </li>
-      </ul>
-    <button class="theme-btn" onclick="toggleTheme()" aria-label="Toggle theme">☀ light</button>
-  </div>
-</nav>
+<div id="site-nav" data-page="lc-similar"></div>
+<script>CSNav.mount();</script>
 
 <!-- ── PAGE HEADER ──────────────────────────────────────────── -->
 <div class="page-header">
@@ -599,21 +548,9 @@ function canonTag(t) {
 }
 
 /* ── Theme ──────────────────────────────────────────────── */
-function toggleTheme() {
-  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-  const next = isDark ? 'light' : 'dark';
-  document.documentElement.setAttribute('data-theme', next);
-  localStorage.setItem('theme', next);
-  const btn = document.querySelector('.theme-btn');
-  if (btn) btn.textContent = isDark ? '● dark' : '☀ light';
-  redrawActive();
-}
-const saved = localStorage.getItem('theme') || 'dark';
-document.documentElement.setAttribute('data-theme', saved);
-document.addEventListener('DOMContentLoaded', () => {
-  const btn = document.querySelector('.theme-btn');
-  if (btn) btn.textContent = saved === 'dark' ? '☀ light' : '● dark';
-});
+// The charts are painted with the theme's CSS variables, so they have to be
+// redrawn when the shared navbar switches theme.
+document.addEventListener('cs:themechange', redrawActive);
 
 function css(v) { return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
 function svgW(id) { return Math.max(document.getElementById(id).parentElement.clientWidth || 900, 600); }
@@ -1946,23 +1883,6 @@ function clearTraversal() {
    INIT
 ══════════════════════════════════════════════════════════ */
 loadData();
-</script>
-<script>
-(function() {
-  var more = document.querySelector('.nav-more');
-  if (!more) return;
-  var btn = more.querySelector('.nav-more-btn');
-  function setOpen(open) {
-    more.classList.toggle('open', open);
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  }
-  btn.addEventListener('click', function(e) {
-    e.stopPropagation();
-    setOpen(!more.classList.contains('open'));
-  });
-  document.addEventListener('click', function(e) { if (!more.contains(e.target)) setOpen(false); });
-  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') setOpen(false); });
-})();
 </script>
 </body>
 </html>

--- a/_site/nav.css
+++ b/_site/nav.css
@@ -1,0 +1,211 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — shared navbar styles
+
+   Companion to nav.js: every page family loads this same file, so the bar
+   looks identical whether it sits on a generated doc page, a visualizer page
+   or one of the hand-maintained LeetCode tools.
+
+   Those page families each grew their own colour tokens, so the navbar reads
+   them through a small set of local aliases with fallbacks rather than
+   depending on any single naming scheme. A page only has to define --bg,
+   --text and --border for the bar to render correctly.
+   ───────────────────────────────────────────────────────────────────────── */
+
+.navbar {
+  --nav-bg:          var(--bg, #ffffff);
+  --nav-ink:         var(--text-muted, var(--text-light, var(--muted, #555555)));
+  --nav-ink-active:  var(--text, #000000);
+  --nav-line:        var(--border, #cccccc);
+  --nav-line-strong: var(--border-strong, var(--border-s, var(--border, #888888)));
+  --nav-surface:     var(--surface, var(--bg-alt, #f0f0f0));
+  --nav-hover-bg:    var(--bg-alt, var(--surface, #f5f5f5));
+
+  background: var(--nav-bg);
+  border-bottom: 1px solid var(--nav-line);
+  position: sticky; top: 0; z-index: 100;
+}
+
+.navbar .nav-inner {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 10px 32px;
+  max-width: 100%;
+}
+
+.nav-brand {
+  display: flex; align-items: center;
+  font-size: 18px; font-weight: 700; text-decoration: none;
+  color: var(--nav-ink-active);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  white-space: nowrap; flex-shrink: 0; margin-right: 24px;
+}
+.nav-brand:hover { opacity: 1; }
+.nav-title { font-size: 18px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+
+/* Right-side nav: all entries in one flex row */
+.nav-links {
+  display: flex; align-items: center;
+  gap: 0; list-style: none; flex-wrap: nowrap;
+  font-size: 18px;
+}
+
+.nav-links a {
+  color: var(--nav-ink);
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 2px 10px;
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s;
+  display: inline-flex; align-items: center;
+  min-height: 44px; /* Apple HIG minimum touch target */
+}
+.nav-links a:hover { color: var(--nav-ink-active); opacity: 1; }
+.nav-links a.active { color: var(--nav-ink-active); border-bottom-color: var(--nav-ink-active); }
+
+/* Separator: a rule BEFORE each entry except the first */
+.nav-links > a + a { border-left: 1px solid var(--nav-line-strong); }
+
+/* ── "more" dropdown — secondary entries ─── */
+.nav-more { position: relative; display: inline-flex; align-items: center; }
+
+.nav-more-btn {
+  background: none; border: none; cursor: pointer;
+  font-family: inherit; font-size: inherit; color: var(--nav-ink);
+  white-space: nowrap; padding: 2px 10px; margin: 0;
+  border-left: 1px solid var(--nav-line-strong);
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s;
+  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
+}
+.nav-more-btn:hover { color: var(--nav-ink-active); }
+.nav-more-btn.active { color: var(--nav-ink-active); border-bottom-color: var(--nav-ink-active); }
+.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
+.nav-more.open .nav-more-caret { transform: rotate(180deg); }
+
+.nav-more-menu {
+  display: none;
+  position: absolute; top: 100%; right: 0; z-index: 300;
+  min-width: 160px;
+  flex-direction: column; align-items: stretch;
+  background: var(--nav-bg);
+  border: 1px solid var(--nav-line-strong);
+}
+.nav-more.open .nav-more-menu { display: flex; }
+
+.nav-links .nav-more-menu a {
+  display: flex; align-items: center;
+  width: 100%; padding: 10px 14px; min-height: 40px;
+  border-left: none; border-bottom: 1px solid var(--nav-line);
+}
+.nav-links .nav-more-menu a:last-child { border-bottom: none; }
+.nav-links .nav-more-menu a:hover { background: var(--nav-hover-bg); color: var(--nav-ink-active); }
+.nav-links .nav-more-menu a.active { color: var(--nav-ink-active); font-weight: 700; }
+
+/* ── Theme toggle ─── */
+.theme-toggle {
+  background: var(--nav-hover-bg); cursor: pointer; color: var(--nav-ink);
+  font-family: inherit; font-size: 16px; padding: 6px 12px; margin: 0;
+  white-space: nowrap; border: 1px solid var(--nav-line-strong);
+  transition: color 0.15s, background 0.15s;
+  text-transform: uppercase; letter-spacing: 0.05em;
+  display: inline-flex; align-items: center; min-height: 44px;
+}
+[data-theme="dark"] .theme-toggle {
+  background: var(--nav-ink-active); color: var(--nav-bg); border-color: var(--nav-ink-active);
+}
+.theme-toggle:hover { color: var(--nav-ink-active); background: var(--nav-hover-bg); }
+
+/* ── Hamburger — hidden on desktop ─── */
+.nav-toggle {
+  display: none; flex-direction: column; gap: 5px;
+  background: none; border: none; cursor: pointer; padding: 4px;
+  flex-shrink: 0; min-height: 44px;
+}
+.nav-toggle span { display: block; width: 20px; height: 1px; background: var(--nav-ink-active); }
+
+/* ═══════════════════════════════════════════════════════
+   Tablet ≤1024px — tighten before anything has to wrap
+   ═══════════════════════════════════════════════════════ */
+@media (max-width: 1024px) {
+  .navbar .nav-inner { padding: 10px 24px; }
+  .nav-links { font-size: 16px; }
+  .nav-links a { padding: 2px 8px; }
+  .nav-title { font-size: 16px; }
+  .nav-brand { font-size: 16px; margin-right: 16px; }
+}
+
+/* ═══════════════════════════════════════════════════════
+   Mobile ≤768px — bar collapses into a hamburger drawer
+   ═══════════════════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .nav-toggle { display: flex; }
+  .navbar .nav-inner { position: relative; padding: 0 16px; min-height: 52px; }
+  .nav-brand { font-size: 15px; margin-right: 0; }
+
+  .nav-links {
+    display: none;
+    position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
+    background: var(--nav-bg);
+    border-top: 1px solid var(--nav-line);
+    border-bottom: 2px solid var(--nav-line-strong);
+    flex-direction: column; align-items: stretch;
+    padding: 0; gap: 0;
+    /* iOS momentum scroll inside the drawer */
+    overflow-y: auto; -webkit-overflow-scrolling: touch;
+    max-height: 80vh;
+  }
+  .nav-links.open { display: flex; }
+
+  .nav-links a {
+    padding: 14px 20px; font-size: 17px;
+    border-bottom: 1px solid var(--nav-line); border-left: none;
+    border-right: none; width: 100%; min-height: 52px;
+  }
+  .nav-links > a + a { border-left: none; }
+  .nav-links a.active { background: var(--nav-surface); border-bottom-color: var(--nav-line); font-weight: 700; }
+
+  /* Dropdown flattens into an indented accordion inside the drawer */
+  .nav-more { display: block; width: 100%; position: static; }
+  .nav-more-btn {
+    padding: 14px 20px; font-size: 17px; width: 100%;
+    border-left: none; border-bottom: 1px solid var(--nav-line);
+    min-height: 52px; justify-content: flex-start;
+  }
+  .nav-more-menu {
+    position: static; min-width: 0; border: none;
+    background: var(--nav-surface);
+  }
+  .nav-links .nav-more-menu a {
+    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
+    border-bottom: 1px solid var(--nav-line);
+  }
+
+  .theme-toggle {
+    padding: 14px 20px; font-size: 17px;
+    border: none; width: 100%; min-height: 52px;
+    justify-content: flex-start;
+    background: var(--nav-surface);
+  }
+}
+
+@media (max-width: 360px) {
+  .navbar .nav-inner { padding: 0 12px; }
+}
+
+/* iOS safe-area insets (notch / home indicator) */
+@supports (padding: env(safe-area-inset-left)) {
+  .navbar .nav-inner {
+    padding-left: max(32px, env(safe-area-inset-left));
+    padding-right: max(32px, env(safe-area-inset-right));
+  }
+  @media (max-width: 768px) {
+    .navbar .nav-inner {
+      padding-left: max(16px, env(safe-area-inset-left));
+      padding-right: max(16px, env(safe-area-inset-right));
+    }
+  }
+}
+
+@media print {
+  .navbar, .nav-toggle { display: none !important; }
+}

--- a/_site/nav.js
+++ b/_site/nav.js
@@ -1,0 +1,245 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — shared navbar
+
+   The single source of truth for the site navigation: the entry list, the
+   markup, and the behaviour (theme toggle, mobile drawer, "more" dropdown).
+   Every page family loads this same file, so adding a nav entry is a one-line
+   change here rather than an edit across four hand-maintained copies:
+
+     - generated doc pages   (site/build-site.js emits the placeholder)
+     - algo_demo/*.html      (visualizer pages)
+     - _site/lc-*.html       (hand-maintained LeetCode tools)
+
+   Usage — load in <head> so the stored theme lands before first paint, then
+   drop a placeholder where the navbar belongs and mount it synchronously:
+
+     <head> <script src="nav.js"></script> </head>
+     <body>
+       <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+       <script>CSNav.mount();</script>
+
+   `data-page` is an entry id (see PRIMARY/MORE below) and marks it active;
+   `data-base` is the prefix that gets a page back to the site root.
+   ───────────────────────────────────────────────────────────────────────── */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.CSNav = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  var THEME_KEY = 'theme';
+  var DEFAULT_THEME = 'dark';
+  // Fired on `document` after every theme change. Pages that paint their own
+  // colours (canvas visualizations, SVG charts) listen for this to repaint.
+  var THEME_EVENT = 'cs:themechange';
+
+  // Entries rendered inline in the bar.
+  var PRIMARY = [
+    { id: 'home',             label: 'home',        href: 'index.html' },
+    { id: 'search',           label: 'search',      href: 'search.html' },
+    { id: 'cheatsheets',      label: 'cheatsheets', href: 'cheatsheets.html' },
+    { id: 'faqs',             label: 'faqs',        href: 'faqs.html' },
+    { id: 'lc-explorer',      label: 'lc-explorer', href: 'lc-explorer.html' },
+    { id: 'lc-random-picker', label: 'random',      href: 'lc-random-picker.html' },
+    { id: 'visualizer',       label: 'visualizer',  href: 'algo_demo/index.html' }
+  ];
+
+  // Secondary entries, collapsed behind the "more" dropdown. The button lights
+  // up when the current page is one of them, so the trail survives collapsing.
+  var MORE = [
+    { id: 'patterns',       label: 'patterns',  href: 'patterns.html' },
+    { id: 'lc-similar',     label: 'similar',   href: 'lc-similar.html' },
+    { id: 'lc-review-plan', label: 'review',    href: 'lc-review-plan.html' },
+    { id: 'resources',      label: 'resources', href: 'resources.html' },
+    { id: 'github',         label: 'github',    href: 'https://github.com/yennanliu/CS_basics', external: true }
+  ];
+
+  // ── Markup ──────────────────────────────────────────────────────────────
+
+  function esc(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function hrefFor(item, basePath) {
+    return item.external ? item.href : (basePath || '') + item.href;
+  }
+
+  function isMoreEntry(id) {
+    for (var i = 0; i < MORE.length; i++) if (MORE[i].id === id) return true;
+    return false;
+  }
+
+  function linkHTML(item, currentPage, basePath) {
+    var attrs = ' href="' + esc(hrefFor(item, basePath)) + '"';
+    if (item.external) attrs += ' target="_blank" rel="noopener"';
+    if (item.id === currentPage) attrs += ' class="active"';
+    return '<a' + attrs + '>' + esc(item.label) + '</a>';
+  }
+
+  function navHTML(options) {
+    options = options || {};
+    var currentPage = options.currentPage || '';
+    var basePath = options.basePath || '';
+    var links = function (item) { return linkHTML(item, currentPage, basePath); };
+
+    return '<nav class="navbar">' +
+      '<div class="nav-inner">' +
+        '<a href="' + esc(basePath + 'index.html') + '" class="nav-brand">' +
+          '<span class="nav-title">CS_basics</span>' +
+        '</a>' +
+        '<button type="button" class="nav-toggle" aria-label="Toggle menu" ' +
+          'aria-controls="nav-links" aria-expanded="false">' +
+          '<span></span><span></span><span></span>' +
+        '</button>' +
+        '<div class="nav-links" id="nav-links">' +
+          PRIMARY.map(links).join('') +
+          '<div class="nav-more">' +
+            '<button type="button" class="nav-more-btn' +
+              (isMoreEntry(currentPage) ? ' active' : '') + '" ' +
+              'aria-haspopup="true" aria-expanded="false">' +
+              'more <span class="nav-more-caret">▾</span>' +
+            '</button>' +
+            '<div class="nav-more-menu">' + MORE.map(links).join('') + '</div>' +
+          '</div>' +
+          '<button type="button" id="theme-toggle" class="theme-toggle" ' +
+            'aria-label="Toggle theme">' + esc(themeLabel(DEFAULT_THEME)) + '</button>' +
+        '</div>' +
+      '</div>' +
+    '</nav>';
+  }
+
+  // ── Theme ───────────────────────────────────────────────────────────────
+
+  // Wrapped because Safari's private mode throws on localStorage access
+  // rather than returning null, which would otherwise break the whole navbar.
+  function storedTheme() {
+    try {
+      return (typeof localStorage !== 'undefined' && localStorage.getItem(THEME_KEY)) || DEFAULT_THEME;
+    } catch (e) {
+      return DEFAULT_THEME;
+    }
+  }
+
+  function persistTheme(theme) {
+    try {
+      if (typeof localStorage !== 'undefined') localStorage.setItem(THEME_KEY, theme);
+    } catch (e) { /* storage unavailable — theme still applies for this page */ }
+  }
+
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-theme') || DEFAULT_THEME;
+  }
+
+  // The label names the theme you would switch TO, not the one you are in.
+  function themeLabel(theme) {
+    return theme === 'dark' ? '☀ light' : '● dark';
+  }
+
+  function syncThemeLabel() {
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.textContent = themeLabel(currentTheme());
+  }
+
+  // Called at load, before <body> is parsed, so no flash of the wrong theme.
+  function applyStoredTheme() {
+    document.documentElement.setAttribute('data-theme', storedTheme());
+  }
+
+  function setTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    persistTheme(theme);
+    syncThemeLabel();
+    if (typeof CustomEvent === 'function') {
+      document.dispatchEvent(new CustomEvent(THEME_EVENT, { detail: { theme: theme } }));
+    }
+  }
+
+  function toggleTheme() {
+    setTheme(currentTheme() === 'dark' ? 'light' : 'dark');
+  }
+
+  // ── Behaviour ───────────────────────────────────────────────────────────
+
+  function initTheme() {
+    applyStoredTheme();
+    syncThemeLabel();
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.addEventListener('click', toggleTheme);
+  }
+
+  // Bound here rather than inline so aria-expanded stays in step with the
+  // drawer — a screen reader otherwise cannot tell whether it is open.
+  function initNavToggle(scope) {
+    scope = scope || document;
+    var btn = scope.querySelector('.nav-toggle');
+    var links = scope.querySelector('.nav-links');
+    if (!btn || !links) return;
+    btn.addEventListener('click', function () {
+      var open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
+
+  function initNavMore(scope) {
+    scope = scope || document;
+    var more = scope.querySelector('.nav-more');
+    if (!more) return;
+    var btn = more.querySelector('.nav-more-btn');
+    if (!btn) return;
+
+    var setOpen = function (open) {
+      more.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    };
+
+    btn.addEventListener('click', function () {
+      setOpen(!more.classList.contains('open'));
+    });
+    document.addEventListener('click', function (event) {
+      if (!more.contains(event.target)) setOpen(false);
+    });
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') setOpen(false);
+    });
+  }
+
+  // Renders the navbar into `#site-nav` (or the given element) and wires it up.
+  function mount(target) {
+    var host = target || document.getElementById('site-nav');
+    if (!host) return null;
+    host.innerHTML = navHTML({
+      currentPage: host.getAttribute('data-page') || '',
+      basePath: host.getAttribute('data-base') || ''
+    });
+    initTheme();
+    initNavToggle(host);
+    initNavMore(host);
+    return host;
+  }
+
+  if (typeof document !== 'undefined' && document.documentElement) applyStoredTheme();
+
+  return {
+    PRIMARY: PRIMARY,
+    MORE: MORE,
+    THEME_EVENT: THEME_EVENT,
+    esc: esc,
+    hrefFor: hrefFor,
+    isMoreEntry: isMoreEntry,
+    navHTML: navHTML,
+    themeLabel: themeLabel,
+    storedTheme: storedTheme,
+    currentTheme: currentTheme,
+    applyStoredTheme: applyStoredTheme,
+    setTheme: setTheme,
+    toggleTheme: toggleTheme,
+    initTheme: initTheme,
+    initNavToggle: initNavToggle,
+    initNavMore: initNavMore,
+    mount: mount
+  };
+});

--- a/_site/patterns.html
+++ b/_site/patterns.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="index.html" class="">home</a>
         <a href="search.html" class="">search</a>
         <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="patterns.html" class="active">patterns</a>
         <a href="faqs.html" class="">faqs</a>
         <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-similar.html" class="">similar</a>
         <a href="lc-random-picker.html" class="">random</a>
-        <a href="lc-review-plan.html" class="">review</a>
         <a href="algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn active" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html" class="active">patterns</a>
+            <a href="lc-similar.html" class="">similar</a>
+            <a href="lc-review-plan.html" class="">review</a>
+            <a href="resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/patterns.html
+++ b/_site/patterns.html
@@ -11,108 +11,17 @@
   <title>Pattern Recognition — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="nav.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <script src="site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="index.html" class="">home</a>
-        <a href="search.html" class="">search</a>
-        <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="faqs.html" class="">faqs</a>
-        <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-random-picker.html" class="">random</a>
-        <a href="algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn active" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html" class="active">patterns</a>
-            <a href="lc-similar.html" class="">similar</a>
-            <a href="lc-review-plan.html" class="">review</a>
-            <a href="resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="patterns" data-base=""></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/resources.html
+++ b/_site/resources.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="index.html" class="">home</a>
         <a href="search.html" class="">search</a>
         <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="patterns.html" class="">patterns</a>
         <a href="faqs.html" class="">faqs</a>
         <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-similar.html" class="">similar</a>
         <a href="lc-random-picker.html" class="">random</a>
-        <a href="lc-review-plan.html" class="">review</a>
         <a href="algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html" class="">patterns</a>
+            <a href="lc-similar.html" class="">similar</a>
+            <a href="lc-review-plan.html" class="">review</a>
+            <a href="resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/resources.html
+++ b/_site/resources.html
@@ -11,108 +11,17 @@
   <title>Resources — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="nav.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <script src="site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="index.html" class="">home</a>
-        <a href="search.html" class="">search</a>
-        <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="faqs.html" class="">faqs</a>
-        <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-random-picker.html" class="">random</a>
-        <a href="algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html" class="">patterns</a>
-            <a href="lc-similar.html" class="">similar</a>
-            <a href="lc-review-plan.html" class="">review</a>
-            <a href="resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="resources" data-base=""></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/search.html
+++ b/_site/search.html
@@ -61,6 +61,24 @@
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -77,15 +95,21 @@
         <a href="index.html" class="">home</a>
         <a href="search.html" class="active">search</a>
         <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="patterns.html" class="">patterns</a>
         <a href="faqs.html" class="">faqs</a>
         <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-similar.html" class="">similar</a>
         <a href="lc-random-picker.html" class="">random</a>
-        <a href="lc-review-plan.html" class="">review</a>
         <a href="algo_demo/index.html" class="">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="patterns.html" class="">patterns</a>
+            <a href="lc-similar.html" class="">similar</a>
+            <a href="lc-review-plan.html" class="">review</a>
+            <a href="resources.html" class="">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/_site/search.html
+++ b/_site/search.html
@@ -11,108 +11,17 @@
   <title>Search — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="nav.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <script src="site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="index.html" class="">home</a>
-        <a href="search.html" class="active">search</a>
-        <a href="cheatsheets.html" class="">cheatsheets</a>
-        <a href="faqs.html" class="">faqs</a>
-        <a href="lc-explorer.html" class="">lc-explorer</a>
-        <a href="lc-random-picker.html" class="">random</a>
-        <a href="algo_demo/index.html" class="">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="patterns.html" class="">patterns</a>
-            <a href="lc-similar.html" class="">similar</a>
-            <a href="lc-review-plan.html" class="">review</a>
-            <a href="resources.html" class="">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="search" data-base=""></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/_site/site.js
+++ b/_site/site.js
@@ -1,0 +1,82 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — shared page behaviour for generated doc pages
+
+   Content-level behaviour that used to be inlined into every generated page
+   by site/build-site.js: copy-to-clipboard on code blocks, horizontal scroll
+   wrappers around wide tables, and the reading progress bar.
+
+   Navbar behaviour lives in nav.js, not here.
+   ───────────────────────────────────────────────────────────────────────── */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.CSSite = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // Called from the inline onclick that build-site.js emits on each copy
+  // button, so it has to reach the page as a global (see the export below).
+  function copyCode(btn) {
+    var wrapper = btn.closest('.code-block-wrapper');
+    var pre = wrapper ? wrapper.querySelector('pre') : null;
+    var text = pre ? pre.innerText : '';
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(text).then(function () {
+      btn.textContent = 'copied';
+      btn.classList.add('copied');
+      setTimeout(function () {
+        btn.textContent = 'copy';
+        btn.classList.remove('copied');
+      }, 2000);
+    });
+  }
+
+  // Markdown tables are emitted bare; wrapping them lets a wide table scroll
+  // inside its own box instead of forcing the whole page sideways.
+  function wrapTables(scope) {
+    scope = scope || document;
+    var tables = scope.querySelectorAll('table');
+    for (var i = 0; i < tables.length; i++) {
+      var table = tables[i];
+      if (table.parentElement && table.parentElement.classList.contains('table-wrap')) continue;
+      var wrapper = document.createElement('div');
+      wrapper.className = 'table-wrap';
+      table.parentNode.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
+    }
+    return tables.length;
+  }
+
+  function readingProgress(doc) {
+    doc = doc || document.documentElement;
+    var height = doc.scrollHeight - doc.clientHeight;
+    return height > 0 ? (doc.scrollTop / height) * 100 : 0;
+  }
+
+  function initReadingProgress() {
+    var bar = document.getElementById('reading-progress');
+    if (!bar) return;
+    var update = function () { bar.style.width = readingProgress() + '%'; };
+    window.addEventListener('scroll', update);
+    update();
+  }
+
+  function init() {
+    wrapTables(document);
+    initReadingProgress();
+  }
+
+  if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('DOMContentLoaded', init);
+    // The copy buttons are wired with inline onclick attributes, which resolve
+    // against the global scope rather than this module.
+    if (typeof self !== 'undefined') self.copyCode = copyCode;
+  }
+
+  return {
+    copyCode: copyCode,
+    wrapTables: wrapTables,
+    readingProgress: readingProgress,
+    initReadingProgress: initReadingProgress,
+    init: init
+  };
+});

--- a/_site/style.css
+++ b/_site/style.css
@@ -72,116 +72,6 @@ a:hover { opacity: 0.6; }
 }
 .progress-bar { height: 100%; width: 0%; background: var(--text); transition: width 0.1s; }
 
-/* ── Navbar ─── */
-.navbar {
-  background: var(--bg);
-  border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 100;
-}
-
-.navbar .container {
-  display: flex; align-items: center;
-  justify-content: space-between;
-  padding: 10px 32px;
-  max-width: 100%;
-}
-
-.nav-brand {
-  display: flex; align-items: center;
-  font-size: 18px; font-weight: 700; text-decoration: none; color: var(--text);
-  text-transform: uppercase; letter-spacing: 0.08em;
-  white-space: nowrap; flex-shrink: 0; margin-right: 24px;
-}
-
-.nav-icon { display: none; }
-.nav-title { font-size: 18px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
-
-/* Right-side nav: all links in one flex row */
-.nav-links {
-  display: flex; align-items: center;
-  gap: 0; list-style: none; flex-wrap: nowrap;
-  font-size: 18px;
-}
-
-/* Each link */
-.nav-links a,
-.nav-links > a {
-  color: var(--text-muted);
-  text-decoration: none;
-  white-space: nowrap;
-  padding: 2px 10px;
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s;
-  display: inline-block;
-}
-.nav-links a:hover,
-.nav-links > a:hover { color: var(--text); opacity: 1; }
-.nav-links a.active,
-.nav-links > a.active { color: var(--text); border-bottom-color: var(--text); }
-
-/* Separator: a pipe BEFORE each link except the first */
-.nav-links a + a,
-.nav-links > a + a { border-left: 1px solid var(--border-strong); }
-
-/* ── "more" dropdown — secondary nav entries ─── */
-.nav-more { position: relative; display: inline-flex; align-items: center; }
-
-.nav-more-btn {
-  background: none; border: none; cursor: pointer;
-  font-family: inherit; font-size: inherit; color: var(--text-muted);
-  white-space: nowrap; padding: 2px 10px; margin: 0;
-  border-left: 1px solid var(--border-strong);
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s;
-  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
-}
-.nav-more-btn:hover { color: var(--text); }
-.nav-more-btn.active { color: var(--text); border-bottom-color: var(--text); }
-.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
-.nav-more.open .nav-more-caret { transform: rotate(180deg); }
-
-.nav-more-menu {
-  display: none;
-  position: absolute; top: 100%; right: 0; z-index: 300;
-  min-width: 160px;
-  flex-direction: column; align-items: stretch;
-  background: var(--bg);
-  border: 1px solid var(--border-strong);
-}
-.nav-more.open .nav-more-menu { display: flex; }
-
-.nav-links .nav-more-menu a,
-.nav-links .nav-more-menu > a {
-  display: flex; align-items: center;
-  width: 100%; padding: 10px 14px; min-height: 40px;
-  border-left: none; border-bottom: 1px solid var(--border);
-}
-.nav-links .nav-more-menu a + a { border-left: none; }
-.nav-links .nav-more-menu a:last-child { border-bottom: none; }
-.nav-links .nav-more-menu a:hover { background: var(--bg-alt); color: var(--text); }
-.nav-links .nav-more-menu a.active { color: var(--text); font-weight: 700; }
-
-.theme-toggle {
-  background: var(--bg-alt); cursor: pointer; color: var(--text-muted);
-  font-family: inherit; font-size: 16px; padding: 6px 12px; margin: 0;
-  white-space: nowrap; border-left: 1px solid var(--border-strong);
-  border-top: 1px solid var(--border-strong); border-right: 1px solid var(--border-strong);
-  border-bottom: 1px solid var(--border-strong);
-  transition: color 0.15s, background 0.15s;
-  text-transform: uppercase; letter-spacing: 0.05em;
-}
-[data-theme="dark"] .theme-toggle {
-  background: var(--text); color: var(--bg); border-color: var(--text);
-}
-.theme-toggle:hover { color: var(--text); background: var(--bg-alt); }
-
-/* hamburger – hidden on desktop */
-.nav-toggle {
-  display: none; flex-direction: column; gap: 5px;
-  background: none; border: none; cursor: pointer; padding: 4px; flex-shrink: 0;
-}
-.nav-toggle span { display: block; width: 20px; height: 1px; background: var(--text); }
-
 /* ── Global mobile resets ─── */
 html {
   -webkit-text-size-adjust: 100%;  /* prevent iOS auto font inflation */
@@ -191,9 +81,8 @@ html {
 a, button, [role="button"] {
   touch-action: manipulation; /* remove 300ms tap delay */
 }
-/* Minimum touch target: 44×44px (Apple HIG) */
-.nav-links a, .nav-links > a, .nav-more-btn, .theme-toggle,
-.nav-toggle, .tab-btn, .copy-btn {
+/* Minimum touch target: 44×44px (Apple HIG) — navbar equivalents in nav.css */
+.tab-btn, .copy-btn {
   min-height: 44px;
   display: inline-flex;
   align-items: center;
@@ -485,13 +374,6 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
    ═══════════════════════════════════════════════════════ */
 @media (max-width: 1024px) {
   .container { padding: 0 24px; }
-  .navbar .container { padding: 10px 24px; }
-
-  /* Slightly tighter nav on tablet */
-  .nav-links a, .nav-links > a { padding: 2px 8px; font-size: 16px; }
-  .nav-links { font-size: 16px; }
-  .nav-title { font-size: 16px; }
-  .nav-brand { font-size: 16px; margin-right: 16px; }
 
   .cheatsheet-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
 }
@@ -503,61 +385,6 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
   .container { padding: 0 16px; }
   .content { padding: 24px 0; }
   main { padding: 24px 0; }
-
-  /* ── Hamburger ── */
-  .nav-toggle { display: flex; }
-  .navbar .container { position: relative; padding: 0 16px; min-height: 52px; }
-  .nav-brand { font-size: 15px; margin-right: 0; }
-
-  .nav-links {
-    display: none;
-    position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
-    background: var(--bg);
-    border-top: 1px solid var(--border);
-    border-bottom: 2px solid var(--border-strong);
-    flex-direction: column; align-items: stretch;
-    padding: 0; gap: 0;
-    /* iOS momentum scroll inside drawer */
-    overflow-y: auto; -webkit-overflow-scrolling: touch;
-    max-height: 80vh;
-  }
-  .nav-links.open { display: flex; }
-
-  .nav-links a, .nav-links > a {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: 1px solid var(--border); border-left: none !important;
-    border-right: none; width: 100%; min-height: 52px;
-    display: flex; align-items: center;
-  }
-  .nav-links a + a, .nav-links > a + a { border-left: none !important; }
-  .nav-links a.active, .nav-links > a.active {
-    background: var(--surface); border-bottom-color: var(--border);
-    font-weight: 700;
-  }
-
-  /* Dropdown flattens into an inline accordion inside the drawer */
-  .nav-more { display: block; width: 100%; position: static; }
-  .nav-more-btn {
-    padding: 14px 20px; font-size: 17px; width: 100%;
-    border-left: none !important; border-bottom: 1px solid var(--border);
-    min-height: 52px; justify-content: flex-start;
-  }
-  .nav-more-menu {
-    position: static; min-width: 0; border: none;
-    background: var(--surface);
-  }
-  .nav-links .nav-more-menu a,
-  .nav-links .nav-more-menu > a {
-    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
-  }
-  .nav-links .nav-more-menu a:last-child { border-bottom: 1px solid var(--border); }
-  .theme-toggle {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: none; border-left: none !important; border-right: none !important;
-    border-top: none; width: 100%; min-height: 52px;
-    display: flex; align-items: center; justify-content: flex-start;
-    background: var(--surface2, var(--surface));
-  }
 
   /* ── Typography ── */
   h1 { font-size: 24px; }
@@ -635,17 +462,12 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
   h1 { font-size: 20px; }
   h2 { font-size: 18px; }
   pre, .cheatsheet-content pre { font-size: 13px !important; }
-  .navbar .container { padding: 0 12px; }
 }
 
 /* ═══════════════════════════════════════════════════════
    iOS safe-area insets (notch / home indicator)
    ═══════════════════════════════════════════════════════ */
 @supports (padding: env(safe-area-inset-left)) {
-  .navbar .container {
-    padding-left: max(32px, env(safe-area-inset-left));
-    padding-right: max(32px, env(safe-area-inset-right));
-  }
   .container {
     padding-left: max(32px, env(safe-area-inset-left));
     padding-right: max(32px, env(safe-area-inset-right));
@@ -654,10 +476,6 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
     padding-bottom: max(24px, env(safe-area-inset-bottom));
   }
   @media (max-width: 768px) {
-    .navbar .container {
-      padding-left: max(16px, env(safe-area-inset-left));
-      padding-right: max(16px, env(safe-area-inset-right));
-    }
     .container {
       padding-left: max(16px, env(safe-area-inset-left));
       padding-right: max(16px, env(safe-area-inset-right));
@@ -667,9 +485,10 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
 
 /* ── Print ─── */
 @media print {
-  .navbar, footer, .progress-container, .back-link,
+  /* .navbar is hidden by nav.css */
+  footer, .progress-container, .back-link,
   .cheatsheet-footer, .breadcrumbs, .prev-next,
-  .copy-btn, .code-block-header, .nav-toggle { display: none !important; }
+  .copy-btn, .code-block-header { display: none !important; }
   body { font-size: 11pt; color: #000; background: #fff; }
   .content { padding: 0; }
   main { padding: 0; }

--- a/_site/style.css
+++ b/_site/style.css
@@ -123,13 +123,43 @@ a:hover { opacity: 0.6; }
 .nav-links a + a,
 .nav-links > a + a { border-left: 1px solid var(--border-strong); }
 
-.github-link {
-  text-decoration: none; color: var(--text-muted); display: inline-flex;
-  align-items: center; background: none; border: none;
-  white-space: nowrap; padding: 2px 10px; border-left: 1px solid var(--border-strong);
+/* ── "more" dropdown — secondary nav entries ─── */
+.nav-more { position: relative; display: inline-flex; align-items: center; }
+
+.nav-more-btn {
+  background: none; border: none; cursor: pointer;
+  font-family: inherit; font-size: inherit; color: var(--text-muted);
+  white-space: nowrap; padding: 2px 10px; margin: 0;
+  border-left: 1px solid var(--border-strong);
+  border-bottom: 1px solid transparent;
   transition: color 0.15s;
+  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
 }
-.github-link:hover { color: var(--text); opacity: 1; }
+.nav-more-btn:hover { color: var(--text); }
+.nav-more-btn.active { color: var(--text); border-bottom-color: var(--text); }
+.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
+.nav-more.open .nav-more-caret { transform: rotate(180deg); }
+
+.nav-more-menu {
+  display: none;
+  position: absolute; top: 100%; right: 0; z-index: 300;
+  min-width: 160px;
+  flex-direction: column; align-items: stretch;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+}
+.nav-more.open .nav-more-menu { display: flex; }
+
+.nav-links .nav-more-menu a,
+.nav-links .nav-more-menu > a {
+  display: flex; align-items: center;
+  width: 100%; padding: 10px 14px; min-height: 40px;
+  border-left: none; border-bottom: 1px solid var(--border);
+}
+.nav-links .nav-more-menu a + a { border-left: none; }
+.nav-links .nav-more-menu a:last-child { border-bottom: none; }
+.nav-links .nav-more-menu a:hover { background: var(--bg-alt); color: var(--text); }
+.nav-links .nav-more-menu a.active { color: var(--text); font-weight: 700; }
 
 .theme-toggle {
   background: var(--bg-alt); cursor: pointer; color: var(--text-muted);
@@ -162,7 +192,7 @@ a, button, [role="button"] {
   touch-action: manipulation; /* remove 300ms tap delay */
 }
 /* Minimum touch target: 44×44px (Apple HIG) */
-.nav-links a, .nav-links > a, .github-link, .theme-toggle,
+.nav-links a, .nav-links > a, .nav-more-btn, .theme-toggle,
 .nav-toggle, .tab-btn, .copy-btn {
   min-height: 44px;
   display: inline-flex;
@@ -505,11 +535,22 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
     font-weight: 700;
   }
 
-  .github-link {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: 1px solid var(--border); border-left: none !important;
-    width: 100%; min-height: 52px; display: flex; align-items: center;
+  /* Dropdown flattens into an inline accordion inside the drawer */
+  .nav-more { display: block; width: 100%; position: static; }
+  .nav-more-btn {
+    padding: 14px 20px; font-size: 17px; width: 100%;
+    border-left: none !important; border-bottom: 1px solid var(--border);
+    min-height: 52px; justify-content: flex-start;
   }
+  .nav-more-menu {
+    position: static; min-width: 0; border: none;
+    background: var(--surface);
+  }
+  .nav-links .nav-more-menu a,
+  .nav-links .nav-more-menu > a {
+    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
+  }
+  .nav-links .nav-more-menu a:last-child { border-bottom: 1px solid var(--border); }
   .theme-toggle {
     padding: 14px 20px; font-size: 17px;
     border-bottom: none; border-left: none !important; border-right: none !important;

--- a/algo_demo/bellman-ford.html
+++ b/algo_demo/bellman-ford.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bellman-Ford - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Bellman-Ford</span>

--- a/algo_demo/bellman-ford.html
+++ b/algo_demo/bellman-ford.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/bfs.html
+++ b/algo_demo/bfs.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BFS - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">BFS</span>

--- a/algo_demo/bfs.html
+++ b/algo_demo/bfs.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/bidirectional-bfs.html
+++ b/algo_demo/bidirectional-bfs.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bidirectional BFS - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Bidirectional BFS</span>

--- a/algo_demo/bidirectional-bfs.html
+++ b/algo_demo/bidirectional-bfs.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/binary-search.html
+++ b/algo_demo/binary-search.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Binary Search - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Binary Search</span>

--- a/algo_demo/binary-search.html
+++ b/algo_demo/binary-search.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/binary-tree-traversal.html
+++ b/algo_demo/binary-tree-traversal.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Binary Tree Traversal - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Binary Tree Traversal</span>

--- a/algo_demo/binary-tree-traversal.html
+++ b/algo_demo/binary-tree-traversal.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/bubble-sort.html
+++ b/algo_demo/bubble-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bubble Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Bubble Sort</span>

--- a/algo_demo/bubble-sort.html
+++ b/algo_demo/bubble-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/bucket-sort.html
+++ b/algo_demo/bucket-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bucket Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Bucket Sort</span>

--- a/algo_demo/bucket-sort.html
+++ b/algo_demo/bucket-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/common.js
+++ b/algo_demo/common.js
@@ -1,12 +1,8 @@
 // Shared helpers for the Algorithm Visualizer pages.
 //
-// Theme is shared with the main CS_basics site: same `theme` localStorage key,
-// same dark-by-default, so a choice made on either side carries across.
-
-(function() {
-  var saved = localStorage.getItem('theme') || 'dark';
-  document.documentElement.setAttribute('data-theme', saved);
-})();
+// The navbar and the theme switch live in the shared site/nav.js, which every
+// page loads before this file. All this module has to do is repaint the
+// canvases when nav.js announces a theme change.
 
 // ── Visualization palette ────────────────────────────────────────────────
 // Canvases must never hardcode a colour: read it from VIZ so both themes and
@@ -83,60 +79,14 @@ function parseColor(c) {
   return m ? [+m[1], +m[2], +m[3]] : null;
 }
 
-// ── Theme toggle ─────────────────────────────────────────────────────────
-function initThemeToggle() {
-  var btn = document.getElementById('theme-toggle');
-  if (!btn) return;
-  var updateLabel = function() {
-    btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark'
-      ? '☀ light' : '● dark';
-  };
-  updateLabel();
-  btn.addEventListener('click', function() {
-    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    var next = isDark ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('theme', next);
-    updateLabel();
+// ── Repaint on theme change ──────────────────────────────────────────────
+// Canvases draw with the --viz-* tokens, which change with the theme. Every
+// visualization already redraws on resize, so re-reading the palette and
+// firing a resize repaints them without each page wiring up its own listener.
+function initThemeRepaint() {
+  document.addEventListener('cs:themechange', function() {
     refreshViz();
-    // Every visualization redraws on resize, so this repaints the canvas
-    // with the new palette without each page wiring up its own listener.
     window.dispatchEvent(new Event('resize'));
-  });
-}
-
-// ── Mobile nav ───────────────────────────────────────────────────────────
-// Bound here rather than inline so the button's aria-expanded stays in step
-// with the menu — a screen reader otherwise can't tell whether it's open.
-function initNavToggle() {
-  var btn = document.querySelector('.nav-toggle');
-  var links = document.getElementById('nav-links');
-  if (!btn || !links) return;
-  btn.addEventListener('click', function() {
-    var open = links.classList.toggle('open');
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  });
-}
-
-// ── "more" nav dropdown ──────────────────────────────────────────────────
-function initNavMore() {
-  var more = document.querySelector('.nav-more');
-  if (!more) return;
-  var btn = more.querySelector('.nav-more-btn');
-  if (!btn) return;
-  var setOpen = function(open) {
-    more.classList.toggle('open', open);
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  };
-  btn.addEventListener('click', function(e) {
-    e.stopPropagation();
-    setOpen(!more.classList.contains('open'));
-  });
-  document.addEventListener('click', function(e) {
-    if (!more.contains(e.target)) setOpen(false);
-  });
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') setOpen(false);
   });
 }
 
@@ -176,7 +126,5 @@ function randomArray(n, max) {
 
 document.addEventListener('DOMContentLoaded', function() {
   refreshViz();
-  initThemeToggle();
-  initNavToggle();
-  initNavMore();
+  initThemeRepaint();
 });

--- a/algo_demo/common.js
+++ b/algo_demo/common.js
@@ -118,6 +118,28 @@ function initNavToggle() {
   });
 }
 
+// ── "more" nav dropdown ──────────────────────────────────────────────────
+function initNavMore() {
+  var more = document.querySelector('.nav-more');
+  if (!more) return;
+  var btn = more.querySelector('.nav-more-btn');
+  if (!btn) return;
+  var setOpen = function(open) {
+    more.classList.toggle('open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  };
+  btn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    setOpen(!more.classList.contains('open'));
+  });
+  document.addEventListener('click', function(e) {
+    if (!more.contains(e.target)) setOpen(false);
+  });
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') setOpen(false);
+  });
+}
+
 // Logging helper
 function createLogger(containerId) {
   var el = document.getElementById(containerId);
@@ -156,4 +178,5 @@ document.addEventListener('DOMContentLoaded', function() {
   refreshViz();
   initThemeToggle();
   initNavToggle();
+  initNavMore();
 });

--- a/algo_demo/dfs.html
+++ b/algo_demo/dfs.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DFS - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">DFS</span>

--- a/algo_demo/dfs.html
+++ b/algo_demo/dfs.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/difference-array.html
+++ b/algo_demo/difference-array.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Difference Array - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Difference Array</span>

--- a/algo_demo/difference-array.html
+++ b/algo_demo/difference-array.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dijkstra.html
+++ b/algo_demo/dijkstra.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dijkstra - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Dijkstra's Algorithm</span>

--- a/algo_demo/dijkstra.html
+++ b/algo_demo/dijkstra.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dp-1d.html
+++ b/algo_demo/dp-1d.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>1D DP (Fibonacci / Climbing Stairs) - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">1D Dynamic Programming</span>

--- a/algo_demo/dp-1d.html
+++ b/algo_demo/dp-1d.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dp-2d.html
+++ b/algo_demo/dp-2d.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dp-2d.html
+++ b/algo_demo/dp-2d.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>2D DP (Unique Paths / LCS) - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">2D Dynamic Programming</span>

--- a/algo_demo/dp-knapsack.html
+++ b/algo_demo/dp-knapsack.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>0/1 Knapsack DP - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">0/1 Knapsack DP</span>

--- a/algo_demo/dp-knapsack.html
+++ b/algo_demo/dp-knapsack.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dp-string.html
+++ b/algo_demo/dp-string.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>String DP (Edit Distance) - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">String DP</span>

--- a/algo_demo/dp-string.html
+++ b/algo_demo/dp-string.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dp-tree.html
+++ b/algo_demo/dp-tree.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/dp-tree.html
+++ b/algo_demo/dp-tree.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tree DP - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Tree DP</span>

--- a/algo_demo/floyd-warshall.html
+++ b/algo_demo/floyd-warshall.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Floyd-Warshall - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Floyd-Warshall</span>

--- a/algo_demo/floyd-warshall.html
+++ b/algo_demo/floyd-warshall.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/graph-backtracking.html
+++ b/algo_demo/graph-backtracking.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Graph + Backtracking - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Graph + Backtracking</span>

--- a/algo_demo/graph-backtracking.html
+++ b/algo_demo/graph-backtracking.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/heap-sort.html
+++ b/algo_demo/heap-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/heap-sort.html
+++ b/algo_demo/heap-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Heap Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Heap Sort</span>

--- a/algo_demo/index.html
+++ b/algo_demo/index.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Algorithm Visualizer - CS_basics</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="page-header">
       <h1>Algorithm Visualizations</h1>

--- a/algo_demo/index.html
+++ b/algo_demo/index.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/insertion-sort.html
+++ b/algo_demo/insertion-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Insertion Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Insertion Sort</span>

--- a/algo_demo/insertion-sort.html
+++ b/algo_demo/insertion-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/kadane.html
+++ b/algo_demo/kadane.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kadane's Algorithm - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Kadane's Algorithm</span>

--- a/algo_demo/kadane.html
+++ b/algo_demo/kadane.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/kmp.html
+++ b/algo_demo/kmp.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/kmp.html
+++ b/algo_demo/kmp.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>KMP Algorithm - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">KMP Algorithm</span>

--- a/algo_demo/lca.html
+++ b/algo_demo/lca.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LCA - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Lowest Common Ancestor</span>

--- a/algo_demo/lca.html
+++ b/algo_demo/lca.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/lfu-cache.html
+++ b/algo_demo/lfu-cache.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LFU Cache - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">LFU Cache</span>

--- a/algo_demo/lfu-cache.html
+++ b/algo_demo/lfu-cache.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/linear-search.html
+++ b/algo_demo/linear-search.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Linear Search - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Linear Search</span>

--- a/algo_demo/linear-search.html
+++ b/algo_demo/linear-search.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/lru-cache.html
+++ b/algo_demo/lru-cache.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LRU Cache - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">LRU Cache</span>

--- a/algo_demo/lru-cache.html
+++ b/algo_demo/lru-cache.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/merge-sort.html
+++ b/algo_demo/merge-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Merge Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Merge Sort</span>

--- a/algo_demo/merge-sort.html
+++ b/algo_demo/merge-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/monotonic-stack.html
+++ b/algo_demo/monotonic-stack.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/monotonic-stack.html
+++ b/algo_demo/monotonic-stack.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Monotonic Stack - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Monotonic Stack</span>

--- a/algo_demo/multi-source-bfs.html
+++ b/algo_demo/multi-source-bfs.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Multi-Source BFS - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Multi-Source BFS</span>

--- a/algo_demo/multi-source-bfs.html
+++ b/algo_demo/multi-source-bfs.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/prefix-sum.html
+++ b/algo_demo/prefix-sum.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prefix Sum - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Prefix Sum</span>

--- a/algo_demo/prefix-sum.html
+++ b/algo_demo/prefix-sum.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/quick-sort.html
+++ b/algo_demo/quick-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Quick Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Quick Sort</span>

--- a/algo_demo/quick-sort.html
+++ b/algo_demo/quick-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/rolling-hash.html
+++ b/algo_demo/rolling-hash.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rolling Hash (Rabin-Karp) - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Rolling Hash (Rabin-Karp)</span>

--- a/algo_demo/rolling-hash.html
+++ b/algo_demo/rolling-hash.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/selection-sort.html
+++ b/algo_demo/selection-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Selection Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Selection Sort</span>

--- a/algo_demo/selection-sort.html
+++ b/algo_demo/selection-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/sliding-window.html
+++ b/algo_demo/sliding-window.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sliding Window - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Sliding Window</span>

--- a/algo_demo/sliding-window.html
+++ b/algo_demo/sliding-window.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/style.css
+++ b/algo_demo/style.css
@@ -142,13 +142,43 @@ a:hover { opacity: 0.6; }
 .nav-links a.active, .nav-links > a.active { color: var(--text); border-bottom-color: var(--text); }
 .nav-links a + a, .nav-links > a + a { border-left: 1px solid var(--border-strong); }
 
-.github-link {
-  text-decoration: none; color: var(--text-muted); display: inline-flex;
-  align-items: center; background: none; border: none; white-space: nowrap;
-  padding: 2px 10px; border-left: 1px solid var(--border-strong);
+/* ── "more" dropdown — secondary nav entries ─── */
+.nav-more { position: relative; display: inline-flex; align-items: center; }
+
+.nav-more-btn {
+  background: none; border: none; cursor: pointer;
+  font-family: inherit; font-size: inherit; color: var(--text-muted);
+  white-space: nowrap; padding: 2px 10px; margin: 0;
+  border-left: 1px solid var(--border-strong);
+  border-bottom: 1px solid transparent;
   transition: color 0.15s;
+  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
 }
-.github-link:hover { color: var(--text); opacity: 1; }
+.nav-more-btn:hover { color: var(--text); }
+.nav-more-btn.active { color: var(--text); border-bottom-color: var(--text); }
+.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
+.nav-more.open .nav-more-caret { transform: rotate(180deg); }
+
+.nav-more-menu {
+  display: none;
+  position: absolute; top: 100%; right: 0; z-index: 300;
+  min-width: 160px;
+  flex-direction: column; align-items: stretch;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+}
+.nav-more.open .nav-more-menu { display: flex; }
+
+.nav-links .nav-more-menu a,
+.nav-links .nav-more-menu > a {
+  display: flex; align-items: center;
+  width: 100%; padding: 10px 14px; min-height: 40px;
+  border-left: none; border-bottom: 1px solid var(--border);
+}
+.nav-links .nav-more-menu a + a { border-left: none; }
+.nav-links .nav-more-menu a:last-child { border-bottom: none; }
+.nav-links .nav-more-menu a:hover { background: var(--bg-alt); color: var(--text); }
+.nav-links .nav-more-menu a.active { color: var(--text); font-weight: 700; }
 
 .theme-toggle {
   background: var(--bg-alt); cursor: pointer; color: var(--text-muted);
@@ -167,7 +197,7 @@ a:hover { opacity: 0.6; }
 .nav-toggle span { display: block; width: 20px; height: 1px; background: var(--text); }
 
 /* Minimum touch target: 44x44px (Apple HIG) */
-.nav-links a, .nav-links > a, .github-link, .theme-toggle {
+.nav-links a, .nav-links > a, .nav-more-btn, .theme-toggle {
   min-height: 44px; display: inline-flex; align-items: center;
 }
 .nav-toggle { min-height: 44px; }
@@ -348,11 +378,23 @@ footer a:hover { color: var(--text); opacity: 1; }
   .nav-links a.active, .nav-links > a.active {
     background: var(--surface); border-bottom-color: var(--border); font-weight: 700;
   }
-  .github-link {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: 1px solid var(--border); border-left: none !important;
-    width: 100%; min-height: 52px; display: flex; align-items: center;
+  /* Dropdown flattens into an inline accordion inside the drawer */
+  .nav-more { display: block; width: 100%; position: static; }
+  .nav-more-btn {
+    padding: 14px 20px; font-size: 17px; width: 100%;
+    border-left: none !important; border-bottom: 1px solid var(--border);
+    min-height: 52px; justify-content: flex-start;
   }
+  .nav-more-menu {
+    position: static; min-width: 0; border: none;
+    background: var(--surface);
+  }
+  .nav-links .nav-more-menu a,
+  .nav-links .nav-more-menu > a {
+    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
+  }
+  .nav-links .nav-more-menu a:last-child { border-bottom: 1px solid var(--border); }
+
   .theme-toggle {
     padding: 14px 20px; font-size: 17px;
     border: none; width: 100%; min-height: 52px;

--- a/algo_demo/style.css
+++ b/algo_demo/style.css
@@ -1,6 +1,7 @@
 /* ── Terminal-Core Design System — Algorithm Visualizer ──────────────
-   Base tokens, typography and navbar mirror site/style.css so the
-   visualizer reads as part of the main CS_basics site. The --viz-*
+   Base tokens and typography mirror site/style.css so the visualizer
+   reads as part of the main CS_basics site; the navbar itself comes
+   from the shared site/nav.css. The --viz-*
    tokens add the semantic palette the canvases draw with; they are the
    ONLY colour source for visualizations (see VIZ in common.js).
    ──────────────────────────────────────────────────────────────────── */
@@ -110,97 +111,6 @@ p { margin-bottom: 16px; line-height: 1.6; }
 
 a { color: var(--text); text-decoration: underline; text-underline-offset: 3px; transition: opacity 0.15s; }
 a:hover { opacity: 0.6; }
-
-/* ── Navbar — mirrors the generated site navbar ─── */
-.navbar {
-  background: var(--bg);
-  border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 100;
-}
-.navbar .container {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 32px; max-width: 100%;
-}
-.nav-brand {
-  display: flex; align-items: center;
-  font-size: 18px; font-weight: 700; text-decoration: none; color: var(--text);
-  text-transform: uppercase; letter-spacing: 0.08em;
-  white-space: nowrap; flex-shrink: 0; margin-right: 24px;
-}
-.nav-title { font-size: 18px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
-
-.nav-links {
-  display: flex; align-items: center;
-  gap: 0; list-style: none; flex-wrap: nowrap; font-size: 18px;
-}
-.nav-links a, .nav-links > a {
-  color: var(--text-muted); text-decoration: none; white-space: nowrap;
-  padding: 2px 10px; border-bottom: 1px solid transparent;
-  transition: color 0.15s; display: inline-block;
-}
-.nav-links a:hover, .nav-links > a:hover { color: var(--text); opacity: 1; }
-.nav-links a.active, .nav-links > a.active { color: var(--text); border-bottom-color: var(--text); }
-.nav-links a + a, .nav-links > a + a { border-left: 1px solid var(--border-strong); }
-
-/* ── "more" dropdown — secondary nav entries ─── */
-.nav-more { position: relative; display: inline-flex; align-items: center; }
-
-.nav-more-btn {
-  background: none; border: none; cursor: pointer;
-  font-family: inherit; font-size: inherit; color: var(--text-muted);
-  white-space: nowrap; padding: 2px 10px; margin: 0;
-  border-left: 1px solid var(--border-strong);
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s;
-  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
-}
-.nav-more-btn:hover { color: var(--text); }
-.nav-more-btn.active { color: var(--text); border-bottom-color: var(--text); }
-.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
-.nav-more.open .nav-more-caret { transform: rotate(180deg); }
-
-.nav-more-menu {
-  display: none;
-  position: absolute; top: 100%; right: 0; z-index: 300;
-  min-width: 160px;
-  flex-direction: column; align-items: stretch;
-  background: var(--bg);
-  border: 1px solid var(--border-strong);
-}
-.nav-more.open .nav-more-menu { display: flex; }
-
-.nav-links .nav-more-menu a,
-.nav-links .nav-more-menu > a {
-  display: flex; align-items: center;
-  width: 100%; padding: 10px 14px; min-height: 40px;
-  border-left: none; border-bottom: 1px solid var(--border);
-}
-.nav-links .nav-more-menu a + a { border-left: none; }
-.nav-links .nav-more-menu a:last-child { border-bottom: none; }
-.nav-links .nav-more-menu a:hover { background: var(--bg-alt); color: var(--text); }
-.nav-links .nav-more-menu a.active { color: var(--text); font-weight: 700; }
-
-.theme-toggle {
-  background: var(--bg-alt); cursor: pointer; color: var(--text-muted);
-  font-family: inherit; font-size: 16px; padding: 6px 12px; margin: 0;
-  white-space: nowrap; border: 1px solid var(--border-strong);
-  transition: color 0.15s, background 0.15s;
-  text-transform: uppercase; letter-spacing: 0.05em;
-}
-[data-theme="dark"] .theme-toggle { background: var(--text); color: var(--bg); border-color: var(--text); }
-.theme-toggle:hover { color: var(--text); background: var(--bg-alt); }
-
-.nav-toggle {
-  display: none; flex-direction: column; gap: 5px;
-  background: none; border: none; cursor: pointer; padding: 4px; flex-shrink: 0;
-}
-.nav-toggle span { display: block; width: 20px; height: 1px; background: var(--text); }
-
-/* Minimum touch target: 44x44px (Apple HIG) */
-.nav-links a, .nav-links > a, .nav-more-btn, .theme-toggle {
-  min-height: 44px; display: inline-flex; align-items: center;
-}
-.nav-toggle { min-height: 44px; }
 
 /* ── Layout ─── */
 .container { max-width: 1100px; margin: 0 auto; padding: 0 32px; }
@@ -341,11 +251,6 @@ footer a:hover { color: var(--text); opacity: 1; }
 /* ── Responsive — tablet <=1024px ─── */
 @media (max-width: 1024px) {
   .container { padding: 0 24px; }
-  .navbar .container { padding: 10px 24px; }
-  .nav-links a, .nav-links > a { padding: 2px 8px; font-size: 16px; }
-  .nav-links { font-size: 16px; }
-  .nav-title { font-size: 16px; }
-  .nav-brand { font-size: 16px; margin-right: 16px; }
   .viz-wrapper { grid-template-columns: 1fr 260px; gap: 16px; }
 }
 
@@ -353,54 +258,6 @@ footer a:hover { color: var(--text); opacity: 1; }
 @media (max-width: 768px) {
   .container { padding: 0 16px; }
   main { padding: 24px 0; }
-
-  .nav-toggle { display: flex; }
-  .navbar .container { position: relative; padding: 0 16px; min-height: 52px; }
-  .nav-brand { font-size: 15px; margin-right: 0; }
-
-  .nav-links {
-    display: none;
-    position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
-    background: var(--bg);
-    border-top: 1px solid var(--border);
-    border-bottom: 2px solid var(--border-strong);
-    flex-direction: column; align-items: stretch; padding: 0; gap: 0;
-    overflow-y: auto; -webkit-overflow-scrolling: touch; max-height: 80vh;
-  }
-  .nav-links.open { display: flex; }
-  .nav-links a, .nav-links > a {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: 1px solid var(--border); border-left: none !important;
-    border-right: none; width: 100%; min-height: 52px;
-    display: flex; align-items: center;
-  }
-  .nav-links a + a, .nav-links > a + a { border-left: none !important; }
-  .nav-links a.active, .nav-links > a.active {
-    background: var(--surface); border-bottom-color: var(--border); font-weight: 700;
-  }
-  /* Dropdown flattens into an inline accordion inside the drawer */
-  .nav-more { display: block; width: 100%; position: static; }
-  .nav-more-btn {
-    padding: 14px 20px; font-size: 17px; width: 100%;
-    border-left: none !important; border-bottom: 1px solid var(--border);
-    min-height: 52px; justify-content: flex-start;
-  }
-  .nav-more-menu {
-    position: static; min-width: 0; border: none;
-    background: var(--surface);
-  }
-  .nav-links .nav-more-menu a,
-  .nav-links .nav-more-menu > a {
-    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
-  }
-  .nav-links .nav-more-menu a:last-child { border-bottom: 1px solid var(--border); }
-
-  .theme-toggle {
-    padding: 14px 20px; font-size: 17px;
-    border: none; width: 100%; min-height: 52px;
-    display: flex; align-items: center; justify-content: flex-start;
-    background: var(--surface);
-  }
 
   h1 { font-size: 24px; }
   .page-header h1 { font-size: 22px; }
@@ -420,13 +277,13 @@ footer a:hover { color: var(--text); opacity: 1; }
 
 /* ── iOS safe-area insets ─── */
 @supports (padding: env(safe-area-inset-left)) {
-  .navbar .container, .container {
+  .container {
     padding-left: max(32px, env(safe-area-inset-left));
     padding-right: max(32px, env(safe-area-inset-right));
   }
   footer .container { padding-bottom: max(24px, env(safe-area-inset-bottom)); }
   @media (max-width: 768px) {
-    .navbar .container, .container {
+    .container {
       padding-left: max(16px, env(safe-area-inset-left));
       padding-right: max(16px, env(safe-area-inset-right));
     }
@@ -435,7 +292,8 @@ footer a:hover { color: var(--text); opacity: 1; }
 
 /* ── Print ─── */
 @media print {
-  .navbar, footer, .nav-toggle, .viz-controls { display: none !important; }
+  /* .navbar / .nav-toggle are hidden by nav.css */
+  footer, .viz-controls { display: none !important; }
   body { font-size: 11pt; color: #000; background: #fff; }
   main { padding: 0; }
   .viz-wrapper { grid-template-columns: 1fr; }

--- a/algo_demo/topological-sort.html
+++ b/algo_demo/topological-sort.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Topological Sort - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Topological Sort</span>

--- a/algo_demo/topological-sort.html
+++ b/algo_demo/topological-sort.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/two-pointers.html
+++ b/algo_demo/two-pointers.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Two Pointers - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Two Pointers</span>

--- a/algo_demo/two-pointers.html
+++ b/algo_demo/two-pointers.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/algo_demo/union-find.html
+++ b/algo_demo/union-find.html
@@ -4,40 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Union-Find - Algorithm Visualizer</title>
+  <link rel="stylesheet" href="../nav.css">
   <link rel="stylesheet" href="style.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="../nav.js"></script>
   <script src="common.js"></script>
 </head>
 <body>
-  <nav class="navbar">
-    <div class="container">
-      <a href="../index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links" id="nav-links">
-        <a href="../index.html">home</a>
-        <a href="../search.html">search</a>
-        <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../faqs.html">faqs</a>
-        <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-random-picker.html">random</a>
-        <a href="index.html" class="active">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
-          <div class="nav-more-menu">
-            <a href="../patterns.html">patterns</a>
-            <a href="../lc-similar.html">similar</a>
-            <a href="../lc-review-plan.html">review</a>
-            <a href="../resources.html">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="visualizer" data-base="../"></div>
+  <script>CSNav.mount();</script>
   <main class="container">
     <div class="breadcrumbs">
       <a href="../index.html">home</a><span class="sep">/</span><a href="index.html">visualizer</a><span class="sep">/</span><span class="current">Union-Find</span>

--- a/algo_demo/union-find.html
+++ b/algo_demo/union-find.html
@@ -20,15 +20,21 @@
         <a href="../index.html">home</a>
         <a href="../search.html">search</a>
         <a href="../cheatsheets.html">cheatsheets</a>
-        <a href="../patterns.html">patterns</a>
         <a href="../faqs.html">faqs</a>
         <a href="../lc-explorer.html">lc-explorer</a>
-        <a href="../lc-similar.html">similar</a>
         <a href="../lc-random-picker.html">random</a>
-        <a href="../lc-review-plan.html">review</a>
         <a href="index.html" class="active">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">&#9662;</span></button>
+          <div class="nav-more-menu">
+            <a href="../patterns.html">patterns</a>
+            <a href="../lc-similar.html">similar</a>
+            <a href="../lc-review-plan.html">review</a>
+            <a href="../resources.html">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#9728; light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/data/progress.txt
+++ b/data/progress.txt
@@ -1,4 +1,4 @@
-20260810: 128(todo),253(todo),2021(todo),3092(todo),173(todo),298(todo),112(todo),108(todo),297(todo),536(todo)
+20260810: 128(again),253(todo),2021(todo),3092(todo),173(todo),298(todo),112(todo),108(todo),297(todo),536(todo)
 20260809: 88(again),343(again!),1943(todo),341(todo),772(todo),must_lc_list,4007(again, todo: add note),4008(ok, but again, todo: add note)
 20260808: 622(again),647(dp again),791(ok),953(again),253(ok),1740(again!!, 3 get_dist),3994(again),652(ok)
 20260807: 680(again),696(again),3092(again!!),5(ok),161(again),263(ok),264(again)

--- a/leetcode_python/Sort/longest-consecutive-sequence.py
+++ b/leetcode_python/Sort/longest-consecutive-sequence.py
@@ -76,6 +76,69 @@ class Solution(object):
         return max_len
 
 
+# V0-0-1
+# IDEA: SET + ONLY loop nums and check existed (GEMINI)
+class Solution(object):
+    def longestConsecutive(self, nums):
+        """
+        :type nums: List[int]
+        :rtype: int
+        """
+        if not nums:
+            return 0
+
+        num_set = set(nums)
+        max_len = 0
+
+        for x in num_set:
+            # ONLY start counting if 'x' is the start of a sequence.
+            # We know it's the start if 'x - 1' is NOT in our set!
+            if (x - 1) not in num_set:
+                current_num = x
+                current_len = 1
+
+                # Now check how high this specific sequence goes
+                while (current_num + 1) in num_set:
+                    current_num += 1
+                    current_len += 1
+
+                # Update max length found so far
+                max_len = max(max_len, current_len)
+
+        return max_len
+
+
+# V0-0-0-1
+# IDEA: SET + ONLY loop nums and check existed (GPT)
+class Solution(object):
+    def longestConsecutive(self, nums):
+        # edge cases
+        if not nums:
+            return 0
+
+        if len(nums) == 1:
+            return 1
+
+        _set = set(nums)
+
+        if len(_set) == 1:
+            return 1
+
+        max_len = 1
+
+        for x in _set:
+            # x is the beginning of a sequence
+            if x - 1 not in _set:
+                _len = 1
+
+                while x + _len in _set:
+                    _len += 1
+
+                max_len = max(max_len, _len)
+
+        return max_len
+
+
 # V0-1
 # IDEA: SET + ONLY loop nums and check existed (GPT)
 # time = O(n)

--- a/site/build-site.js
+++ b/site/build-site.js
@@ -331,10 +331,6 @@ if (fs.existsSync(faqDir)) {
 
 // ── HTML template ─────────────────────────────────────────────────────────────
 
-// Secondary nav entries live behind the "more" dropdown; the button lights up
-// when the current page is one of them, so the trail is not lost when collapsed.
-const MORE_PAGES = ['patterns', 'lc-similar', 'lc-review-plan', 'resources'];
-
 const htmlTemplate = (title, bodyContent, currentPage = 'home', basePath = '') => `
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -348,108 +344,17 @@ const htmlTemplate = (title, bodyContent, currentPage = 'home', basePath = '') =
   <title>${title} — CS_basics</title>
   <meta name="description" content="Computer Science fundamentals: algorithms, data structures, system design, and LeetCode solutions">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='white'>$</text></svg>">
+  <link rel="stylesheet" href="${basePath}nav.css">
   <link rel="stylesheet" href="${basePath}style.css">
   <link rel="stylesheet" href="${basePath}vendor/highlight/atom-one-dark.min.css">
-  <script>
-  (function() {
-    var saved = localStorage.getItem('theme') || 'dark';
-    document.documentElement.setAttribute('data-theme', saved);
-  })();
-  </script>
-  <script>
-  function copyCode(btn) {
-    var pre = btn.closest('.code-block-wrapper').querySelector('pre');
-    var text = pre ? pre.innerText : '';
-    navigator.clipboard.writeText(text).then(function() {
-      btn.textContent = 'copied';
-      btn.classList.add('copied');
-      setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-  </script>
-  <script>document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('table').forEach(function(table) {
-      if (!table.parentElement.classList.contains('table-wrap')) {
-        var wrapper = document.createElement('div');
-        wrapper.className = 'table-wrap';
-        table.parentNode.insertBefore(wrapper, table);
-        wrapper.appendChild(table);
-      }
-    });
-    var progressBar = document.getElementById('reading-progress');
-    if (progressBar) {
-      window.addEventListener('scroll', function() {
-        var winScroll = document.documentElement.scrollTop;
-        var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        progressBar.style.width = height > 0 ? (winScroll / height * 100) + '%' : '0%';
-      });
-    }
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      var updateLabel = function() {
-        toggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀ light' : '● dark';
-      };
-      updateLabel();
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        var next = isDark ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-        updateLabel();
-      });
-    }
-    var more = document.querySelector('.nav-more');
-    if (more) {
-      var moreBtn = more.querySelector('.nav-more-btn');
-      var setOpen = function(open) {
-        more.classList.toggle('open', open);
-        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      moreBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        setOpen(!more.classList.contains('open'));
-      });
-      document.addEventListener('click', function(e) {
-        if (!more.contains(e.target)) setOpen(false);
-      });
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') setOpen(false);
-      });
-    }
-  });</script>
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="${basePath}nav.js"></script>
+  <script src="${basePath}site.js"></script>
 </head>
 <body>
   <div class="progress-container"><div class="progress-bar" id="reading-progress"></div></div>
-  <nav class="navbar">
-    <div class="container">
-      <a href="${basePath}index.html" class="nav-brand">
-        <span class="nav-title">CS_basics</span>
-      </a>
-      <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Toggle menu">
-        <span></span><span></span><span></span>
-      </button>
-      <div class="nav-links">
-        <a href="${basePath}index.html" class="${currentPage === 'home' ? 'active' : ''}">home</a>
-        <a href="${basePath}search.html" class="${currentPage === 'search' ? 'active' : ''}">search</a>
-        <a href="${basePath}cheatsheets.html" class="${currentPage === 'cheatsheets' ? 'active' : ''}">cheatsheets</a>
-        <a href="${basePath}faqs.html" class="${currentPage === 'faqs' ? 'active' : ''}">faqs</a>
-        <a href="${basePath}lc-explorer.html" class="${currentPage === 'lc-explorer' ? 'active' : ''}">lc-explorer</a>
-        <a href="${basePath}lc-random-picker.html" class="${currentPage === 'lc-random-picker' ? 'active' : ''}">random</a>
-        <a href="${basePath}algo_demo/index.html" class="${currentPage === 'visualizer' ? 'active' : ''}">visualizer</a>
-        <div class="nav-more">
-          <button type="button" class="nav-more-btn${MORE_PAGES.includes(currentPage) ? ' active' : ''}" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
-          <div class="nav-more-menu">
-            <a href="${basePath}patterns.html" class="${currentPage === 'patterns' ? 'active' : ''}">patterns</a>
-            <a href="${basePath}lc-similar.html" class="${currentPage === 'lc-similar' ? 'active' : ''}">similar</a>
-            <a href="${basePath}lc-review-plan.html" class="${currentPage === 'lc-review-plan' ? 'active' : ''}">review</a>
-            <a href="${basePath}resources.html" class="${currentPage === 'resources' ? 'active' : ''}">resources</a>
-            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
-          </div>
-        </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-      </div>
-    </div>
-  </nav>
+  <div id="site-nav" data-page="${currentPage}" data-base="${basePath}"></div>
+  <script>CSNav.mount();</script>
 
   <main class="container">
     <div class="content">

--- a/site/build-site.js
+++ b/site/build-site.js
@@ -331,6 +331,10 @@ if (fs.existsSync(faqDir)) {
 
 // ── HTML template ─────────────────────────────────────────────────────────────
 
+// Secondary nav entries live behind the "more" dropdown; the button lights up
+// when the current page is one of them, so the trail is not lost when collapsed.
+const MORE_PAGES = ['patterns', 'lc-similar', 'lc-review-plan', 'resources'];
+
 const htmlTemplate = (title, bodyContent, currentPage = 'home', basePath = '') => `
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -394,6 +398,24 @@ const htmlTemplate = (title, bodyContent, currentPage = 'home', basePath = '') =
         updateLabel();
       });
     }
+    var more = document.querySelector('.nav-more');
+    if (more) {
+      var moreBtn = more.querySelector('.nav-more-btn');
+      var setOpen = function(open) {
+        more.classList.toggle('open', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      };
+      moreBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setOpen(!more.classList.contains('open'));
+      });
+      document.addEventListener('click', function(e) {
+        if (!more.contains(e.target)) setOpen(false);
+      });
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') setOpen(false);
+      });
+    }
   });</script>
 </head>
 <body>
@@ -410,15 +432,21 @@ const htmlTemplate = (title, bodyContent, currentPage = 'home', basePath = '') =
         <a href="${basePath}index.html" class="${currentPage === 'home' ? 'active' : ''}">home</a>
         <a href="${basePath}search.html" class="${currentPage === 'search' ? 'active' : ''}">search</a>
         <a href="${basePath}cheatsheets.html" class="${currentPage === 'cheatsheets' ? 'active' : ''}">cheatsheets</a>
-        <a href="${basePath}patterns.html" class="${currentPage === 'patterns' ? 'active' : ''}">patterns</a>
         <a href="${basePath}faqs.html" class="${currentPage === 'faqs' ? 'active' : ''}">faqs</a>
         <a href="${basePath}lc-explorer.html" class="${currentPage === 'lc-explorer' ? 'active' : ''}">lc-explorer</a>
-        <a href="${basePath}lc-similar.html" class="${currentPage === 'lc-similar' ? 'active' : ''}">similar</a>
         <a href="${basePath}lc-random-picker.html" class="${currentPage === 'lc-random-picker' ? 'active' : ''}">random</a>
-        <a href="${basePath}lc-review-plan.html" class="${currentPage === 'lc-review-plan' ? 'active' : ''}">review</a>
         <a href="${basePath}algo_demo/index.html" class="${currentPage === 'visualizer' ? 'active' : ''}">visualizer</a>
+        <div class="nav-more">
+          <button type="button" class="nav-more-btn${MORE_PAGES.includes(currentPage) ? ' active' : ''}" aria-haspopup="true" aria-expanded="false">more <span class="nav-more-caret">▾</span></button>
+          <div class="nav-more-menu">
+            <a href="${basePath}patterns.html" class="${currentPage === 'patterns' ? 'active' : ''}">patterns</a>
+            <a href="${basePath}lc-similar.html" class="${currentPage === 'lc-similar' ? 'active' : ''}">similar</a>
+            <a href="${basePath}lc-review-plan.html" class="${currentPage === 'lc-review-plan' ? 'active' : ''}">review</a>
+            <a href="${basePath}resources.html" class="${currentPage === 'resources' ? 'active' : ''}">resources</a>
+            <a href="https://github.com/yennanliu/CS_basics" target="_blank" rel="noopener">github</a>
+          </div>
+        </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">☀ light</button>
-        <a href="https://github.com/yennanliu/CS_basics" target="_blank" class="github-link" aria-label="GitHub">github</a>
       </div>
     </div>
   </nav>

--- a/site/nav.css
+++ b/site/nav.css
@@ -1,0 +1,211 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — shared navbar styles
+
+   Companion to nav.js: every page family loads this same file, so the bar
+   looks identical whether it sits on a generated doc page, a visualizer page
+   or one of the hand-maintained LeetCode tools.
+
+   Those page families each grew their own colour tokens, so the navbar reads
+   them through a small set of local aliases with fallbacks rather than
+   depending on any single naming scheme. A page only has to define --bg,
+   --text and --border for the bar to render correctly.
+   ───────────────────────────────────────────────────────────────────────── */
+
+.navbar {
+  --nav-bg:          var(--bg, #ffffff);
+  --nav-ink:         var(--text-muted, var(--text-light, var(--muted, #555555)));
+  --nav-ink-active:  var(--text, #000000);
+  --nav-line:        var(--border, #cccccc);
+  --nav-line-strong: var(--border-strong, var(--border-s, var(--border, #888888)));
+  --nav-surface:     var(--surface, var(--bg-alt, #f0f0f0));
+  --nav-hover-bg:    var(--bg-alt, var(--surface, #f5f5f5));
+
+  background: var(--nav-bg);
+  border-bottom: 1px solid var(--nav-line);
+  position: sticky; top: 0; z-index: 100;
+}
+
+.navbar .nav-inner {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 10px 32px;
+  max-width: 100%;
+}
+
+.nav-brand {
+  display: flex; align-items: center;
+  font-size: 18px; font-weight: 700; text-decoration: none;
+  color: var(--nav-ink-active);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  white-space: nowrap; flex-shrink: 0; margin-right: 24px;
+}
+.nav-brand:hover { opacity: 1; }
+.nav-title { font-size: 18px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+
+/* Right-side nav: all entries in one flex row */
+.nav-links {
+  display: flex; align-items: center;
+  gap: 0; list-style: none; flex-wrap: nowrap;
+  font-size: 18px;
+}
+
+.nav-links a {
+  color: var(--nav-ink);
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 2px 10px;
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s;
+  display: inline-flex; align-items: center;
+  min-height: 44px; /* Apple HIG minimum touch target */
+}
+.nav-links a:hover { color: var(--nav-ink-active); opacity: 1; }
+.nav-links a.active { color: var(--nav-ink-active); border-bottom-color: var(--nav-ink-active); }
+
+/* Separator: a rule BEFORE each entry except the first */
+.nav-links > a + a { border-left: 1px solid var(--nav-line-strong); }
+
+/* ── "more" dropdown — secondary entries ─── */
+.nav-more { position: relative; display: inline-flex; align-items: center; }
+
+.nav-more-btn {
+  background: none; border: none; cursor: pointer;
+  font-family: inherit; font-size: inherit; color: var(--nav-ink);
+  white-space: nowrap; padding: 2px 10px; margin: 0;
+  border-left: 1px solid var(--nav-line-strong);
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s;
+  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
+}
+.nav-more-btn:hover { color: var(--nav-ink-active); }
+.nav-more-btn.active { color: var(--nav-ink-active); border-bottom-color: var(--nav-ink-active); }
+.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
+.nav-more.open .nav-more-caret { transform: rotate(180deg); }
+
+.nav-more-menu {
+  display: none;
+  position: absolute; top: 100%; right: 0; z-index: 300;
+  min-width: 160px;
+  flex-direction: column; align-items: stretch;
+  background: var(--nav-bg);
+  border: 1px solid var(--nav-line-strong);
+}
+.nav-more.open .nav-more-menu { display: flex; }
+
+.nav-links .nav-more-menu a {
+  display: flex; align-items: center;
+  width: 100%; padding: 10px 14px; min-height: 40px;
+  border-left: none; border-bottom: 1px solid var(--nav-line);
+}
+.nav-links .nav-more-menu a:last-child { border-bottom: none; }
+.nav-links .nav-more-menu a:hover { background: var(--nav-hover-bg); color: var(--nav-ink-active); }
+.nav-links .nav-more-menu a.active { color: var(--nav-ink-active); font-weight: 700; }
+
+/* ── Theme toggle ─── */
+.theme-toggle {
+  background: var(--nav-hover-bg); cursor: pointer; color: var(--nav-ink);
+  font-family: inherit; font-size: 16px; padding: 6px 12px; margin: 0;
+  white-space: nowrap; border: 1px solid var(--nav-line-strong);
+  transition: color 0.15s, background 0.15s;
+  text-transform: uppercase; letter-spacing: 0.05em;
+  display: inline-flex; align-items: center; min-height: 44px;
+}
+[data-theme="dark"] .theme-toggle {
+  background: var(--nav-ink-active); color: var(--nav-bg); border-color: var(--nav-ink-active);
+}
+.theme-toggle:hover { color: var(--nav-ink-active); background: var(--nav-hover-bg); }
+
+/* ── Hamburger — hidden on desktop ─── */
+.nav-toggle {
+  display: none; flex-direction: column; gap: 5px;
+  background: none; border: none; cursor: pointer; padding: 4px;
+  flex-shrink: 0; min-height: 44px;
+}
+.nav-toggle span { display: block; width: 20px; height: 1px; background: var(--nav-ink-active); }
+
+/* ═══════════════════════════════════════════════════════
+   Tablet ≤1024px — tighten before anything has to wrap
+   ═══════════════════════════════════════════════════════ */
+@media (max-width: 1024px) {
+  .navbar .nav-inner { padding: 10px 24px; }
+  .nav-links { font-size: 16px; }
+  .nav-links a { padding: 2px 8px; }
+  .nav-title { font-size: 16px; }
+  .nav-brand { font-size: 16px; margin-right: 16px; }
+}
+
+/* ═══════════════════════════════════════════════════════
+   Mobile ≤768px — bar collapses into a hamburger drawer
+   ═══════════════════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .nav-toggle { display: flex; }
+  .navbar .nav-inner { position: relative; padding: 0 16px; min-height: 52px; }
+  .nav-brand { font-size: 15px; margin-right: 0; }
+
+  .nav-links {
+    display: none;
+    position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
+    background: var(--nav-bg);
+    border-top: 1px solid var(--nav-line);
+    border-bottom: 2px solid var(--nav-line-strong);
+    flex-direction: column; align-items: stretch;
+    padding: 0; gap: 0;
+    /* iOS momentum scroll inside the drawer */
+    overflow-y: auto; -webkit-overflow-scrolling: touch;
+    max-height: 80vh;
+  }
+  .nav-links.open { display: flex; }
+
+  .nav-links a {
+    padding: 14px 20px; font-size: 17px;
+    border-bottom: 1px solid var(--nav-line); border-left: none;
+    border-right: none; width: 100%; min-height: 52px;
+  }
+  .nav-links > a + a { border-left: none; }
+  .nav-links a.active { background: var(--nav-surface); border-bottom-color: var(--nav-line); font-weight: 700; }
+
+  /* Dropdown flattens into an indented accordion inside the drawer */
+  .nav-more { display: block; width: 100%; position: static; }
+  .nav-more-btn {
+    padding: 14px 20px; font-size: 17px; width: 100%;
+    border-left: none; border-bottom: 1px solid var(--nav-line);
+    min-height: 52px; justify-content: flex-start;
+  }
+  .nav-more-menu {
+    position: static; min-width: 0; border: none;
+    background: var(--nav-surface);
+  }
+  .nav-links .nav-more-menu a {
+    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
+    border-bottom: 1px solid var(--nav-line);
+  }
+
+  .theme-toggle {
+    padding: 14px 20px; font-size: 17px;
+    border: none; width: 100%; min-height: 52px;
+    justify-content: flex-start;
+    background: var(--nav-surface);
+  }
+}
+
+@media (max-width: 360px) {
+  .navbar .nav-inner { padding: 0 12px; }
+}
+
+/* iOS safe-area insets (notch / home indicator) */
+@supports (padding: env(safe-area-inset-left)) {
+  .navbar .nav-inner {
+    padding-left: max(32px, env(safe-area-inset-left));
+    padding-right: max(32px, env(safe-area-inset-right));
+  }
+  @media (max-width: 768px) {
+    .navbar .nav-inner {
+      padding-left: max(16px, env(safe-area-inset-left));
+      padding-right: max(16px, env(safe-area-inset-right));
+    }
+  }
+}
+
+@media print {
+  .navbar, .nav-toggle { display: none !important; }
+}

--- a/site/nav.js
+++ b/site/nav.js
@@ -1,0 +1,245 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — shared navbar
+
+   The single source of truth for the site navigation: the entry list, the
+   markup, and the behaviour (theme toggle, mobile drawer, "more" dropdown).
+   Every page family loads this same file, so adding a nav entry is a one-line
+   change here rather than an edit across four hand-maintained copies:
+
+     - generated doc pages   (site/build-site.js emits the placeholder)
+     - algo_demo/*.html      (visualizer pages)
+     - _site/lc-*.html       (hand-maintained LeetCode tools)
+
+   Usage — load in <head> so the stored theme lands before first paint, then
+   drop a placeholder where the navbar belongs and mount it synchronously:
+
+     <head> <script src="nav.js"></script> </head>
+     <body>
+       <div id="site-nav" data-page="cheatsheets" data-base="../"></div>
+       <script>CSNav.mount();</script>
+
+   `data-page` is an entry id (see PRIMARY/MORE below) and marks it active;
+   `data-base` is the prefix that gets a page back to the site root.
+   ───────────────────────────────────────────────────────────────────────── */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.CSNav = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  var THEME_KEY = 'theme';
+  var DEFAULT_THEME = 'dark';
+  // Fired on `document` after every theme change. Pages that paint their own
+  // colours (canvas visualizations, SVG charts) listen for this to repaint.
+  var THEME_EVENT = 'cs:themechange';
+
+  // Entries rendered inline in the bar.
+  var PRIMARY = [
+    { id: 'home',             label: 'home',        href: 'index.html' },
+    { id: 'search',           label: 'search',      href: 'search.html' },
+    { id: 'cheatsheets',      label: 'cheatsheets', href: 'cheatsheets.html' },
+    { id: 'faqs',             label: 'faqs',        href: 'faqs.html' },
+    { id: 'lc-explorer',      label: 'lc-explorer', href: 'lc-explorer.html' },
+    { id: 'lc-random-picker', label: 'random',      href: 'lc-random-picker.html' },
+    { id: 'visualizer',       label: 'visualizer',  href: 'algo_demo/index.html' }
+  ];
+
+  // Secondary entries, collapsed behind the "more" dropdown. The button lights
+  // up when the current page is one of them, so the trail survives collapsing.
+  var MORE = [
+    { id: 'patterns',       label: 'patterns',  href: 'patterns.html' },
+    { id: 'lc-similar',     label: 'similar',   href: 'lc-similar.html' },
+    { id: 'lc-review-plan', label: 'review',    href: 'lc-review-plan.html' },
+    { id: 'resources',      label: 'resources', href: 'resources.html' },
+    { id: 'github',         label: 'github',    href: 'https://github.com/yennanliu/CS_basics', external: true }
+  ];
+
+  // ── Markup ──────────────────────────────────────────────────────────────
+
+  function esc(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function hrefFor(item, basePath) {
+    return item.external ? item.href : (basePath || '') + item.href;
+  }
+
+  function isMoreEntry(id) {
+    for (var i = 0; i < MORE.length; i++) if (MORE[i].id === id) return true;
+    return false;
+  }
+
+  function linkHTML(item, currentPage, basePath) {
+    var attrs = ' href="' + esc(hrefFor(item, basePath)) + '"';
+    if (item.external) attrs += ' target="_blank" rel="noopener"';
+    if (item.id === currentPage) attrs += ' class="active"';
+    return '<a' + attrs + '>' + esc(item.label) + '</a>';
+  }
+
+  function navHTML(options) {
+    options = options || {};
+    var currentPage = options.currentPage || '';
+    var basePath = options.basePath || '';
+    var links = function (item) { return linkHTML(item, currentPage, basePath); };
+
+    return '<nav class="navbar">' +
+      '<div class="nav-inner">' +
+        '<a href="' + esc(basePath + 'index.html') + '" class="nav-brand">' +
+          '<span class="nav-title">CS_basics</span>' +
+        '</a>' +
+        '<button type="button" class="nav-toggle" aria-label="Toggle menu" ' +
+          'aria-controls="nav-links" aria-expanded="false">' +
+          '<span></span><span></span><span></span>' +
+        '</button>' +
+        '<div class="nav-links" id="nav-links">' +
+          PRIMARY.map(links).join('') +
+          '<div class="nav-more">' +
+            '<button type="button" class="nav-more-btn' +
+              (isMoreEntry(currentPage) ? ' active' : '') + '" ' +
+              'aria-haspopup="true" aria-expanded="false">' +
+              'more <span class="nav-more-caret">▾</span>' +
+            '</button>' +
+            '<div class="nav-more-menu">' + MORE.map(links).join('') + '</div>' +
+          '</div>' +
+          '<button type="button" id="theme-toggle" class="theme-toggle" ' +
+            'aria-label="Toggle theme">' + esc(themeLabel(DEFAULT_THEME)) + '</button>' +
+        '</div>' +
+      '</div>' +
+    '</nav>';
+  }
+
+  // ── Theme ───────────────────────────────────────────────────────────────
+
+  // Wrapped because Safari's private mode throws on localStorage access
+  // rather than returning null, which would otherwise break the whole navbar.
+  function storedTheme() {
+    try {
+      return (typeof localStorage !== 'undefined' && localStorage.getItem(THEME_KEY)) || DEFAULT_THEME;
+    } catch (e) {
+      return DEFAULT_THEME;
+    }
+  }
+
+  function persistTheme(theme) {
+    try {
+      if (typeof localStorage !== 'undefined') localStorage.setItem(THEME_KEY, theme);
+    } catch (e) { /* storage unavailable — theme still applies for this page */ }
+  }
+
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-theme') || DEFAULT_THEME;
+  }
+
+  // The label names the theme you would switch TO, not the one you are in.
+  function themeLabel(theme) {
+    return theme === 'dark' ? '☀ light' : '● dark';
+  }
+
+  function syncThemeLabel() {
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.textContent = themeLabel(currentTheme());
+  }
+
+  // Called at load, before <body> is parsed, so no flash of the wrong theme.
+  function applyStoredTheme() {
+    document.documentElement.setAttribute('data-theme', storedTheme());
+  }
+
+  function setTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    persistTheme(theme);
+    syncThemeLabel();
+    if (typeof CustomEvent === 'function') {
+      document.dispatchEvent(new CustomEvent(THEME_EVENT, { detail: { theme: theme } }));
+    }
+  }
+
+  function toggleTheme() {
+    setTheme(currentTheme() === 'dark' ? 'light' : 'dark');
+  }
+
+  // ── Behaviour ───────────────────────────────────────────────────────────
+
+  function initTheme() {
+    applyStoredTheme();
+    syncThemeLabel();
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.addEventListener('click', toggleTheme);
+  }
+
+  // Bound here rather than inline so aria-expanded stays in step with the
+  // drawer — a screen reader otherwise cannot tell whether it is open.
+  function initNavToggle(scope) {
+    scope = scope || document;
+    var btn = scope.querySelector('.nav-toggle');
+    var links = scope.querySelector('.nav-links');
+    if (!btn || !links) return;
+    btn.addEventListener('click', function () {
+      var open = links.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
+
+  function initNavMore(scope) {
+    scope = scope || document;
+    var more = scope.querySelector('.nav-more');
+    if (!more) return;
+    var btn = more.querySelector('.nav-more-btn');
+    if (!btn) return;
+
+    var setOpen = function (open) {
+      more.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    };
+
+    btn.addEventListener('click', function () {
+      setOpen(!more.classList.contains('open'));
+    });
+    document.addEventListener('click', function (event) {
+      if (!more.contains(event.target)) setOpen(false);
+    });
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') setOpen(false);
+    });
+  }
+
+  // Renders the navbar into `#site-nav` (or the given element) and wires it up.
+  function mount(target) {
+    var host = target || document.getElementById('site-nav');
+    if (!host) return null;
+    host.innerHTML = navHTML({
+      currentPage: host.getAttribute('data-page') || '',
+      basePath: host.getAttribute('data-base') || ''
+    });
+    initTheme();
+    initNavToggle(host);
+    initNavMore(host);
+    return host;
+  }
+
+  if (typeof document !== 'undefined' && document.documentElement) applyStoredTheme();
+
+  return {
+    PRIMARY: PRIMARY,
+    MORE: MORE,
+    THEME_EVENT: THEME_EVENT,
+    esc: esc,
+    hrefFor: hrefFor,
+    isMoreEntry: isMoreEntry,
+    navHTML: navHTML,
+    themeLabel: themeLabel,
+    storedTheme: storedTheme,
+    currentTheme: currentTheme,
+    applyStoredTheme: applyStoredTheme,
+    setTheme: setTheme,
+    toggleTheme: toggleTheme,
+    initTheme: initTheme,
+    initNavToggle: initNavToggle,
+    initNavMore: initNavMore,
+    mount: mount
+  };
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,6 +11,213 @@
         "highlight.js": "^11.9.0",
         "markdown-it": "^14.0.0",
         "markdown-it-anchor": "^9.0.1"
+      },
+      "devDependencies": {
+        "jsdom": "^30.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/linkify-it": {
@@ -44,6 +251,66 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -65,6 +332,67 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -72,6 +400,16 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/markdown-it": {
@@ -101,11 +439,54 @@
         "markdown-it": "*"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
@@ -116,10 +497,171 @@
         "node": ">=6"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     }
   }

--- a/site/package.json
+++ b/site/package.json
@@ -7,5 +7,11 @@
     "highlight.js": "^11.9.0",
     "markdown-it": "^14.0.0",
     "markdown-it-anchor": "^9.0.1"
+  },
+  "devDependencies": {
+    "jsdom": "^30.0.1"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
   }
 }

--- a/site/site.js
+++ b/site/site.js
@@ -1,0 +1,82 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — shared page behaviour for generated doc pages
+
+   Content-level behaviour that used to be inlined into every generated page
+   by site/build-site.js: copy-to-clipboard on code blocks, horizontal scroll
+   wrappers around wide tables, and the reading progress bar.
+
+   Navbar behaviour lives in nav.js, not here.
+   ───────────────────────────────────────────────────────────────────────── */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.CSSite = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // Called from the inline onclick that build-site.js emits on each copy
+  // button, so it has to reach the page as a global (see the export below).
+  function copyCode(btn) {
+    var wrapper = btn.closest('.code-block-wrapper');
+    var pre = wrapper ? wrapper.querySelector('pre') : null;
+    var text = pre ? pre.innerText : '';
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(text).then(function () {
+      btn.textContent = 'copied';
+      btn.classList.add('copied');
+      setTimeout(function () {
+        btn.textContent = 'copy';
+        btn.classList.remove('copied');
+      }, 2000);
+    });
+  }
+
+  // Markdown tables are emitted bare; wrapping them lets a wide table scroll
+  // inside its own box instead of forcing the whole page sideways.
+  function wrapTables(scope) {
+    scope = scope || document;
+    var tables = scope.querySelectorAll('table');
+    for (var i = 0; i < tables.length; i++) {
+      var table = tables[i];
+      if (table.parentElement && table.parentElement.classList.contains('table-wrap')) continue;
+      var wrapper = document.createElement('div');
+      wrapper.className = 'table-wrap';
+      table.parentNode.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
+    }
+    return tables.length;
+  }
+
+  function readingProgress(doc) {
+    doc = doc || document.documentElement;
+    var height = doc.scrollHeight - doc.clientHeight;
+    return height > 0 ? (doc.scrollTop / height) * 100 : 0;
+  }
+
+  function initReadingProgress() {
+    var bar = document.getElementById('reading-progress');
+    if (!bar) return;
+    var update = function () { bar.style.width = readingProgress() + '%'; };
+    window.addEventListener('scroll', update);
+    update();
+  }
+
+  function init() {
+    wrapTables(document);
+    initReadingProgress();
+  }
+
+  if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('DOMContentLoaded', init);
+    // The copy buttons are wired with inline onclick attributes, which resolve
+    // against the global scope rather than this module.
+    if (typeof self !== 'undefined') self.copyCode = copyCode;
+  }
+
+  return {
+    copyCode: copyCode,
+    wrapTables: wrapTables,
+    readingProgress: readingProgress,
+    initReadingProgress: initReadingProgress,
+    init: init
+  };
+});

--- a/site/style.css
+++ b/site/style.css
@@ -72,116 +72,6 @@ a:hover { opacity: 0.6; }
 }
 .progress-bar { height: 100%; width: 0%; background: var(--text); transition: width 0.1s; }
 
-/* ── Navbar ─── */
-.navbar {
-  background: var(--bg);
-  border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 100;
-}
-
-.navbar .container {
-  display: flex; align-items: center;
-  justify-content: space-between;
-  padding: 10px 32px;
-  max-width: 100%;
-}
-
-.nav-brand {
-  display: flex; align-items: center;
-  font-size: 18px; font-weight: 700; text-decoration: none; color: var(--text);
-  text-transform: uppercase; letter-spacing: 0.08em;
-  white-space: nowrap; flex-shrink: 0; margin-right: 24px;
-}
-
-.nav-icon { display: none; }
-.nav-title { font-size: 18px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
-
-/* Right-side nav: all links in one flex row */
-.nav-links {
-  display: flex; align-items: center;
-  gap: 0; list-style: none; flex-wrap: nowrap;
-  font-size: 18px;
-}
-
-/* Each link */
-.nav-links a,
-.nav-links > a {
-  color: var(--text-muted);
-  text-decoration: none;
-  white-space: nowrap;
-  padding: 2px 10px;
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s;
-  display: inline-block;
-}
-.nav-links a:hover,
-.nav-links > a:hover { color: var(--text); opacity: 1; }
-.nav-links a.active,
-.nav-links > a.active { color: var(--text); border-bottom-color: var(--text); }
-
-/* Separator: a pipe BEFORE each link except the first */
-.nav-links a + a,
-.nav-links > a + a { border-left: 1px solid var(--border-strong); }
-
-/* ── "more" dropdown — secondary nav entries ─── */
-.nav-more { position: relative; display: inline-flex; align-items: center; }
-
-.nav-more-btn {
-  background: none; border: none; cursor: pointer;
-  font-family: inherit; font-size: inherit; color: var(--text-muted);
-  white-space: nowrap; padding: 2px 10px; margin: 0;
-  border-left: 1px solid var(--border-strong);
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s;
-  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
-}
-.nav-more-btn:hover { color: var(--text); }
-.nav-more-btn.active { color: var(--text); border-bottom-color: var(--text); }
-.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
-.nav-more.open .nav-more-caret { transform: rotate(180deg); }
-
-.nav-more-menu {
-  display: none;
-  position: absolute; top: 100%; right: 0; z-index: 300;
-  min-width: 160px;
-  flex-direction: column; align-items: stretch;
-  background: var(--bg);
-  border: 1px solid var(--border-strong);
-}
-.nav-more.open .nav-more-menu { display: flex; }
-
-.nav-links .nav-more-menu a,
-.nav-links .nav-more-menu > a {
-  display: flex; align-items: center;
-  width: 100%; padding: 10px 14px; min-height: 40px;
-  border-left: none; border-bottom: 1px solid var(--border);
-}
-.nav-links .nav-more-menu a + a { border-left: none; }
-.nav-links .nav-more-menu a:last-child { border-bottom: none; }
-.nav-links .nav-more-menu a:hover { background: var(--bg-alt); color: var(--text); }
-.nav-links .nav-more-menu a.active { color: var(--text); font-weight: 700; }
-
-.theme-toggle {
-  background: var(--bg-alt); cursor: pointer; color: var(--text-muted);
-  font-family: inherit; font-size: 16px; padding: 6px 12px; margin: 0;
-  white-space: nowrap; border-left: 1px solid var(--border-strong);
-  border-top: 1px solid var(--border-strong); border-right: 1px solid var(--border-strong);
-  border-bottom: 1px solid var(--border-strong);
-  transition: color 0.15s, background 0.15s;
-  text-transform: uppercase; letter-spacing: 0.05em;
-}
-[data-theme="dark"] .theme-toggle {
-  background: var(--text); color: var(--bg); border-color: var(--text);
-}
-.theme-toggle:hover { color: var(--text); background: var(--bg-alt); }
-
-/* hamburger – hidden on desktop */
-.nav-toggle {
-  display: none; flex-direction: column; gap: 5px;
-  background: none; border: none; cursor: pointer; padding: 4px; flex-shrink: 0;
-}
-.nav-toggle span { display: block; width: 20px; height: 1px; background: var(--text); }
-
 /* ── Global mobile resets ─── */
 html {
   -webkit-text-size-adjust: 100%;  /* prevent iOS auto font inflation */
@@ -191,9 +81,8 @@ html {
 a, button, [role="button"] {
   touch-action: manipulation; /* remove 300ms tap delay */
 }
-/* Minimum touch target: 44×44px (Apple HIG) */
-.nav-links a, .nav-links > a, .nav-more-btn, .theme-toggle,
-.nav-toggle, .tab-btn, .copy-btn {
+/* Minimum touch target: 44×44px (Apple HIG) — navbar equivalents in nav.css */
+.tab-btn, .copy-btn {
   min-height: 44px;
   display: inline-flex;
   align-items: center;
@@ -485,13 +374,6 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
    ═══════════════════════════════════════════════════════ */
 @media (max-width: 1024px) {
   .container { padding: 0 24px; }
-  .navbar .container { padding: 10px 24px; }
-
-  /* Slightly tighter nav on tablet */
-  .nav-links a, .nav-links > a { padding: 2px 8px; font-size: 16px; }
-  .nav-links { font-size: 16px; }
-  .nav-title { font-size: 16px; }
-  .nav-brand { font-size: 16px; margin-right: 16px; }
 
   .cheatsheet-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
 }
@@ -503,61 +385,6 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
   .container { padding: 0 16px; }
   .content { padding: 24px 0; }
   main { padding: 24px 0; }
-
-  /* ── Hamburger ── */
-  .nav-toggle { display: flex; }
-  .navbar .container { position: relative; padding: 0 16px; min-height: 52px; }
-  .nav-brand { font-size: 15px; margin-right: 0; }
-
-  .nav-links {
-    display: none;
-    position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
-    background: var(--bg);
-    border-top: 1px solid var(--border);
-    border-bottom: 2px solid var(--border-strong);
-    flex-direction: column; align-items: stretch;
-    padding: 0; gap: 0;
-    /* iOS momentum scroll inside drawer */
-    overflow-y: auto; -webkit-overflow-scrolling: touch;
-    max-height: 80vh;
-  }
-  .nav-links.open { display: flex; }
-
-  .nav-links a, .nav-links > a {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: 1px solid var(--border); border-left: none !important;
-    border-right: none; width: 100%; min-height: 52px;
-    display: flex; align-items: center;
-  }
-  .nav-links a + a, .nav-links > a + a { border-left: none !important; }
-  .nav-links a.active, .nav-links > a.active {
-    background: var(--surface); border-bottom-color: var(--border);
-    font-weight: 700;
-  }
-
-  /* Dropdown flattens into an inline accordion inside the drawer */
-  .nav-more { display: block; width: 100%; position: static; }
-  .nav-more-btn {
-    padding: 14px 20px; font-size: 17px; width: 100%;
-    border-left: none !important; border-bottom: 1px solid var(--border);
-    min-height: 52px; justify-content: flex-start;
-  }
-  .nav-more-menu {
-    position: static; min-width: 0; border: none;
-    background: var(--surface);
-  }
-  .nav-links .nav-more-menu a,
-  .nav-links .nav-more-menu > a {
-    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
-  }
-  .nav-links .nav-more-menu a:last-child { border-bottom: 1px solid var(--border); }
-  .theme-toggle {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: none; border-left: none !important; border-right: none !important;
-    border-top: none; width: 100%; min-height: 52px;
-    display: flex; align-items: center; justify-content: flex-start;
-    background: var(--surface2, var(--surface));
-  }
 
   /* ── Typography ── */
   h1 { font-size: 24px; }
@@ -635,17 +462,12 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
   h1 { font-size: 20px; }
   h2 { font-size: 18px; }
   pre, .cheatsheet-content pre { font-size: 13px !important; }
-  .navbar .container { padding: 0 12px; }
 }
 
 /* ═══════════════════════════════════════════════════════
    iOS safe-area insets (notch / home indicator)
    ═══════════════════════════════════════════════════════ */
 @supports (padding: env(safe-area-inset-left)) {
-  .navbar .container {
-    padding-left: max(32px, env(safe-area-inset-left));
-    padding-right: max(32px, env(safe-area-inset-right));
-  }
   .container {
     padding-left: max(32px, env(safe-area-inset-left));
     padding-right: max(32px, env(safe-area-inset-right));
@@ -654,10 +476,6 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
     padding-bottom: max(24px, env(safe-area-inset-bottom));
   }
   @media (max-width: 768px) {
-    .navbar .container {
-      padding-left: max(16px, env(safe-area-inset-left));
-      padding-right: max(16px, env(safe-area-inset-right));
-    }
     .container {
       padding-left: max(16px, env(safe-area-inset-left));
       padding-right: max(16px, env(safe-area-inset-right));
@@ -667,9 +485,10 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
 
 /* ── Print ─── */
 @media print {
-  .navbar, footer, .progress-container, .back-link,
+  /* .navbar is hidden by nav.css */
+  footer, .progress-container, .back-link,
   .cheatsheet-footer, .breadcrumbs, .prev-next,
-  .copy-btn, .code-block-header, .nav-toggle { display: none !important; }
+  .copy-btn, .code-block-header { display: none !important; }
   body { font-size: 11pt; color: #000; background: #fff; }
   .content { padding: 0; }
   main { padding: 0; }

--- a/site/style.css
+++ b/site/style.css
@@ -123,13 +123,43 @@ a:hover { opacity: 0.6; }
 .nav-links a + a,
 .nav-links > a + a { border-left: 1px solid var(--border-strong); }
 
-.github-link {
-  text-decoration: none; color: var(--text-muted); display: inline-flex;
-  align-items: center; background: none; border: none;
-  white-space: nowrap; padding: 2px 10px; border-left: 1px solid var(--border-strong);
+/* ── "more" dropdown — secondary nav entries ─── */
+.nav-more { position: relative; display: inline-flex; align-items: center; }
+
+.nav-more-btn {
+  background: none; border: none; cursor: pointer;
+  font-family: inherit; font-size: inherit; color: var(--text-muted);
+  white-space: nowrap; padding: 2px 10px; margin: 0;
+  border-left: 1px solid var(--border-strong);
+  border-bottom: 1px solid transparent;
   transition: color 0.15s;
+  display: inline-flex; align-items: center; gap: 4px; min-height: 44px;
 }
-.github-link:hover { color: var(--text); opacity: 1; }
+.nav-more-btn:hover { color: var(--text); }
+.nav-more-btn.active { color: var(--text); border-bottom-color: var(--text); }
+.nav-more-caret { font-size: 0.8em; transition: transform 0.15s; }
+.nav-more.open .nav-more-caret { transform: rotate(180deg); }
+
+.nav-more-menu {
+  display: none;
+  position: absolute; top: 100%; right: 0; z-index: 300;
+  min-width: 160px;
+  flex-direction: column; align-items: stretch;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+}
+.nav-more.open .nav-more-menu { display: flex; }
+
+.nav-links .nav-more-menu a,
+.nav-links .nav-more-menu > a {
+  display: flex; align-items: center;
+  width: 100%; padding: 10px 14px; min-height: 40px;
+  border-left: none; border-bottom: 1px solid var(--border);
+}
+.nav-links .nav-more-menu a + a { border-left: none; }
+.nav-links .nav-more-menu a:last-child { border-bottom: none; }
+.nav-links .nav-more-menu a:hover { background: var(--bg-alt); color: var(--text); }
+.nav-links .nav-more-menu a.active { color: var(--text); font-weight: 700; }
 
 .theme-toggle {
   background: var(--bg-alt); cursor: pointer; color: var(--text-muted);
@@ -162,7 +192,7 @@ a, button, [role="button"] {
   touch-action: manipulation; /* remove 300ms tap delay */
 }
 /* Minimum touch target: 44×44px (Apple HIG) */
-.nav-links a, .nav-links > a, .github-link, .theme-toggle,
+.nav-links a, .nav-links > a, .nav-more-btn, .theme-toggle,
 .nav-toggle, .tab-btn, .copy-btn {
   min-height: 44px;
   display: inline-flex;
@@ -505,11 +535,22 @@ h4 > a.header-anchor:hover { text-decoration: underline; }
     font-weight: 700;
   }
 
-  .github-link {
-    padding: 14px 20px; font-size: 17px;
-    border-bottom: 1px solid var(--border); border-left: none !important;
-    width: 100%; min-height: 52px; display: flex; align-items: center;
+  /* Dropdown flattens into an inline accordion inside the drawer */
+  .nav-more { display: block; width: 100%; position: static; }
+  .nav-more-btn {
+    padding: 14px 20px; font-size: 17px; width: 100%;
+    border-left: none !important; border-bottom: 1px solid var(--border);
+    min-height: 52px; justify-content: flex-start;
   }
+  .nav-more-menu {
+    position: static; min-width: 0; border: none;
+    background: var(--surface);
+  }
+  .nav-links .nav-more-menu a,
+  .nav-links .nav-more-menu > a {
+    padding: 14px 20px 14px 36px; font-size: 17px; min-height: 52px;
+  }
+  .nav-links .nav-more-menu a:last-child { border-bottom: 1px solid var(--border); }
   .theme-toggle {
     padding: 14px 20px; font-size: 17px;
     border-bottom: none; border-left: none !important; border-right: none !important;

--- a/site/test/helpers.js
+++ b/site/test/helpers.js
@@ -1,0 +1,38 @@
+// Shared jsdom bootstrap for the site unit tests.
+//
+// nav.js and site.js are browser scripts that read `document`, `localStorage`
+// and `CustomEvent` off the global scope at call time (never at load time), so
+// a test can swap in a fresh jsdom between cases and the already-required
+// module picks it up.
+const { JSDOM } = require('jsdom');
+
+const GLOBALS = ['window', 'document', 'localStorage', 'CustomEvent', 'Event', 'navigator', 'self'];
+
+/**
+ * Installs a fresh jsdom as the global environment and returns it.
+ * Pass `html` to control the document body.
+ */
+function setupDOM(html = '<div id="site-nav"></div>') {
+  const dom = new JSDOM(`<!DOCTYPE html><html><head></head><body>${html}</body></html>`, {
+    url: 'https://example.test/',
+  });
+  for (const key of GLOBALS) {
+    global[key] = key === 'self' ? dom.window : dom.window[key];
+  }
+  return dom;
+}
+
+function teardownDOM() {
+  for (const key of GLOBALS) delete global[key];
+}
+
+/** Dispatches a real click so listeners bound with addEventListener fire. */
+function click(el) {
+  el.dispatchEvent(new global.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+}
+
+function keydown(key) {
+  global.document.dispatchEvent(new global.window.KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+module.exports = { setupDOM, teardownDOM, click, keydown };

--- a/site/test/nav.test.js
+++ b/site/test/nav.test.js
@@ -1,0 +1,231 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { setupDOM, teardownDOM, click, keydown } = require('./helpers');
+
+// nav.js applies the stored theme at load time, so a DOM has to exist first.
+setupDOM();
+const CSNav = require('../nav.js');
+
+test.afterEach(() => { setupDOM(); });
+test.after(() => { teardownDOM(); });
+
+// ── Markup ────────────────────────────────────────────────────────────────
+
+test('navHTML renders every primary entry inline, in order', () => {
+  const html = CSNav.navHTML();
+  const labels = [...html.matchAll(/>([a-z-]+)<\/a>/g)].map((m) => m[1]);
+  assert.deepEqual(labels.slice(0, CSNav.PRIMARY.length), CSNav.PRIMARY.map((i) => i.label));
+});
+
+test('navHTML puts the secondary entries inside the dropdown menu', () => {
+  const menu = CSNav.navHTML().match(/<div class="nav-more-menu">(.*?)<\/div>/)[1];
+  for (const item of CSNav.MORE) {
+    assert.ok(menu.includes('>' + item.label + '</a>'), `${item.label} missing from dropdown`);
+  }
+  // ...and keeps them out of the inline row.
+  const inline = CSNav.navHTML().split('<div class="nav-more">')[0];
+  assert.ok(!inline.includes('>patterns</a>'));
+});
+
+test('navHTML marks the current primary entry active', () => {
+  const html = CSNav.navHTML({ currentPage: 'cheatsheets' });
+  assert.match(html, /<a href="cheatsheets\.html" class="active">cheatsheets<\/a>/);
+  assert.equal((html.match(/class="active"/g) || []).length, 1);
+});
+
+test('navHTML activates the "more" button when the page is inside the dropdown', () => {
+  const html = CSNav.navHTML({ currentPage: 'lc-review-plan' });
+  assert.match(html, /class="nav-more-btn active"/);
+  assert.match(html, /<a href="lc-review-plan\.html" class="active">review<\/a>/);
+});
+
+test('navHTML leaves the "more" button inactive for a primary page', () => {
+  assert.match(CSNav.navHTML({ currentPage: 'home' }), /class="nav-more-btn"/);
+});
+
+test('navHTML prefixes internal links with basePath but never external ones', () => {
+  const html = CSNav.navHTML({ basePath: '../' });
+  assert.match(html, /href="\.\.\/cheatsheets\.html"/);
+  assert.match(html, /href="\.\.\/algo_demo\/index\.html"/);
+  assert.match(html, /href="https:\/\/github\.com\/yennanliu\/CS_basics"/);
+  assert.ok(!html.includes('href="../https://'));
+});
+
+test('navHTML opens external entries in a new tab with rel=noopener', () => {
+  assert.match(CSNav.navHTML(), /href="https:\/\/github[^"]*" target="_blank" rel="noopener"/);
+});
+
+test('navHTML renders the brand, hamburger and theme toggle exactly once', () => {
+  const html = CSNav.navHTML();
+  for (const needle of ['nav-brand', 'nav-toggle', 'id="theme-toggle"', 'nav-more-menu']) {
+    assert.equal(html.split(needle).length - 1, 1, `${needle} should appear once`);
+  }
+});
+
+test('navHTML defaults to no active entry when the page is unknown', () => {
+  const html = CSNav.navHTML({ currentPage: 'not-a-page' });
+  assert.ok(!html.includes('class="active"'));
+  assert.match(html, /class="nav-more-btn"/);
+});
+
+test('esc neutralises characters that would break out of an attribute', () => {
+  assert.equal(CSNav.esc('a"b<c>d&e'), 'a&quot;b&lt;c&gt;d&amp;e');
+});
+
+test('isMoreEntry distinguishes dropdown entries from primary ones', () => {
+  assert.equal(CSNav.isMoreEntry('patterns'), true);
+  assert.equal(CSNav.isMoreEntry('home'), false);
+});
+
+test('every entry has a unique id', () => {
+  const ids = [...CSNav.PRIMARY, ...CSNav.MORE].map((i) => i.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+// ── Mounting ──────────────────────────────────────────────────────────────
+
+test('mount fills #site-nav and reads its data attributes', () => {
+  document.getElementById('site-nav').setAttribute('data-page', 'faqs');
+  document.getElementById('site-nav').setAttribute('data-base', '../');
+  CSNav.mount();
+
+  assert.ok(document.querySelector('nav.navbar'), 'navbar not rendered');
+  assert.equal(document.querySelector('.nav-links a.active').textContent, 'faqs');
+  assert.equal(document.querySelector('.nav-brand').getAttribute('href'), '../index.html');
+});
+
+test('mount is a no-op when the placeholder is absent', () => {
+  setupDOM('<p>no placeholder</p>');
+  assert.equal(CSNav.mount(), null);
+  assert.equal(document.querySelector('nav.navbar'), null);
+});
+
+test('mount accepts an explicit target element', () => {
+  setupDOM('<div id="elsewhere" data-page="search"></div>');
+  const host = document.getElementById('elsewhere');
+  assert.equal(CSNav.mount(host), host);
+  assert.equal(document.querySelector('.nav-links a.active').textContent, 'search');
+});
+
+// ── Theme ─────────────────────────────────────────────────────────────────
+
+test('applyStoredTheme falls back to dark when nothing is stored', () => {
+  CSNav.applyStoredTheme();
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
+});
+
+test('applyStoredTheme restores a previously chosen theme', () => {
+  localStorage.setItem('theme', 'light');
+  CSNav.applyStoredTheme();
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'light');
+});
+
+test('themeLabel names the theme you would switch to', () => {
+  assert.equal(CSNav.themeLabel('dark'), '☀ light');
+  assert.equal(CSNav.themeLabel('light'), '● dark');
+});
+
+test('clicking the toggle flips the theme, persists it and relabels the button', () => {
+  CSNav.mount();
+  const btn = document.getElementById('theme-toggle');
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
+  assert.equal(btn.textContent, '☀ light');
+
+  click(btn);
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'light');
+  assert.equal(localStorage.getItem('theme'), 'light');
+  assert.equal(btn.textContent, '● dark');
+
+  click(btn);
+  assert.equal(document.documentElement.getAttribute('data-theme'), 'dark');
+  assert.equal(localStorage.getItem('theme'), 'dark');
+  assert.equal(btn.textContent, '☀ light');
+});
+
+test('a theme change announces itself so pages can repaint', () => {
+  CSNav.mount();
+  const seen = [];
+  document.addEventListener(CSNav.THEME_EVENT, (e) => seen.push(e.detail.theme));
+
+  click(document.getElementById('theme-toggle'));
+  click(document.getElementById('theme-toggle'));
+
+  assert.deepEqual(seen, ['light', 'dark']);
+});
+
+test('mount shows the stored theme on the button, not the default', () => {
+  localStorage.setItem('theme', 'light');
+  CSNav.mount();
+  assert.equal(document.getElementById('theme-toggle').textContent, '● dark');
+});
+
+// ── Dropdown ──────────────────────────────────────────────────────────────
+
+test('the "more" button toggles the dropdown and keeps aria-expanded in step', () => {
+  CSNav.mount();
+  const more = document.querySelector('.nav-more');
+  const btn = more.querySelector('.nav-more-btn');
+
+  assert.equal(more.classList.contains('open'), false);
+  assert.equal(btn.getAttribute('aria-expanded'), 'false');
+
+  click(btn);
+  assert.equal(more.classList.contains('open'), true);
+  assert.equal(btn.getAttribute('aria-expanded'), 'true');
+
+  click(btn);
+  assert.equal(more.classList.contains('open'), false);
+  assert.equal(btn.getAttribute('aria-expanded'), 'false');
+});
+
+test('a click outside closes the dropdown', () => {
+  setupDOM('<div id="site-nav"></div><p id="outside">elsewhere</p>');
+  CSNav.mount();
+  const more = document.querySelector('.nav-more');
+
+  click(more.querySelector('.nav-more-btn'));
+  assert.equal(more.classList.contains('open'), true);
+
+  click(document.getElementById('outside'));
+  assert.equal(more.classList.contains('open'), false);
+});
+
+test('a click inside the dropdown leaves it open', () => {
+  CSNav.mount();
+  const more = document.querySelector('.nav-more');
+  click(more.querySelector('.nav-more-btn'));
+
+  click(more.querySelector('.nav-more-menu a'));
+  assert.equal(more.classList.contains('open'), true);
+});
+
+test('Escape closes the dropdown, other keys do not', () => {
+  CSNav.mount();
+  const more = document.querySelector('.nav-more');
+  click(more.querySelector('.nav-more-btn'));
+
+  keydown('a');
+  assert.equal(more.classList.contains('open'), true);
+
+  keydown('Escape');
+  assert.equal(more.classList.contains('open'), false);
+});
+
+// ── Mobile drawer ─────────────────────────────────────────────────────────
+
+test('the hamburger toggles the drawer and keeps aria-expanded in step', () => {
+  CSNav.mount();
+  const btn = document.querySelector('.nav-toggle');
+  const links = document.querySelector('.nav-links');
+
+  assert.equal(links.classList.contains('open'), false);
+  assert.equal(btn.getAttribute('aria-expanded'), 'false');
+
+  click(btn);
+  assert.equal(links.classList.contains('open'), true);
+  assert.equal(btn.getAttribute('aria-expanded'), 'true');
+
+  click(btn);
+  assert.equal(links.classList.contains('open'), false);
+  assert.equal(btn.getAttribute('aria-expanded'), 'false');
+});

--- a/site/test/site.test.js
+++ b/site/test/site.test.js
@@ -1,0 +1,126 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { setupDOM, teardownDOM, click } = require('./helpers');
+
+setupDOM();
+const CSSite = require('../site.js');
+
+test.afterEach(() => { setupDOM(); });
+test.after(() => { teardownDOM(); });
+
+// ── Table wrapping ────────────────────────────────────────────────────────
+
+test('wrapTables puts a scroll container around each bare table', () => {
+  setupDOM('<table id="t"><tr><td>a</td></tr></table>');
+  CSSite.wrapTables(document);
+
+  const table = document.getElementById('t');
+  assert.equal(table.parentElement.className, 'table-wrap');
+});
+
+test('wrapTables is idempotent', () => {
+  setupDOM('<table><tr><td>a</td></tr></table>');
+  CSSite.wrapTables(document);
+  CSSite.wrapTables(document);
+
+  assert.equal(document.querySelectorAll('.table-wrap').length, 1);
+});
+
+test('wrapTables handles every table on the page', () => {
+  setupDOM('<table></table><div><table></table></div><table></table>');
+  CSSite.wrapTables(document);
+
+  assert.equal(document.querySelectorAll('.table-wrap').length, 3);
+});
+
+test('wrapTables keeps the table in its original position', () => {
+  setupDOM('<div id="host"><p>before</p><table id="t"></table><p>after</p></div>');
+  CSSite.wrapTables(document);
+
+  const kids = [...document.getElementById('host').children].map((el) => el.tagName + '.' + el.className);
+  assert.deepEqual(kids, ['P.', 'DIV.table-wrap', 'P.']);
+});
+
+// ── Reading progress ──────────────────────────────────────────────────────
+
+test('readingProgress reports how far down the document is scrolled', () => {
+  assert.equal(CSSite.readingProgress({ scrollHeight: 2000, clientHeight: 1000, scrollTop: 0 }), 0);
+  assert.equal(CSSite.readingProgress({ scrollHeight: 2000, clientHeight: 1000, scrollTop: 500 }), 50);
+  assert.equal(CSSite.readingProgress({ scrollHeight: 2000, clientHeight: 1000, scrollTop: 1000 }), 100);
+});
+
+test('readingProgress reports 0 rather than dividing by zero on a short page', () => {
+  assert.equal(CSSite.readingProgress({ scrollHeight: 800, clientHeight: 800, scrollTop: 0 }), 0);
+});
+
+test('initReadingProgress is a no-op when the page has no progress bar', () => {
+  setupDOM('<p>no bar</p>');
+  assert.doesNotThrow(() => CSSite.initReadingProgress());
+});
+
+test('initReadingProgress sizes the bar on scroll', () => {
+  setupDOM('<div id="reading-progress"></div>');
+  CSSite.initReadingProgress();
+
+  const doc = document.documentElement;
+  Object.defineProperty(doc, 'scrollHeight', { value: 2000, configurable: true });
+  Object.defineProperty(doc, 'clientHeight', { value: 1000, configurable: true });
+  doc.scrollTop = 250;
+  window.dispatchEvent(new window.Event('scroll'));
+
+  assert.equal(document.getElementById('reading-progress').style.width, '25%');
+});
+
+// ── Copy button ───────────────────────────────────────────────────────────
+
+test('copyCode copies the sibling <pre> and flashes confirmation on the button', async () => {
+  setupDOM(`<div class="code-block-wrapper">
+      <button class="copy-btn">copy</button>
+      <pre>print("hi")</pre>
+    </div>`);
+
+  const written = [];
+  global.navigator.clipboard = { writeText: (t) => { written.push(t); return Promise.resolve(); } };
+
+  const btn = document.querySelector('.copy-btn');
+  // jsdom does not implement innerText, which is what the browser reads.
+  Object.defineProperty(document.querySelector('pre'), 'innerText', { value: 'print("hi")' });
+
+  CSSite.copyCode(btn);
+  await Promise.resolve();
+
+  assert.deepEqual(written, ['print("hi")']);
+  assert.equal(btn.textContent, 'copied');
+  assert.equal(btn.classList.contains('copied'), true);
+});
+
+test('copyCode does nothing when the clipboard API is unavailable', () => {
+  setupDOM('<div class="code-block-wrapper"><button class="copy-btn">copy</button><pre>x</pre></div>');
+  global.navigator.clipboard = undefined;
+
+  const btn = document.querySelector('.copy-btn');
+  assert.doesNotThrow(() => CSSite.copyCode(btn));
+  assert.equal(btn.textContent, 'copy');
+});
+
+// ── Wiring ────────────────────────────────────────────────────────────────
+
+test('init wires tables and the progress bar together', () => {
+  setupDOM('<div id="reading-progress"></div><table></table>');
+  CSSite.init();
+
+  assert.equal(document.querySelectorAll('.table-wrap').length, 1);
+});
+
+test('loading site.js exposes copyCode as a global', () => {
+  // The generated pages emit onclick="copyCode(this)", which resolves against
+  // the global scope rather than the module — so loading the file has to
+  // install it there. Re-required to model a fresh page load.
+  setupDOM();
+  assert.equal(typeof global.self.copyCode, 'undefined');
+
+  delete require.cache[require.resolve('../site.js')];
+  require('../site.js');
+
+  assert.equal(typeof global.self.copyCode, 'function');
+});


### PR DESCRIPTION
The navbar carried 10 links plus a github link and the theme toggle, which overflowed the bar on narrower desktops. Keep the primary seven — home, search, cheatsheets, faqs, lc-explorer, random, visualizer — and collapse patterns, similar, review, resources and github into a "more" dropdown.

The dropdown button lights up when the current page lives inside it, so the active trail is not lost when collapsed. On mobile it flattens into an indented accordion inside the existing hamburger drawer.

Applied across all four places the navbar is authored: the build-site.js template, the 37 algo_demo pages (+ common.js/style.css), the four hand-maintained _site/lc-*.html pages, and the committed generated pages (patched in place rather than rebuilt, since the committed _site lags doc/ and a full rebuild would bury the nav change in unrelated churn).