### PR TITLE
Scrape recent interview questions from Reddit, Blind and HN too

### DIFF
--- a/doc/g_recent_asked.md
+++ b/doc/g_recent_asked.md
@@ -1,523 +1,597 @@
-# Google SWE — Recently Asked LeetCode Questions (scraped)
+# Google SWE — Recently Asked Interview Questions (scraped)
 
-> **Generated**: 2026-08-09  
-> **Source**: `leetcode.com/graphql` — public Discuss API (`ugcArticleDiscussionArticles`, `ugcArticleDiscussionArticle`, `topicComments`)  
-> **Regenerate**: `python3 script/scrape_lc_discuss_company.py --tag google`  
-> **Corpus**: 274 `google`-tagged discuss posts, 2026-01-23 → 2026-08-09 (274 full bodies, 1153 comments)
+> **Generated**: 2026-08-11  
+> **Sources**: LeetCode Discuss, Reddit, Blind, Hacker News  
+> **Regenerate**: `python3 script/scrape_lc_discuss_company.py --tag google --sources leetcode,reddit,blind,hn`  
+> **Corpus**: 1719 posts, 2016-11-07 → 2026-08-11
+
+| Source | Posts | Range | What is scraped |
+|--------|-------|-------|-----------------|
+| LeetCode Discuss | 274 | 2026-01-23 → 2026-08-08 | threads + bodies + comments |
+| Reddit | 851 | 2018-09-18 → 2026-08-11 | posts (full selftext) + rationed comment threads |
+| Blind | 62 | 2017-09-24 → 2026-08-10 | search cards + full post bodies (**no comments**) |
+| Hacker News | 532 | 2016-11-07 → 2026-08-04 | stories + comments |
 
 ## ⚠️ Read this first — what this data is and is not
 
 - LeetCode's **official company tag list** (`companyTag`) is **Premium-gated** and returns `null` for anonymous requests. This doc is **not** that list.
-- What is scraped here is **user-reported interview experience** from the public Discuss forum, tagged `google`. It is self-reported, unverified, and skewed toward whoever bothers to post.
-- The **legacy** discuss API (`categoryTopicList`, category `interview-question`) is frozen at **2025-03-04** — LeetCode migrated Discuss during 2025. Anything claiming to scrape "recent" questions from that endpoint is serving stale data.
+- Everything here is **user-reported interview experience** from public forums. It is self-reported, unverified, and skewed toward whoever bothers to post.
+- Sources differ in signal. LeetCode Discuss and Reddit posters cite problems by number or link; Blind and Hacker News posters mostly do not, so those two contribute breadth (and noise) rather than precise references.
+- The **legacy** LeetCode discuss API (`categoryTopicList`, category `interview-question`) is frozen at **2025-03-04** — LeetCode migrated Discuss during 2025. Anything claiming to scrape "recent" questions from that endpoint is serving stale data.
 - Treat problem counts as **weak signal** (mention frequency), not ground-truth interview frequency. A single well-linked compilation post can put a dozen problems on the board at once.
 - Mentions are **not all interview reports** — some describe a practice routine, and a title match can even land inside a sentence saying the problem is *not* what was asked. The `Match` column and the quotes exist so you can check.
 
 ## 1) Most-referenced LC problems
 
-**`Posts`** = number of **distinct discuss threads** referencing the problem anywhere in `title + summary + body + comments`. It counts threads, not mentions: a thread naming the same problem five times counts once, so `Posts` is *not* the sum of the quotes below.
+**`Posts`** = number of **distinct threads** referencing the problem anywhere in `title + body + comments`. It counts threads, not mentions: a thread naming the same problem five times counts once, so `Posts` is *not* the sum of the quotes below.
 
-`Match` = how the reference was found, showing the **strongest** evidence anywhere in that thread set. **url** = the post linked `leetcode.com/problems/<slug>` (high confidence); **num** = wrote `LC 200` / `#200`; **title** = the exact title appeared in prose — weakest, worth eyeballing the quote before trusting it.
+`Where` = which sources the thread(s) came from. `Match` = how the reference was found, showing the **strongest** evidence anywhere in that thread set. **url** = the post linked `leetcode.com/problems/<slug>` (high confidence); **num** = wrote `LC 200` / `#200`; **title** = the exact title appeared in prose — weakest, worth eyeballing the quote before trusting it.
 
 The table below is **complete** — every problem extracted from the corpus is listed.
 
-| # | Problem | Diff | Type / Tags | Posts | Match | Last seen | In repo? |
-|---|---------|------|-------------|-------|-------|-----------|----------|
-| 200 | [Number of Islands](https://leetcode.com/problems/number-of-islands/) | Medium | Array, Depth-First Search, Breadth-First Search | 4 | url | 2026-05-11 | ✅ |
-| 207 | [Course Schedule](https://leetcode.com/problems/course-schedule/) | Medium | Depth-First Search, Breadth-First Search, Graph | 2 | url | 2026-05-18 | ✅ |
-| 1944 | [Number of Visible People in a Queue](https://leetcode.com/problems/number-of-visible-people-in-a-queue/) | Hard | array, stack, monotonic-stack | 2 | url | 2026-05-11 | ✅ |
-| 23 | [Merge k Sorted Lists](https://leetcode.com/problems/merge-k-sorted-lists/) | Hard | Linked List, Divide and Conquer, Heap (Priority Queue) | 2 | url | 2026-05-11 | ✅ |
-| 300 | [Longest Increasing Subsequence](https://leetcode.com/problems/longest-increasing-subsequence/) | Medium | Array, Binary Search, Dynamic Programming | 2 | url | 2026-05-11 | ✅ |
-| 210 | [Course Schedule II](https://leetcode.com/problems/course-schedule-ii/) | Medium | Depth-First Search, Breadth-First Search, Graph | 2 | url | 2026-05-18 | ✅ |
-| 239 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum/) | Hard | Array, Queue, Sliding Window | 1 | url | 2026-05-11 | ✅ |
-| 354 | [Russian Doll Envelopes](https://leetcode.com/problems/russian-doll-envelopes/) | Hard | Array, Binary Search, Dynamic Programming | 1 | url | 2026-05-11 | ✅ |
-| 4 | [Median of Two Sorted Arrays](https://leetcode.com/problems/median-of-two-sorted-arrays/) | Hard | Array, Binary Search, Divide and Conquer | 1 | url | 2026-05-11 | ✅ |
-| 10 | [Regular Expression Matching](https://leetcode.com/problems/regular-expression-matching/) | Hard | String, Dynamic Programming, Recursion | 1 | url | 2026-05-11 | ✅ |
-| 31 | [Next Permutation](https://leetcode.com/problems/next-permutation/) | Medium | — | 1 | url | 2026-05-11 | — |
-| 33 | [Search in Rotated Sorted Array](https://leetcode.com/problems/search-in-rotated-sorted-array/) | Medium | Array, Binary Search | 1 | url | 2026-05-11 | ✅ |
-| 34 | [Find First and Last Position of Element in Sorted Array](https://leetcode.com/problems/find-first-and-last-position-of-element-in-sorted-array/) | Medium | Array, Binary Search | 1 | url | 2026-05-11 | ✅ |
-| 60 | [Permutation Sequence](https://leetcode.com/problems/permutation-sequence/) | Hard | — | 1 | url | 2026-02-10 | — |
-| 84 | [Largest Rectangle in Histogram](https://leetcode.com/problems/largest-rectangle-in-histogram/) | Hard | Array, Stack, Monotonic Stack | 1 | url | 2026-05-11 | ✅ |
-| 85 | [Maximal Rectangle](https://leetcode.com/problems/maximal-rectangle/) | Hard | Array, Dynamic Programming, Stack | 1 | url | 2026-05-11 | ✅ |
-| 93 | [Restore IP Addresses](https://leetcode.com/problems/restore-ip-addresses/) | Medium | String, Backtracking | 1 | url | 2026-02-28 | ✅ |
-| 128 | [Longest Consecutive Sequence](https://leetcode.com/problems/longest-consecutive-sequence/) | Medium | Array, Hash Table, Union Find | 1 | url | 2026-05-11 | ✅ |
-| 253 | [Meeting Rooms II](https://leetcode.com/problems/meeting-rooms-ii/) 🔒 | Medium | Array, Two Pointers, Greedy | 1 | url | 2026-05-11 | ✅ |
-| 410 | [Split Array Largest Sum](https://leetcode.com/problems/split-array-largest-sum/) | Hard | Array, Binary Search, Dynamic Programming | 1 | url | 2026-05-11 | ✅ |
-| 424 | [Longest Repeating Character Replacement](https://leetcode.com/problems/longest-repeating-character-replacement/) | Medium | hash-table, string, sliding-window | 1 | url | 2026-05-11 | ✅ |
-| 560 | [Subarray Sum Equals K](https://leetcode.com/problems/subarray-sum-equals-k/) | Medium | Array, Hash Table, Prefix Sum | 1 | url | 2026-05-11 | ✅ |
-| 875 | [Koko Eating Bananas](https://leetcode.com/problems/koko-eating-bananas/) | Medium | Array, Binary Search | 1 | url | 2026-05-11 | ✅ |
-| 3 | [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/) | Medium | Hash Table, String, Sliding Window | 1 | url | 2026-05-11 | ✅ |
-| 5 | [Longest Palindromic Substring](https://leetcode.com/problems/longest-palindromic-substring/) | Medium | String, Dynamic Programming | 1 | url | 2026-05-11 | ✅ |
-| 6 | [Zigzag Conversion](https://leetcode.com/problems/zigzag-conversion/) | Medium | String | 1 | num | 2026-03-25 | ✅ |
-| 37 | [Sudoku Solver](https://leetcode.com/problems/sudoku-solver/) | Hard | Array, Backtracking, Matrix | 1 | url | 2026-05-11 | ✅ |
-| 42 | [Trapping Rain Water](https://leetcode.com/problems/trapping-rain-water/) | Hard | Array, Two Pointers, Dynamic Programming | 1 | url | 2026-05-11 | ✅ |
-| 48 | [Rotate Image](https://leetcode.com/problems/rotate-image/) | Medium | Array, Math, Matrix | 1 | url | 2026-05-11 | ✅ |
-| 72 | [Edit Distance](https://leetcode.com/problems/edit-distance/) | Medium | String, Dynamic Programming | 1 | url | 2026-05-11 | ✅ |
-| 146 | [LRU Cache](https://leetcode.com/problems/lru-cache/) | Medium | Hash Table, Linked List, Design | 1 | url | 2026-05-11 | ✅ |
-| 286 | [Walls and Gates](https://leetcode.com/problems/walls-and-gates/) 🔒 | Medium | Array, Breadth-First Search, Matrix | 1 | title | 2026-04-12 | ✅ |
-| 351 | [Android Unlock Patterns](https://leetcode.com/problems/android-unlock-patterns/) 🔒 | Medium | dynamic-programming, backtracking, array | 1 | url | 2026-02-08 | ✅ |
-| 394 | [Decode String](https://leetcode.com/problems/decode-string/) | Medium | String, Stack, Recursion | 1 | url | 2026-05-11 | ✅ |
-| 994 | [Rotting Oranges](https://leetcode.com/problems/rotting-oranges/) | Medium | Array, Breadth-First Search, Matrix | 1 | title | 2026-04-12 | ✅ |
-| 1970 | [Last Day Where You Can Still Cross](https://leetcode.com/problems/last-day-where-you-can-still-cross/) | Hard | — | 1 | url | 2026-02-08 | — |
-| 2013 | [Detect Squares](https://leetcode.com/problems/detect-squares/) | Medium | Array, Hash Table, Design | 1 | title | 2026-02-07 | ✅ |
-| 2402 | [Meeting Rooms III](https://leetcode.com/problems/meeting-rooms-iii/) | Hard | — | 1 | url | 2026-03-25 | — |
-| 2812 | [Find the Safest Path in a Grid](https://leetcode.com/problems/find-the-safest-path-in-a-grid/) | Medium | — | 1 | url | 2026-02-08 | — |
-| 3169 | [Count Days Without Meetings](https://leetcode.com/problems/count-days-without-meetings/) | Medium | — | 1 | num | 2026-02-04 | — |
-| 3671 | [Sum of Beautiful Subsequences](https://leetcode.com/problems/sum-of-beautiful-subsequences/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3676 | [Count Bowl Subarrays](https://leetcode.com/problems/count-bowl-subarrays/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3677 | [Count Binary Palindromic Numbers](https://leetcode.com/problems/count-binary-palindromic-numbers/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3680 | [Generate Schedule](https://leetcode.com/problems/generate-schedule/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3681 | [Maximum XOR of Subsequences](https://leetcode.com/problems/maximum-xor-of-subsequences/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3685 | [Subsequence Sum After Capping Elements](https://leetcode.com/problems/subsequence-sum-after-capping-elements/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3686 | [Number of Stable Subsequences](https://leetcode.com/problems/number-of-stable-subsequences/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3690 | [Split and Merge Array Transformation](https://leetcode.com/problems/split-and-merge-array-transformation/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3691 | [Maximum Total Subarray Value II](https://leetcode.com/problems/maximum-total-subarray-value-ii/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3695 | [Maximize Alternating Sum Using Swaps](https://leetcode.com/problems/maximize-alternating-sum-using-swaps/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3699 | [Number of ZigZag Arrays I](https://leetcode.com/problems/number-of-zigzag-arrays-i/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3700 | [Number of ZigZag Arrays II](https://leetcode.com/problems/number-of-zigzag-arrays-ii/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3703 | [Remove K-Balanced Substrings](https://leetcode.com/problems/remove-k-balanced-substrings/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3704 | [Count No-Zero Pairs That Sum to N](https://leetcode.com/problems/count-no-zero-pairs-that-sum-to-n/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3709 | [Design Exam Scores Tracker](https://leetcode.com/problems/design-exam-scores-tracker/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3710 | [Maximum Partition Factor](https://leetcode.com/problems/maximum-partition-factor/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3714 | [Longest Balanced Substring II](https://leetcode.com/problems/longest-balanced-substring-ii/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3715 | [Sum of Perfect Square Ancestors](https://leetcode.com/problems/sum-of-perfect-square-ancestors/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3720 | [Lexicographically Smallest Permutation Greater Than Target](https://leetcode.com/problems/lexicographically-smallest-permutation-greater-than-target/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3721 | [Longest Balanced Subarray II](https://leetcode.com/problems/longest-balanced-subarray-ii/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3724 | [Minimum Operations to Transform Array](https://leetcode.com/problems/minimum-operations-to-transform-array/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3733 | [Minimum Time to Complete All Deliveries](https://leetcode.com/problems/minimum-time-to-complete-all-deliveries/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3738 | [Longest Non-Decreasing Subarray After Replacing at Most One Element](https://leetcode.com/problems/longest-non-decreasing-subarray-after-replacing-at-most-one-element/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3739 | [Count Subarrays With Majority Element II](https://leetcode.com/problems/count-subarrays-with-majority-element-ii/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3742 | [Maximum Path Score in a Grid](https://leetcode.com/problems/maximum-path-score-in-a-grid/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3743 | [Maximize Cyclic Partition Score](https://leetcode.com/problems/maximize-cyclic-partition-score/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3747 | [Count Distinct Integers After Removing Zeros](https://leetcode.com/problems/count-distinct-integers-after-removing-zeros/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3748 | [Count Stable Subarrays](https://leetcode.com/problems/count-stable-subarrays/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3753 | [Total Waviness of Numbers in Range II](https://leetcode.com/problems/total-waviness-of-numbers-in-range-ii/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3757 | [Number of Effective Subsequences](https://leetcode.com/problems/number-of-effective-subsequences/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3761 | [Minimum Absolute Distance Between Mirror Pairs](https://leetcode.com/problems/minimum-absolute-distance-between-mirror-pairs/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3762 | [Minimum Operations to Equalize Subarrays](https://leetcode.com/problems/minimum-operations-to-equalize-subarrays/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3767 | [Maximize Points After Choosing K Tasks](https://leetcode.com/problems/maximize-points-after-choosing-k-tasks/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3771 | [Total Score of Dungeon Runs](https://leetcode.com/problems/total-score-of-dungeon-runs/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3772 | [Maximum Subgraph Score in a Tree](https://leetcode.com/problems/maximum-subgraph-score-in-a-tree/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3776 | [Minimum Moves to Balance Circular Array](https://leetcode.com/problems/minimum-moves-to-balance-circular-array/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3777 | [Minimum Deletions to Make Alternating Substring](https://leetcode.com/problems/minimum-deletions-to-make-alternating-substring/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3781 | [Maximum Score After Binary Swaps](https://leetcode.com/problems/maximum-score-after-binary-swaps/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3785 | [Minimum Swaps to Avoid Forbidden Values](https://leetcode.com/problems/minimum-swaps-to-avoid-forbidden-values/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3786 | [Total Sum of Interaction Cost in Tree Groups](https://leetcode.com/problems/total-sum-of-interaction-cost-in-tree-groups/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3790 | [Smallest All-Ones Multiple](https://leetcode.com/problems/smallest-all-ones-multiple/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3791 | [Number of Balanced Integers in a Range](https://leetcode.com/problems/number-of-balanced-integers-in-a-range/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3796 | [Find Maximum Value in a Constrained Sequence](https://leetcode.com/problems/find-maximum-value-in-a-constrained-sequence/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3797 | [Count Routes to Climb a Rectangular Grid](https://leetcode.com/problems/count-routes-to-climb-a-rectangular-grid/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3800 | [Minimum Cost to Make Two Binary Strings Equal](https://leetcode.com/problems/minimum-cost-to-make-two-binary-strings-equal/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3801 | [Minimum Cost to Merge Sorted Lists](https://leetcode.com/problems/minimum-cost-to-merge-sorted-lists/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3805 | [Count Caesar Cipher Pairs](https://leetcode.com/problems/count-caesar-cipher-pairs/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3806 | [Maximum Bitwise AND After Increment Operations](https://leetcode.com/problems/maximum-bitwise-and-after-increment-operations/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3811 | [Number of Alternating XOR Partitions](https://leetcode.com/problems/number-of-alternating-xor-partitions/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3812 | [Minimum Edge Toggles on a Tree](https://leetcode.com/problems/minimum-edge-toggles-on-a-tree/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3815 | [Design Auction System](https://leetcode.com/problems/design-auction-system/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3816 | [Lexicographically Smallest String After Deleting Duplicate Characters](https://leetcode.com/problems/lexicographically-smallest-string-after-deleting-duplicate-characters/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3820 | [Pythagorean Distance Nodes in a Tree](https://leetcode.com/problems/pythagorean-distance-nodes-in-a-tree/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3821 | [Find Nth Smallest Integer With K One Bits](https://leetcode.com/problems/find-nth-smallest-integer-with-k-one-bits/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3825 | [Longest Strictly Increasing Subsequence With Non-Zero Bitwise AND](https://leetcode.com/problems/longest-strictly-increasing-subsequence-with-non-zero-bitwise-and/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3826 | [Minimum Partition Score](https://leetcode.com/problems/minimum-partition-score/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3829 | [Design Ride Sharing System](https://leetcode.com/problems/design-ride-sharing-system/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3830 | [Longest Alternating Subarray After Removing At Most One Element](https://leetcode.com/problems/longest-alternating-subarray-after-removing-at-most-one-element/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 22 | [Generate Parentheses](https://leetcode.com/problems/generate-parentheses/) | Medium | String, Dynamic Programming, Backtracking | 1 | url | 2026-02-28 | ✅ |
-| 47 | [Permutations II](https://leetcode.com/problems/permutations-ii/) | Medium | — | 1 | num | 2026-02-06 | — |
-| 56 | [Merge Intervals](https://leetcode.com/problems/merge-intervals/) | Medium | Array, Sorting | 1 | title | 2026-04-11 | ✅ |
-| 303 | [Range Sum Query - Immutable](https://leetcode.com/problems/range-sum-query-immutable/) | Easy | Immutable - Array, Design, Prefix Sum | 1 | title | 2026-03-04 | ✅ |
-| 307 | [Range Sum Query - Mutable](https://leetcode.com/problems/range-sum-query-mutable/) | Medium | Mutable - Array, Design, Binary Indexed Tree | 1 | title | 2026-03-04 | ✅ |
-| 355 | [Design Twitter](https://leetcode.com/problems/design-twitter/) | Medium | — | 1 | title | 2026-02-07 | — |
-| 359 | [Logger Rate Limiter](https://leetcode.com/problems/logger-rate-limiter/) 🔒 | Easy | Hash Table, Design | 1 | title | 2026-02-26 | ✅ |
-| 809 | [Expressive Words](https://leetcode.com/problems/expressive-words/) | Medium | Array, Two Pointers, String | 1 | url | 2026-04-10 | ✅ |
-| 907 | [Sum of Subarray Minimums](https://leetcode.com/problems/sum-of-subarray-minimums/) | Medium | Array, Dynamic Programming, Stack | 1 | url | 2026-03-28 | ✅ |
-| 1277 | [Count Square Submatrices with All Ones](https://leetcode.com/problems/count-square-submatrices-with-all-ones/) | Medium | array, dynamic-programming, matrix | 1 | url | 2026-02-07 | ✅ |
-| 1671 | [Minimum Number of Removals to Make Mountain Array](https://leetcode.com/problems/minimum-number-of-removals-to-make-mountain-array/) | Hard | — | 1 | url | 2026-02-11 | — |
-| 1937 | [Maximum Number of Points with Cost](https://leetcode.com/problems/maximum-number-of-points-with-cost/) | Medium | array, dynamic-programming, stack | 1 | url | 2026-02-24 | ✅ |
-| 2026 | [Low-Quality Problems](https://leetcode.com/problems/low-quality-problems/) 🔒 | Easy | — | 1 | num | 2026-02-07 | — |
-| 2093 | [Minimum Cost to Reach City With Discounts](https://leetcode.com/problems/minimum-cost-to-reach-city-with-discounts/) 🔒 | Medium | — | 1 | url | 2026-05-22 | — |
-| 2615 | [Sum of Distances](https://leetcode.com/problems/sum-of-distances/) | Medium | — | 1 | title | 2026-03-27 | — |
-| 2810 | [Faulty Keyboard](https://leetcode.com/problems/faulty-keyboard/) | Easy | — | 1 | title | 2026-04-10 | — |
-| 3481 | [Apply Substitutions](https://leetcode.com/problems/apply-substitutions/) 🔒 | Medium | — | 1 | title | 2026-05-14 | — |
-| 3670 | [Maximum Product of Two Integers With No Common Bits](https://leetcode.com/problems/maximum-product-of-two-integers-with-no-common-bits/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3694 | [Distinct Points Reachable After Substring Removal](https://leetcode.com/problems/distinct-points-reachable-after-substring-removal/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3725 | [Count Ways to Choose Coprime Integers from Rows](https://leetcode.com/problems/count-ways-to-choose-coprime-integers-from-rows/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3728 | [Stable Subarrays With Equal Boundary and Interior Sum](https://leetcode.com/problems/stable-subarrays-with-equal-boundary-and-interior-sum/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3729 | [Count Distinct Subarrays Divisible by K in Sorted Array](https://leetcode.com/problems/count-distinct-subarrays-divisible-by-k-in-sorted-array/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3734 | [Lexicographically Smallest Palindromic Permutation Greater Than Target](https://leetcode.com/problems/lexicographically-smallest-palindromic-permutation-greater-than-target/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3752 | [Lexicographically Smallest Negated Permutation that Sums to Target](https://leetcode.com/problems/lexicographically-smallest-negated-permutation-that-sums-to-target/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3756 | [Concatenate Non-Zero Digits and Multiply by Sum II](https://leetcode.com/problems/concatenate-non-zero-digits-and-multiply-by-sum-ii/) | Medium | — | 1 | url | 2026-02-05 | — |
-| 3768 | [Minimum Inversion Count in Subarrays of Fixed Length](https://leetcode.com/problems/minimum-inversion-count-in-subarrays-of-fixed-length/) | Hard | — | 1 | url | 2026-02-05 | — |
-| 3782 | [Last Remaining Integer After Alternating Deletion Operations](https://leetcode.com/problems/last-remaining-integer-after-alternating-deletion-operations/) | Hard | — | 1 | url | 2026-02-05 | — |
+| # | Problem | Diff | Type / Tags | Posts | Where | Match | Last seen | In repo? |
+|---|---------|------|-------------|-------|-------|-------|-----------|----------|
+| 200 | [Number of Islands](https://leetcode.com/problems/number-of-islands/) | Medium | Array, Depth-First Search, Breadth-First Search | 6 | leetcode, reddit | url | 2026-06-02 | ✅ |
+| 56 | [Merge Intervals](https://leetcode.com/problems/merge-intervals/) | Medium | Array, Sorting | 3 | leetcode, reddit | title | 2026-06-02 | ✅ |
+| 207 | [Course Schedule](https://leetcode.com/problems/course-schedule/) | Medium | Depth-First Search, Breadth-First Search, Graph | 2 | leetcode | url | 2026-05-18 | ✅ |
+| 253 | [Meeting Rooms II](https://leetcode.com/problems/meeting-rooms-ii/) 🔒 | Medium | Array, Two Pointers, Greedy | 2 | leetcode | url | 2026-05-11 | ✅ |
+| 1944 | [Number of Visible People in a Queue](https://leetcode.com/problems/number-of-visible-people-in-a-queue/) | Hard | array, stack, monotonic-stack | 2 | leetcode | url | 2026-05-11 | ✅ |
+| 23 | [Merge k Sorted Lists](https://leetcode.com/problems/merge-k-sorted-lists/) | Hard | Linked List, Divide and Conquer, Heap (Priority Queue) | 2 | leetcode | url | 2026-05-11 | ✅ |
+| 300 | [Longest Increasing Subsequence](https://leetcode.com/problems/longest-increasing-subsequence/) | Medium | Array, Binary Search, Dynamic Programming | 2 | leetcode | url | 2026-05-11 | ✅ |
+| 3 | [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/) | Medium | Hash Table, String, Sliding Window | 2 | leetcode, reddit | url | 2026-08-03 | ✅ |
+| 286 | [Walls and Gates](https://leetcode.com/problems/walls-and-gates/) 🔒 | Medium | Array, Breadth-First Search, Matrix | 2 | leetcode, reddit | title | 2026-04-12 | ✅ |
+| 994 | [Rotting Oranges](https://leetcode.com/problems/rotting-oranges/) | Medium | Array, Breadth-First Search, Matrix | 2 | leetcode, reddit | title | 2026-06-02 | ✅ |
+| 210 | [Course Schedule II](https://leetcode.com/problems/course-schedule-ii/) | Medium | Depth-First Search, Breadth-First Search, Graph | 2 | leetcode | url | 2026-05-18 | ✅ |
+| 269 | [Alien Dictionary](https://leetcode.com/problems/alien-dictionary/) 🔒 | Hard | Array, String, Depth-First Search | 2 | hn | title | 2025-11-30 | ✅ |
+| 208 | [Implement Trie (Prefix Tree)](https://leetcode.com/problems/implement-trie-prefix-tree/) | Medium | Hash Table, String, Design | 1 | reddit | num | 2026-07-06 | ✅ |
+| 239 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum/) | Hard | Array, Queue, Sliding Window | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 354 | [Russian Doll Envelopes](https://leetcode.com/problems/russian-doll-envelopes/) | Hard | Array, Binary Search, Dynamic Programming | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 4 | [Median of Two Sorted Arrays](https://leetcode.com/problems/median-of-two-sorted-arrays/) | Hard | Array, Binary Search, Divide and Conquer | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 10 | [Regular Expression Matching](https://leetcode.com/problems/regular-expression-matching/) | Hard | String, Dynamic Programming, Recursion | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 31 | [Next Permutation](https://leetcode.com/problems/next-permutation/) | Medium | — | 1 | leetcode | url | 2026-05-11 | — |
+| 33 | [Search in Rotated Sorted Array](https://leetcode.com/problems/search-in-rotated-sorted-array/) | Medium | Array, Binary Search | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 34 | [Find First and Last Position of Element in Sorted Array](https://leetcode.com/problems/find-first-and-last-position-of-element-in-sorted-array/) | Medium | Array, Binary Search | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 60 | [Permutation Sequence](https://leetcode.com/problems/permutation-sequence/) | Hard | — | 1 | leetcode | url | 2026-02-10 | — |
+| 84 | [Largest Rectangle in Histogram](https://leetcode.com/problems/largest-rectangle-in-histogram/) | Hard | Array, Stack, Monotonic Stack | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 85 | [Maximal Rectangle](https://leetcode.com/problems/maximal-rectangle/) | Hard | Array, Dynamic Programming, Stack | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 93 | [Restore IP Addresses](https://leetcode.com/problems/restore-ip-addresses/) | Medium | String, Backtracking | 1 | leetcode | url | 2026-02-28 | ✅ |
+| 128 | [Longest Consecutive Sequence](https://leetcode.com/problems/longest-consecutive-sequence/) | Medium | Array, Hash Table, Union Find | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 410 | [Split Array Largest Sum](https://leetcode.com/problems/split-array-largest-sum/) | Hard | Array, Binary Search, Dynamic Programming | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 424 | [Longest Repeating Character Replacement](https://leetcode.com/problems/longest-repeating-character-replacement/) | Medium | hash-table, string, sliding-window | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 560 | [Subarray Sum Equals K](https://leetcode.com/problems/subarray-sum-equals-k/) | Medium | Array, Hash Table, Prefix Sum | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 875 | [Koko Eating Bananas](https://leetcode.com/problems/koko-eating-bananas/) | Medium | Array, Binary Search | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 5 | [Longest Palindromic Substring](https://leetcode.com/problems/longest-palindromic-substring/) | Medium | String, Dynamic Programming | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 37 | [Sudoku Solver](https://leetcode.com/problems/sudoku-solver/) | Hard | Array, Backtracking, Matrix | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 42 | [Trapping Rain Water](https://leetcode.com/problems/trapping-rain-water/) | Hard | Array, Two Pointers, Dynamic Programming | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 48 | [Rotate Image](https://leetcode.com/problems/rotate-image/) | Medium | Array, Math, Matrix | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 72 | [Edit Distance](https://leetcode.com/problems/edit-distance/) | Medium | String, Dynamic Programming | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 146 | [LRU Cache](https://leetcode.com/problems/lru-cache/) | Medium | Hash Table, Linked List, Design | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 351 | [Android Unlock Patterns](https://leetcode.com/problems/android-unlock-patterns/) 🔒 | Medium | dynamic-programming, backtracking, array | 1 | leetcode | url | 2026-02-08 | ✅ |
+| 378 | [Kth Smallest Element in a Sorted Matrix](https://leetcode.com/problems/kth-smallest-element-in-a-sorted-matrix/) | Medium | Array, Binary Search, Sorting | 1 | reddit | num | 2026-03-12 | ✅ |
+| 394 | [Decode String](https://leetcode.com/problems/decode-string/) | Medium | String, Stack, Recursion | 1 | leetcode | url | 2026-05-11 | ✅ |
+| 1970 | [Last Day Where You Can Still Cross](https://leetcode.com/problems/last-day-where-you-can-still-cross/) | Hard | — | 1 | leetcode | url | 2026-02-08 | — |
+| 2013 | [Detect Squares](https://leetcode.com/problems/detect-squares/) | Medium | Array, Hash Table, Design | 1 | leetcode | title | 2026-02-07 | ✅ |
+| 2402 | [Meeting Rooms III](https://leetcode.com/problems/meeting-rooms-iii/) | Hard | — | 1 | leetcode | url | 2026-03-25 | — |
+| 2812 | [Find the Safest Path in a Grid](https://leetcode.com/problems/find-the-safest-path-in-a-grid/) | Medium | — | 1 | leetcode | url | 2026-02-08 | — |
+| 3169 | [Count Days Without Meetings](https://leetcode.com/problems/count-days-without-meetings/) | Medium | — | 1 | leetcode | num | 2026-02-04 | — |
+| 3671 | [Sum of Beautiful Subsequences](https://leetcode.com/problems/sum-of-beautiful-subsequences/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3676 | [Count Bowl Subarrays](https://leetcode.com/problems/count-bowl-subarrays/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3677 | [Count Binary Palindromic Numbers](https://leetcode.com/problems/count-binary-palindromic-numbers/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3680 | [Generate Schedule](https://leetcode.com/problems/generate-schedule/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3681 | [Maximum XOR of Subsequences](https://leetcode.com/problems/maximum-xor-of-subsequences/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3685 | [Subsequence Sum After Capping Elements](https://leetcode.com/problems/subsequence-sum-after-capping-elements/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3686 | [Number of Stable Subsequences](https://leetcode.com/problems/number-of-stable-subsequences/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3690 | [Split and Merge Array Transformation](https://leetcode.com/problems/split-and-merge-array-transformation/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3691 | [Maximum Total Subarray Value II](https://leetcode.com/problems/maximum-total-subarray-value-ii/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3695 | [Maximize Alternating Sum Using Swaps](https://leetcode.com/problems/maximize-alternating-sum-using-swaps/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3699 | [Number of ZigZag Arrays I](https://leetcode.com/problems/number-of-zigzag-arrays-i/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3700 | [Number of ZigZag Arrays II](https://leetcode.com/problems/number-of-zigzag-arrays-ii/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3703 | [Remove K-Balanced Substrings](https://leetcode.com/problems/remove-k-balanced-substrings/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3704 | [Count No-Zero Pairs That Sum to N](https://leetcode.com/problems/count-no-zero-pairs-that-sum-to-n/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3709 | [Design Exam Scores Tracker](https://leetcode.com/problems/design-exam-scores-tracker/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3710 | [Maximum Partition Factor](https://leetcode.com/problems/maximum-partition-factor/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3714 | [Longest Balanced Substring II](https://leetcode.com/problems/longest-balanced-substring-ii/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3715 | [Sum of Perfect Square Ancestors](https://leetcode.com/problems/sum-of-perfect-square-ancestors/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3720 | [Lexicographically Smallest Permutation Greater Than Target](https://leetcode.com/problems/lexicographically-smallest-permutation-greater-than-target/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3721 | [Longest Balanced Subarray II](https://leetcode.com/problems/longest-balanced-subarray-ii/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3724 | [Minimum Operations to Transform Array](https://leetcode.com/problems/minimum-operations-to-transform-array/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3733 | [Minimum Time to Complete All Deliveries](https://leetcode.com/problems/minimum-time-to-complete-all-deliveries/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3738 | [Longest Non-Decreasing Subarray After Replacing at Most One Element](https://leetcode.com/problems/longest-non-decreasing-subarray-after-replacing-at-most-one-element/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3739 | [Count Subarrays With Majority Element II](https://leetcode.com/problems/count-subarrays-with-majority-element-ii/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3742 | [Maximum Path Score in a Grid](https://leetcode.com/problems/maximum-path-score-in-a-grid/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3743 | [Maximize Cyclic Partition Score](https://leetcode.com/problems/maximize-cyclic-partition-score/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3747 | [Count Distinct Integers After Removing Zeros](https://leetcode.com/problems/count-distinct-integers-after-removing-zeros/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3748 | [Count Stable Subarrays](https://leetcode.com/problems/count-stable-subarrays/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3753 | [Total Waviness of Numbers in Range II](https://leetcode.com/problems/total-waviness-of-numbers-in-range-ii/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3757 | [Number of Effective Subsequences](https://leetcode.com/problems/number-of-effective-subsequences/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3761 | [Minimum Absolute Distance Between Mirror Pairs](https://leetcode.com/problems/minimum-absolute-distance-between-mirror-pairs/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3762 | [Minimum Operations to Equalize Subarrays](https://leetcode.com/problems/minimum-operations-to-equalize-subarrays/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3767 | [Maximize Points After Choosing K Tasks](https://leetcode.com/problems/maximize-points-after-choosing-k-tasks/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3771 | [Total Score of Dungeon Runs](https://leetcode.com/problems/total-score-of-dungeon-runs/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3772 | [Maximum Subgraph Score in a Tree](https://leetcode.com/problems/maximum-subgraph-score-in-a-tree/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3776 | [Minimum Moves to Balance Circular Array](https://leetcode.com/problems/minimum-moves-to-balance-circular-array/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3777 | [Minimum Deletions to Make Alternating Substring](https://leetcode.com/problems/minimum-deletions-to-make-alternating-substring/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3781 | [Maximum Score After Binary Swaps](https://leetcode.com/problems/maximum-score-after-binary-swaps/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3785 | [Minimum Swaps to Avoid Forbidden Values](https://leetcode.com/problems/minimum-swaps-to-avoid-forbidden-values/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3786 | [Total Sum of Interaction Cost in Tree Groups](https://leetcode.com/problems/total-sum-of-interaction-cost-in-tree-groups/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3790 | [Smallest All-Ones Multiple](https://leetcode.com/problems/smallest-all-ones-multiple/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3791 | [Number of Balanced Integers in a Range](https://leetcode.com/problems/number-of-balanced-integers-in-a-range/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3796 | [Find Maximum Value in a Constrained Sequence](https://leetcode.com/problems/find-maximum-value-in-a-constrained-sequence/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3797 | [Count Routes to Climb a Rectangular Grid](https://leetcode.com/problems/count-routes-to-climb-a-rectangular-grid/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3800 | [Minimum Cost to Make Two Binary Strings Equal](https://leetcode.com/problems/minimum-cost-to-make-two-binary-strings-equal/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3801 | [Minimum Cost to Merge Sorted Lists](https://leetcode.com/problems/minimum-cost-to-merge-sorted-lists/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3805 | [Count Caesar Cipher Pairs](https://leetcode.com/problems/count-caesar-cipher-pairs/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3806 | [Maximum Bitwise AND After Increment Operations](https://leetcode.com/problems/maximum-bitwise-and-after-increment-operations/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3811 | [Number of Alternating XOR Partitions](https://leetcode.com/problems/number-of-alternating-xor-partitions/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3812 | [Minimum Edge Toggles on a Tree](https://leetcode.com/problems/minimum-edge-toggles-on-a-tree/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3815 | [Design Auction System](https://leetcode.com/problems/design-auction-system/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3816 | [Lexicographically Smallest String After Deleting Duplicate Characters](https://leetcode.com/problems/lexicographically-smallest-string-after-deleting-duplicate-characters/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3820 | [Pythagorean Distance Nodes in a Tree](https://leetcode.com/problems/pythagorean-distance-nodes-in-a-tree/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3821 | [Find Nth Smallest Integer With K One Bits](https://leetcode.com/problems/find-nth-smallest-integer-with-k-one-bits/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3825 | [Longest Strictly Increasing Subsequence With Non-Zero Bitwise AND](https://leetcode.com/problems/longest-strictly-increasing-subsequence-with-non-zero-bitwise-and/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3826 | [Minimum Partition Score](https://leetcode.com/problems/minimum-partition-score/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3829 | [Design Ride Sharing System](https://leetcode.com/problems/design-ride-sharing-system/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3830 | [Longest Alternating Subarray After Removing At Most One Element](https://leetcode.com/problems/longest-alternating-subarray-after-removing-at-most-one-element/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 6 | [Zigzag Conversion](https://leetcode.com/problems/zigzag-conversion/) | Medium | String | 1 | reddit | url | 2026-06-27 | ✅ |
+| 22 | [Generate Parentheses](https://leetcode.com/problems/generate-parentheses/) | Medium | String, Dynamic Programming, Backtracking | 1 | leetcode | url | 2026-02-28 | ✅ |
+| 47 | [Permutations II](https://leetcode.com/problems/permutations-ii/) | Medium | — | 1 | leetcode | num | 2026-02-06 | — |
+| 53 | [Maximum Subarray](https://leetcode.com/problems/maximum-subarray/) | Medium | Array, Divide and Conquer, Dynamic Programming | 1 | hn | title | 2024-04-27 | ✅ |
+| 68 | [Text Justification](https://leetcode.com/problems/text-justification/) | Hard | Array, String, Simulation | 1 | hn | title | 2021-10-13 | ✅ |
+| 118 | [Pascal's Triangle](https://leetcode.com/problems/pascals-triangle/) | Easy | Array, Dynamic Programming | 1 | hn | title | 2025-01-14 | ✅ |
+| 206 | [Reverse Linked List](https://leetcode.com/problems/reverse-linked-list/) | Easy | linked-list, recursion | 1 | reddit | title | 2026-08-04 | ✅ |
+| 226 | [Invert Binary Tree](https://leetcode.com/problems/invert-binary-tree/) | Easy | Tree, Depth-First Search, Breadth-First Search | 1 | hn | url | 2021-09-07 | ✅ |
+| 303 | [Range Sum Query - Immutable](https://leetcode.com/problems/range-sum-query-immutable/) | Easy | Immutable - Array, Design, Prefix Sum | 1 | leetcode | title | 2026-03-04 | ✅ |
+| 307 | [Range Sum Query - Mutable](https://leetcode.com/problems/range-sum-query-mutable/) | Medium | Mutable - Array, Design, Binary Indexed Tree | 1 | leetcode | title | 2026-03-04 | ✅ |
+| 332 | [Reconstruct Itinerary](https://leetcode.com/problems/reconstruct-itinerary/) | Hard | Depth-First Search, Graph, Eulerian Circuit | 1 | reddit | title | 2026-06-29 | ✅ |
+| 338 | [Counting Bits](https://leetcode.com/problems/counting-bits/) | Easy | Dynamic Programming, Bit Manipulation | 1 | reddit | num | 2026-06-29 | ✅ |
+| 355 | [Design Twitter](https://leetcode.com/problems/design-twitter/) | Medium | — | 1 | leetcode | title | 2026-02-07 | — |
+| 359 | [Logger Rate Limiter](https://leetcode.com/problems/logger-rate-limiter/) 🔒 | Easy | Hash Table, Design | 1 | leetcode | title | 2026-02-26 | ✅ |
+| 518 | [Coin Change II](https://leetcode.com/problems/coin-change-ii/) | Medium | Array, Dynamic Programming | 1 | reddit | title | 2026-07-30 | ✅ |
+| 753 | [Cracking the Safe](https://leetcode.com/problems/cracking-the-safe/) | Hard | Depth-First Search, Graph, Eulerian Circuit | 1 | blind | num | 2019-07-06 | ✅ |
+| 809 | [Expressive Words](https://leetcode.com/problems/expressive-words/) | Medium | Array, Two Pointers, String | 1 | leetcode | url | 2026-04-10 | ✅ |
+| 907 | [Sum of Subarray Minimums](https://leetcode.com/problems/sum-of-subarray-minimums/) | Medium | Array, Dynamic Programming, Stack | 1 | leetcode | url | 2026-03-28 | ✅ |
+| 1277 | [Count Square Submatrices with All Ones](https://leetcode.com/problems/count-square-submatrices-with-all-ones/) | Medium | array, dynamic-programming, matrix | 1 | leetcode | url | 2026-02-07 | ✅ |
+| 1671 | [Minimum Number of Removals to Make Mountain Array](https://leetcode.com/problems/minimum-number-of-removals-to-make-mountain-array/) | Hard | — | 1 | leetcode | url | 2026-02-11 | — |
+| 1937 | [Maximum Number of Points with Cost](https://leetcode.com/problems/maximum-number-of-points-with-cost/) | Medium | array, dynamic-programming, stack | 1 | leetcode | url | 2026-02-24 | ✅ |
+| 2026 | [Low-Quality Problems](https://leetcode.com/problems/low-quality-problems/) 🔒 | Easy | — | 1 | leetcode | num | 2026-02-07 | — |
+| 2093 | [Minimum Cost to Reach City With Discounts](https://leetcode.com/problems/minimum-cost-to-reach-city-with-discounts/) 🔒 | Medium | — | 1 | leetcode | url | 2026-05-22 | — |
+| 2254 | [Design Video Sharing Platform](https://leetcode.com/problems/design-video-sharing-platform/) 🔒 | Hard | — | 1 | reddit | title | 2026-03-12 | — |
+| 2615 | [Sum of Distances](https://leetcode.com/problems/sum-of-distances/) | Medium | — | 1 | leetcode | title | 2026-03-27 | — |
+| 2810 | [Faulty Keyboard](https://leetcode.com/problems/faulty-keyboard/) | Easy | — | 1 | leetcode | title | 2026-04-10 | — |
+| 3481 | [Apply Substitutions](https://leetcode.com/problems/apply-substitutions/) 🔒 | Medium | — | 1 | leetcode | title | 2026-05-14 | — |
+| 3592 | [Inverse Coin Change](https://leetcode.com/problems/inverse-coin-change/) | Medium | — | 1 | reddit | title | 2026-07-30 | — |
+| 3670 | [Maximum Product of Two Integers With No Common Bits](https://leetcode.com/problems/maximum-product-of-two-integers-with-no-common-bits/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3694 | [Distinct Points Reachable After Substring Removal](https://leetcode.com/problems/distinct-points-reachable-after-substring-removal/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3725 | [Count Ways to Choose Coprime Integers from Rows](https://leetcode.com/problems/count-ways-to-choose-coprime-integers-from-rows/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3728 | [Stable Subarrays With Equal Boundary and Interior Sum](https://leetcode.com/problems/stable-subarrays-with-equal-boundary-and-interior-sum/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3729 | [Count Distinct Subarrays Divisible by K in Sorted Array](https://leetcode.com/problems/count-distinct-subarrays-divisible-by-k-in-sorted-array/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3734 | [Lexicographically Smallest Palindromic Permutation Greater Than Target](https://leetcode.com/problems/lexicographically-smallest-palindromic-permutation-greater-than-target/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3752 | [Lexicographically Smallest Negated Permutation that Sums to Target](https://leetcode.com/problems/lexicographically-smallest-negated-permutation-that-sums-to-target/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3756 | [Concatenate Non-Zero Digits and Multiply by Sum II](https://leetcode.com/problems/concatenate-non-zero-digits-and-multiply-by-sum-ii/) | Medium | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3768 | [Minimum Inversion Count in Subarrays of Fixed Length](https://leetcode.com/problems/minimum-inversion-count-in-subarrays-of-fixed-length/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
+| 3782 | [Last Remaining Integer After Alternating Deletion Operations](https://leetcode.com/problems/last-remaining-integer-after-alternating-deletion-operations/) | Hard | — | 1 | leetcode | url | 2026-02-05 | — |
 
 ### Evidence (quotes from the scraped posts)
 
-**This is a sample, not a full audit trail.** It covers the top 25 problems of 125, with at most 3 quotes each (one per thread, from the first match in that thread). Where a problem has more threads than quotes shown, the surplus is noted inline. For the rest, follow the links in the table and section 2.
+**This is a sample, not a full audit trail.** It covers the top 25 problems of 139, with at most 3 quotes each (one per thread, from the first match in that thread). Where a problem has more threads than quotes shown, the surplus is noted inline. For the rest, follow the links in the table and section 2.
 
-**LC 200 — Number of Islands** (Medium) · 4 threads — _1 further thread not quoted_  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+**LC 200 — Number of Islands** (Medium) · 6 threads — _3 further threads not quoted_  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …problems/russian-doll-envelopes/) * Number of Islands [#200](https://leetcode.com/problems/number-of-islands/) * Koko Eating Bananas [#875](https://leetcode.com/problems/koko-eating-bananas/) * Nex…
-- _2026-04-22_ · [# 🔥 Top Google DSA Questions I Practiced (With Approach)](https://leetcode.com/discuss/post/8054808/top-google-dsa-questions-i-practiced-wit-quup/)  
-  > …o Sum → HashMap Subarray Sum = K → Prefix Sum Graph Word Ladder → BFS Number of Islands → Hi everyone 👋 I am currently preparing for product-based companies like Google, and I wanted to share som…
-- _2026-04-12_ · [I have rotting oranges now. 994. Rotten Oranges — finally clicked.](https://leetcode.com/discuss/post/7883464/i-have-rotting-oranges-now-994-rotten-or-t4bw/)  
+- `leetcode` _2026-04-22_ · [# 🔥 Top Google DSA Questions I Practiced (With Approach)](https://leetcode.com/discuss/post/8054808/top-google-dsa-questions-i-practiced-wit-quup/)  
+  > …o Sum → HashMap Subarray Sum = K → Prefix Sum Graph Word Ladder → BFS Number of Islands → Hi everyone 👋 I am currently preparing for product-based companies like Google, and I wanted to share some im…
+- `leetcode` _2026-04-12_ · [I have rotting oranges now. 994. Rotten Oranges — finally clicked.](https://leetcode.com/discuss/post/7883464/i-have-rotting-oranges-now-994-rotten-or-t4bw/)  
   > …Rotten Oranges after 3 days of struggling with BFSSpent days stuck on Number of Islands, then this problem hit me again like wtf.But the whole thing clicked with just one line:This line freezes which…
 
+**LC 56 — Merge Intervals** (Medium) · 3 threads  
+- `leetcode` _2026-04-11_ · [Google L4 | Bengaluru | Rejected](https://leetcode.com/discuss/post/7867127/google-l4-bengaluru-reject-by-anonymous_-vho0/)  
+  > …m (bid price and execute lowest bid) ##### Round 2 (DSA) Variant of Merge Intervals and Overlapping Intervals (Line Sweep & Priority Queue) ##### Round 3 (Googlyness) Standard behavioural Question…
+- `reddit` _2026-03-06_ · [Google L3 vs. Amazon SDE2](https://www.reddit.com/r/cscareerquestions/comments/1rm7ip0/google_l3_vs_amazon_sde2/)  
+  > …o I take the pay cut and title hit for the dream? Edit - I was asked Merge Intervals, Permutations of a string, and code for nested recycler view android…
+- `reddit` _2026-06-02_ · [The 80/20 DSA Framework: How I stopped doing random LeetCode questions](https://www.reddit.com/r/leetcode/comments/1tuoc5j/the_8020_dsa_framework_how_i_stopped_doing_random/)  
+  > …ys and finding pairs. Fast & Slow Pointers: For Linked List cycles. Merge Intervals: For overlapping scheduling problems. Modified Binary Search: Essential for O(log n) constraints. Phase 3: Advan…
+
 **LC 207 — Course Schedule** (Medium) · 2 threads  
-- _2026-05-18_ · [Google L4 Interview || Reject](https://leetcode.com/discuss/post/8265899/google-l4-interview-reject-by-anonymous_-xsc3/)  
+- `leetcode` _2026-05-18_ · [Google L4 Interview || Reject](https://leetcode.com/discuss/post/8265899/google-l4-interview-reject-by-anonymous_-xsc3/)  
   > …Sort Question very similar to the below problems.Question 1 : https://leetcode.com/problems/course-schedule/description/ Question 2 : https://leetcode.com/problems/ # Google L4 Interview Location : B…
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …eetcode.com/problems/rotate-image/) * Course Schedule [#207](https://leetcode.com/problems/course-schedule/) * Regular Expression Matching [#10](https://leetcode.com/problems/regular-expression-matc…
 
+**LC 253 — Meeting Rooms II** (Medium) · 2 threads  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+  > …/leetcode.com/problems/lru-cache/) * Meeting Rooms II [#253](https://leetcode.com/problems/meeting-rooms-ii/) * Longest Repeating Character Replacement [#424](https://leetcode.com/problems/longest-r…
+- `leetcode` _2026-01-23_ · [Google DSA Question](https://leetcode.com/discuss/post/7516532/google-dsa-question-by-anonymous_user-3tjh/)  
+  > …e starting time could be used in one CPU? If so, then this is exactly meeting rooms II problem but with duplicate intervals (with same starting times) removed variation.\n\nDid you ask clarifying ques…
+
 **LC 1944 — Number of Visible People in a Queue** (Hard) · 2 threads  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …ecode-string/) * Number of Visible People in a Queue [#1944](https://leetcode.com/problems/number-of-visible-people-in-a-queue/) * LRU Cache [#146](https://leetcode.com/problems/lru-cache/) * Meeti…
-- _2026-03-04_ · [Interview Experience: Google | L3 Web Solutions Engineer (GTech)](https://leetcode.com/discuss/post/7624355/interview-experience-google-l3-web-solut-ger7/)  
-  > …sounds similar to [1944. Number of Visible People in a Queue](https://leetcode.com/problems/number-of-visible-people-in-a-queue/description/).\n for section 3\n```\n#include <bits/stdc++.h>\nusing nam…
+- `leetcode` _2026-03-04_ · [Interview Experience: Google | L3 Web Solutions Engineer (GTech)](https://leetcode.com/discuss/post/7624355/interview-experience-google-l3-web-solut-ger7/)  
+  > …sounds similar to [1944. Number of Visible People in a Queue](https://leetcode.com/problems/number-of-visible-people-in-a-queue/description/).\n for section 3\n```\n#include \nusing namespace std;\n\n…
 
 **LC 23 — Merge k Sorted Lists** (Hard) · 2 threads  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …oblems/sliding-window-maximum/) * Merge k Sorted Lists [#23](https://leetcode.com/problems/merge-k-sorted-lists/) Some questions are the closest that it can get to the actual question. Especially LR…
-- _2026-04-22_ · [# 🔥 Top Google DSA Questions I Practiced (With Approach)](https://leetcode.com/discuss/post/8054808/top-google-dsa-questions-i-practiced-wit-quup/)  
-  > …S * Number of Islands → DFS --- ## Heap / Priority Queue * Merge K Sorted Lists --- ## Dynamic Programming * Longest Increasing Subsequence * 0/1 Knapsack --- ## My Learni…
+- `leetcode` _2026-04-22_ · [# 🔥 Top Google DSA Questions I Practiced (With Approach)](https://leetcode.com/discuss/post/8054808/top-google-dsa-questions-i-practiced-wit-quup/)  
+  > …FS * Number of Islands → DFS --- ## Heap / Priority Queue * Merge K Sorted Lists --- ## Dynamic Programming * Longest Increasing Subsequence * 0/1 Knapsack --- ## My Learning…
 
 **LC 300 — Longest Increasing Subsequence** (Medium) · 2 threads  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …lems/edit-distance/) * Longest Increasing Subsequence [#300](https://leetcode.com/problems/longest-increasing-subsequence/) * Split Array Largest Sum [#410](https://leetcode.com/problems/split-array…
-- _2026-04-22_ · [# 🔥 Top Google DSA Questions I Practiced (With Approach)](https://leetcode.com/discuss/post/8054808/top-google-dsa-questions-i-practiced-wit-quup/)  
-  > …ueue * Merge K Sorted Lists --- ## Dynamic Programming * Longest Increasing Subsequence * 0/1 Knapsack --- ## My Learning * Most Google questions focus on **Graph + DP + Optimi…
+- `leetcode` _2026-04-22_ · [# 🔥 Top Google DSA Questions I Practiced (With Approach)](https://leetcode.com/discuss/post/8054808/top-google-dsa-questions-i-practiced-wit-quup/)  
+  > …Queue * Merge K Sorted Lists --- ## Dynamic Programming * Longest Increasing Subsequence * 0/1 Knapsack --- ## My Learning * Most Google questions focus on **Graph + DP + Optimiz…
+
+**LC 3 — Longest Substring Without Repeating Characters** (Medium) · 2 threads  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+  > …ater/) * Longest Substring Without Repeating Characters [#3](https://leetcode.com/problems/longest-substring-without-repeating-characters/) * Longest Palindromic Substring [#5](https://leetcode.com/…
+- `reddit` _2026-08-03_ · [Codeforces vs LeetCode for Product-Based Company Placements – Need Adv](https://www.reddit.com/r/leetcode/comments/1vecluk/codeforces_vs_leetcode_for_productbased_company/)  
+  > …for 1400-1600 Codeforces rating by end of second year, then switch to LeetCode 3-4 months before internship season. In second year, focus on Codeforces. In third year, shift to LC for interview simula…
+
+**LC 286 — Walls and Gates** (Medium) · 2 threads  
+- `leetcode` _2026-04-12_ · [I have rotting oranges now. 994. Rotten Oranges — finally clicked.](https://leetcode.com/discuss/post/7883464/i-have-rotting-oranges-now-994-rotten-or-t4bw/)  
+  > …ven starts. That's literally it. Two ideas. One problem. **Trying Walls and Gates tomorrow. If you've solved it — does the same pattern hold? Upvote if you read this, shows me someone out there is…
+- `reddit` _2026-01-23_ · [interviewer led me to direction of unoptimal solution should I be worr](https://www.reddit.com/r/csMajors/comments/1qki32w/interviewer_led_me_to_direction_of_unoptimal/)  
+  > …, I was asked a standard matrix BFS question (I believe its literally walls and gates LC) originally I was describing a multisource BFS to my interviewer, but he seemed hesitant about it and kept push…
+
+**LC 994 — Rotting Oranges** (Medium) · 2 threads  
+- `leetcode` _2026-04-12_ · [I have rotting oranges now. 994. Rotten Oranges — finally clicked.](https://leetcode.com/discuss/post/7883464/i-have-rotting-oranges-now-994-rotten-or-t4bw/)  
+  > …I have rotting oranges now. 994. Rotten Oranges — finally clicked. Finally got Rotten Oranges after 3 days of struggling with BFSSpent days stuck on Number of Islands, then this problem hit me again l…
+- `reddit` _2026-06-02_ · [The 80/20 DSA Framework: How I stopped doing random LeetCode questions](https://www.reddit.com/r/leetcode/comments/1tuoc5j/the_8020_dsa_framework_how_i_stopped_doing_random/)  
+  > …Advanced Structures BFS/DFS on Trees and Graphs: (Number of Islands, Rotting Oranges). Backtracking/Subsets: (Permutations, N-Queens). Top K Elements (Heaps): Whenever you see "Find the Kth largest…
 
 **LC 210 — Course Schedule II** (Medium) · 2 threads  
-- _2026-05-18_ · [Google L4 Interview || Reject](https://leetcode.com/discuss/post/8265899/google-l4-interview-reject-by-anonymous_-xsc3/)  
+- `leetcode` _2026-05-18_ · [Google L4 Interview || Reject](https://leetcode.com/discuss/post/8265899/google-l4-interview-reject-by-anonymous_-xsc3/)  
   > …etcode.com/problems/course-schedule/description/ Question 2 : https://leetcode.com/problems/course-schedule-ii/description/ ## Round 2 : Standard Behavioral questions. The below link helped me a lot…
-- _2026-03-28_ · [L4 DSA Round Question](https://leetcode.com/discuss/post/7705895/google-l4-dsa-round-question-by-anonymou-nh2t/)  
+- `leetcode` _2026-03-28_ · [L4 DSA Round Question](https://leetcode.com/discuss/post/7705895/google-l4-dsa-round-question-by-anonymou-nh2t/)  
   > …ave been successfully compiled. This problem is similar to https://leetcode.com/problems/course-schedule-ii/description/, but with the added complexity of multithreading. Points to consider:…
 
+**LC 269 — Alien Dictionary** (Hard) · 2 threads  
+- `hn` _2025-11-30_ · [Americans no longer see four-year college degrees as worth the cost](https://news.ycombinator.com/item?id=46094362)  
+  > …ok bad if you don’t. Let’s not pretend that any of us are ready to do alien dictionary at the spur of a moment, or thats a useful skill for our role.…
+- `hn` _2022-06-05_ · [I cheated on my Microsoft interview (2019)](https://news.ycombinator.com/item?id=31630843)  
+  > …off balance (it became adversarial after I pointed out this was just alien dictionary, I probably would have had a better result pretending not to have seen the problem before). Or maybe that’s just…
+
+**LC 208 — Implement Trie (Prefix Tree)** (Medium) · 1 thread  
+- `reddit` _2026-07-06_ · [I Built a Boggle Game. LeetCode Problem #208 Saved It.](https://www.reddit.com/r/leetcode/comments/1uop0fq/i_built_a_boggle_game_leetcode_problem_208_saved/)  
+  > …I Built a Boggle Game. LeetCode Problem #208 Saved It. I never thought I'd write the words "LeetCode saved my app." I am writing them now. Last week I shipped de Broglie , a Boggle-style word game fo…
+
 **LC 239 — Sliding Window Maximum** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …ms/split-array-largest-sum/) * Sliding Window Maximum [#239](https://leetcode.com/problems/sliding-window-maximum/) * Merge k Sorted Lists [#23](https://leetcode.com/problems/merge-k-sorted-lists/)…
 
 **LC 354 — Russian Doll Envelopes** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …lems/subarray-sum-equals-k/) * Russian Doll Envelopes [#354](https://leetcode.com/problems/russian-doll-envelopes/) * Number of Islands [#200](https://leetcode.com/problems/number-of-islands/) * Ko…
 
 **LC 4 — Median of Two Sorted Arrays** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …e too. Here is the list: * Median of Two Sorted Arrays [#4](https://leetcode.com/problems/median-of-two-sorted-arrays/) * Trapping Rain Water [#42](https://leetcode.com/problems/trapping-rain-water…
 
 **LC 10 — Regular Expression Matching** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …oblems/course-schedule/) * Regular Expression Matching [#10](https://leetcode.com/problems/regular-expression-matching/) * Sudoku Solver [#37](https://leetcode.com/problems/sudoku-solver/) * Edit D…
 
 **LC 31 — Next Permutation** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > ….com/problems/koko-eating-bananas/) * Next Permutation [#31](https://leetcode.com/problems/next-permutation/) * Search in Rotated Sorted Array [#33](https://leetcode.com/problems/search-in-rotated-s…
 
 **LC 33 — Search in Rotated Sorted Array** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …ms/next-permutation/) * Search in Rotated Sorted Array [#33](https://leetcode.com/problems/search-in-rotated-sorted-array/) * Decode String [#394](https://leetcode.com/problems/decode-string/) * Nu…
 
 **LC 34 — Find First and Last Position of Element in Sorted Array** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …Find First and Last Position of Element in Sorted Array [#34](https://leetcode.com/problems/find-first-and-last-position-of-element-in-sorted-array/) * Maximal Rectangle [#85](https://leetcode.com/pr…
 
 **LC 60 — Permutation Sequence** (Hard) · 1 thread  
-- _2026-02-10_ · [[Interview Experience] Sharing First In-Person Google Onsite After Yea](https://leetcode.com/discuss/post/7567827/interview-experience-sharing-first-in-pe-oyg1/)  
+- `leetcode` _2026-02-10_ · [[Interview Experience] Sharing First In-Person Google Onsite After Yea](https://leetcode.com/discuss/post/7567827/interview-experience-sharing-first-in-pe-oyg1/)  
   > …sked a problem similiar to this permutation sequence problem: https://leetcode.com/problems/permutation-sequence/description/ It's not the exact same but if you know how to solve this one, you can…
 
 **LC 84 — Largest Rectangle in Histogram** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …s/maximal-rectangle/) * Largest Rectangle in Histogram [#84](https://leetcode.com/problems/largest-rectangle-in-histogram/) * Rotate Image [#48](https://leetcode.com/problems/rotate-image/) * Cours…
 
 **LC 85 — Maximal Rectangle** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …ition-of-element-in-sorted-array/) * Maximal Rectangle [#85](https://leetcode.com/problems/maximal-rectangle/) * Largest Rectangle in Histogram [#84](https://leetcode.com/problems/largest-rectangle-…
 
 **LC 93 — Restore IP Addresses** (Medium) · 1 thread  
-- _2026-02-28_ · [Understanding Time Complexity for Backtracking with Pruning](https://leetcode.com/discuss/post/7614127/understanding-time-complexity-for-backtr-rn7u/)  
+- `leetcode` _2026-02-28_ · [Understanding Time Complexity for Backtracking with Pruning](https://leetcode.com/discuss/post/7614127/understanding-time-complexity-for-backtr-rn7u/)  
   > …tps://leetcode.com/problems/generate-parentheses/description/ https://leetcode.com/problems/restore-ip-addresses/description/ In problems like Restore IP Addresses, the maximum length is constant, so…
 
 **LC 128 — Longest Consecutive Sequence** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
+- `leetcode` _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
   > …alindromic-substring/) * Longest Consecutive Sequence [#128](https://leetcode.com/problems/longest-consecutive-sequence/) * Subarray Sum Equals K [#560](https://leetcode.com/problems/subarray-sum-eq…
-
-**LC 253 — Meeting Rooms II** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …/leetcode.com/problems/lru-cache/) * Meeting Rooms II [#253](https://leetcode.com/problems/meeting-rooms-ii/) * Longest Repeating Character Replacement [#424](https://leetcode.com/problems/longest-r…
-
-**LC 410 — Split Array Largest Sum** (Hard) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …st-increasing-subsequence/) * Split Array Largest Sum [#410](https://leetcode.com/problems/split-array-largest-sum/) * Sliding Window Maximum [#239](https://leetcode.com/problems/sliding-window-maxi…
-
-**LC 424 — Longest Repeating Character Replacement** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …-rooms-ii/) * Longest Repeating Character Replacement [#424](https://leetcode.com/problems/longest-repeating-character-replacement/) * Find First and Last Position of Element in Sorted Array [#34](h…
-
-**LC 560 — Subarray Sum Equals K** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …ongest-consecutive-sequence/) * Subarray Sum Equals K [#560](https://leetcode.com/problems/subarray-sum-equals-k/) * Russian Doll Envelopes [#354](https://leetcode.com/problems/russian-doll-envelope…
-
-**LC 875 — Koko Eating Bananas** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …om/problems/number-of-islands/) * Koko Eating Bananas [#875](https://leetcode.com/problems/koko-eating-bananas/) * Next Permutation [#31](https://leetcode.com/problems/next-permutation/) * Search i…
-
-**LC 3 — Longest Substring Without Repeating Characters** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …ater/) * Longest Substring Without Repeating Characters [#3](https://leetcode.com/problems/longest-substring-without-repeating-characters/) * Longest Palindromic Substring [#5](https://leetcode.com/…
-
-**LC 5 — Longest Palindromic Substring** (Medium) · 1 thread  
-- _2026-05-11_ · [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/)  
-  > …-repeating-characters/) * Longest Palindromic Substring [#5](https://leetcode.com/problems/longest-palindromic-substring/) * Longest Consecutive Sequence [#128](https://leetcode.com/problems/longest…
 
 ## 2) Recent interview posts (raw feed)
 
-Newest first — the primary sources. Open them for full text and comment threads.
+Newest first — the primary sources. Open them for full text and comment threads. Only interview-flavoured posts are listed, at most 60 per source.
 
-Every row already carries the `google` tag (that is the scrape filter: `tagSlugs: ["google"]`), so it is omitted from `Tags` as redundant. Long tag lists are trimmed at a whole-tag boundary with the remainder as `+N more`.
+### LeetCode Discuss
 
-| Date | Post | Tags (excl. `google`) | Views |
-|------|------|------------------------|-------|
-| 2026-08-08 | [LeetCode problems for AI Interviews](https://leetcode.com/discuss/post/8448866/leetcode-problems-for-ai-interviews-by-a-cnj8/) | amazon, openai, career, feedback, machine-learning-engineer +4 more | 172 |
-| 2026-08-06 | [Can I ask for virtual onsite at Google?](https://leetcode.com/discuss/post/8444095/can-i-ask-for-virtual-onsite-at-google-b-19jx/) |  | 424 |
-| 2026-08-03 | [Google Staff Software Engineer (L6)](https://leetcode.com/discuss/post/8439367/google-staff-software-engineer-l6-by-abh-n36g/) | interview | 1342 |
-| 2026-08-03 | [Google L4 chances](https://leetcode.com/discuss/post/8439101/google-l4-chances-by-anonymous_user-n5il/) | career, feedback, interview, l4-google | 602 |
-| 2026-08-03 | [Google L4 Chances](https://leetcode.com/discuss/post/8438964/google-l4-chances-by-pushya_bansal-y3ph/) |  | 606 |
-| 2026-07-27 | [Screening Round with Recruiter for Web Solutions Engineer at Google](https://leetcode.com/discuss/post/8423751/screening-round-with-recruiter-for-web-s-5897/) | career, interview, l4-google | 454 |
-| 2026-07-25 | [Feedback from reqruiter](https://leetcode.com/discuss/post/8418035/feedback-from-reqruiter-by-barez59-spgt/) | feedback | 592 |
-| 2026-07-22 | [What to expect in Google's tech lead interview and role](https://leetcode.com/discuss/post/8412228/what-to-expect-in-googles-tech-lead-inte-aq1g/) | technical-interview | 540 |
-| 2026-07-20 | [Google L4](https://leetcode.com/discuss/post/8409212/google-l4-by-anonymous_user-n4gg/) |  | 1411 |
-| 2026-07-20 | [Need help in coding round of L4 PhD early careers Google India](https://leetcode.com/discuss/post/8408470/need-help-in-coding-round-of-l4-phd-earl-z9o4/) | interview | 255 |
-| 2026-07-19 | [Forward Deployed Engineer Interview Google Cloud US](https://leetcode.com/discuss/post/8407969/forward-deployed-engineer-interview-goog-90sp/) |  | 434 |
-| 2026-07-17 | [Google SRE (Software Developer III) Interview Coming Up – Looking for Recent Interview Insights](https://leetcode.com/discuss/post/8403716/google-sre-software-developer-iii-interv-n5mg/) | interview | 578 |
-| 2026-07-17 | [Google L3 (India) Interview Experience need help (ex interviewers especially welcome)](https://leetcode.com/discuss/post/8403050/google-l3-india-interview-experience-nee-ya6h/) | interview | 1567 |
-| 2026-07-14 | [Google L4 \| Team Match](https://leetcode.com/discuss/post/8397122/google-l4-team-match-by-anonymous_user-kcfb/) | interview | 1692 |
-| 2026-07-12 | [Can someone help with last 6 months Google Questions ?](https://leetcode.com/discuss/post/8392512/can-someone-help-with-last-6-months-goog-k1do/) | career, l4-google, google-interview-questions | 1942 |
-| 2026-07-10 | [System Design Board Built for Mock Interviews](https://leetcode.com/discuss/post/8388985/system-design-board-built-for-mock-inter-5dsq/) | microsoft, leetcode, backend, interview, l4-google +3 more | 662 |
-| 2026-07-04 | [Any Updates for Google Software engineer intern 2027 summer?](https://leetcode.com/discuss/post/8375211/any-updates-for-google-software-engineer-0cye/) | career, interview, internship-2 | 1005 |
-| 2026-07-02 | [c# in Google Interview](https://leetcode.com/discuss/post/8371223/c-in-google-interview-by-anonymous_user-pslg/) |  | 265 |
-| 2026-07-02 | [After 6 Months, It's Time to Build Again](https://leetcode.com/discuss/post/8370596/after-6-months-its-time-to-build-again-b-6cu6/) | microsoft, amazon, leetcode, career, interview +1 more | 1926 |
-| 2026-07-01 | [I need advice on my Google Intern Interview](https://leetcode.com/discuss/post/8370237/i-need-advice-on-my-google-intern-interv-owuo/) | interview, google-interview-questions | 496 |
-| 2026-06-30 | [Google L4 Team Matching Phase](https://leetcode.com/discuss/post/8368243/google-l4-team-matching-phase-by-vj_tirt-k0vq/) | l4-google, l1-google, google-interview-questions | 1267 |
-| 2026-06-30 | [Google Googliness round 2025 and 2026](https://leetcode.com/discuss/post/8367035/google-googliness-round-2025-and-2026-by-qemm/) |  | 1508 |
-| 2026-06-28 | [Data and AI roles Job interviews guidance](https://leetcode.com/discuss/post/8362765/data-and-ai-roles-job-interviews-guidanc-4q47/) | microsoft, amazon, uber, flipkart, data-science +4 more | 431 |
-| 2026-06-28 | [Google Doesn't Just Want Answers, They Want Every Detail - My HR Round Breakdown](https://leetcode.com/discuss/post/8362764/google-doesnt-just-want-answers-they-wan-26hk/) | backend, interview | 1874 |
-| 2026-06-27 | [Google L4 \| Onsite Expectations](https://leetcode.com/discuss/post/8361591/google-l4-onsite-expectations-by-anonymo-728k/) | onsite, interview | 2426 |
-| 2026-06-26 | [Seeking Guidance for Cracking Google + Looking for Serious Study Partners](https://leetcode.com/discuss/post/8359851/seeking-guidance-for-cracking-google-loo-zlg6/) | amazon, career, feedback, dsa, interview, study-group-2 +2 more | 781 |
-| 2026-06-26 | [Buddy For DSA and Interview Prepration](https://leetcode.com/discuss/post/8359294/buddy-for-dsa-and-interview-prepration-b-3kh3/) | interview | 291 |
-| 2026-06-25 | [Google Offer](https://leetcode.com/discuss/post/8357173/google-offer-by-anonymous_user-ik5u/) | career, feedback, compensation, interview, l4-google +1 more | 4156 |
-| 2026-06-21 | [Google \| SWE-2 (L3)  \| Team Match Query](https://leetcode.com/discuss/post/8348520/google-swe-2-team-match-query-by-anonymo-7ftp/) | team-fit | 1890 |
-| 2026-06-21 | [Learn System Design for Interviews](https://leetcode.com/discuss/post/8348146/learn-system-design-for-interviews-by-ar-o1sz/) | microsoft, dsa, dsa-resources, system-design-2 | 630 |
-| 2026-06-20 | [How long does Google usually take to make a decision after onsite interviews?](https://leetcode.com/discuss/post/8347721/how-long-does-google-usually-take-to-mak-tx0m/) | feedback, interview | 447 |
-| 2026-06-20 | [Google L4 Interview feedback](https://leetcode.com/discuss/post/8347017/google-l4-interview-feedback-by-anonymou-unin/) | feedback | 556 |
-| 2026-06-19 | [Google L3 SWE (India) Interview Experience \| Offer Received](https://leetcode.com/discuss/post/8345294/google-l3-swe-india-interview-experience-z8un/) | interview | 2015 |
-| 2026-06-17 | [Google L4 \| Banglore](https://leetcode.com/discuss/post/8340444/google-l4-banglore-by-anonymous_user-i96q/) |  | 2209 |
-| 2026-06-15 | [Referaal status while in team match](https://leetcode.com/discuss/post/8334901/referaal-status-while-in-team-match-by-a-m244/) |  | 704 |
-| 2026-06-14 | [Have Google virtual rounds (Domain specific + DSA and GL) on Wednesday any suggestions?](https://leetcode.com/discuss/post/8334107/have-google-virtual-rounds-domain-specif-ufky/) | career, interview, l4-google | 1213 |
-| 2026-06-14 | [Upcoming Amazon interview Prep - Need Help](https://leetcode.com/discuss/post/8332865/upcoming-amazon-interview-prep-need-help-ocdw/) | amazon, career, feedback, dsa, interview, amazon-sde1-2 | 1133 |
-| 2026-06-13 | [SDE-2 Microsoft Azure Team Interview Questions (LLD + HLD)](https://leetcode.com/discuss/post/8331863/sde-2-microsoft-azure-team-interview-que-93y6/) | microsoft, amazon, career, feedback, compensation, interview +2 more | 4058 |
-| 2026-06-12 | [L5 Google Rating Feedback](https://leetcode.com/discuss/post/8330164/l5-google-rating-feedback-by-anonymous_u-yku7/) | career, feedback, interview | 1031 |
-| 2026-06-10 | [Google L4 India - Compensation](https://leetcode.com/discuss/post/8326052/salary-expectations-for-google-l4-india-y5m1h/) | career, feedback, compensation, interview, l4-google | 5855 |
-| 2026-06-10 | [Google \| L4 \| Interview Experience \| Chances](https://leetcode.com/discuss/post/8325811/google-l4-interview-experience-chances-b-3qmq/) | career, feedback, interview, l4-google | 3293 |
-| 2026-06-09 | [Google L4 - Team Match](https://leetcode.com/discuss/post/8323053/google-l4-team-match-by-anonymous_user-zx63/) | career, feedback, interview, l4-google, team-fit | 1204 |
-| 2026-06-08 | [From Zero to Offer Interview Preparation Roadmap](https://leetcode.com/discuss/post/8321890/from-zero-to-offer-interview-preparation-ek23/) | facebook, microsoft, amazon, uber, linkedin, salesforce +3 more | 4549 |
-| 2026-06-08 | [Google SRE-SWE (L3/L4) prep advice for someone strong on systems but rusty on DSA?](https://leetcode.com/discuss/post/8321689/google-sre-swe-l3l4-prep-advice-for-some-6jnl/) | interview | 647 |
-| 2026-06-07 | [Google L4 \| Interview Experience \| Bangalore \| Next Steps](https://leetcode.com/discuss/post/8319665/google-l4-interview-experience-bangalore-mwp1/) | interview, l4-google | 3206 |
-| 2026-06-07 | [Cracking MANG with 10 YEO - Reality check](https://leetcode.com/discuss/post/8319567/cracking-mang-with-10-yeo-reality-check-zi6j7/) | microsoft, amazon | 552 |
-| 2026-06-05 | [Google L3 Interview - looking for prep advice!](https://leetcode.com/discuss/post/8315751/google-l3-interview-looking-for-prep-adv-udzw/) | interview, google-interview-questions, swe-ii-google | 687 |
-| 2026-06-05 | [Google Cloud Web Application Engineer (Gurugram/Pune) – Updates After GHA?](https://leetcode.com/discuss/post/8315591/google-cloud-web-application-engineer-gu-dbb4/) | interview | 336 |
-| 2026-06-05 | [Google L4 Team match India](https://leetcode.com/discuss/post/8314530/google-l4-team-match-india-by-anonymous_-fyaa/) | career, feedback, compensation, interview | 2221 |
-| 2026-06-04 | [I had questions about system design round.](https://leetcode.com/discuss/post/8313663/i-had-questions-about-system-design-roun-jqo2/) | uber, career, interview-experience, system-design, interview | 659 |
-| 2026-06-02 | [Anyone given Domain Specific round (Android/iOS) at Google?](https://leetcode.com/discuss/post/8308783/anyone-given-domain-specific-round-andro-jdtq/) | interview | 368 |
-| 2026-06-01 | [Uber/Google Phone Screen Feedback Counts?](https://leetcode.com/discuss/post/8306742/uber-phone-screen-feedback-counts-by-ano-naz8/) | uber, interview | 999 |
-| 2026-06-01 | [Amaon SDE - I : In Person Interview at BLR office \|\| 4th Round(Leadership Principles)](https://leetcode.com/discuss/post/8306214/amaon-sde-i-in-person-interview-at-blr-o-ey3v/) | amazon, low-level-design, dsa-java, amazon-sde1-2 | 1095 |
-| 2026-06-01 | [Stuck in Google Team Matching for 4 Months, Any Advice?](https://leetcode.com/discuss/post/8306204/stuck-in-google-team-matching-for-4-mont-0qzb/) | interview | 950 |
-| 2026-05-31 | [Preparing for Google Interview in Embedded Domain](https://leetcode.com/discuss/post/8304833/preparing-for-google-interview-in-embedd-y1l2/) | interview | 291 |
-| 2026-05-31 | [Google(L4) intervew loop - In progess \| Need partner for further Prep](https://leetcode.com/discuss/post/8304156/uber-hld-upcoming-by-anonymous_user-vk6g/) |  | 937 |
-| 2026-05-31 | [Google Interview Process Timeline Question](https://leetcode.com/discuss/post/8303584/google-interview-process-timeline-questi-gyjd/) | l4-google | 853 |
-| 2026-05-30 | [2 YOE and completely lost on System Design — help!](https://leetcode.com/discuss/post/8303012/2-yoe-and-completely-lost-on-system-desi-r7ot/) | microsoft, amazon, uber, career, system-design, compensation +1 more | 1755 |
-| 2026-05-30 | [Google interview question about unnoticed bugs](https://leetcode.com/discuss/post/8302587/google-interview-question-about-unnotice-6tjm/) | l4-google, google-interview-questions | 1097 |
-| 2026-05-30 | [UBER Freight - SDE - II : Round - 3](https://leetcode.com/discuss/post/8302462/uber-freight-sde-ii-round-3-by-anonymous-mr1m/) | uber, low-level-design, dsa, sde-2-3 | 912 |
-| 2026-05-30 | [Google L4 \| Domain Specific Round for Full Stack?](https://leetcode.com/discuss/post/8302430/google-l4-domain-specific-round-for-full-d33s/) |  | 569 |
-| 2026-05-30 | [Google L4 Team Matching — Looking for Recent Experiences](https://leetcode.com/discuss/post/8301980/google-l4-team-matching-looking-for-rece-hbpj/) | india, feedback, interview, l4-google | 735 |
-| 2026-05-29 | [Google Interview Experience - L4](https://leetcode.com/discuss/post/8301524/google-interview-experience-l4-by-anonym-gjl3/) | career, feedback, interview, l4-google | 2429 |
-| 2026-05-29 | [Looking for a study / mock partner (SSE and above)](https://leetcode.com/discuss/post/8301486/looking-for-a-study-mock-partner-sse-and-wsxr/) | career, interview | 141 |
-| 2026-05-29 | [Google L4 \| Interviewer No Show](https://leetcode.com/discuss/post/8300512/google-l4-interviewer-no-show-by-anonymo-24hw/) | interview | 880 |
-| 2026-05-28 | [Google L4/L5 Prep](https://leetcode.com/discuss/post/8299704/google-l4l5-prep-by-anonymous_user-gtay/) | career, online-assessment, compensation, interview +2 more | 4181 |
-| 2026-05-28 | [Interview prep for Forward Deployed Engineer FDE , GENAI, AI Engineer for Big Tech Companies](https://leetcode.com/discuss/post/8298597/interview-prep-for-forward-deployed-engi-jq9b/) | databricks, openai, career, machine-learning-engineer +4 more | 1213 |
-| 2026-05-27 | [Seeking Advice from FAANG Engineers — How to Break In with ~10 Months of Experience?](https://leetcode.com/discuss/post/8297185/seeking-advice-from-faang-engineers-how-1mho4/) | microsoft, amazon, flipkart, career | 438 |
-| 2026-05-27 | [Google L4 - Software Engineer III - Bengaluru](https://leetcode.com/discuss/post/8296795/google-l4-software-engineer-iii-bengalur-1kgb/) | career, l4-google | 1622 |
-| 2026-05-27 | [Google L5 team matching](https://leetcode.com/discuss/post/8295978/google-l5-team-matching-by-anonymous_use-yk2e/) | career, feedback, interview, senior-level | 628 |
-| 2026-05-25 | [Google L4 Chance of Team Match and HC approval](https://leetcode.com/discuss/post/8292554/google-l4-chance-of-team-match-and-hc-ap-sdvk/) | career, interview, l4-google | 1721 |
-| 2026-05-23 | [Google  \| Amazon \| SDE-2 \| Bangalore](https://leetcode.com/discuss/post/8287855/google-amazon-sde-2-bangalore-by-anonymo-8qew/) | amazon, career, interview, l4-google | 4010 |
-| 2026-05-22 | [Google \| Application Engineer \| Upcoming Coding Rounds - Insights Needed](https://leetcode.com/discuss/post/8286412/google-application-engineer-upcoming-cod-99aa/) | technical-interview, interview-experience, interview +2 more | 656 |
-| 2026-05-22 | [Onsite feedback delay](https://leetcode.com/discuss/post/8285817/onsite-feedback-delay-by-anonymous_user-tfw4/) |  | 277 |
-| 2026-05-19 | [Google \| Application Engineer \| Upcoming Coding Rounds - Insights Needed](https://leetcode.com/discuss/post/8277469/google-application-engineer-upcoming-cod-ndk6/) | technical-interview, interview-experience, interview +2 more | 553 |
-| 2026-05-19 | [Google L4 \| Banglore](https://leetcode.com/discuss/post/8276966/google-l4-banglore-by-anonymous_user-97gh/) | career, interview, l4-google | 5758 |
-| 2026-05-18 | [Google L3 \|\| Bangalore, India \|\| Interview Experience](https://leetcode.com/discuss/post/8268786/google-l3-bangalore-india-interview-expe-dt1h/) | career, feedback, interview, job-transition | 4390 |
-| 2026-05-18 | [Google L4 Interview \|\| Reject](https://leetcode.com/discuss/post/8265899/google-l4-interview-reject-by-anonymous_-xsc3/) | bengaluru, interview, l4-google | 4628 |
-| 2026-05-18 | [Onsite Feedback delay](https://leetcode.com/discuss/post/8263531/onsite-feedback-delay-by-anonymous_user-co18/) |  | 429 |
-| 2026-05-16 | [Targeting L5/Senior (Google, Meta, HFT) \| UK{LONDON} Based](https://leetcode.com/discuss/post/8252864/targeting-l5senior-google-meta-hft-uklon-5pvr/) | facebook, microsoft, amazon, bloomberg, optiver, career +3 more | 1656 |
-| 2026-05-15 | [Amazon SDE - I In - Person Interview at BLR Office](https://leetcode.com/discuss/post/8241486/amazon-sde-i-in-person-interview-at-blr-7drz2/) | amazon, java, career, low-level-design, dsa, interview +3 more | 1635 |
-| 2026-05-14 | [Google L4 In-person Interview](https://leetcode.com/discuss/post/8218498/google-l4-in-person-interview-by-anonymo-eqbq/) | interview, l4-google | 3902 |
-| 2026-05-13 | [Google L4 interview](https://leetcode.com/discuss/post/8217371/google-l4-interview-by-anonymous_user-n071/) | career, interview, l4-google | 2277 |
-| 2026-05-12 | [Next Steps after Onsite Interviews](https://leetcode.com/discuss/post/8198530/next-steps-after-onsite-interviews-by-an-4jnw/) | l4-google | 748 |
-| 2026-05-11 | [Google Phone Interview Questions](https://leetcode.com/discuss/post/8195929/google-phone-interview-questions-by-anon-mk7j/) | interview | 1404 |
-| 2026-05-11 | [[URGENT] - Google Onsite Interview](https://leetcode.com/discuss/post/8193404/urgent-google-onsite-interview-by-anonym-wi2v/) | career, feedback, interview, l4-google | 1297 |
-| 2026-05-08 | [🚀 Google Interview Experience (2 Rounds) SWE - II (L3)](https://leetcode.com/discuss/post/8173874/google-interview-experience-2-rounds-swe-ku5d/) | interview, l3-google, swe-2-google, swe-ii-google | 2439 |
-| 2026-05-07 | [[PART-2] 100+ interviews \| 50+ companies \| 1 offer](https://leetcode.com/discuss/post/8162098/part-2-100-interviews-50-companies-1-off-cjdq/) | microsoft, amazon, uber, salesforce, career, oraclesql +2 more | 3063 |
-| 2026-05-07 | [Google L4 OA + Interviews](https://leetcode.com/discuss/post/8159666/google-l4-oa-interviews-by-anonymous_use-6mmf/) | interview | 1164 |
-| 2026-05-04 | [Google \| Senior Software Engineer \| Preparation Help](https://leetcode.com/discuss/post/8140583/google-senior-software-engineer-preparat-b4fw/) | interview | 1334 |
-| 2026-05-03 | [Google L4 screening](https://leetcode.com/discuss/post/8134146/google-l4-screening-by-user9501hm-jgmz/) |  | 539 |
-| 2026-05-03 | [ONSITE GOOGLE INTERVIEW L4 Bangalore](https://leetcode.com/discuss/post/8133843/onsite-google-interview-l4-bangalore-by-czhvf/) | top-interview-questions, interview-experience, india +2 more | 1702 |
-| 2026-04-29 | [Google L4](https://leetcode.com/discuss/post/8113604/google-l4-by-anonymous_user-y9xg/) | interview | 1869 |
-| 2026-04-27 | [Google L4 Team matching](https://leetcode.com/discuss/post/8102178/google-l4-team-matching-looker-team-by-a-lhav/) | interview, l4-google, team-fit | 1353 |
-| 2026-04-25 | [Google SDEIII L4 Interview Experience](https://leetcode.com/discuss/post/8096071/google-sdeiii-interview-experience-by-an-67tm/) | dsa, l4-google, g-l | 2982 |
-| 2026-04-24 | [Onsite Interviews in May first week](https://leetcode.com/discuss/post/8095461/onsite-interviews-in-may-first-week-by-a-18s8/) |  | 725 |
-| 2026-04-22 | [Google Bangalore Onsite (L4) – Final 2 DSA Rounds (In-Person, Back-to-Back) – What to Expect?](https://leetcode.com/discuss/post/8052794/google-bangalore-onsite-l4-final-2-dsa-r-okwd/) | technical-interview, career, india, interview-question +2 more | 2105 |
-| 2026-04-20 | [Google Onsite SWE-II](https://leetcode.com/discuss/post/8019003/google-onsite-swe-ii-by-anonymous_user-yd0w/) | onsite, interview | 717 |
-| 2026-04-20 | [Help needed for the coming Google onsite full loop interview(L5)](https://leetcode.com/discuss/post/8008818/help-needed-for-the-coming-google-onsite-ps8y/) |  | 744 |
-| 2026-04-19 | [What theory questions are commonly asked for Java (Core Java) interviews?](https://leetcode.com/discuss/post/7994659/what-theory-questions-are-commonly-asked-pxwg/) | nike, blinkit, java, career, interview-experience | 398 |
-| 2026-04-17 | [Advice for Google L4 Rounds](https://leetcode.com/discuss/post/7967734/advice-for-google-l4-rounds-by-anonymous-5dzr/) | career, feedback, interview, l4-google | 1340 |
-| 2026-04-16 | [Just Got Amazon 6m Internhip offer 🧿🎊](https://leetcode.com/discuss/post/7945762/just-got-amazon-6m-internhip-offer-by-an-brp9/) | amazon, technical-interview, career, interview-experience +5 more | 718 |
-| 2026-04-16 | [Google Interview Update](https://leetcode.com/discuss/post/7939900/google-interview-update-by-anonymous_use-7q3a/) |  | 1018 |
-| 2026-04-16 | [Google \| Hiring Manager Round \| Gemini Applications \| SWE III ML \| Bengaluru](https://leetcode.com/discuss/post/7936329/google-hiring-manager-round-gemini-appli-mb5k/) | gemini, data-science, machine-learning-engineer +4 more | 2067 |
-| 2026-04-15 | [Amazon \| SDE-I Contract(1 year) \| Expectations \| Location - BLR \| YOE - 2 years](https://leetcode.com/discuss/post/7926825/amazon-sde-i-contract1-year-expectations-mc10/) | microsoft, amazon, technical-interview, java, career +2 more | 735 |
-| 2026-04-14 | [Google Recruitment Process - 2 weeks and no update](https://leetcode.com/discuss/post/7911003/google-recruitment-process-2-weeks-and-n-vosh/) | career, feedback, interview, l4-google | 1064 |
-| 2026-04-14 | [Google L4 onsite: strong DSA, failed coding round, invited to retry](https://leetcode.com/discuss/post/7909727/google-l4-onsite-strong-dsa-failed-codin-bed9/) | l4-google | 1385 |
-| 2026-04-13 | [Google Web Solutions Engineer – Delay after final round](https://leetcode.com/discuss/post/7889060/google-web-solutions-engineer-delay-afte-pmz3/) | career, feedback, interview | 419 |
-| 2026-04-12 | [Google Interview Retake: Do Interviewers See Previous Questions or Vary Problem Types?](https://leetcode.com/discuss/post/7882921/google-interview-retake-do-interviewers-24928/) | interview | 770 |
-| 2026-04-12 | [Google L4 Chances](https://leetcode.com/discuss/post/7881477/google-l4-chances-by-anonymous_user-ik8e/) | interview, l4-google | 3216 |
-| 2026-04-11 | [reverser LL nodes with verifying hash values coding question onsite google](https://leetcode.com/discuss/post/7873505/reverser-ll-nodes-with-verifying-hash-va-wng3/) | interview | 618 |
-| 2026-04-11 | [Google Web Solutions Engineer \| Need help](https://leetcode.com/discuss/post/7870214/google-web-solutions-engineer-need-help-rhubf/) | career, feedback, compensation, interview | 664 |
-| 2026-04-11 | [Google L4 \|](https://leetcode.com/discuss/post/7869055/google-l4-by-anonymous_user-i3e3/) | career, interview, l4-google | 2764 |
-| 2026-04-11 | [Google L4 \| Bengaluru \| Rejected](https://leetcode.com/discuss/post/7867127/google-l4-bengaluru-reject-by-anonymous_-vho0/) | interview-experience, interview | 2846 |
-| 2026-04-10 | [Google L5 screening : Reject](https://leetcode.com/discuss/post/7855988/google-l5-screening-reject-by-anonymous_-4a2i/) | interview | 2239 |
-| 2026-04-09 | [Stuck in Google team match (4 months)](https://leetcode.com/discuss/post/7845117/stuck-in-google-team-match-4-months-by-a-aa4e/) | l4-google, team-fit | 896 |
-| 2026-04-08 | [Google SDE-3 \| Phone Screen & Behavioral \| Got a second chance for a coding round](https://leetcode.com/discuss/post/7827768/google-sde-3-phone-screen-behavioral-got-pao9/) | feedback, phone-screening, interview, l4-google +1 more | 1145 |
-| 2026-04-08 | [Google Forward Deployed Engineer (FDE)](https://leetcode.com/discuss/post/7821696/google-forward-deployed-engineer-fde-by-l4th5/) | microsoft, amazon, linkedin, palantir, atlassian, career +3 more | 2085 |
-| 2026-04-08 | [Google L3 Team Matching - 11 Months and Expiring Soon. Anyone else in the same boat?](https://leetcode.com/discuss/post/7819881/google-l3-team-matching-11-months-and-ex-xwiq/) | career | 819 |
-| 2026-04-07 | [are google interviews happening f2f ?](https://leetcode.com/discuss/post/7811123/are-google-interviews-happening-f2f-by-r-9fv3/) |  | 893 |
-| 2026-04-07 | [Switch Company PBC](https://leetcode.com/discuss/post/7807781/switch-company-pbc-by-nidhirajpatel-te4n/) |  | 369 |
-| 2026-04-05 | [Google L4 DSA Phone Screen (India, 5 YOE)](https://leetcode.com/discuss/post/7785661/google-l4-dsa-phone-screen-india-5-yoe-b-8umr/) | technical-interview, top-interview-questions +4 more | 2279 |
-| 2026-04-04 | [Is Goolge asking multithreading/concurrency questions ?](https://leetcode.com/discuss/post/7777574/is-goolge-asking-multithreadingconcurren-mdft/) | interview | 997 |
-| 2026-04-02 | [Google WSE First Round - What to expect?](https://leetcode.com/discuss/post/7753715/google-wse-first-round-what-to-expect-by-ire9/) |  | 440 |
-| 2026-04-01 | [Google \| Team Match round with tech lead](https://leetcode.com/discuss/post/7742939/google-team-match-round-with-tech-lead-b-3frb/) | l4-google, team-fit, l1-google | 1352 |
-| 2026-03-29 | [google](https://leetcode.com/discuss/post/7714230/google-by-anonymous_user-qmbu/) |  | 1443 |
-| 2026-03-28 | [L3 google onsite Arithmetic sequence question.](https://leetcode.com/discuss/post/7708808/l3-google-onsite-arithmetic-sequence-que-85x3/) | interview, l3-google | 1518 |
-| 2026-03-28 | [Google L5 Interview phone screening](https://leetcode.com/discuss/post/7706368/google-l5-interview-phone-screening-by-a-4tjw/) | interview, google-interview-questions | 1831 |
-| 2026-03-28 | [L4 DSA Round Question](https://leetcode.com/discuss/post/7705895/google-l4-dsa-round-question-by-anonymou-nh2t/) | facebook, microsoft, amazon, career, interview-question +1 more | 2581 |
-| 2026-03-27 | [Google Recently Asked Coding Questions Compilation [Mar 2025-26, SWE-L3,L4]](https://leetcode.com/discuss/post/7701662/google-recently-asked-coding-questions-c-296m/) | career, interview, l4-google, google-interview-questions | 3524 |
-| 2026-03-27 | [Google Interview for PSE (Product Solutions Engineer) role (India)](https://leetcode.com/discuss/post/7700921/google-interview-for-pse-product-solutio-apwn/) | interview-experience, interview-question, interview | 495 |
-| 2026-03-26 | [Amazon Logical and Maintainability Round](https://leetcode.com/discuss/post/7697546/amazon-logical-and-maintainability-round-kx6e/) | amazon, interview | 293 |
-| 2026-03-23 | [Google - Partner Engineer, Device Ops YouTube- Bangalore](https://leetcode.com/discuss/post/7684068/google-partner-engineer-device-ops-youtu-h7t2/) |  | 417 |
-| 2026-03-18 | [How I failed L3 interview at Google](https://leetcode.com/discuss/post/7662694/how-i-failed-l3-interview-at-google-by-m-dbh2/) | career, interview | 2335 |
-| 2026-03-18 | [Google Team Matching Stuck ~1 Year , Is This Basically Dead?](https://leetcode.com/discuss/post/7659329/google-team-matching-stuck-1-year-is-thi-q4kx/) | interview | 1134 |
-| 2026-03-17 | [Offer Suggestion Needed: Google vs NVIDIA](https://leetcode.com/discuss/post/7654767/offer-comparison-google-vs-nvidia-by-ano-rar5/) | nvidia, career, feedback, compensation | 3048 |
-| 2026-03-14 | [Google L3 Team Matching Process Info](https://leetcode.com/discuss/post/7646569/google-l3-team-matching-process-info-by-aohqg/) |  | 1158 |
-| 2026-03-13 | [[URGENT HELP NEEDED] Google Interview Stuck in “Approval Pending to start interview process”](https://leetcode.com/discuss/post/7644812/google-interview-stuck-in-approval-pendi-8p0j/) | technical-interview, india, dsa, interview, l4-google | 989 |
-| 2026-03-12 | [google virtual onsite deny](https://leetcode.com/discuss/post/7643272/google-virtual-onsite-deny-by-anonymous_-6vgl/) | interview | 813 |
-| 2026-03-12 | [Sharing Regular Off-Campus Job Opportunities (0–5 YOE + Internships)](https://leetcode.com/discuss/post/7643229/sharing-regular-off-campus-job-opportuni-8f9u/) | microsoft, amazon, apple, flipkart, career, interview | 957 |
-| 2026-03-12 | [Google Team Matching Hell](https://leetcode.com/discuss/post/7642901/google-team-matching-hell-by-sachinbhola-dt1h/) | l4-google, team-fit | 921 |
-| 2026-03-11 | [Google L4 chances](https://leetcode.com/discuss/post/7641721/google-l4-chances-by-anonymous_user-m7h3/) | feedback, interview, l4-google | 1441 |
-| 2026-03-11 | [What are my chances of proceeding to team matching? (L3 - Google Europe)](https://leetcode.com/discuss/post/7641689/what-are-the-chances-to-pass-to-the-team-5sog/) | interview | 866 |
-| 2026-03-11 | [Google L3 Interview Process - Recruiter Asked for Documents, Is this pre-HC?](https://leetcode.com/discuss/post/7641112/google-l3-interview-process-recruiter-as-5e6t/) | career, interview | 932 |
-| 2026-03-10 | [DSA Mock Interview Partner - Google](https://leetcode.com/discuss/post/7639416/dsa-mock-interview-partner-google-by-ano-oqyi/) | interview | 490 |
-| 2026-03-09 | [Beginner Preparing for Google Interviews — Where Should I Start?](https://leetcode.com/discuss/post/7637023/beginner-preparing-for-google-interviews-3vb4/) |  | 471 |
-| 2026-03-08 | [Google interview upcoming](https://leetcode.com/discuss/post/7635145/google-interview-upcoming-dsa-partner-by-hhav/) | dsa, interview-question, interview | 1106 |
-| 2026-03-07 | [🔥 Honest Poll for People Preparing for Google Interviews](https://leetcode.com/discuss/post/7632214/honest-poll-for-people-preparing-for-goo-djwn/) | interview | 1506 |
-| 2026-03-07 | [Google Interview query](https://leetcode.com/discuss/post/7632037/google-interview-query-by-anonymous_user-0xnw/) |  | 973 |
-| 2026-03-06 | [Extremely sad Google L5 interview experience](https://leetcode.com/discuss/post/7631077/extremely-sad-google-l5-interview-experi-jm8b/) | atlassian, interview | 2732 |
-| 2026-03-06 | [Google L3 interview experience - HC approval chances](https://leetcode.com/discuss/post/7629725/google-l3-interview-experience-hc-approv-akpm/) | interview | 1900 |
-| 2026-03-05 | [Allowed time gap between each round of interview at Google](https://leetcode.com/discuss/post/7626255/allowed-time-gap-between-each-round-of-i-yyb6/) |  | 492 |
-| 2026-03-05 | [Looking for LLD/HLD Practice Partner](https://leetcode.com/discuss/post/7626143/looking-for-lldhld-practice-partner-by-a-junj/) | microsoft, amazon, career, compensation, interview | 1257 |
-| 2026-03-04 | [Google L5 Interview Experience](https://leetcode.com/discuss/post/7624444/google-l5-interview-experience-by-anonym-o9ja/) | interview | 2757 |
-| 2026-03-04 | [Interview Experience: Google \| L3 Web Solutions Engineer (GTech)](https://leetcode.com/discuss/post/7624355/interview-experience-google-l3-web-solut-ger7/) | interview-experience | 1355 |
-| 2026-03-03 | [Advice for Google onsite interview](https://leetcode.com/discuss/post/7623228/advice-for-google-onsite-interview-by-vk-zzte/) | interview, l4-google, google-interview-questions | 1139 |
-| 2026-03-02 | [Need advice, Google onsite round offline](https://leetcode.com/discuss/post/7619877/need-advice-google-onsite-round-offline-q7ewb/) | career, interview | 1754 |
-| 2026-03-01 | [Google Team Match \| SWE L3](https://leetcode.com/discuss/post/7617480/google-team-match-swe-l3-by-anonymous_us-b7jn/) | career, feedback, interview, team-fit | 786 |
-| 2026-03-01 | [Google L5 interview screening](https://leetcode.com/discuss/post/7617354/google-l5-interview-screening-by-anonymo-ld26/) | technical-interview, interview-experience, senior-level +1 more | 2157 |
-| 2026-02-28 | [Google \| Team Matching \| L3 \| Waitlist](https://leetcode.com/discuss/post/7615069/google-team-matching-l3-doubt-by-anonymo-fe5h/) | interview-experience, general-discussion-2, team-fit | 1189 |
-| 2026-02-28 | [Understanding Time Complexity for Backtracking with Pruning](https://leetcode.com/discuss/post/7614127/understanding-time-complexity-for-backtr-rn7u/) | amazon, apple, atlassian, technical-interview, dsa | 714 |
-| 2026-02-26 | [Google Web Solutions Engineer \| L3](https://leetcode.com/discuss/post/7611418/google-web-solutions-engineer-l3-by-anon-fo7v/) | interview | 1637 |
-| 2026-02-26 | [Google L5 Interview Experience \| Onsite Bangalore 2025](https://leetcode.com/discuss/post/7610148/google-l5-interview-experience-onsite-ba-mk1z/) | google-interview-questions | 2206 |
-| 2026-02-24 | [GOOGLE L4 DSA Round: Difficulty Converting to Bottom-Up DP, Interview Advice Needed](https://leetcode.com/discuss/post/7605894/google-l4-dsa-round-difficulty-convertin-cy0n/) |  | 1700 |
-| 2026-02-23 | [Google L3 SWE AI/ML Onsite Confusion: In-Person vs “Virtual” Docs](https://leetcode.com/discuss/post/7603486/google-l3-swe-aiml-onsite-confusion-in-p-kkya/) |  | 567 |
-| 2026-02-23 | [Compensation at GOOGLE](https://leetcode.com/discuss/post/7602545/compensation-at-google-by-anonymous_user-019s/) | compensation, l4-google | 5026 |
-| 2026-02-20 | [Google L3 interview 2026](https://leetcode.com/discuss/post/7595211/google-l3-interview-2026-by-anonymous_us-cxtr/) | interview, l3-google | 2836 |
-| 2026-02-20 | ["My code Passed all test cases, but i failed the interview." ---Let's talk about the 2026 'Oper](https://leetcode.com/discuss/post/7594408/my-code-passed-all-test-cases-but-i-fail-dz5r/) | rejection-sampling, career, interview, job-search-2 | 1850 |
-| 2026-02-19 | [Need help with Integration Round.](https://leetcode.com/discuss/post/7591308/need-help-with-integration-round-by-nish-5t41/) |  | 124 |
-| 2026-02-18 | [Google Interview.](https://leetcode.com/discuss/post/7589816/google-interview-by-helloarjun111-7r88/) | interview | 2421 |
-| 2026-02-18 | [Google Team Match \| L3](https://leetcode.com/discuss/post/7589707/google-team-match-l3-by-anonymous_user-bg7i/) |  | 1202 |
-| 2026-02-17 | [Google L3 Android Domain Interview \|\| Need Help](https://leetcode.com/discuss/post/7585533/google-l3-android-domain-interview-need-30ty7/) |  | 327 |
-| 2026-02-17 | [Need LeetCode Premium for a Day](https://leetcode.com/discuss/post/7585292/need-leetcode-premium-for-a-day-by-anony-anoz/) | leetcode, career, google-interview-questions | 1117 |
-| 2026-02-15 | [Google Interview Process Changed \| Need Help](https://leetcode.com/discuss/post/7581438/google-interview-process-changed-need-he-oaqx/) | interview, l4-google | 3210 |
-| 2026-02-14 | [Google DSA Mock](https://leetcode.com/discuss/post/7579291/google-dsa-mock-by-tharun55-i5qq/) | interview | 899 |
-| 2026-02-13 | [Google dream ruined \| L 3](https://leetcode.com/discuss/post/7577253/google-dream-ruined-l-3-by-anonymous_use-isia/) | interview-experience | 2126 |
-| 2026-02-13 | [Google L4 USA (moved to TM)](https://leetcode.com/discuss/post/7577153/google-l4-usa-moved-to-tm-by-user9071bo-4sbr/) | career, feedback, interview, l4-google | 1004 |
-| 2026-02-13 | [System Design for Google L4 (India)?](https://leetcode.com/discuss/post/7576666/system-design-for-google-l4-india-by-ano-kx61/) | india, interview, l4-google | 1061 |
-| 2026-02-12 | [Offerretriever Marketing Tactics](https://leetcode.com/discuss/post/7574980/offerretriever-marketing-tactics-by-anon-kb2i/) |  | 150 |
-| 2026-02-12 | [Looking for Career Transition Advice After 2.5 Years at OCI](https://leetcode.com/discuss/post/7573941/looking-for-career-transition-advice-aft-bwg9/) | oci, career, compensation | 917 |
-| 2026-02-12 | [Google L4 infinite loop](https://leetcode.com/discuss/post/7572765/google-l4-infinite-loop-by-anonymous_use-3dgh/) | l4-google | 1321 |
-| 2026-02-11 | [Google Interview Experience \| L4 \| Onsite MountainView(UPDATE: Moved to TM)](https://leetcode.com/discuss/post/7571793/google-interview-experience-l4-onsite-mo-u7cr/) | career, feedback, interview, l4-google +1 more | 2126 |
-| 2026-02-11 | [Google Interview Experience \| L3 \| Onsite Banglore](https://leetcode.com/discuss/post/7570658/google-interview-experience-l3-onsite-ba-6eig/) | career, interview-experience, interview | 1923 |
-| 2026-02-10 | [[Interview Experience] Sharing First In-Person Google Onsite After Years of Virtual](https://leetcode.com/discuss/post/7567827/interview-experience-sharing-first-in-pe-oyg1/) | technical-interview, onsite, google-interview-questions | 2032 |
-| 2026-02-09 | [Free resources for recent OA (online assessment) questions.](https://leetcode.com/discuss/post/7565779/free-resources-for-recent-oa-online-asse-q9he/) | microsoft, amazon, salesforce, technical-interview, career +4 more | 2302 |
-| 2026-02-08 | [Google INDIA Bangalore L3 Cleared](https://leetcode.com/discuss/post/7563535/google-india-bangalore-l3-cleared-by-ano-u1kd/) |  | 1880 |
-| 2026-02-08 | [Google L4 Interview](https://leetcode.com/discuss/post/7563483/google-l4-interview-by-ay_ila-n7yp/) | interview, l4-google, google-interview-questions | 3191 |
-| 2026-02-07 | [Why Your System Design Interview Failed (And You Didn’t Even Realize It)](https://leetcode.com/discuss/post/7561018/why-your-system-design-interview-failed-uxbk5/) | microsoft, amazon, top-interview-questions, career +5 more | 1152 |
-| 2026-02-07 | [US: Google coding interview - find squares-ish](https://leetcode.com/discuss/post/7558860/us-google-coding-interview-find-squares-l4ngs/) | backend, feedback, interview, senior-level | 1216 |
-| 2026-02-06 | [Essential Graph Problems for SDE Interviews](https://leetcode.com/discuss/post/7556431/essential-graph-problems-for-sde-intervi-4iuy/) | graph, microsoft, amazon, leetcode, career +4 more | 1876 |
-| 2026-02-05 | [Q3 & Q4 Problems from Recent 34 Contests for OA Preparation](https://leetcode.com/discuss/post/7553438/q3-q4-problems-from-recent-34-contests-f-r1n8/) | microsoft, amazon, leetcode, career, online-assessment +3 more | 1187 |
-| 2026-02-04 | [Google Product Support Engineer (University Graduate 2026) What Questions asked In Interview?](https://leetcode.com/discuss/post/7551791/google-product-support-engineer-universi-l4sa/) | top-interview-questions, career, interview-experience +6 more | 460 |
-| 2026-02-04 | [Google \| L3 New York \| Unseen segments Problem. Need Advices please!](https://leetcode.com/discuss/post/7550619/google-l3-new-york-unseen-segments-probl-5hd3/) | interview-experience | 1111 |
-| 2026-02-03 | [Beyond the "Accepted" Screen: What 2026 Interviews Actually Want from You](https://leetcode.com/discuss/post/7549546/beyond-the-accepted-screen-what-2026-int-an4a/) | amazon, career, feedback, compensation, interview +4 more | 892 |
-| 2026-02-02 | [Google L3 \| Onsite \| Delayed interview once but I think it worked](https://leetcode.com/discuss/post/7544550/google-l3-onsite-delayed-interview-once-592ok/) | interview-experience | 1833 |
-| 2026-02-01 | [Google Interview Query](https://leetcode.com/discuss/post/7543997/google-interview-query-by-anonymous_user-gq6g/) |  | 401 |
-| 2026-02-01 | [Google Interview: Unknown Question](https://leetcode.com/discuss/post/7542615/google-interview-unknown-question-by-ano-4s4y/) | interview | 1936 |
-| 2026-02-01 | [Complete Greedy Problems & Resources Guide](https://leetcode.com/discuss/post/7541035/complete-greedy-problems-resources-guide-woyo/) | greedy, microsoft, amazon, leetcode, career, beginner +2 more | 912 |
-| 2026-01-31 | [Queries regarding the Latest GOOGLE Interview Process](https://leetcode.com/discuss/post/7540443/urgent-queries-regarding-the-latest-goog-eh4y/) | technical-interview, top-interview-questions +7 more | 1504 |
-| 2026-01-31 | [Don't waste time giving interviews at Google India](https://leetcode.com/discuss/post/7539543/dont-waste-time-giving-interviews-at-goo-k5ih/) | career, compensation, l4-google | 4390 |
-| 2026-01-31 | [Complete String Problems & Resources Guide](https://leetcode.com/discuss/post/7538070/complete-string-problems-resources-guide-5xk8/) | string, microsoft, amazon, leetcode, career, interview +2 more | 726 |
-| 2026-01-30 | [Complete Array Problems & Resources Guide](https://leetcode.com/discuss/post/7535587/complete-array-problems-resources-guide-6ssxp/) | array, microsoft, amazon, leetcode, career, interview +2 more | 1030 |
-| 2026-01-29 | [Google \| Onsite Invite Banglore \| L3](https://leetcode.com/discuss/post/7535385/google-onsite-invite-banglore-l3-by-anon-li3m/) | interview-experience, interview | 1447 |
-| 2026-01-29 | [Google L4 Interview Loop (India) – HC Outcome & Team Matching Chances?](https://leetcode.com/discuss/post/7534319/google-l4-interview-loop-india-hc-outcom-p70d/) | career, feedback, interview, l4-google, team-fit | 1331 |
-| 2026-01-29 | [Google \| Recruiter Call \| Feedback \| Team Matching \| L3](https://leetcode.com/discuss/post/7534265/google-recruiter-call-feedback-team-matc-6f35/) | team-matching-2, wait-list | 1128 |
-| 2026-01-29 | [Google Frontend L4/L5 - Prep](https://leetcode.com/discuss/post/7533263/google-frontend-l4l5-prep-by-up32guy-buc2/) | frontend | 928 |
-| 2026-01-26 | [Complete Binary Search Problems & Resources Guide](https://leetcode.com/discuss/post/7525228/complete-binary-search-problems-resource-qj2y/) | binary-search, microsoft, amazon, leetcode, career +3 more | 1499 |
-| 2026-01-25 | [Interview experience](https://leetcode.com/discuss/post/7523211/interview-experience-by-anonymous_user-sbsr/) | microsoft, flipkart | 904 |
-| 2026-01-25 | [SDE-1 AMAZON ON CONTRACT BASIS FOR 1 YEAR...](https://leetcode.com/discuss/post/7522876/sde-1-amazon-on-contract-basis-for-1-yea-7ofg/) | amazon, career, feedback, compensation, interview, l4-google +3 more | 1174 |
-| 2026-01-24 | [Google SDE-3 \| India Position \| Rejected](https://leetcode.com/discuss/post/7521416/google-sde-3-india-position-rejected-by-73mi8/) | india, sde-3-2 | 2280 |
-| 2026-01-24 | [gRPC Explained Like You Actually Need It in System Design Interviews](https://leetcode.com/discuss/post/7521173/grpc-explained-like-you-actually-need-it-4ci6/) | facebook, microsoft, amazon, top-interview-questions, career +4 more | 1041 |
-| 2026-01-24 | [Google Interview for SWE/SRE internship EMEA](https://leetcode.com/discuss/post/7520741/google-interview-for-swesre-internship-e-cbd5/) | interview | 552 |
-| 2026-01-24 | [Google \| L4 \| SWE 3 \| India \| 3.5 YOE](https://leetcode.com/discuss/post/7520006/google-l4-swe-3-india-35-yoe-by-anonymou-8pvq/) | career, india, compensation, bengaluru, l4-google | 15466 |
-| 2026-01-24 | [Google SWE Intern](https://leetcode.com/discuss/post/7519819/google-swe-intern-by-anonymous_user-fn4f/) | singapore, career | 370 |
-| 2026-01-23 | [Need Guidance: Not Getting Interview Calls Despite DSA Preparation](https://leetcode.com/discuss/post/7517620/need-guidance-not-getting-interview-call-ywuz/) | microsoft, amazon, uber, career, system-design, feedback +3 more | 743 |
+| Date | Post | Context |
+|------|------|---------|
+| 2026-08-08 | [LeetCode problems for AI Interviews](https://leetcode.com/discuss/post/8448866/leetcode-problems-for-ai-interviews-by-a-cnj8/) | amazon, openai, career, feedback, machine-learning-engineer +4 more |
+| 2026-08-06 | [Can I ask for virtual onsite at Google?](https://leetcode.com/discuss/post/8444095/can-i-ask-for-virtual-onsite-at-google-b-19jx/) |  |
+| 2026-08-03 | [Google Staff Software Engineer (L6)](https://leetcode.com/discuss/post/8439367/google-staff-software-engineer-l6-by-abh-n36g/) | interview |
+| 2026-08-03 | [Google L4 chances](https://leetcode.com/discuss/post/8439101/google-l4-chances-by-anonymous_user-n5il/) | career, feedback, interview, l4-google |
+| 2026-08-03 | [Google L4 Chances](https://leetcode.com/discuss/post/8438964/google-l4-chances-by-pushya_bansal-y3ph/) |  |
+| 2026-07-27 | [Screening Round with Recruiter for Web Solutions Engineer at Google](https://leetcode.com/discuss/post/8423751/screening-round-with-recruiter-for-web-s-5897/) | career, interview, l4-google |
+| 2026-07-25 | [Feedback from reqruiter](https://leetcode.com/discuss/post/8418035/feedback-from-reqruiter-by-barez59-spgt/) | feedback |
+| 2026-07-22 | [What to expect in Google's tech lead interview and role](https://leetcode.com/discuss/post/8412228/what-to-expect-in-googles-tech-lead-inte-aq1g/) | technical-interview |
+| 2026-07-20 | [Google L4](https://leetcode.com/discuss/post/8409212/google-l4-by-anonymous_user-n4gg/) |  |
+| 2026-07-20 | [Need help in coding round of L4 PhD early careers Google India](https://leetcode.com/discuss/post/8408470/need-help-in-coding-round-of-l4-phd-earl-z9o4/) | interview |
+| 2026-07-19 | [Forward Deployed Engineer Interview Google Cloud US](https://leetcode.com/discuss/post/8407969/forward-deployed-engineer-interview-goog-90sp/) |  |
+| 2026-07-17 | [Google SRE (Software Developer III) Interview Coming Up – Looking for Recent Interview Insights](https://leetcode.com/discuss/post/8403716/google-sre-software-developer-iii-interv-n5mg/) | interview |
+| 2026-07-17 | [Google L3 (India) Interview Experience need help (ex interviewers especially welcome)](https://leetcode.com/discuss/post/8403050/google-l3-india-interview-experience-nee-ya6h/) | interview |
+| 2026-07-14 | [Google L4 \| Team Match](https://leetcode.com/discuss/post/8397122/google-l4-team-match-by-anonymous_user-kcfb/) | interview |
+| 2026-07-12 | [Can someone help with last 6 months Google Questions ?](https://leetcode.com/discuss/post/8392512/can-someone-help-with-last-6-months-goog-k1do/) | career, l4-google, google-interview-questions |
+| 2026-07-10 | [System Design Board Built for Mock Interviews](https://leetcode.com/discuss/post/8388985/system-design-board-built-for-mock-inter-5dsq/) | microsoft, leetcode, backend, interview, l4-google +3 more |
+| 2026-07-04 | [Any Updates for Google Software engineer intern 2027 summer?](https://leetcode.com/discuss/post/8375211/any-updates-for-google-software-engineer-0cye/) | career, interview, internship-2 |
+| 2026-07-02 | [c# in Google Interview](https://leetcode.com/discuss/post/8371223/c-in-google-interview-by-anonymous_user-pslg/) |  |
+| 2026-07-02 | [After 6 Months, It's Time to Build Again](https://leetcode.com/discuss/post/8370596/after-6-months-its-time-to-build-again-b-6cu6/) | microsoft, amazon, leetcode, career, interview +1 more |
+| 2026-07-01 | [I need advice on my Google Intern Interview](https://leetcode.com/discuss/post/8370237/i-need-advice-on-my-google-intern-interv-owuo/) | interview, google-interview-questions |
+| 2026-06-30 | [Google L4 Team Matching Phase](https://leetcode.com/discuss/post/8368243/google-l4-team-matching-phase-by-vj_tirt-k0vq/) | l4-google, l1-google, google-interview-questions |
+| 2026-06-30 | [Google Googliness round 2025 and 2026](https://leetcode.com/discuss/post/8367035/google-googliness-round-2025-and-2026-by-qemm/) |  |
+| 2026-06-28 | [Data and AI roles Job interviews guidance](https://leetcode.com/discuss/post/8362765/data-and-ai-roles-job-interviews-guidanc-4q47/) | microsoft, amazon, uber, flipkart, data-science +4 more |
+| 2026-06-28 | [Google Doesn't Just Want Answers, They Want Every Detail - My HR Round Breakdown](https://leetcode.com/discuss/post/8362764/google-doesnt-just-want-answers-they-wan-26hk/) | backend, interview |
+| 2026-06-27 | [Google L4 \| Onsite Expectations](https://leetcode.com/discuss/post/8361591/google-l4-onsite-expectations-by-anonymo-728k/) | onsite, interview |
+| 2026-06-26 | [Seeking Guidance for Cracking Google + Looking for Serious Study Partners](https://leetcode.com/discuss/post/8359851/seeking-guidance-for-cracking-google-loo-zlg6/) | amazon, career, feedback, dsa, interview, study-group-2 +2 more |
+| 2026-06-26 | [Buddy For DSA and Interview Prepration](https://leetcode.com/discuss/post/8359294/buddy-for-dsa-and-interview-prepration-b-3kh3/) | interview |
+| 2026-06-25 | [Google Offer](https://leetcode.com/discuss/post/8357173/google-offer-by-anonymous_user-ik5u/) | career, feedback, compensation, interview, l4-google +1 more |
+| 2026-06-21 | [Google \| SWE-2 (L3)  \| Team Match Query](https://leetcode.com/discuss/post/8348520/google-swe-2-team-match-query-by-anonymo-7ftp/) | team-fit |
+| 2026-06-21 | [Learn System Design for Interviews](https://leetcode.com/discuss/post/8348146/learn-system-design-for-interviews-by-ar-o1sz/) | microsoft, dsa, dsa-resources, system-design-2 |
+| 2026-06-20 | [How long does Google usually take to make a decision after onsite interviews?](https://leetcode.com/discuss/post/8347721/how-long-does-google-usually-take-to-mak-tx0m/) | feedback, interview |
+| 2026-06-20 | [Google L4 Interview feedback](https://leetcode.com/discuss/post/8347017/google-l4-interview-feedback-by-anonymou-unin/) | feedback |
+| 2026-06-19 | [Google L3 SWE (India) Interview Experience \| Offer Received](https://leetcode.com/discuss/post/8345294/google-l3-swe-india-interview-experience-z8un/) | interview |
+| 2026-06-17 | [Google L4 \| Banglore](https://leetcode.com/discuss/post/8340444/google-l4-banglore-by-anonymous_user-i96q/) |  |
+| 2026-06-15 | [Referaal status while in team match](https://leetcode.com/discuss/post/8334901/referaal-status-while-in-team-match-by-a-m244/) |  |
+| 2026-06-14 | [Have Google virtual rounds (Domain specific + DSA and GL) on Wednesday any suggestions?](https://leetcode.com/discuss/post/8334107/have-google-virtual-rounds-domain-specif-ufky/) | career, interview, l4-google |
+| 2026-06-14 | [Upcoming Amazon interview Prep - Need Help](https://leetcode.com/discuss/post/8332865/upcoming-amazon-interview-prep-need-help-ocdw/) | amazon, career, feedback, dsa, interview, amazon-sde1-2 |
+| 2026-06-13 | [SDE-2 Microsoft Azure Team Interview Questions (LLD + HLD)](https://leetcode.com/discuss/post/8331863/sde-2-microsoft-azure-team-interview-que-93y6/) | microsoft, amazon, career, feedback, compensation, interview +2 more |
+| 2026-06-12 | [L5 Google Rating Feedback](https://leetcode.com/discuss/post/8330164/l5-google-rating-feedback-by-anonymous_u-yku7/) | career, feedback, interview |
+| 2026-06-10 | [Google L4 India - Compensation](https://leetcode.com/discuss/post/8326052/salary-expectations-for-google-l4-india-y5m1h/) | career, feedback, compensation, interview, l4-google |
+| 2026-06-10 | [Google \| L4 \| Interview Experience \| Chances](https://leetcode.com/discuss/post/8325811/google-l4-interview-experience-chances-b-3qmq/) | career, feedback, interview, l4-google |
+| 2026-06-09 | [Google L4 - Team Match](https://leetcode.com/discuss/post/8323053/google-l4-team-match-by-anonymous_user-zx63/) | career, feedback, interview, l4-google, team-fit |
+| 2026-06-08 | [From Zero to Offer Interview Preparation Roadmap](https://leetcode.com/discuss/post/8321890/from-zero-to-offer-interview-preparation-ek23/) | facebook, microsoft, amazon, uber, linkedin, salesforce +3 more |
+| 2026-06-08 | [Google SRE-SWE (L3/L4) prep advice for someone strong on systems but rusty on DSA?](https://leetcode.com/discuss/post/8321689/google-sre-swe-l3l4-prep-advice-for-some-6jnl/) | interview |
+| 2026-06-07 | [Google L4 \| Interview Experience \| Bangalore \| Next Steps](https://leetcode.com/discuss/post/8319665/google-l4-interview-experience-bangalore-mwp1/) | interview, l4-google |
+| 2026-06-07 | [Cracking MANG with 10 YEO - Reality check](https://leetcode.com/discuss/post/8319567/cracking-mang-with-10-yeo-reality-check-zi6j7/) | microsoft, amazon |
+| 2026-06-05 | [Google L3 Interview - looking for prep advice!](https://leetcode.com/discuss/post/8315751/google-l3-interview-looking-for-prep-adv-udzw/) | interview, google-interview-questions, swe-ii-google |
+| 2026-06-05 | [Google Cloud Web Application Engineer (Gurugram/Pune) – Updates After GHA?](https://leetcode.com/discuss/post/8315591/google-cloud-web-application-engineer-gu-dbb4/) | interview |
+| 2026-06-05 | [Google L4 Team match India](https://leetcode.com/discuss/post/8314530/google-l4-team-match-india-by-anonymous_-fyaa/) | career, feedback, compensation, interview |
+| 2026-06-04 | [I had questions about system design round.](https://leetcode.com/discuss/post/8313663/i-had-questions-about-system-design-roun-jqo2/) | uber, career, interview-experience, system-design, interview |
+| 2026-06-02 | [Anyone given Domain Specific round (Android/iOS) at Google?](https://leetcode.com/discuss/post/8308783/anyone-given-domain-specific-round-andro-jdtq/) | interview |
+| 2026-06-01 | [Uber/Google Phone Screen Feedback Counts?](https://leetcode.com/discuss/post/8306742/uber-phone-screen-feedback-counts-by-ano-naz8/) | uber, interview |
+| 2026-06-01 | [Amaon SDE - I : In Person Interview at BLR office \|\| 4th Round(Leadership Principles)](https://leetcode.com/discuss/post/8306214/amaon-sde-i-in-person-interview-at-blr-o-ey3v/) | amazon, low-level-design, dsa-java, amazon-sde1-2 |
+| 2026-06-01 | [Stuck in Google Team Matching for 4 Months, Any Advice?](https://leetcode.com/discuss/post/8306204/stuck-in-google-team-matching-for-4-mont-0qzb/) | interview |
+| 2026-05-31 | [Preparing for Google Interview in Embedded Domain](https://leetcode.com/discuss/post/8304833/preparing-for-google-interview-in-embedd-y1l2/) | interview |
+| 2026-05-31 | [Google(L4) intervew loop - In progess \| Need partner for further Prep](https://leetcode.com/discuss/post/8304156/uber-hld-upcoming-by-anonymous_user-vk6g/) |  |
+| 2026-05-31 | [Google Interview Process Timeline Question](https://leetcode.com/discuss/post/8303584/google-interview-process-timeline-questi-gyjd/) | l4-google |
+| 2026-05-30 | [2 YOE and completely lost on System Design — help!](https://leetcode.com/discuss/post/8303012/2-yoe-and-completely-lost-on-system-desi-r7ot/) | microsoft, amazon, uber, career, system-design, compensation +1 more |
+| 2026-05-30 | [Google interview question about unnoticed bugs](https://leetcode.com/discuss/post/8302587/google-interview-question-about-unnotice-6tjm/) | l4-google, google-interview-questions |
+| 2026-05-30 | [UBER Freight - SDE - II : Round - 3](https://leetcode.com/discuss/post/8302462/uber-freight-sde-ii-round-3-by-anonymous-mr1m/) | uber, low-level-design, dsa, sde-2-3 |
+
+_156 more not shown._
+
+### Reddit
+
+| Date | Post | Context |
+|------|------|---------|
+| 2026-08-11 | [Google interview next week: forward deployed engineer](https://www.reddit.com/r/leetcode/comments/1vlahav/google_interview_next_week_forward_deployed/) | r/leetcode |
+| 2026-08-11 | [Rants of a laid off developer: LinkedIn office visit got me rage applying to jobs again](https://www.reddit.com/r/cscareerquestions/comments/1vl9hxq/rants_of_a_laid_off_developer_linkedin_office/) | r/cscareerquestions |
+| 2026-08-10 | [Google 3 weeks post onsite and still no feedback? Is this normal?](https://www.reddit.com/r/leetcode/comments/1vkx47f/google_3_weeks_post_onsite_and_still_no_feedback/) | r/leetcode |
+| 2026-08-10 | [Google FDE (GenAI) — team match before HC? Curious about others' timelines](https://www.reddit.com/r/leetcode/comments/1vkwmrl/google_fde_genai_team_match_before_hc_curious/) | r/leetcode |
+| 2026-08-10 | [Google SWE ML/AI III interview process: what are the first two interviews](https://www.reddit.com/r/leetcode/comments/1vkwhig/google_swe_mlai_iii_interview_process_what_are/) | r/leetcode |
+| 2026-08-10 | [Google SRE-SWE Interview - LeetCode](https://www.reddit.com/r/leetcode/comments/1vkv8b6/google_sreswe_interview_leetcode/) | r/leetcode |
+| 2026-08-10 | [Google interview exp](https://www.reddit.com/r/leetcode/comments/1vkr2hq/google_interview_exp/) | r/leetcode |
+| 2026-08-10 | [Google Interview](https://www.reddit.com/r/leetcode/comments/1vkizpj/google_interview/) | r/leetcode |
+| 2026-08-09 | [Google Cloud Silicon Validation Engineer Interview – What Topics Are Typically Covered?](https://www.reddit.com/r/csMajors/comments/1vjf10j/google_cloud_silicon_validation_engineer/) | r/csMajors |
+| 2026-08-08 | [Google SRE-SWE interview coming up — looking for recent prep advice/resources](https://www.reddit.com/r/leetcode/comments/1vj8exr/google_sreswe_interview_coming_up_looking_for/) | r/leetcode |
+| 2026-08-08 | [Google STEP interview](https://www.reddit.com/r/leetcode/comments/1vik2x7/google_step_interview/) | r/leetcode |
+| 2026-08-08 | [Google STEP interview difficulty](https://www.reddit.com/r/csMajors/comments/1vik1n7/google_step_interview_difficulty/) | r/csMajors |
+| 2026-08-07 | [ML Domain interview at Google](https://www.reddit.com/r/leetcode/comments/1vig549/ml_domain_interview_at_google/) | r/leetcode |
+| 2026-08-07 | [Reapplying timeline to google after interview rejection](https://www.reddit.com/r/leetcode/comments/1vidqmx/reapplying_timeline_to_google_after_interview/) | r/leetcode |
+| 2026-08-07 | [Reapplying timeline to google after interview rejection](https://www.reddit.com/r/csMajors/comments/1vidrqf/reapplying_timeline_to_google_after_interview/) | r/csMajors |
+| 2026-08-06 | [Google recruiter went silent for 6+ weeks after 6 months in "Team Matching" (L3 SWE)](https://www.reddit.com/r/leetcode/comments/1vhklxw/google_recruiter_went_silent_for_6_weeks_after_6/) | r/leetcode |
+| 2026-08-06 | [SWE 2: 6 months of consistently reaching final rounds and still getting rejected, where am I go](https://www.reddit.com/r/leetcode/comments/1vgsosy/swe_2_6_months_of_consistently_reaching_final/) | r/leetcode |
+| 2026-08-06 | [Google Team Matching (USA) – Entered TM on June 3, Still No Team Match Calls. Looking for Advic](https://www.reddit.com/r/csMajors/comments/1vhgwyb/google_team_matching_usa_entered_tm_on_june_3/) | r/csMajors |
+| 2026-08-05 | [I need serious help, have Google Non-Tech and Amazon Tech interview in next week](https://www.reddit.com/r/leetcode/comments/1vgmyl9/i_need_serious_help_have_google_nontech_and/) | r/leetcode |
+| 2026-08-05 | [Bizarre Google Screening Experience (3.3 YOE): Mixed signals, a second chance, and an instant f](https://www.reddit.com/r/leetcode/comments/1vg3sfj/bizarre_google_screening_experience_33_yoe_mixed/) | r/leetcode |
+| 2026-08-05 | [Google Forward Deploy Engineer interview europe](https://www.reddit.com/r/leetcode/comments/1vg2id0/google_forward_deploy_engineer_interview_europe/) | r/leetcode |
+| 2026-08-05 | [Terrified of freezing up during my Google interview this Friday (L4) — any advice for when you ](https://www.reddit.com/r/leetcode/comments/1vg1u0p/terrified_of_freezing_up_during_my_google/) | r/leetcode |
+| 2026-08-05 | [undergrad program acceptance](https://www.reddit.com/r/csMajors/comments/1vgiso9/undergrad_program_acceptance/) | r/csMajors |
+| 2026-08-05 | [System design learning resources for Agentic solutions](https://www.reddit.com/r/ExperiencedDevs/comments/1vg886s/system_design_learning_resources_for_agentic/) | r/ExperiencedDevs |
+| 2026-08-04 | [Google TPM interview questions](https://www.reddit.com/r/leetcode/comments/1vfbn31/google_tpm_interview_questions/) | r/leetcode |
+| 2026-08-04 | [Leetcode is slowing dying and that's a good thing!!](https://www.reddit.com/r/leetcode/comments/1vf8yn6/leetcode_is_slowing_dying_and_thats_a_good_thing/) | r/leetcode |
+| 2026-08-04 | [Google cool off period](https://www.reddit.com/r/leetcode/comments/1vf36n9/google_cool_off_period/) | r/leetcode |
+| 2026-08-03 | [Google HC Approved → Team Match → 1 Additional Coding Interview. What are my chances?](https://www.reddit.com/r/leetcode/comments/1vetlfo/google_hc_approved_team_match_1_additional_coding/) | r/leetcode |
+| 2026-08-03 | [How technical is a Google TPM I interview?](https://www.reddit.com/r/leetcode/comments/1veq4km/how_technical_is_a_google_tpm_i_interview/) | r/leetcode |
+| 2026-08-03 | [Google L4 (US) Onsite next week](https://www.reddit.com/r/leetcode/comments/1vehy6i/google_l4_us_onsite_next_week/) | r/leetcode |
+| 2026-08-03 | [Google Team Matching Question: SRE-SWE L3 to SWE L3?](https://www.reddit.com/r/leetcode/comments/1vef29w/google_team_matching_question_sreswe_l3_to_swe_l3/) | r/leetcode |
+| 2026-08-03 | [Codeforces vs LeetCode for Product-Based Company Placements – Need Advice from Experienced Peop](https://www.reddit.com/r/leetcode/comments/1vecluk/codeforces_vs_leetcode_for_productbased_company/) | r/leetcode |
+| 2026-08-02 | [What to expect at Google L4 Onsite ?](https://www.reddit.com/r/leetcode/comments/1vdx7uv/what_to_expect_at_google_l4_onsite/) | r/leetcode |
+| 2026-08-02 | [What does “waiting for the feedback regarding your candidacy” usually mean at Google?](https://www.reddit.com/r/leetcode/comments/1vdk6w0/what_does_waiting_for_the_feedback_regarding_your/) | r/leetcode |
+| 2026-08-02 | [Hi folks ,is there any cool off period at Google to re-apply for other roles ,I have interview ](https://www.reddit.com/r/leetcode/comments/1vdjqs8/hi_folks_is_there_any_cool_off_period_at_google/) | r/leetcode |
+| 2026-08-02 | [Need tips for Google L4 SWE interview loop (SWE - III) US](https://www.reddit.com/r/leetcode/comments/1vdjj5a/need_tips_for_google_l4_swe_interview_loop_swe/) | r/leetcode |
+| 2026-08-02 | [Google 2027 SWE Internship Interview](https://www.reddit.com/r/csMajors/comments/1vdtp1p/google_2027_swe_internship_interview/) | r/csMajors |
+| 2026-08-01 | [Google L5 Preparation](https://www.reddit.com/r/leetcode/comments/1vcmy9q/google_l5_preparation/) | r/leetcode |
+| 2026-08-01 | [Getting an offer with Google in NYC is impossible right?](https://www.reddit.com/r/cscareerquestions/comments/1vcrl5w/getting_an_offer_with_google_in_nyc_is_impossible/) | r/cscareerquestions |
+| 2026-08-01 | [Need tips for Google L4 SWE interview loop (SWE - III)](https://www.reddit.com/r/csMajors/comments/1vczfec/need_tips_for_google_l4_swe_interview_loop_swe_iii/) | r/csMajors |
+| 2026-07-31 | [SWE Interview Review 1](https://www.reddit.com/r/leetcode/comments/1vc6vw1/swe_interview_review_1/) | r/leetcode |
+| 2026-07-31 | [Ai coding rounds?](https://www.reddit.com/r/cscareerquestions/comments/1vbks0g/ai_coding_rounds/) | r/cscareerquestions |
+| 2026-07-30 | [Google US L4 interview experience, waiting for results , was asked sys design??](https://www.reddit.com/r/leetcode/comments/1vb5ra2/google_us_l4_interview_experience_waiting_for/) | r/leetcode |
+| 2026-07-30 | [Interview Guidance for Software Engineer III, AI/ML, Google Cloud AI - United States - 2026](https://www.reddit.com/r/leetcode/comments/1vb390p/interview_guidance_for_software_engineer_iii_aiml/) | r/leetcode |
+| 2026-07-30 | ["Even someone who doesn't know about recursion could see this DP problem" Google Poland L4 SWE ](https://www.reddit.com/r/leetcode/comments/1vb32h2/even_someone_who_doesnt_know_about_recursion/) | r/leetcode |
+| 2026-07-30 | [How to get back to speed after 1 year off? Did I miss anything?](https://www.reddit.com/r/leetcode/comments/1vaqx29/how_to_get_back_to_speed_after_1_year_off_did_i/) | r/leetcode |
+| 2026-07-30 | [Google L4 Interview Experience \| Ratings: H, NH -> H, H, LH \| Will I survive Team Matching?](https://www.reddit.com/r/leetcode/comments/1vam78s/google_l4_interview_experience_ratings_h_nh_h_h/) | r/leetcode |
+| 2026-07-30 | [Google Onsite](https://www.reddit.com/r/leetcode/comments/1vaer7b/google_onsite/) | r/leetcode |
+| 2026-07-29 | [Google AI Catalyst Interviews](https://www.reddit.com/r/leetcode/comments/1va86p9/google_ai_catalyst_interviews/) | r/leetcode |
+| 2026-07-29 | [GOOG Senior SWE Prep](https://www.reddit.com/r/leetcode/comments/1v9z5lq/goog_senior_swe_prep/) | r/leetcode |
+| 2026-07-29 | [Staff Software Engineer L6 Tech screen system design](https://www.reddit.com/r/leetcode/comments/1v9l576/staff_software_engineer_l6_tech_screen_system/) | r/leetcode |
+| 2026-07-29 | [My Resume isn’t getting any responses despite FAANG internship](https://www.reddit.com/r/csMajors/comments/1v9l36n/my_resume_isnt_getting_any_responses_despite/) | r/csMajors |
+| 2026-07-28 | [Google SRE Coding Interview Question I Was Asked](https://www.reddit.com/r/leetcode/comments/1v98vik/google_sre_coding_interview_question_i_was_asked/) | r/leetcode |
+| 2026-07-28 | [How to land an interview at Google (ZH/UK)](https://www.reddit.com/r/leetcode/comments/1v98gw5/how_to_land_an_interview_at_google_zhuk/) | r/leetcode |
+| 2026-07-28 | [Could anyone share their recent Google SDE interview experience?](https://www.reddit.com/r/leetcode/comments/1v97yre/could_anyone_share_their_recent_google_sde/) | r/leetcode |
+| 2026-07-28 | [Cleared Google Round 1 and have onsite in ~1 month: looking for DSA prep advice](https://www.reddit.com/r/leetcode/comments/1v8kxiq/cleared_google_round_1_and_have_onsite_in_1_month/) | r/leetcode |
+| 2026-07-28 | [I analyzed 1.2M candidate job experiences. Offer rates fell from 51% in 2015 to 38.6% in 2026](https://www.reddit.com/r/cscareerquestions/comments/1v9ekv1/i_analyzed_12m_candidate_job_experiences_offer/) | r/cscareerquestions |
+| 2026-07-28 | [Career advice: Asked to do FDE sort of work after an unexpected reorg in new job](https://www.reddit.com/r/cscareerquestions/comments/1v8og9x/career_advice_asked_to_do_fde_sort_of_work_after/) | r/cscareerquestions |
+| 2026-07-27 | [I need serious help, have Google and Amazon interview in 3 weeks; haven’t done DSA since 1 year](https://www.reddit.com/r/leetcode/comments/1v896mg/i_need_serious_help_have_google_and_amazon/) | r/leetcode |
+| 2026-07-27 | [Looking for Claude prompts/skills for Google L5/L6](https://www.reddit.com/r/leetcode/comments/1v81bj3/looking_for_claude_promptsskills_for_google_l5l6/) | r/leetcode |
+
+_637 more not shown._
+
+### Blind
+
+| Date | Post | Context |
+|------|------|---------|
+| 2026-08-10 | [Google in person interviews](https://www.teamblind.com/post/google-in-person-interviews-073vm4jp) | India |
+| 2026-08-10 | [Google Product Manager Interview](https://www.teamblind.com/post/google-product-manager-interview-70qnr6o8) | Product Management Career |
+| 2026-08-08 | [google interviewer not submitting feedback](https://www.teamblind.com/post/google-interviewer-not-submitting-feedback-an58202o) | Interview Experiences |
+| 2026-08-08 | [Didn't pass google interview](https://www.teamblind.com/post/didnt-pass-google-interview-jr5na3i8) | Software Engineering Career |
+| 2026-08-08 | [Google Product Vision Interview](https://www.teamblind.com/post/google-product-vision-interview-sz6j3zx8) | Product Management Career |
+| 2026-08-07 | [L5 Google Interviews](https://www.teamblind.com/post/l5-google-interviews-xp23wa87) | Tech Industry |
+| 2026-08-05 | [Google on-site interviews](https://www.teamblind.com/post/google-on-site-interviews-pdwl8eqv) | Tech Industry |
+| 2026-08-03 | [Messed up Google interview](https://www.teamblind.com/post/messed-up-google-interview-zdb0hk43) | Software Engineering Career |
+| 2026-08-01 | [Google coding interview in 90 days?](https://www.teamblind.com/post/google-coding-interview-in-90-days-vmofjxr8) | Software Engineering Career |
+| 2026-07-31 | [Why are Google Interviewers all assholes??](https://www.teamblind.com/post/why-are-google-interviewers-all-assholes-lebbprxx) | Software Engineering Career |
+| 2026-07-28 | [Google recruiter call after onsite](https://www.teamblind.com/post/google-recruiter-call-after-onsite-8rqba7cn) | Software Engineering Career |
+| 2026-07-20 | [GOOGLE HIRING PROCESS](https://www.teamblind.com/post/google-hiring-process-qvs84vh0) | Software Engineering Career |
+| 2026-07-17 | [Google onsite](https://www.teamblind.com/post/google-onsite-46hhgcjq) | Tech Industry |
+| 2026-07-16 | [New Interview Process at Google](https://www.teamblind.com/post/new-interview-process-at-google-wegovb2j) | Interview Experiences |
+| 2026-07-12 | [Google onsite tomorrow. Nervous as hell](https://www.teamblind.com/post/google-onsite-tomorrow-nervous-as-hell-17kems3d) | Software Engineering Career |
+| 2026-07-08 | [Google L4 Onsite](https://www.teamblind.com/post/google-l4-onsite-ptzk1xrz) | Software Engineering Career |
+| 2026-07-02 | [What difficulty leetcode questions does Google ask these days?](https://www.teamblind.com/post/what-difficulty-leetcode-questions-does-google-ask-these-days-wmrcng78) | Software Engineering Career |
+| 2026-07-02 | [What difficulty leetcode questions does Google ask these days?](https://www.teamblind.com/post/what-difficulty-leetcode-questions-does-google-ask-these-days-f8r01nam) | Software Engineering Career |
+| 2026-06-17 | [Google interview leetcode?](https://www.teamblind.com/post/google-interview-leetcode-3xyv28x5) | Interview Experiences |
+| 2026-06-09 | [Google Phone Screen result](https://www.teamblind.com/post/google-phone-screen-result-vn0cn634) | Software Engineering Career |
+| 2026-05-14 | [Please don't interview at Google if you want to do 996.](https://www.teamblind.com/post/please-dont-interview-at-google-if-you-want-to-do-996-3pwm2j0f) | Tech Industry |
+| 2026-05-01 | [Average leetcode rating of people who pass Google algo interviews USA?](https://www.teamblind.com/post/average-leetcode-rating-of-people-who-pass-google-algo-interviews-usa-vyotx22n) | Software Engineering Career |
+| 2026-04-11 | [Why is Google interview still so tough ?](https://www.teamblind.com/post/why-is-google-interview-still-so-tough-fzefcodm) | Software Engineering Career |
+| 2026-04-06 | [Google return to in-person interviews](https://www.teamblind.com/post/google-return-to-in-person-interviews-fhuewkip) | FAANG Lounge |
+| 2025-11-16 | [Why google asking Leetcode hards ?](https://www.teamblind.com/post/why-google-asking-leetcode-hards-yqytmhk0) | Tech Industry |
+| 2025-06-28 | [Google reject after passing online assessment](https://www.teamblind.com/post/google-reject-after-passing-online-assessment-t8tedg8w) | FAANG Lounge |
+| 2024-10-02 | [Google DS Online Assessment](https://www.teamblind.com/post/google-ds-online-assessment-0k7ccquy) | Data Science Career |
+| 2024-08-15 | [Google interview questions](https://www.teamblind.com/post/google-interview-questions-rqwvdhem) | Interview Experiences |
+| 2024-03-19 | [Google online assessment has only HR questions](https://www.teamblind.com/post/google-online-assessment-has-only-hr-questions-pky1zaad) | Software Engineering Career |
+| 2024-02-14 | [Google online hiring assessment for PM-1](https://www.teamblind.com/post/google-online-hiring-assessment-for-pm-1-y8o8pbvr) | Product Management Career |
+| 2024-02-05 | [Google PM online assessment](https://www.teamblind.com/post/google-pm-online-assessment-5ynpjk3w) | Product Management Career |
+| 2024-02-01 | [Google PM interview - Online Assessment](https://www.teamblind.com/post/google-pm-interview-online-assessment-ydkkzqpd) | Tech Industry |
+| 2024-02-01 | [Google PM interview - Online assessment questions](https://www.teamblind.com/post/google-pm-interview-online-assessment-questions-xc3uh4hs) | Product Management Career |
+| 2022-12-02 | [SQL online assessment at Google](https://www.teamblind.com/post/sql-online-assessment-at-google-6nzekyz2) | Tech Industry |
+| 2022-06-16 | [Google Online Assessment](https://www.teamblind.com/post/google-online-assessment-lrcg7ugy) | Tech Industry |
+| 2022-06-13 | [Google Onsite - All LeetCode Hard](https://www.teamblind.com/post/google-onsite-all-leetcode-hard-pgwdrgsb) | Software Engineering Career |
+| 2022-03-28 | [What to expect on Microsoft/Google online assessments?](https://www.teamblind.com/post/what-to-expect-on-microsoftgoogle-online-assessments-iygur8pj) | Tech Industry |
+| 2021-10-04 | [Google Summer 2022 internship online assessment](https://www.teamblind.com/post/google-summer-2022-internship-online-assessment-zlh7zsvk) | Software Engineering Career |
+| 2021-09-24 | [Can you Google during Amazon online assessment?](https://www.teamblind.com/post/can-you-google-during-amazon-online-assessment-pxzxut32) | Software Engineering Career |
+| 2021-09-23 | [Fuck Google Interviews](https://www.teamblind.com/post/fuck-google-interviews-1zrxgfcy) | Tech Industry |
+| 2021-06-21 | [Google online assessment insights](https://www.teamblind.com/post/google-online-assessment-insights-oydejp31) | Tech Industry |
+| 2021-04-25 | [Mr Pichai ban LeetCode questions at Google!](https://www.teamblind.com/post/mr-pichai-ban-leetcode-questions-at-google-b0k8bufo) | Tech Industry |
+| 2021-03-20 | [How can I motivate my bf to leetcode and interview with Google?](https://www.teamblind.com/post/how-can-i-motivate-my-bf-to-leetcode-and-interview-with-google-qzu8smb0) | Software Engineering Career |
+| 2020-11-23 | [A Guy got rejected by Google , has done 900+ Leetcode. It got me sad.](https://www.teamblind.com/post/a-guy-got-rejected-by-google-has-done-900-leetcode-it-got-me-sad-2h838wte) | Software Engineering Career |
+| 2020-10-15 | [Google 90 min online interview assessment](https://www.teamblind.com/post/google-90-min-online-interview-assessment-k7htconv) | Tech Industry |
+| 2020-04-26 | [Google interview and Leetcode](https://www.teamblind.com/post/google-interview-and-leetcode-gvqukyv2) | Tech Industry |
+| 2020-04-25 | [Leetcode Banned at Google](https://www.teamblind.com/post/leetcode-banned-at-google-carcakb6) | Tech Industry |
+| 2019-09-28 | [How to study for Google online assessment](https://www.teamblind.com/post/how-to-study-for-google-online-assessment-alntcpst) | Tech Industry |
+| 2019-08-19 | [Google leetcode strategy](https://www.teamblind.com/post/google-leetcode-strategy-gzttdhtt) | Tech Industry |
+| 2019-08-07 | [Google online assessment for internship](https://www.teamblind.com/post/google-online-assessment-for-internship-446mjlsv) | Tech Industry |
+| 2019-07-06 | [Google really ask questions like Leetcode #753?](https://www.teamblind.com/post/google-really-ask-questions-like-leetcode-753-yjcn8vtp) | Tech Industry |
+| 2019-05-02 | [Did You Try To Google Answers In Online Assessment?](https://www.teamblind.com/post/did-you-try-to-google-answers-in-online-assessment-rstgbu2e) | Tech Industry |
+| 2019-05-01 | [Do you google while taking pre onsite online assessment test?](https://www.teamblind.com/post/do-you-google-while-taking-pre-onsite-online-assessment-test-3w7xwdet) | Auto |
+| 2018-12-27 | [Google tag leetcode accuracy](https://www.teamblind.com/post/google-tag-leetcode-accuracy-g2bxn11i) | Tech Industry |
+| 2018-11-02 | [Google Onsite. Leetcode level?](https://www.teamblind.com/post/google-onsite-leetcode-level-omsjwsqe) | Tech Industry |
+| 2018-01-09 | [Google Onsite Interview. Leetcode difficulty](https://www.teamblind.com/post/google-onsite-interview-leetcode-difficulty-dctfcjfq) | Software Engineering Career |
+| 2017-09-24 | [Leetcode questions level - google / Facebook](https://www.teamblind.com/post/leetcode-questions-level-google-facebook-hrjr1dax) | Housing |
+
+### Hacker News
+
+| Date | Post | Context |
+|------|------|---------|
+| 2026-08-04 | [That time when I failed the Microsoft interview](https://news.ycombinator.com/item?id=49169912) | That time when I failed the Microsoft in |
+| 2026-08-04 | [That time when I failed the Microsoft interview](https://news.ycombinator.com/item?id=49167166) | That time when I failed the Microsoft in |
+| 2026-06-06 | [Ask HN: Will your company be doing "LeetCode" interviews a year from now?](https://news.ycombinator.com/item?id=48420519) | story |
+| 2026-06-05 | [Technical Interviews Reject the Wrong Engineers](https://news.ycombinator.com/item?id=48414386) | Technical Interviews Reject the Wrong En |
+| 2026-05-31 | [The Last Technical Interview](https://news.ycombinator.com/item?id=48341805) | The Last Technical Interview |
+| 2026-05-30 | [The Last Technical Interview](https://news.ycombinator.com/item?id=48339793) | The Last Technical Interview |
+| 2026-05-30 | [The Last Technical Interview](https://news.ycombinator.com/item?id=48331694) | The Last Technical Interview |
+| 2026-05-14 | [Rewrite Bun in Rust has been merged](https://news.ycombinator.com/item?id=48141599) | Rewrite Bun in Rust has been merged |
+| 2026-04-12 | [I propose a new programming language, CPC](https://news.ycombinator.com/item?id=47735439) | story |
+| 2026-03-22 | [Brute-forcing my algorithmic ignorance](https://news.ycombinator.com/item?id=47478764) | Brute-forcing my algorithmic ignorance |
+| 2026-03-06 | [Tech employment now significantly worse than the 2008 or 2020 recessions](https://news.ycombinator.com/item?id=47281406) | Tech employment now significantly worse  |
+| 2026-03-05 | [Stop the Interviews](https://news.ycombinator.com/item?id=47266491) | Stop the Interviews |
+| 2026-02-26 | [Google Street View in 2026](https://news.ycombinator.com/item?id=47172067) | Google Street View in 2026 |
+| 2026-02-26 | [Google Street View in 2026](https://news.ycombinator.com/item?id=47170161) | Google Street View in 2026 |
+| 2025-12-18 | [Why Senior Engineers Fail "Google SRE" Interviews (2026 Analysis)](https://news.ycombinator.com/item?id=46314406) | story |
+| 2025-11-30 | [Americans no longer see four-year college degrees as worth the cost](https://news.ycombinator.com/item?id=46094362) | Americans no longer see four-year colleg |
+| 2025-11-25 | [Show HN: AlgoVoice – Voice-based mock technical interviews for L3-L4 roles](https://news.ycombinator.com/item?id=46047402) | Show HN: AlgoVoice – Voice-based mock te |
+| 2025-11-20 | [RLCDev](https://news.ycombinator.com/item?id=45988586) | RLCDev |
+| 2025-11-17 | [The fate of "small" open source](https://news.ycombinator.com/item?id=45952961) | The fate of "small" open source |
+| 2025-11-02 | [AI Broke Interviews](https://news.ycombinator.com/item?id=45793634) | AI Broke Interviews |
+| 2025-11-01 | [AI Broke Interviews](https://news.ycombinator.com/item?id=45786239) | AI Broke Interviews |
+| 2025-09-14 | [Ask HN: Getting over Burnout with Imposter Syndrome](https://news.ycombinator.com/item?id=45237339) | Ask HN: Getting over Burnout with Impost |
+| 2025-09-12 | [Many hard LeetCode problems are easy constraint problems](https://news.ycombinator.com/item?id=45225782) | Many hard LeetCode problems are easy con |
+| 2025-09-12 | [Many hard LeetCode problems are easy constraint problems](https://news.ycombinator.com/item?id=45224301) | Many hard LeetCode problems are easy con |
+| 2025-08-22 | [What is going on right now?](https://news.ycombinator.com/item?id=44984772) | What is going on right now? |
+| 2025-08-11 | [An engineer's perspective on hiring](https://news.ycombinator.com/item?id=44863439) | An engineer's perspective on hiring |
+| 2025-08-09 | [An engineer's perspective on hiring](https://news.ycombinator.com/item?id=44845567) | An engineer's perspective on hiring |
+| 2025-08-01 | [Live coding interviews measure stress, not coding skills](https://news.ycombinator.com/item?id=44760142) | Live coding interviews measure stress, n |
+| 2025-08-01 | [Live coding interviews measure stress, not coding skills](https://news.ycombinator.com/item?id=44756983) | Live coding interviews measure stress, n |
+| 2025-08-01 | [Live coding interviews measure stress, not coding skills](https://news.ycombinator.com/item?id=44756578) | Live coding interviews measure stress, n |
+| 2025-07-27 | [Teach Yourself Programming in Ten Years (1998)](https://news.ycombinator.com/item?id=44705133) | Teach Yourself Programming in Ten Years  |
+| 2025-07-27 | [Teach Yourself Programming in Ten Years (1998)](https://news.ycombinator.com/item?id=44699328) | Teach Yourself Programming in Ten Years  |
+| 2025-07-18 | [Ask HN: Bad at Interviewing](https://news.ycombinator.com/item?id=44599709) | story |
+| 2025-07-09 | [Async Queue – One of my favorite programming interview questions](https://news.ycombinator.com/item?id=44507101) | Async Queue – One of my favorite program |
+| 2025-07-08 | [Mercury: Ultra-fast language models based on diffusion](https://news.ycombinator.com/item?id=44497595) | Mercury: Ultra-fast language models base |
+| 2025-06-22 | [How to negotiate your salary package](https://news.ycombinator.com/item?id=44349857) | How to negotiate your salary package |
+| 2025-05-30 | [Show HN: Every problem and solution in Beyond Cracking the Coding Interview](https://news.ycombinator.com/item?id=44137995) | Show HN: Every problem and solution in B |
+| 2025-05-16 | [Material 3 Expressive](https://news.ycombinator.com/item?id=44003899) | Material 3 Expressive |
+| 2025-05-01 | [Office is too slow, so Microsoft is making it load at Windows startup](https://news.ycombinator.com/item?id=43855620) | Office is too slow, so Microsoft is maki |
+| 2025-04-29 | [Ask HN: CS degrees, do they matter again?](https://news.ycombinator.com/item?id=43833350) | Ask HN: CS degrees, do they matter again |
+| 2025-04-15 | [Ask HN: What Tools Did You Use to Land Your Current Job?](https://news.ycombinator.com/item?id=43696711) | Ask HN: What Tools Did You Use to Land Y |
+| 2025-04-08 | [Interviewing a software engineer who prepared with AI](https://news.ycombinator.com/item?id=43624302) | Interviewing a software engineer who pre |
+| 2025-04-08 | [Interviewing a software engineer who prepared with AI](https://news.ycombinator.com/item?id=43622997) | Interviewing a software engineer who pre |
+| 2025-04-03 | [Ask HN: Who is hiring? (April 2025)](https://news.ycombinator.com/item?id=43566269) | Ask HN: Who is hiring? (April 2025) |
+| 2025-04-02 | [The Reality of Tech Interviews in 2025](https://news.ycombinator.com/item?id=43560980) | The Reality of Tech Interviews in 2025 |
+| 2025-03-20 | [Ask HN: Moving from startups (mixed success) into product?](https://news.ycombinator.com/item?id=43427736) | Ask HN: Moving from startups (mixed succ |
+| 2025-03-10 | [We built a crowdsourced interview question database for tech interviews](https://news.ycombinator.com/item?id=43321014) | We built a crowdsourced interview questi |
+| 2025-03-09 | [Layoffs Don't Work](https://news.ycombinator.com/item?id=43311966) | Layoffs Don't Work |
+| 2025-03-07 | [Show HN: Stealth Interview](https://news.ycombinator.com/item?id=43287174) | story |
+| 2025-02-26 | [TypeScript types can run DOOM [video]](https://news.ycombinator.com/item?id=43188691) | TypeScript types can run DOOM [video] |
+| 2025-02-22 | [AI killed the tech interview. Now what?](https://news.ycombinator.com/item?id=43137804) | AI killed the tech interview. Now what? |
+| 2025-02-07 | [The impact of AI on the technical interview process](https://news.ycombinator.com/item?id=42978231) | The impact of AI on the technical interv |
+| 2025-02-05 | [Google kills diversity hiring targets](https://news.ycombinator.com/item?id=42955439) | Google kills diversity hiring targets |
+| 2025-02-03 | [Ask HN: What is interviewing like now with everyone using AI?](https://news.ycombinator.com/item?id=42914690) | Ask HN: What is interviewing like now wi |
+| 2025-02-03 | [Ask HN: What is interviewing like now with everyone using AI?](https://news.ycombinator.com/item?id=42914387) | Ask HN: What is interviewing like now wi |
+| 2025-02-03 | [Ask HN: What is interviewing like now with everyone using AI?](https://news.ycombinator.com/item?id=42913848) | Ask HN: What is interviewing like now wi |
+| 2025-01-14 | [Ask HN: How do you guard against ChatGPT use in technical interviews?](https://news.ycombinator.com/item?id=42704252) | Ask HN: How do you guard against ChatGPT |
+| 2025-01-14 | [Meta announces 5% cuts in preparation for 'intense year'](https://news.ycombinator.com/item?id=42702197) | Meta announces 5% cuts in preparation fo |
+| 2025-01-10 | [Meta's memo to employees rolling back DEI programs](https://news.ycombinator.com/item?id=42661782) | Meta's memo to employees rolling back DE |
+| 2025-01-09 | [Scientists uncover how the brain washes itself during sleep](https://news.ycombinator.com/item?id=42649717) | Scientists uncover how the brain washes  |
+
+_377 more not shown._
 
 ## 3) Method
 
-Generated by [`script/scrape_lc_discuss_company.py`](../script/scrape_lc_discuss_company.py). The figures above come from a **full paginated run**: all 274 threads listed by paging `skip` to exhaustion, then every thread's body and comments fetched individually (274 bodies, 1153 comments).
+Generated by [`script/scrape_lc_discuss_company.py`](../script/scrape_lc_discuss_company.py). Each source is scraped independently, cached one file per post, then all posts are pooled and scanned for LeetCode references (problem link, `LC <n>` / `#<n>`, or an exact problem title in prose).
 
 ```bash
-python3 script/scrape_lc_discuss_company.py --tag google   # full run (slow, ~2.5s/request)
-python3 script/scrape_lc_discuss_company.py --build-only  # rebuild doc from cache
+python3 script/scrape_lc_discuss_company.py --tag google  # full run (slow)
+python3 script/scrape_lc_discuss_company.py --build-only    # rebuild doc from cache
 ```
 
-Three calls are involved, because the list endpoint does **not** return bodies:
+| Source | Endpoint | Pagination | Returns |
+|--------|----------|------------|---------|
+| LeetCode Discuss | `leetcode.com/graphql` — `ugcArticleDiscussionArticles`, `ugcArticleDiscussionArticle`, `topicComments` | `skip` += `first`, then one call per thread | threads + bodies + comments |
+| Reddit | `reddit.com/r/<sub>/search.rss` + `<permalink>/.rss` | `after=t3_<id>`, `limit=100` | posts (full selftext) + rationed comment threads |
+| Blind | `teamblind.com/search/<query>` + `/post/<slug>` (HTML) | none — several queries instead (`?page` is ignored) | search cards + full post bodies (**no comments**) |
+| Hacker News | `hn.algolia.com/api/v1/search_by_date` | `page` 0..n, `hitsPerPage=100` | stories + comments |
 
-| Stage | Field | Paginate with | Returns |
-|-------|-------|---------------|---------|
-| 1 | `ugcArticleDiscussionArticles` | `skip` += `first` | thread list + `summary` (**no body**) |
-| 2 | `ugcArticleDiscussionArticle` | one call per `topicId` | post body (`content`) |
-| 3 | `topicComments` | `pageNo` 1..n | comment threads |
+**Gotchas worth knowing** (none of this is documented by any of these sites):
 
-**Schema gotchas** (introspection is disabled; all found by reading error messages):
-
-- `tagSlugs` is required on `ugcArticleDiscussionArticles`; omitting it returns `argument of type 'NoneType' is not iterable`.
-- Variable types must be exact: `$keywords: [String]!` but `$tagSlugs: [String!]`.
-- `ugcArticleDiscussionArticle` keys off **`topicId`**, not `uuid`.
-- **The two `topicId` arguments have different types, and this is not a typo**: `ugcArticleDiscussionArticle` takes `ID`, `topicComments` takes `Int!`. Using one type for both fails on whichever call you guessed wrong.
-- `content` is **null in list mode** — only `summary` is populated; bodies need stage 2.
-- `totalNum` on the list connection is **capped** (3000), not the real result count — page until a short page instead of trusting it.
-- `topicComments.orderBy` is a plain `String` (`most_votes` / `newest_to_oldest` / `oldest_to_newest` / `hot`), not an enum.
-- Rapid probing trips a WAF returning **HTML 403s, not JSON** — parse defensively and keep ~2–3 s between requests.
+- LeetCode: introspection is disabled, `tagSlugs` is required, `content` is null in list mode, `totalNum` is capped at 3000, and — **not a typo** — `ugcArticleDiscussionArticle` takes `topicId: ID` while `topicComments` takes `topicId: Int!`. Rapid probing trips a WAF returning HTML 403s, not JSON.
+- Reddit: `.json` is 403 for anonymous clients but **the `.rss` twin of the same path is not**. Search feeds page with `after=t3_<id>` and carry the full selftext, so ~12 requests fetch hundreds of posts. Comment feeds (permalink + `.rss`) are another matter: measured anonymous throughput is **~1 request per 52 s**, so they are rationed by `--reddit-comments N`. The `x-ratelimit-reset` header on a 429 is accurate and is obeyed.
+- Blind: no pagination at all (`?page=2` re-serves page 1, 20 cards per query), so breadth comes from several queries. Card bodies truncate at ~312 chars, hence the per-post fetch; comments are client-rendered and unreachable. The card's exact date hides in a `title="MM/DD/YYYY"` attribute next to the human one.
+- Hacker News: Algolia is the easy one — public, unauthenticated, `hitsPerPage` up to 1000. Matching is fuzzy, so expect noise.
 
 ## 4) Related docs in this repo
 

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -37,14 +37,24 @@ The doc → tag mapping lives in `DOC_TAGS` inside the script; edit it there rat
 
 ## scrape_lc_discuss_company.py
 
-Scrapes recently-asked LeetCode problems for a company from LeetCode's **public Discuss forum** and writes a markdown report (default [`doc/g_recent_asked.md`](./g_recent_asked.md)).
+Scrapes recently-asked interview questions for a company from **four public sources**, maps every mention back to a LeetCode problem, and writes one markdown report (default [`doc/g_recent_asked.md`](./g_recent_asked.md)).
+
+| Source | Endpoint | What it gives | Signal |
+|--------|----------|---------------|--------|
+| `leetcode` | `leetcode.com/graphql` Discuss API | threads + bodies + comments | high — posters cite `LC <n>` and links |
+| `reddit` | `search.rss` over r/leetcode, r/cscareerquestions, r/csMajors, r/ExperiencedDevs | posts (full selftext) + comment threads | high — the densest source of recent reports |
+| `blind` | `teamblind.com/search/<query>` HTML | search cards + full post bodies (no comments) | medium — lots of process chatter, few problem ids |
+| `hn` | `hn.algolia.com` search API | stories + comments | low — breadth and noise |
 
 ```bash
-# Full run for Google -> doc/g_recent_asked.md  (slow: ~2.5s/request, ~1h for ~275 posts)
+# Full run for Google, all sources -> doc/g_recent_asked.md  (slow: hours, mostly comments)
 python3 script/scrape_lc_discuss_company.py
 
 # Another company -> doc/meta_recent_asked.md
 python3 script/scrape_lc_discuss_company.py --tag meta
+
+# Just the fast sources
+python3 script/scrape_lc_discuss_company.py --sources blind,hn
 
 # Rebuild the report from cache, no network at all
 python3 script/scrape_lc_discuss_company.py --build-only
@@ -53,15 +63,17 @@ python3 script/scrape_lc_discuss_company.py --build-only
 python3 script/scrape_lc_discuss_company.py --tag amazon --max-pages 2
 ```
 
-Output: ranked table of referenced LC problems (number, link, difficulty, tags, thread count, match strength, last-seen date, whether the repo already solves it), evidence quotes linking back to each source thread, and the raw feed of interview-flavoured posts.
+Output: ranked table of referenced LC problems (number, link, difficulty, tags, thread count, which sources, match strength, last-seen date, whether the repo already solves it), evidence quotes linking back to each source post, and a per-source raw feed of interview-flavoured posts.
 
-**This is not LeetCode's official company list.** `companyTag` is Premium-gated and returns `null` anonymously, so this is self-reported interview experience — treat the counts as weak signal. Note also that the legacy discuss API (`categoryTopicList`, category `interview-question`) still responds but is **frozen at 2025-03-04**; live data lives behind the `ugcArticle*` fields the script uses.
+**This is not LeetCode's official company list.** `companyTag` is Premium-gated and returns `null` anonymously, so all of this is self-reported interview experience — treat the counts as weak signal. Note also that the legacy discuss API (`categoryTopicList`, category `interview-question`) still responds but is **frozen at 2025-03-04**; live data lives behind the `ugcArticle*` fields the script uses.
 
-Downloads are cached one-file-per-post under `data/.lc_discuss_cache/<tag>/` (gitignored), so interrupted runs resume instead of re-fetching. Delete that directory for a clean pull.
+Downloads are cached one-file-per-post under `data/.lc_discuss_cache/<tag>/` (gitignored) — LeetCode at the root, other sources in a subdirectory each — so interrupted runs resume instead of re-fetching. Comment fetching (the slow stage) goes newest-first, so a run you cut short still has the freshest threads. Delete that directory for a clean pull.
 
-Useful flags: `--delay` (default 2.5s — below ~2s trips LeetCode's WAF, which returns HTML 403s rather than JSON), `--no-comments` (much faster, but comments are usually where the actual questions are), `--refresh-index` (re-download the LC problem index).
+Useful flags: `--sources` (subset of `leetcode,reddit,blind,hn`), `--delay` (overrides the per-source defaults — 2.5s LeetCode, 8s Reddit, 2s Blind, 1s HN; going faster gets you blocked, not throttled), `--reddit-subs`, `--no-comments` (much faster, but comments are usually where the actual questions are), `--refresh-index` (re-download the LC problem index).
 
-The script's module docstring records the reverse-engineered schema, since introspection is disabled. The sharpest trap: `ugcArticleDiscussionArticle(topicId:)` takes `ID` while `topicComments(topicId:)` takes `Int!` — the same argument name with two different types.
+Adding a source is one function: return `record()`s, honour `ctx.build_only`, register it in `SOURCES`. Extraction, ranking and the report never look at where a post came from.
+
+The module docstring records what each site does *not* document. The sharpest traps: LeetCode's `ugcArticleDiscussionArticle(topicId:)` takes `ID` while `topicComments(topicId:)` takes `Int!` (same argument name, two types); Reddit 403s `.json` for anonymous clients but still serves the `.rss` twin of the same path; Blind ignores `?page` entirely, so breadth comes from asking several queries.
 
 ## Other Scripts
 

--- a/script/scrape_lc_discuss_company.py
+++ b/script/scrape_lc_discuss_company.py
@@ -65,9 +65,14 @@ reddit
   * Comments feed: append `.rss` to a post permalink. Entry 1 is the post itself,
     the rest are comments (ids `t1_*`), newest first.
   * `<content type="html">` carries the full selftext — no per-post body fetch needed.
-  * Rate limiting is aggressive and runs on a rolling window: two requests 4s apart can
-    429, and so can the 5th request at a steady 5s. ~8s is a workable floor, and a 429
-    needs a real sleep (~90s+) rather than a quick retry.
+    That makes the search feeds superb value: ~12 requests for ~850 posts with bodies.
+  * Rate limiting is brutal and IP-based (a descriptive User-Agent does not help — it
+    was measured, it does not). Sustained anonymous throughput is about **one request
+    per 52 seconds**: a 10-request probe took 525s, 429ing 9 times.
+  * A 429 carries `x-ratelimit-reset` and it is ACCURATE (43-59s observed). Obey it —
+    guessing high wastes hours, guessing low burns the retry budget.
+  * So comment feeds are rationed (`--reddit-comments N`, default 0): 850 of them would
+    take ~12 hours, while the post bodies they supplement are already free.
 
 blind
   * No API and no login wall on search: `teamblind.com/search/<urlencoded query>` is
@@ -115,6 +120,17 @@ DELAYS = {"leetcode": 2.5, "reddit": 8.0, "blind": 2.0, "hn": 1.0}
 
 
 # --------------------------------------------------------------------------- net
+def retry_after(exc):
+    """Some servers say exactly how long to wait. Obey them instead of guessing —
+    reddit's `x-ratelimit-reset` is accurate, and guessing high wastes hours."""
+    for header in ("retry-after", "x-ratelimit-reset"):
+        try:
+            return float(exc.headers.get(header)) + 1.0
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
 def fetch(url, delay, data=None, headers=None, tries=4):
     """HTTP GET (or POST when `data` is given), with backoff. Returns bytes, or None
     when the request is hopeless (4xx that a retry cannot fix, or tries exhausted)."""
@@ -129,9 +145,10 @@ def fetch(url, delay, data=None, headers=None, tries=4):
                 detail = exc.read().decode("utf-8", "replace")[:200]
                 print(f"    HTTP {exc.code} {url}: {detail}", file=sys.stderr)
                 return None
-            # Reddit throttles on a rolling window, so a 429 needs a real sleep —
-            # retrying on the normal backoff just burns the remaining tries.
-            wait = (90.0 if exc.code == 429 else max(30.0, delay * 12)) * (attempt + 1)
+            # A rate limiter wants a real sleep; retrying on the normal backoff just
+            # burns the remaining tries.
+            wait = retry_after(exc) or (
+                (90.0 if exc.code == 429 else max(30.0, delay * 12)) * (attempt + 1))
             print(f"    HTTP {exc.code}; sleeping {wait:.0f}s", file=sys.stderr)
         except Exception as exc:  # network hiccup, or a WAF serving HTML
             print(f"    {type(exc).__name__}: {exc}; retrying", file=sys.stderr)
@@ -396,14 +413,20 @@ def source_reddit(ctx):
             time.sleep(delay)
         cache.save(posts, "posts.json")
 
-        # Newest first: comment fetching is the slow part, and a run that is cut short
-        # should have spent its requests on the freshest threads.
+        # Newest first, and capped: at ~1 request/minute (see docstring) the whole
+        # backlog would take half a day, so spend the budget on the freshest threads.
+        # Post selftext is already in hand for free — this only buys the replies.
+        budget = ctx.args.reddit_comments if ctx.want_comments else 0
         todo = sorted((p for p in posts.values()
-                       if ctx.want_comments and interviewish(p["title"], p["content"])
+                       if interviewish(p["title"], p["content"])
                        and not cache.has("comments", f'{p["id"]}.json')),
                       key=lambda p: p["date"], reverse=True)
+        skipped = max(0, len(todo) - budget)
+        todo = todo[:budget]
         print(f"  {len(todo)} comment threads to fetch"
-              f"{' (--no-comments)' if not ctx.want_comments else ''}")
+              + (f" — {skipped} interview posts left without comments "
+                 f"(--reddit-comments {ctx.args.reddit_comments}, ~1 req/min)"
+                 if skipped else ""))
         for i, p in enumerate(todo, 1):
             raw = fetch(p["url"].rstrip("/") + "/.rss?limit=100", delay) or b""
             # Entry 1 of a comment feed is the post itself; the rest are comments.
@@ -540,7 +563,7 @@ ENDPOINTS = {
                  "threads + bodies + comments"),
     "reddit": ("`reddit.com/r/<sub>/search.rss` + `<permalink>/.rss`",
                "`after=t3_<id>`, `limit=100`",
-               "posts (full selftext) + comment threads"),
+               "posts (full selftext) + rationed comment threads"),
     "blind": ("`teamblind.com/search/<query>` + `/post/<slug>` (HTML)",
               "none — several queries instead (`?page` is ignored)",
               "search cards + full post bodies (**no comments**)"),
@@ -561,9 +584,11 @@ UNIT_RE = re.compile(r"\s*(?:\+|k\b|%|hours?|hrs?|minutes?|mins?|days?|weeks?|mo
 # "leetcode 75 / 150 / 169" is nearly always a study *list* (LeetCode 75, NeetCode 150,
 # Grind 169), not problem #75. Written the problem way — "LC 75" — it still counts.
 LIST_NUMS = {50, 75, 100, 150, 169}
-# Titles that are ordinary English and would match constantly in prose.
+# Titles that are ordinary English and would match constantly in prose. The last two
+# were caught by the wider corpus: an HN story called "Function Composition in
+# Programming Languages", and a bus brainteaser quoted as "the average waiting time".
 BAD_TITLES = {"design", "sort colors", "word break", "jump game", "candy",
-              "trapping rain water"}
+              "trapping rain water", "function composition", "average waiting time"}
 INTERVIEW_HINT = re.compile(
     r"interview|onsite|phone screen|screen|round|oa\b|online assessment|asked|coding", re.I)
 
@@ -807,10 +832,11 @@ def render(ctx, posts, ranked, solved, out_path, sources, generated_on):
       "`ugcArticleDiscussionArticle` takes `topicId: ID` while `topicComments` takes "
       "`topicId: Int!`. Rapid probing trips a WAF returning HTML 403s, not JSON.")
     w("- Reddit: `.json` is 403 for anonymous clients but **the `.rss` twin of the same "
-      "path is not**. Search feeds page with `after=t3_<id>`; comment feeds are the post "
-      "permalink + `.rss`, first entry being the post itself. Rate limiting runs on a "
-      "rolling window — ~8 s between requests is the floor, and a 429 needs a ~90 s sleep "
-      "rather than a quick retry.")
+      "path is not**. Search feeds page with `after=t3_<id>` and carry the full selftext, "
+      "so ~12 requests fetch hundreds of posts. Comment feeds (permalink + `.rss`) are "
+      "another matter: measured anonymous throughput is **~1 request per 52 s**, so they "
+      "are rationed by `--reddit-comments N`. The `x-ratelimit-reset` header on a 429 is "
+      "accurate and is obeyed.")
     w("- Blind: no pagination at all (`?page=2` re-serves page 1, 20 cards per query), so "
       "breadth comes from several queries. Card bodies truncate at ~312 chars, hence the "
       "per-post fetch; comments are client-rendered and unreachable. The card's exact date "
@@ -861,6 +887,11 @@ def main():
                     help="cap list pages per source (default: page to exhaustion)")
     ap.add_argument("--reddit-subs", default=",".join(REDDIT_SUBS),
                     help=f'subreddits to search (default: {",".join(REDDIT_SUBS)})')
+    ap.add_argument("--reddit-comments", type=int, default=0, metavar="N",
+                    help="also fetch reddit comment threads, for the N newest "
+                         "interview-flavoured posts. Anonymous reddit allows roughly one "
+                         "request per minute, so N is minutes: budget accordingly "
+                         "(default: 0 — post bodies only, which cost nothing extra)")
     ap.add_argument("--no-comments", action="store_true",
                     help="skip comment fetching (much faster, but comments are where the "
                          "actual questions usually are)")

--- a/script/scrape_lc_discuss_company.py
+++ b/script/scrape_lc_discuss_company.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
-"""Scrape recently-asked LeetCode problems for a company from LeetCode's public Discuss forum.
+"""Scrape recently-asked interview questions for a company from several public
+sources, and map every mention back to a LeetCode problem.
 
-Produces a markdown report (default `doc/g_recent_asked.md` for Google) listing the LC
-problems referenced in recent company-tagged discuss threads, with evidence quotes and
-links back to every source post.
+Sources (pick with `--sources`, default all four):
 
-    python3 script/scrape_lc_discuss_company.py                     # google -> doc/g_recent_asked.md
-    python3 script/scrape_lc_discuss_company.py --tag meta          # -> doc/meta_recent_asked.md
-    python3 script/scrape_lc_discuss_company.py --build-only        # rebuild doc from cache, no network
-    python3 script/scrape_lc_discuss_company.py --max-pages 4       # quick sample
+    leetcode   leetcode.com Discuss   GraphQL   threads + bodies + comments
+    reddit     r/leetcode & friends   Atom RSS  posts + comment threads
+    blind      teamblind.com          HTML      search cards + post bodies
+    hn         Hacker News            Algolia   stories + comments
+
+Produces one markdown report (default `doc/g_recent_asked.md` for Google) listing the
+LC problems referenced across all sources, with evidence quotes and links back to
+every source post.
+
+    python3 script/scrape_lc_discuss_company.py                        # google, all sources
+    python3 script/scrape_lc_discuss_company.py --tag meta             # -> doc/meta_recent_asked.md
+    python3 script/scrape_lc_discuss_company.py --sources reddit,blind # skip the slow one
+    python3 script/scrape_lc_discuss_company.py --build-only           # rebuild doc from cache
+    python3 script/scrape_lc_discuss_company.py --max-pages 2          # quick sample
 
 Everything downloaded is cached under `--cache-dir` (default `data/.lc_discuss_cache/<tag>/`),
 one file per post, so re-runs resume instead of re-fetching. Delete the cache dir for a
@@ -17,56 +26,201 @@ clean pull, or pass `--refresh-index` to re-download just the LC problem index.
 WHY THIS EXISTS / WHAT IT IS NOT
 --------------------------------
 LeetCode's official company question list (`companyTag`) is Premium-gated and returns
-`null` to anonymous requests. This scrapes the *public* Discuss forum instead, so the
-output is self-reported interview experience, not LeetCode's own frequency data. Treat
-the counts as weak signal.
+`null` to anonymous requests. Every source here is *public chatter* instead, so the
+output is self-reported interview experience, not anybody's frequency data. Treat the
+counts as weak signal.
 
-Note also that the *legacy* discuss API (`categoryTopicList`, category
-`interview-question`) still responds but is frozen at 2025-03-04 — LeetCode migrated
-Discuss during 2025. Live data lives behind the `ugcArticle*` fields used here.
+ADDING A SOURCE
+---------------
+Write `def source_x(ctx) -> list[record]` (use `record()` and `ctx.cache("x")`), honour
+`ctx.build_only` by returning whatever is already cached, and add it to `SOURCES`.
+Extraction, ranking and reporting are source-agnostic — they only read `record()` fields.
 
-SCHEMA NOTES (introspection is disabled; these were found by reading error messages)
------------------------------------------------------------------------------------
-* `tagSlugs` is required on `ugcArticleDiscussionArticles`; omitting it fails with
-  "argument of type 'NoneType' is not iterable".
-* Variable types must match exactly: `$keywords: [String]!` but `$tagSlugs: [String!]`.
-* `content` is NULL in list mode — only `summary` is populated. Bodies need stage 2.
-* `totalNum` on the list connection is CAPPED (3000) and is not the real result count;
-  page until a short page instead of trusting it.
-* The two `topicId` arguments have DIFFERENT types, and this is not a typo:
-      ugcArticleDiscussionArticle(topicId:) -> ID
-      topicComments(topicId:)               -> Int!
-  Using one type for both fails on whichever call guessed wrong.
-* `topicComments.orderBy` is a plain String ("most_votes" / "newest_to_oldest" /
-  "oldest_to_newest" / "hot"), not an enum.
-* Rapid requests trip a WAF that returns HTML 403s rather than JSON — keep ~2-3s
-  between calls and parse defensively.
+PER-SOURCE NOTES (all found the hard way; no source documents any of this)
+-------------------------------------------------------------------------
+leetcode
+  * The *legacy* discuss API (`categoryTopicList`, category `interview-question`) still
+    responds but is frozen at 2025-03-04 — LeetCode migrated Discuss during 2025. Live
+    data lives behind the `ugcArticle*` fields used here.
+  * Introspection is disabled; the schema below was found by reading error messages.
+  * `tagSlugs` is required on `ugcArticleDiscussionArticles`; omitting it fails with
+    "argument of type 'NoneType' is not iterable".
+  * Variable types must match exactly: `$keywords: [String]!` but `$tagSlugs: [String!]`.
+  * `content` is NULL in list mode — only `summary` is populated. Bodies need stage 2.
+  * `totalNum` on the list connection is CAPPED (3000) and is not the real result count;
+    page until a short page instead of trusting it.
+  * The two `topicId` arguments have DIFFERENT types, and this is not a typo:
+        ugcArticleDiscussionArticle(topicId:) -> ID
+        topicComments(topicId:)               -> Int!
+    Using one type for both fails on whichever call guessed wrong.
+  * `topicComments.orderBy` is a plain String ("most_votes" / "newest_to_oldest" /
+    "oldest_to_newest" / "hot"), not an enum.
+  * Rapid requests trip a WAF that returns HTML 403s rather than JSON.
+
+reddit
+  * `www.reddit.com/...json` returns HTML 403 to anonymous clients, but the **`.rss`
+    twin of the same path still serves anonymously** — that is the whole trick here.
+  * Search feed: `/r/<sub>/search.rss?q=&restrict_sr=1&sort=new&limit=100`, paged with
+    `after=t3_<id>` (the id of the last entry). `limit` caps at 100.
+  * Comments feed: append `.rss` to a post permalink. Entry 1 is the post itself,
+    the rest are comments (ids `t1_*`), newest first.
+  * `<content type="html">` carries the full selftext — no per-post body fetch needed.
+  * Rate limiting is aggressive and runs on a rolling window: two requests 4s apart can
+    429, and so can the 5th request at a steady 5s. ~8s is a workable floor, and a 429
+    needs a real sleep (~90s+) rather than a quick retry.
+
+blind
+  * No API and no login wall on search: `teamblind.com/search/<urlencoded query>` is
+    server-rendered HTML. Cards are `<article data-article-alias="...">`.
+  * There is NO pagination — `?page=2` returns page 1 again, and a query yields exactly
+    20 cards. Breadth comes from asking several queries (see `BLIND_QUERIES`).
+  * Card bodies are truncated at ~312 chars, so stage 2 fetches `/post/<slug>` for the
+    full text. Comments are client-rendered and are NOT visible to this scraper.
+  * The relative date on a card ("Jun 17") has an exact `title="MM/DD/YYYY, ..."`
+    attribute next to it — parse that, not the human string.
+
+hn
+  * `hn.algolia.com/api/v1/search_by_date` is public, unauthenticated and generous:
+    `hitsPerPage` up to 1000, `page` 0-based, `tags=story|comment`.
+  * Matching is fuzzy/OR-ish, so results are noisy — this source is breadth, not signal.
 """
 
 import argparse
 import collections
+import html
 import json
 import os
 import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
+import xml.etree.ElementTree as ET
 
-GRAPHQL_URL = "https://leetcode.com/graphql/"
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROBLEM_INDEX_URL = "https://leetcode.com/api/problems/all/"
 HEADERS = {
-    "Content-Type": "application/json",
     "Accept": "*/*",
     "Accept-Language": "en-US,en;q=0.9",
-    "Origin": "https://leetcode.com",
-    "Referer": "https://leetcode.com/discuss/",
     "User-Agent": (
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
     ),
 }
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Seconds between requests, per source. Below the leetcode/reddit values you get
+# blocked rather than throttled; blind and hn are relaxed but not free.
+DELAYS = {"leetcode": 2.5, "reddit": 8.0, "blind": 2.0, "hn": 1.0}
+
+
+# --------------------------------------------------------------------------- net
+def fetch(url, delay, data=None, headers=None, tries=4):
+    """HTTP GET (or POST when `data` is given), with backoff. Returns bytes, or None
+    when the request is hopeless (4xx that a retry cannot fix, or tries exhausted)."""
+    hdrs = dict(HEADERS, **(headers or {}))
+    for attempt in range(tries):
+        try:
+            req = urllib.request.Request(url, data=data, headers=hdrs)
+            with urllib.request.urlopen(req, timeout=45) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code in (400, 404):  # retrying cannot help
+                detail = exc.read().decode("utf-8", "replace")[:200]
+                print(f"    HTTP {exc.code} {url}: {detail}", file=sys.stderr)
+                return None
+            # Reddit throttles on a rolling window, so a 429 needs a real sleep —
+            # retrying on the normal backoff just burns the remaining tries.
+            wait = (90.0 if exc.code == 429 else max(30.0, delay * 12)) * (attempt + 1)
+            print(f"    HTTP {exc.code}; sleeping {wait:.0f}s", file=sys.stderr)
+        except Exception as exc:  # network hiccup, or a WAF serving HTML
+            print(f"    {type(exc).__name__}: {exc}; retrying", file=sys.stderr)
+            wait = max(30.0, delay * 12) * (attempt + 1)
+        time.sleep(wait)
+    return None
+
+
+def fetch_json(url, delay, **kw):
+    raw = fetch(url, delay, **kw)
+    try:
+        return json.loads(raw) if raw else None
+    except ValueError:
+        return None
+
+
+def text_of(fragment):
+    """HTML fragment -> plain text. Good enough for keyword extraction."""
+    s = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", fragment or "", flags=re.S | re.I)
+    s = re.sub(r"<!--.*?-->", "", s, flags=re.S)
+    s = re.sub(r"<br\s*/?>|</p>|</div>|</li>|</h\d>", "\n", s, flags=re.I)
+    s = re.sub(r"<[^>]+>", " ", s)
+    return re.sub(r"[ \t]+", " ", html.unescape(s)).strip()
+
+
+# ------------------------------------------------------------------------- state
+class Cache:
+    """One JSON file per key, so an interrupted run resumes instead of re-fetching."""
+
+    def __init__(self, directory):
+        self.dir = directory
+        os.makedirs(self.dir, exist_ok=True)
+
+    def path(self, *parts):
+        return os.path.join(self.dir, *parts)
+
+    def load(self, *parts, default=None):
+        try:
+            with open(self.path(*parts)) as fh:
+                return json.load(fh)
+        except Exception:
+            return default
+
+    def save(self, obj, *parts):
+        os.makedirs(os.path.dirname(self.path(*parts)), exist_ok=True)
+        with open(self.path(*parts), "w") as fh:
+            json.dump(obj, fh)
+
+    def has(self, *parts):
+        return os.path.exists(self.path(*parts))
+
+
+class Ctx:
+    """Everything a source needs: what to look for, where to cache, how fast to go."""
+
+    def __init__(self, args, root):
+        self.args = args
+        self.root = root
+        self.tag = args.tag
+        self.company = args.tag.replace("-", " ")
+        self.build_only = args.build_only
+        self.max_pages = args.max_pages
+        self.want_comments = not args.no_comments
+
+    def delay(self, source):
+        return self.args.delay if self.args.delay is not None else DELAYS[source]
+
+    def cache(self, source):
+        # leetcode keeps the historical layout at the cache root so existing (slow to
+        # rebuild) caches keep working; sources added later get their own subdir.
+        return Cache(self.root if source == "leetcode"
+                     else os.path.join(self.root, source))
+
+
+def record(source, ident, title, text, url, date, meta=""):
+    """The one shape every source returns and everything downstream reads.
+
+    `text` is the full searchable blob for the thread: body plus comments, if any.
+    `date` is `YYYY-MM-DD`; `meta` is a short source-specific label (subreddit,
+    Blind channel, HN story title) shown in the raw feed.
+    """
+    return {"source": source, "key": f"{source}:{ident}", "title": title or "",
+            "text": text or "", "url": url, "date": (date or "")[:10], "meta": meta}
+
+
+# -------------------------------------------------------------------- source: LC
+GRAPHQL_URL = "https://leetcode.com/graphql/"
+GQL_HEADERS = {"Content-Type": "application/json", "Origin": "https://leetcode.com",
+               "Referer": "https://leetcode.com/discuss/"}
 
 LIST_Q = """query list($keywords: [String]!, $tagSlugs: [String!], $skip: Int, $first: Int) {
   ugcArticleDiscussionArticles(keywords: $keywords, tagSlugs: $tagSlugs,
@@ -92,130 +246,343 @@ COMMENTS_Q = """query comments($topicId: Int!, $pageNo: Int, $numPerPage: Int) {
 }"""
 
 
-# --------------------------------------------------------------------------- net
-def gql(query, variables, delay, tries=3, quiet=False):
+def gql(query, variables, delay):
     """POST a GraphQL query. Returns `data`, or None if the query is unrecoverable."""
     body = json.dumps({"query": query, "variables": variables}).encode()
-    for attempt in range(tries):
-        try:
-            req = urllib.request.Request(GRAPHQL_URL, data=body, headers=HEADERS)
-            with urllib.request.urlopen(req, timeout=45) as resp:
-                payload = json.loads(resp.read().decode())
-        except urllib.error.HTTPError as exc:
-            detail = exc.read().decode()[:300]
-            if exc.code == 400:
-                # Malformed query - retrying cannot help.
-                print(f"    HTTP 400 (bad query): {detail}", file=sys.stderr)
-                return None
-            if not quiet:
-                print(f"    HTTP {exc.code}; backing off", file=sys.stderr)
-            time.sleep(max(45, delay * 18) * (attempt + 1))
-            continue
-        except Exception as exc:  # network hiccup, or WAF returning HTML instead of JSON
-            if not quiet:
-                print(f"    {type(exc).__name__}: {exc}; retrying", file=sys.stderr)
-            time.sleep(max(30, delay * 12) * (attempt + 1))
-            continue
-
-        if payload.get("errors"):
-            msg = payload["errors"][0].get("message", "")
-            print(f"    GraphQL error: {msg[:200]}", file=sys.stderr)
-            return None
-        return payload.get("data")
-    return None
+    payload = fetch_json(GRAPHQL_URL, delay, data=body, headers=GQL_HEADERS)
+    if payload is None:
+        return None
+    if payload.get("errors"):
+        print(f'    GraphQL error: {payload["errors"][0].get("message", "")[:200]}',
+              file=sys.stderr)
+        return None
+    return payload.get("data")
 
 
-# ------------------------------------------------------------------------ stages
-def fetch_post_list(tag, cache_dir, delay, per_page, max_pages):
-    """Stage 1: page the discuss list to exhaustion. Always re-run (cheap, and it is
-    the only way to notice new threads)."""
-    dst = os.path.join(cache_dir, "posts.json")
-    posts = {}
-    if os.path.exists(dst):
-        posts = {n["uuid"]: n for n in json.load(open(dst))}
-    skip, page = 0, 0
-    while max_pages is None or page < max_pages:
-        data = gql(LIST_Q, {"keywords": [], "tagSlugs": [tag],
-                            "skip": skip, "first": per_page}, delay)
-        conn = (data or {}).get("ugcArticleDiscussionArticles")
-        if not conn:
-            print(f"  list stopped at skip={skip} (no data)", file=sys.stderr)
-            break
-        edges = conn["edges"]
-        for edge in edges:
-            posts[edge["node"]["uuid"]] = edge["node"]
-        print(f"  skip={skip:<5} got={len(edges):<3} unique={len(posts)}")
-        # `totalNum` is capped and unreliable; a short page is the real end marker.
-        if len(edges) < per_page:
-            break
-        skip += per_page
-        page += 1
-        time.sleep(delay)
-    with open(dst, "w") as fh:
-        json.dump(list(posts.values()), fh)
-    return posts
+def source_leetcode(ctx):
+    """Three calls, because the list endpoint returns no bodies and no comments —
+    and the comments are where the actual questions usually are (most threads are
+    compensation/team-match chatter with the problems buried in replies)."""
+    cache, delay = ctx.cache("leetcode"), ctx.delay("leetcode")
+    posts = {n["uuid"]: n for n in cache.load("posts.json", default=[])}
 
-
-def fetch_bodies(posts, cache_dir, delay):
-    """Stage 2: one call per post; the list endpoint does not return bodies."""
-    out_dir = os.path.join(cache_dir, "bodies")
-    os.makedirs(out_dir, exist_ok=True)
-    todo = [n for n in posts.values()
-            if n.get("topicId") and not os.path.exists(os.path.join(out_dir, f'{n["uuid"]}.json'))]
-    print(f"  {len(todo)} bodies to fetch ({len(posts) - len(todo)} cached)")
-    for i, n in enumerate(todo, 1):
-        data = gql(BODY_Q, {"topicId": n["topicId"]}, delay)
-        node = (data or {}).get("ugcArticleDiscussionArticle")
-        if data is None:
-            print("  aborting body stage (unrecoverable)", file=sys.stderr)
-            break
-        with open(os.path.join(out_dir, f'{n["uuid"]}.json'), "w") as fh:
-            json.dump(node or {"uuid": n["uuid"], "content": ""}, fh)
-        if i % 25 == 0:
-            print(f"    {i}/{len(todo)}")
-        time.sleep(delay)
-
-
-def fetch_comments(posts, cache_dir, delay, max_comment_pages=4):
-    """Stage 3: comments, paged. This is where the actual questions usually are —
-    most threads are compensation/team-match chatter with the problems in replies."""
-    out_dir = os.path.join(cache_dir, "comments")
-    os.makedirs(out_dir, exist_ok=True)
-    todo = [n for n in posts.values()
-            if n.get("topicId") and not os.path.exists(os.path.join(out_dir, f'{n["uuid"]}.json'))]
-    print(f"  {len(todo)} comment threads to fetch ({len(posts) - len(todo)} cached)")
-    for i, n in enumerate(todo, 1):
-        got, page = [], 1
-        while page <= max_comment_pages:
-            data = gql(COMMENTS_Q, {"topicId": int(n["topicId"]),
-                                    "pageNo": page, "numPerPage": 50}, delay)
-            conn = (data or {}).get("topicComments")
+    if not ctx.build_only:
+        # Stage 1: page the discuss list to exhaustion. Always re-run — it is cheap,
+        # and it is the only way to notice new threads.
+        skip = page = 0
+        while ctx.max_pages is None or page < ctx.max_pages:
+            data = gql(LIST_Q, {"keywords": [], "tagSlugs": [ctx.tag],
+                                "skip": skip, "first": ctx.args.per_page}, delay)
+            conn = (data or {}).get("ugcArticleDiscussionArticles")
             if not conn:
+                print(f"  list stopped at skip={skip} (no data)", file=sys.stderr)
                 break
-            got.extend(conn["data"])
-            if not conn["data"] or len(got) >= conn["totalNum"]:
+            edges = conn["edges"]
+            posts.update({e["node"]["uuid"]: e["node"] for e in edges})
+            print(f"  skip={skip:<5} got={len(edges):<3} unique={len(posts)}")
+            # `totalNum` is capped and unreliable; a short page is the real end marker.
+            if len(edges) < ctx.args.per_page:
                 break
-            page += 1
+            skip, page = skip + ctx.args.per_page, page + 1
             time.sleep(delay)
-        with open(os.path.join(out_dir, f'{n["uuid"]}.json'), "w") as fh:
-            json.dump({"uuid": n["uuid"], "comments": got}, fh)
-        if i % 25 == 0:
-            print(f"    {i}/{len(todo)}")
-        time.sleep(delay)
+        cache.save(list(posts.values()), "posts.json")
+
+        # Stage 2: bodies, one call per thread.
+        todo = [n for n in posts.values()
+                if n.get("topicId") and not cache.has("bodies", f'{n["uuid"]}.json')]
+        print(f"  {len(todo)} bodies to fetch ({len(posts) - len(todo)} cached)")
+        for i, n in enumerate(todo, 1):
+            data = gql(BODY_Q, {"topicId": n["topicId"]}, delay)
+            if data is None:
+                print("  aborting body stage (unrecoverable)", file=sys.stderr)
+                break
+            node = data.get("ugcArticleDiscussionArticle")
+            cache.save(node or {"uuid": n["uuid"], "content": ""},
+                       "bodies", f'{n["uuid"]}.json')
+            if i % 25 == 0:
+                print(f"    {i}/{len(todo)}")
+            time.sleep(delay)
+
+        # Stage 3: comments, paged. Newest first — this is the slow stage, and a run
+        # that is cut short should have spent its requests on the freshest threads.
+        todo = sorted((n for n in posts.values() if ctx.want_comments and n.get("topicId")
+                       and not cache.has("comments", f'{n["uuid"]}.json')),
+                      key=lambda n: n["createdAt"], reverse=True)
+        print(f"  {len(todo)} comment threads to fetch"
+              f"{' (--no-comments)' if not ctx.want_comments else ''}")
+        for i, n in enumerate(todo, 1):
+            got, page = [], 1
+            while page <= 4:
+                data = gql(COMMENTS_Q, {"topicId": int(n["topicId"]),
+                                        "pageNo": page, "numPerPage": 50}, delay)
+                conn = (data or {}).get("topicComments")
+                if not conn:
+                    break
+                got.extend(conn["data"])
+                if not conn["data"] or len(got) >= conn["totalNum"]:
+                    break
+                page += 1
+                time.sleep(delay)
+            cache.save(got, "comments", f'{n["uuid"]}.json')
+            if i % 25 == 0:
+                print(f"    {i}/{len(todo)}")
+            time.sleep(delay)
+
+    out = []
+    for uuid, n in posts.items():
+        body = cache.load("bodies", f"{uuid}.json", default={}) or {}
+        comments = cache.load("comments", f"{uuid}.json", default=[]) or []
+        chunks = [n.get("summary") or "", body.get("content") or ""]
+        chunks += [(c.get("post") or {}).get("content") or "" for c in comments]
+        tags = [t["slug"] for t in (n.get("tags") or []) if t["slug"] != ctx.tag]
+        out.append(record(
+            "leetcode", uuid, n["title"], "\n".join(text_of(c) for c in chunks),
+            f'https://leetcode.com/discuss/post/{n["topicId"]}/{n.get("slug") or ""}/',
+            n["createdAt"], meta=fit(tags)))
+    return out
 
 
-def load_problem_index(cache_dir, refresh):
+# ---------------------------------------------------------------- source: reddit
+REDDIT_SUBS = ["leetcode", "cscareerquestions", "csMajors", "ExperiencedDevs"]
+ATOM = "{http://www.w3.org/2005/Atom}"
+# Every RSS entry ends with this; it is feed furniture, and it pollutes the quotes.
+REDDIT_FOOTER = re.compile(r"\s*submitted by\s*/u/\S+\s*\[link\]\s*\[comments\]\s*$", re.I)
+
+
+def atom_entries(raw):
+    """Parse a reddit Atom feed into dicts. Reddit serves well-formed XML; a parse
+    failure means we got an error page instead, so treat it as an empty feed."""
+    try:
+        root = ET.fromstring(raw)
+    except Exception:
+        return []
+    out = []
+    for e in root.findall(ATOM + "entry"):
+        def txt(tag):
+            node = e.find(ATOM + tag)
+            return (node.text or "") if node is not None else ""
+        link = e.find(ATOM + "link")
+        out.append({"id": txt("id"), "title": txt("title"),
+                    "content": txt("content"), "date": txt("published"),
+                    "url": link.get("href") if link is not None else ""})
+    return out
+
+
+def source_reddit(ctx):
+    """Search feed per subreddit, then the comment feed of every interview-flavoured
+    hit. The `.rss` twin of each blocked `.json` path is the whole trick — see the
+    module docstring."""
+    cache, delay = ctx.cache("reddit"), ctx.delay("reddit")
+    posts = cache.load("posts.json", default={})
+    query = urllib.parse.quote_plus(f"{ctx.company} interview")
+
+    if not ctx.build_only:
+        for sub in ctx.args.reddit_subs:
+            after, page = None, 0
+            while ctx.max_pages is None or page < ctx.max_pages:
+                url = (f"https://www.reddit.com/r/{sub}/search.rss?q={query}"
+                       f"&restrict_sr=1&sort=new&limit=100"
+                       + (f"&after={after}" if after else ""))
+                entries = atom_entries(fetch(url, delay) or b"")
+                for e in entries:
+                    e["sub"] = sub
+                    posts[e["id"]] = e
+                print(f"  r/{sub:<20} page={page} got={len(entries):<4} "
+                      f"unique={len(posts)}")
+                if len(entries) < 100:
+                    break
+                after, page = entries[-1]["id"], page + 1
+                time.sleep(delay)
+            time.sleep(delay)
+        cache.save(posts, "posts.json")
+
+        # Newest first: comment fetching is the slow part, and a run that is cut short
+        # should have spent its requests on the freshest threads.
+        todo = sorted((p for p in posts.values()
+                       if ctx.want_comments and interviewish(p["title"], p["content"])
+                       and not cache.has("comments", f'{p["id"]}.json')),
+                      key=lambda p: p["date"], reverse=True)
+        print(f"  {len(todo)} comment threads to fetch"
+              f"{' (--no-comments)' if not ctx.want_comments else ''}")
+        for i, p in enumerate(todo, 1):
+            raw = fetch(p["url"].rstrip("/") + "/.rss?limit=100", delay) or b""
+            # Entry 1 of a comment feed is the post itself; the rest are comments.
+            cache.save([e["content"] for e in atom_entries(raw)[1:]],
+                       "comments", f'{p["id"]}.json')
+            if i % 25 == 0:
+                print(f"    {i}/{len(todo)}")
+            time.sleep(delay)
+
+    out = []
+    for pid, p in posts.items():
+        comments = cache.load("comments", f"{pid}.json", default=[]) or []
+        blob = "\n".join(REDDIT_FOOTER.sub("", text_of(c))
+                         for c in [p["content"]] + comments)
+        out.append(record("reddit", pid, p["title"], blob, p["url"], p["date"],
+                          meta=f'r/{p.get("sub", "?")}'))
+    return out
+
+
+# ----------------------------------------------------------------- source: blind
+# Blind serves exactly 20 cards per query and ignores `?page`, so breadth has to come
+# from asking several questions instead of paging one.
+BLIND_QUERIES = ["interview", "onsite", "leetcode", "phone screen", "online assessment"]
+BLIND_CARD_RE = re.compile(
+    r'data-testid="article-preview-title"[^>]*>(.*?)</h2>\s*<p[^>]*>(.*?)</p>', re.S)
+BLIND_BODY_RE = re.compile(
+    r'data-testid="article-title"[^>]*>(.*?)</h1>\s*<p[^>]*>(.*?)</p>', re.S)
+
+
+def blind_cards(page):
+    """Pull the search-result cards out of Blind's server-rendered HTML."""
+    out = []
+    for chunk in (page or "").split('data-article-alias="')[1:]:
+        alias = chunk.split('"', 1)[0]
+        card = chunk.split("</article>", 1)[0]
+        body = BLIND_CARD_RE.search(card)
+        slug = re.search(r'href="/post/([^"]+)"', card)
+        if not (body and slug):
+            continue
+        # The human date ("Jun 17") is ambiguous; the tooltip next to it is not.
+        date = re.search(r'title="(\d\d)/(\d\d)/(\d{4})', card)
+        chan = re.search(r'article-preview-channel"[^>]*>(?:<[^>]*>)*([^<]+)', card)
+        out.append({"id": alias, "slug": slug.group(1),
+                    "title": text_of(body.group(1)), "preview": text_of(body.group(2)),
+                    "date": (f"{date.group(3)}-{date.group(1)}-{date.group(2)}"
+                             if date else ""),
+                    "channel": text_of(chan.group(1)) if chan else ""})
+    return out
+
+
+def source_blind(ctx):
+    """Search cards, then the post page for the full body — cards truncate at ~312
+    chars. Comments are client-rendered and stay out of reach."""
+    cache, delay = ctx.cache("blind"), ctx.delay("blind")
+    posts = cache.load("posts.json", default={})
+
+    if not ctx.build_only:
+        for suffix in BLIND_QUERIES:
+            q = urllib.parse.quote(f"{ctx.company} {suffix}")
+            raw = fetch(f"https://www.teamblind.com/search/{q}", delay) or b""
+            cards = blind_cards(raw.decode("utf-8", "replace"))
+            for c in cards:
+                posts[c["id"]] = c
+            print(f'  "{ctx.company} {suffix}"'.ljust(38)
+                  + f"got={len(cards):<3} unique={len(posts)}")
+            time.sleep(delay)
+        cache.save(posts, "posts.json")
+
+        todo = [p for p in posts.values() if not cache.has("bodies", f'{p["id"]}.json')]
+        print(f"  {len(todo)} bodies to fetch ({len(posts) - len(todo)} cached)")
+        for i, p in enumerate(todo, 1):
+            raw = fetch(f'https://www.teamblind.com/post/{p["slug"]}', delay) or b""
+            m = BLIND_BODY_RE.search(raw.decode("utf-8", "replace"))
+            cache.save(text_of(m.group(2)) if m else "", "bodies", f'{p["id"]}.json')
+            if i % 25 == 0:
+                print(f"    {i}/{len(todo)}")
+            time.sleep(delay)
+
+    out = []
+    for pid, p in posts.items():
+        body = cache.load("bodies", f"{pid}.json", default="") or ""
+        out.append(record("blind", pid, p["title"],
+                          body if len(body) > len(p["preview"]) else p["preview"],
+                          f'https://www.teamblind.com/post/{p["slug"]}',
+                          p["date"], meta=p.get("channel", "")))
+    return out
+
+
+# -------------------------------------------------------------------- source: hn
+def source_hn(ctx):
+    """Algolia's HN index: public, fast and generous. Matching is fuzzy, so this is a
+    breadth source — expect noise, and lean on the evidence quotes."""
+    cache, delay = ctx.cache("hn"), ctx.delay("hn")
+    posts = cache.load("posts.json", default={})
+    query = urllib.parse.quote_plus(f"{ctx.company} leetcode interview")
+
+    if not ctx.build_only:
+        for kind in ("story", "comment"):
+            page = 0
+            while page < (ctx.max_pages or 5):
+                data = fetch_json(
+                    f"https://hn.algolia.com/api/v1/search_by_date?query={query}"
+                    f"&tags={kind}&hitsPerPage=100&page={page}", delay)
+                hits = (data or {}).get("hits") or []
+                for h in hits:
+                    posts[h["objectID"]] = {
+                        "id": h["objectID"],
+                        "title": h.get("title") or h.get("story_title") or "",
+                        "text": text_of(h.get("comment_text") or h.get("story_text") or ""),
+                        "date": h.get("created_at", ""), "kind": kind,
+                        "story": h.get("story_title") or ""}
+                print(f"  {kind:<8} page={page} got={len(hits):<4} unique={len(posts)}")
+                if page + 1 >= (data or {}).get("nbPages", 0) or len(hits) < 100:
+                    break
+                page += 1
+                time.sleep(delay)
+            time.sleep(delay)
+        cache.save(posts, "posts.json")
+
+    return [record("hn", p["id"], p["title"] or p["story"], p["text"],
+                   f'https://news.ycombinator.com/item?id={p["id"]}', p["date"],
+                   meta=(p["story"][:40] if p["kind"] == "comment" else "story"))
+            for p in posts.values()]
+
+
+SOURCES = {"leetcode": source_leetcode, "reddit": source_reddit,
+           "blind": source_blind, "hn": source_hn}
+LABELS = {"leetcode": "LeetCode Discuss", "reddit": "Reddit",
+          "blind": "Blind", "hn": "Hacker News"}
+ENDPOINTS = {
+    "leetcode": ("`leetcode.com/graphql` — `ugcArticleDiscussionArticles`, "
+                 "`ugcArticleDiscussionArticle`, `topicComments`",
+                 "`skip` += `first`, then one call per thread",
+                 "threads + bodies + comments"),
+    "reddit": ("`reddit.com/r/<sub>/search.rss` + `<permalink>/.rss`",
+               "`after=t3_<id>`, `limit=100`",
+               "posts (full selftext) + comment threads"),
+    "blind": ("`teamblind.com/search/<query>` + `/post/<slug>` (HTML)",
+              "none — several queries instead (`?page` is ignored)",
+              "search cards + full post bodies (**no comments**)"),
+    "hn": ("`hn.algolia.com/api/v1/search_by_date`", "`page` 0..n, `hitsPerPage=100`",
+           "stories + comments"),
+}
+
+
+# -------------------------------------------------------------------- extraction
+URL_RE = re.compile(r"leetcode\.com/problems/([a-z0-9][a-z0-9\-]{2,})", re.I)
+# "LC 200" / "leetcode 200" take 1+ digits; a bare "#200" needs 2+ so that prose like
+# "#1 priority" does not resolve to a real problem number.
+NUM_RE = re.compile(r"(?:\bLC\s*#?\s*|\bleetcode\s*#?\s*)(\d{1,4})\b"
+                    r"|(?<![\w.])#(\d{2,4})\b", re.I)
+# "leetcode 8+ hrs a day", "leetcode 300 problems" — that is a count, not a problem id.
+UNIT_RE = re.compile(r"\s*(?:\+|k\b|%|hours?|hrs?|minutes?|mins?|days?|weeks?|months?|"
+                     r"years?|times?|problems?|questions?|qs?\b|easy|mediums?|hards?)", re.I)
+# "leetcode 75 / 150 / 169" is nearly always a study *list* (LeetCode 75, NeetCode 150,
+# Grind 169), not problem #75. Written the problem way — "LC 75" — it still counts.
+LIST_NUMS = {50, 75, 100, 150, 169}
+# Titles that are ordinary English and would match constantly in prose.
+BAD_TITLES = {"design", "sort colors", "word break", "jump game", "candy",
+              "trapping rain water"}
+INTERVIEW_HINT = re.compile(
+    r"interview|onsite|phone screen|screen|round|oa\b|online assessment|asked|coding", re.I)
+
+
+def interviewish(*chunks):
+    return bool(INTERVIEW_HINT.search(" ".join(c or "" for c in chunks)))
+
+
+def load_problem_index(cache, refresh, delay=1.0):
     """LeetCode's public problem index: slug/number/title/difficulty for every problem."""
-    dst = os.path.join(cache_dir, "all_problems.json")
-    if refresh or not os.path.exists(dst):
+    if refresh or not cache.has("all_problems.json"):
         print("  downloading LC problem index")
-        req = urllib.request.Request(PROBLEM_INDEX_URL, headers=HEADERS)
-        with urllib.request.urlopen(req, timeout=60) as resp:
-            open(dst, "wb").write(resp.read())
-    raw = json.load(open(dst))["stat_status_pairs"]
+        raw = fetch(PROBLEM_INDEX_URL, delay)
+        if not raw:
+            sys.exit("could not download the LC problem index")
+        cache.save(json.loads(raw), "all_problems.json")
     difficulty = {1: "Easy", 2: "Medium", 3: "Hard"}
     by_slug, by_num, by_title = {}, {}, {}
-    for entry in raw:
+    for entry in cache.load("all_problems.json")["stat_status_pairs"]:
         stat = entry["stat"]
         rec = {"num": stat["frontend_question_id"],
                "slug": stat["question__title_slug"],
@@ -232,20 +599,10 @@ def load_repo_solved():
     """Problems already solved in this repo, for the 'In repo?' column. Optional."""
     path = os.path.join(REPO_ROOT, "_site", "data", "lc-problems.json")
     try:
-        return {int(p["id"]): p for p in json.load(open(path))["problems"]}
+        with open(path) as fh:
+            return {int(p["id"]): p for p in json.load(fh)["problems"]}
     except Exception:
         return {}
-
-
-# -------------------------------------------------------------------- extraction
-URL_RE = re.compile(r"leetcode\.com/problems/([a-z0-9][a-z0-9\-]{2,})", re.I)
-# "LC 200" / "leetcode 200" take 1+ digits; a bare "#200" needs 2+ so that prose like
-# "#1 priority" does not resolve to a real problem number.
-NUM_RE = re.compile(r"(?:\bLC\s*#?\s*|\bleetcode\s*#?\s*)(\d{1,4})\b"
-                    r"|(?<![\w.])#(\d{2,4})\b", re.I)
-# Titles that are ordinary English and would match constantly in prose.
-BAD_TITLES = {"design", "sort colors", "word break", "jump game", "candy",
-              "trapping rain water"}
 
 
 def build_title_regex(by_title):
@@ -255,77 +612,71 @@ def build_title_regex(by_title):
     return candidates, re.compile(r"(?<!\w)(" + pattern + r")(?!\w)", re.I)
 
 
-def extract(posts, comments, by_slug, by_num, by_title):
+def extract(posts, by_slug, by_num, by_title):
     candidates, title_re = build_title_regex(by_title)
     hits = {}
 
-    def record(rec, post, how, text, pos):
+    def note(rec, post, how, text, pos):
         hit = hits.setdefault(rec["num"], {"rec": rec, "posts": {}, "seen": set(),
                                            "evidence": [], "methods": collections.Counter()})
-        hit["posts"][post["uuid"]] = post
+        hit["posts"][post["key"]] = post
         hit["methods"][how] += 1
-        if post["uuid"] in hit["seen"]:
+        if post["key"] in hit["seen"]:
             return  # one quote per (problem, thread): url/num/title all fire on one sentence
-        hit["seen"].add(post["uuid"])
+        hit["seen"].add(post["key"])
         start = max(0, pos - 70)
         hit["evidence"].append({
             "snippet": re.sub(r"\s+", " ", text[start:start + 200]).strip(),
-            "post": post["title"], "date": post["createdAt"][:10],
-            "url": post_url(post), "how": how})
+            "post": post["title"], "date": post["date"], "source": post["source"],
+            "url": post["url"], "how": how})
 
-    for post in posts.values():
-        chunks = [post.get("title") or "", post.get("summary") or "", post.get("content") or ""]
-        chunks += [(c.get("post") or {}).get("content") or ""
-                   for c in comments.get(post["uuid"], [])]
-        text = "\n".join(chunks)
+    for post in posts:
+        text = post["title"] + "\n" + post["text"]
         for m in URL_RE.finditer(text):
             rec = by_slug.get(m.group(1).lower())
             if rec:
-                record(rec, post, "url", text, m.start())
+                note(rec, post, "url", text, m.start())
         for m in NUM_RE.finditer(text):
-            rec = by_num.get(int(m.group(1) or m.group(2)))
+            num = int(m.group(1) or m.group(2))
+            if UNIT_RE.match(text, m.end()):
+                continue
+            if num in LIST_NUMS and m.group(0).lower().lstrip("#").startswith("leetcode"):
+                continue
+            rec = by_num.get(num)
             if rec:
-                record(rec, post, "number", text, m.start())
+                note(rec, post, "number", text, m.start())
         for m in title_re.finditer(text):
             key = m.group(1).lower()
-            if key in BAD_TITLES:
-                continue
             rec = candidates.get(key)
-            if rec:
-                record(rec, post, "title", text, m.start())
+            if rec and key not in BAD_TITLES:
+                note(rec, post, "title", text, m.start())
 
     return sorted(hits.values(),
                   key=lambda h: (-len(h["posts"]), -sum(h["methods"].values()), h["rec"]["num"]))
 
 
 # ------------------------------------------------------------------------ report
-def post_url(node):
-    return f'https://leetcode.com/discuss/post/{node["topicId"]}/{node.get("slug") or ""}/'
+EV_PROBLEMS, EV_QUOTES, FEED_ROWS = 25, 3, 60
 
 
-def fit_tags(slugs, budget=60):
-    """Drop whole tags that do not fit; never cut a slug mid-token."""
+def fit(items, budget=60):
+    """Join labels to a budget, dropping whole items rather than cutting one in half."""
     kept, used = [], 0
-    for slug in slugs:
-        need = len(slug) + (2 if kept else 0)
+    for item in items:
+        need = len(item) + (2 if kept else 0)
         if used + need > budget:
-            return ", ".join(kept) + f" +{len(slugs) - len(kept)} more"
-        kept.append(slug)
+            return ", ".join(kept) + f" +{len(items) - len(kept)} more"
+        kept.append(item)
         used += need
     return ", ".join(kept)
 
 
-INTERVIEW_HINT = re.compile(
-    r"interview|onsite|phone screen|screen|round|oa\b|online assessment|asked|coding", re.I)
-EV_PROBLEMS, EV_QUOTES = 25, 3
-
-
-def render(tag, posts, comments, ranked, solved, out_path, generated_on):
-    company = tag.replace("-", " ").title()
-    recent = sorted(posts.values(), key=lambda n: n["createdAt"], reverse=True)
-    dates = [n["createdAt"][:10] for n in recent]
-    n_bodies = sum(1 for n in posts.values() if n.get("content"))
-    n_comments = sum(len(v) for v in comments.values())
+def render(ctx, posts, ranked, solved, out_path, sources, generated_on):
+    company = ctx.tag.replace("-", " ").title()
+    by_source = collections.defaultdict(list)
+    for p in posts:
+        by_source[p["source"]].append(p)
+    dated = [p["date"] for p in posts if p["date"]]
     lines = []
     w = lines.append
 
@@ -333,42 +684,55 @@ def render(tag, posts, comments, ranked, solved, out_path, generated_on):
         entry = solved.get(rec["num"])
         return ", ".join(entry["tags"][:3]) if entry and entry.get("tags") else "—"
 
-    w(f"# {company} SWE — Recently Asked LeetCode Questions (scraped)\n")
+    w(f"# {company} SWE — Recently Asked Interview Questions (scraped)\n")
     w(f"> **Generated**: {generated_on}  ")
-    w("> **Source**: `leetcode.com/graphql` — public Discuss API "
-      "(`ugcArticleDiscussionArticles`, `ugcArticleDiscussionArticle`, `topicComments`)  ")
-    w(f"> **Regenerate**: `python3 script/scrape_lc_discuss_company.py --tag {tag}`  ")
-    w(f"> **Corpus**: {len(posts)} `{tag}`-tagged discuss posts, {dates[-1]} → {dates[0]} "
-      f"({n_bodies} full bodies, {n_comments} comments)\n")
+    w(f'> **Sources**: {", ".join(LABELS[s] for s in sources)}  ')
+    w(f"> **Regenerate**: `python3 script/scrape_lc_discuss_company.py --tag {ctx.tag} "
+      f'--sources {",".join(sources)}`  ')
+    w(f"> **Corpus**: {len(posts)} posts, {min(dated)} → {max(dated)}\n"
+      if dated else f"> **Corpus**: {len(posts)} posts\n")
+
+    w("| Source | Posts | Range | What is scraped |")
+    w("|--------|-------|-------|-----------------|")
+    for s in sources:
+        got = by_source.get(s, [])
+        span = sorted(p["date"] for p in got if p["date"])
+        w(f"| {LABELS[s]} | {len(got)} | "
+          f'{f"{span[0]} → {span[-1]}" if span else "—"} | {ENDPOINTS[s][2]} |')
+    w("")
 
     w("## ⚠️ Read this first — what this data is and is not\n")
     w("- LeetCode's **official company tag list** (`companyTag`) is **Premium-gated** and "
       "returns `null` for anonymous requests. This doc is **not** that list.")
-    w(f"- What is scraped here is **user-reported interview experience** from the public "
-      f"Discuss forum, tagged `{tag}`. It is self-reported, unverified, and skewed toward "
-      "whoever bothers to post.")
-    w("- The **legacy** discuss API (`categoryTopicList`, category `interview-question`) is "
-      "frozen at **2025-03-04** — LeetCode migrated Discuss during 2025. Anything claiming to "
-      "scrape \"recent\" questions from that endpoint is serving stale data.")
+    w("- Everything here is **user-reported interview experience** from public forums. It "
+      "is self-reported, unverified, and skewed toward whoever bothers to post.")
+    w("- Sources differ in signal. LeetCode Discuss and Reddit posters cite problems by "
+      "number or link; Blind and Hacker News posters mostly do not, so those two "
+      "contribute breadth (and noise) rather than precise references.")
+    w("- The **legacy** LeetCode discuss API (`categoryTopicList`, category "
+      "`interview-question`) is frozen at **2025-03-04** — LeetCode migrated Discuss "
+      "during 2025. Anything claiming to scrape \"recent\" questions from that endpoint "
+      "is serving stale data.")
     w("- Treat problem counts as **weak signal** (mention frequency), not ground-truth "
-      "interview frequency. A single well-linked compilation post can put a dozen problems on "
-      "the board at once.")
-    w("- Mentions are **not all interview reports** — some describe a practice routine, and a "
-      "title match can even land inside a sentence saying the problem is *not* what was asked. "
-      "The `Match` column and the quotes exist so you can check.\n")
+      "interview frequency. A single well-linked compilation post can put a dozen problems "
+      "on the board at once.")
+    w("- Mentions are **not all interview reports** — some describe a practice routine, and "
+      "a title match can even land inside a sentence saying the problem is *not* what was "
+      "asked. The `Match` column and the quotes exist so you can check.\n")
 
     w("## 1) Most-referenced LC problems\n")
-    w("**`Posts`** = number of **distinct discuss threads** referencing the problem anywhere in "
-      "`title + summary + body + comments`. It counts threads, not mentions: a thread naming the "
-      "same problem five times counts once, so `Posts` is *not* the sum of the quotes below.\n")
-    w("`Match` = how the reference was found, showing the **strongest** evidence anywhere in "
-      "that thread set. **url** = the post linked `leetcode.com/problems/<slug>` (high "
-      "confidence); **num** = wrote `LC 200` / `#200`; **title** = the exact title appeared in "
-      "prose — weakest, worth eyeballing the quote before trusting it.\n")
+    w("**`Posts`** = number of **distinct threads** referencing the problem anywhere in "
+      "`title + body + comments`. It counts threads, not mentions: a thread naming the same "
+      "problem five times counts once, so `Posts` is *not* the sum of the quotes below.\n")
+    w("`Where` = which sources the thread(s) came from. `Match` = how the reference was "
+      "found, showing the **strongest** evidence anywhere in that thread set. **url** = the "
+      "post linked `leetcode.com/problems/<slug>` (high confidence); **num** = wrote "
+      "`LC 200` / `#200`; **title** = the exact title appeared in prose — weakest, worth "
+      "eyeballing the quote before trusting it.\n")
     w("The table below is **complete** — every problem extracted from the corpus is listed.\n")
     if ranked:
-        w("| # | Problem | Diff | Type / Tags | Posts | Match | Last seen | In repo? |")
-        w("|---|---------|------|-------------|-------|-------|-----------|----------|")
+        w("| # | Problem | Diff | Type / Tags | Posts | Where | Match | Last seen | In repo? |")
+        w("|---|---------|------|-------------|-------|-------|-------|-----------|----------|")
         for hit in ranked:
             rec = hit["rec"]
             link = f'https://leetcode.com/problems/{rec["slug"]}/'
@@ -376,82 +740,87 @@ def render(tag, posts, comments, ranked, solved, out_path, generated_on):
             # Strongest evidence, not most frequent: one link outweighs ten prose mentions.
             how = ("url" if hit["methods"]["url"]
                    else "num" if hit["methods"]["number"] else "title")
-            last = max(p["createdAt"][:10] for p in hit["posts"].values())
+            where = ", ".join(sorted({p["source"] for p in hit["posts"].values()}))
+            last = max((p["date"] for p in hit["posts"].values() if p["date"]), default="—")
             w(f'| {rec["num"]} | [{rec["title"]}]({link}){paid} | {rec["difficulty"]} '
-              f'| {type_of(rec)} | {len(hit["posts"])} | {how} | {last} '
+              f'| {type_of(rec)} | {len(hit["posts"])} | {where} | {how} | {last} '
               f'| {"✅" if rec["num"] in solved else "—"} |')
     else:
         w("_No LC problem references extracted from the scraped corpus._")
     w("")
 
     w("### Evidence (quotes from the scraped posts)\n")
-    w(f"**This is a sample, not a full audit trail.** It covers the top {EV_PROBLEMS} problems "
-      f"of {len(ranked)}, with at most {EV_QUOTES} quotes each (one per thread, from the first "
-      "match in that thread). Where a problem has more threads than quotes shown, the surplus is "
-      "noted inline. For the rest, follow the links in the table and section 2.\n")
+    w(f"**This is a sample, not a full audit trail.** It covers the top {EV_PROBLEMS} "
+      f"problems of {len(ranked)}, with at most {EV_QUOTES} quotes each (one per thread, "
+      "from the first match in that thread). Where a problem has more threads than quotes "
+      "shown, the surplus is noted inline. For the rest, follow the links in the table and "
+      "section 2.\n")
     for hit in ranked[:EV_PROBLEMS]:
-        rec = hit["rec"]
-        n_posts = len(hit["posts"])
+        rec, n_posts = hit["rec"], len(hit["posts"])
         extra = n_posts - min(len(hit["evidence"]), EV_QUOTES)
         more = f' — _{extra} further thread{"s" if extra > 1 else ""} not quoted_' if extra > 0 else ""
         w(f'**LC {rec["num"]} — {rec["title"]}** ({rec["difficulty"]}) · '
           f'{n_posts} thread{"s" if n_posts > 1 else ""}{more}  ')
         for ev in hit["evidence"][:EV_QUOTES]:
-            w(f'- _{ev["date"]}_ · [{ev["post"][:70]}]({ev["url"]})  ')
+            w(f'- `{ev["source"]}` _{ev["date"]}_ · [{ev["post"][:70]}]({ev["url"]})  ')
             w(f'  > …{ev["snippet"][:230]}…')
         w("")
 
     w("## 2) Recent interview posts (raw feed)\n")
-    w("Newest first — the primary sources. Open them for full text and comment threads.\n")
-    w(f"Every row already carries the `{tag}` tag (that is the scrape filter: "
-      f"`tagSlugs: [\"{tag}\"]`), so it is omitted from `Tags` as redundant. Long tag lists are "
-      "trimmed at a whole-tag boundary with the remainder as `+N more`.\n")
-    w(f"| Date | Post | Tags (excl. `{tag}`) | Views |")
-    w("|------|------|------------------------|-------|")
-    for node in recent:
-        if not INTERVIEW_HINT.search(node["title"] + " " + (node.get("summary") or "")):
+    w("Newest first — the primary sources. Open them for full text and comment threads. "
+      f"Only interview-flavoured posts are listed, at most {FEED_ROWS} per source.\n")
+    for s in sources:
+        feed = sorted((p for p in by_source.get(s, [])
+                       if interviewish(p["title"], p["text"][:400])),
+                      key=lambda p: p["date"], reverse=True)
+        w(f"### {LABELS[s]}\n")
+        if not feed:
+            w("_Nothing matched._\n")
             continue
-        tags = fit_tags([t["slug"] for t in (node.get("tags") or []) if t["slug"] != tag])
-        title = node["title"].replace("|", "\\|").strip()[:95]
-        w(f'| {node["createdAt"][:10]} | [{title}]({post_url(node)}) | {tags} '
-          f'| {node.get("hitCount", 0)} |')
-    w("")
+        w("| Date | Post | Context |")
+        w("|------|------|---------|")
+        for p in feed[:FEED_ROWS]:
+            title = p["title"].replace("|", "\\|").strip()[:95] or "(untitled)"
+            w(f'| {p["date"] or "—"} | [{title}]({p["url"]}) | {p["meta"]} |')
+        if len(feed) > FEED_ROWS:
+            w(f"\n_{len(feed) - FEED_ROWS} more not shown._")
+        w("")
 
     w("## 3) Method\n")
-    w(f"Generated by [`script/scrape_lc_discuss_company.py`](../script/"
-      f"scrape_lc_discuss_company.py). The figures above come from a **full paginated run**: "
-      f"all {len(posts)} threads listed by paging `skip` to exhaustion, then every thread's body "
-      f"and comments fetched individually ({n_bodies} bodies, {n_comments} comments).\n")
+    w("Generated by [`script/scrape_lc_discuss_company.py`](../script/"
+      "scrape_lc_discuss_company.py). Each source is scraped independently, cached one "
+      "file per post, then all posts are pooled and scanned for LeetCode references "
+      "(problem link, `LC <n>` / `#<n>`, or an exact problem title in prose).\n")
     w("```bash")
-    w(f"python3 script/scrape_lc_discuss_company.py --tag {tag}   # full run (slow, ~2.5s/request)")
-    w("python3 script/scrape_lc_discuss_company.py --build-only  # rebuild doc from cache")
+    w(f"python3 script/scrape_lc_discuss_company.py --tag {ctx.tag}  # full run (slow)")
+    w("python3 script/scrape_lc_discuss_company.py --build-only    # rebuild doc from cache")
     w("```\n")
-    w("Three calls are involved, because the list endpoint does **not** return bodies:\n")
-    w("| Stage | Field | Paginate with | Returns |")
-    w("|-------|-------|---------------|---------|")
-    w("| 1 | `ugcArticleDiscussionArticles` | `skip` += `first` | thread list + `summary` "
-      "(**no body**) |")
-    w("| 2 | `ugcArticleDiscussionArticle` | one call per `topicId` | post body (`content`) |")
-    w("| 3 | `topicComments` | `pageNo` 1..n | comment threads |\n")
-    w("**Schema gotchas** (introspection is disabled; all found by reading error messages):\n")
-    w("- `tagSlugs` is required on `ugcArticleDiscussionArticles`; omitting it returns "
-      "`argument of type 'NoneType' is not iterable`.")
-    w("- Variable types must be exact: `$keywords: [String]!` but `$tagSlugs: [String!]`.")
-    w("- `ugcArticleDiscussionArticle` keys off **`topicId`**, not `uuid`.")
-    w("- **The two `topicId` arguments have different types, and this is not a typo**: "
-      "`ugcArticleDiscussionArticle` takes `ID`, `topicComments` takes `Int!`. Using one type "
-      "for both fails on whichever call you guessed wrong.")
-    w("- `content` is **null in list mode** — only `summary` is populated; bodies need stage 2.")
-    w("- `totalNum` on the list connection is **capped** (3000), not the real result count — "
-      "page until a short page instead of trusting it.")
-    w("- `topicComments.orderBy` is a plain `String` (`most_votes` / `newest_to_oldest` / "
-      "`oldest_to_newest` / `hot`), not an enum.")
-    w("- Rapid probing trips a WAF returning **HTML 403s, not JSON** — parse defensively and "
-      "keep ~2–3 s between requests.\n")
+    w("| Source | Endpoint | Pagination | Returns |")
+    w("|--------|----------|------------|---------|")
+    for s in sources:
+        ep, pag, ret = ENDPOINTS[s]
+        w(f"| {LABELS[s]} | {ep} | {pag} | {ret} |")
+    w("")
+    w("**Gotchas worth knowing** (none of this is documented by any of these sites):\n")
+    w("- LeetCode: introspection is disabled, `tagSlugs` is required, `content` is null in "
+      "list mode, `totalNum` is capped at 3000, and — **not a typo** — "
+      "`ugcArticleDiscussionArticle` takes `topicId: ID` while `topicComments` takes "
+      "`topicId: Int!`. Rapid probing trips a WAF returning HTML 403s, not JSON.")
+    w("- Reddit: `.json` is 403 for anonymous clients but **the `.rss` twin of the same "
+      "path is not**. Search feeds page with `after=t3_<id>`; comment feeds are the post "
+      "permalink + `.rss`, first entry being the post itself. Rate limiting runs on a "
+      "rolling window — ~8 s between requests is the floor, and a 429 needs a ~90 s sleep "
+      "rather than a quick retry.")
+    w("- Blind: no pagination at all (`?page=2` re-serves page 1, 20 cards per query), so "
+      "breadth comes from several queries. Card bodies truncate at ~312 chars, hence the "
+      "per-post fetch; comments are client-rendered and unreachable. The card's exact date "
+      "hides in a `title=\"MM/DD/YYYY\"` attribute next to the human one.")
+    w("- Hacker News: Algolia is the easy one — public, unauthenticated, `hitsPerPage` up "
+      "to 1000. Matching is fuzzy, so expect noise.\n")
 
     # Surface sibling docs about the same company, rather than a hardcoded Google list.
     doc_dir = os.path.join(REPO_ROOT, "doc")
-    needles = {tag, tag[:4]} | ({"goog"} if tag == "google" else set())
+    needles = {ctx.tag, ctx.tag[:4]} | ({"goog"} if ctx.tag == "google" else set())
     related = sorted(
         name for name in (os.listdir(doc_dir) if os.path.isdir(doc_dir) else [])
         if name.endswith(".md") and name != os.path.basename(out_path)
@@ -470,20 +839,28 @@ def render(tag, posts, comments, ranked, solved, out_path, generated_on):
 # -------------------------------------------------------------------------- main
 def main():
     ap = argparse.ArgumentParser(
-        description="Scrape recently-asked LC problems for a company from LeetCode Discuss.",
+        description="Scrape recently-asked LC problems for a company from LeetCode "
+                    "Discuss, Reddit, Blind and Hacker News.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__.split("WHY THIS EXISTS")[0])
     ap.add_argument("--tag", default="google",
-                    help="LeetCode discuss tag slug to scrape (default: google)")
+                    help="company to scrape; also the LeetCode discuss tag slug "
+                         "(default: google)")
+    ap.add_argument("--sources", default=",".join(SOURCES),
+                    help=f'comma-separated subset of {",".join(SOURCES)} (default: all)')
     ap.add_argument("--out", default=None,
                     help="output markdown path (default: doc/<g|tag>_recent_asked.md)")
     ap.add_argument("--cache-dir", default=None,
                     help="cache dir (default: data/.lc_discuss_cache/<tag>/)")
-    ap.add_argument("--delay", type=float, default=2.5,
-                    help="seconds between requests; below ~2s trips the WAF (default: 2.5)")
-    ap.add_argument("--per-page", type=int, default=25, help="list page size (default: 25)")
+    ap.add_argument("--delay", type=float, default=None,
+                    help=f"seconds between requests, overriding the per-source defaults "
+                         f"{DELAYS}")
+    ap.add_argument("--per-page", type=int, default=25,
+                    help="LeetCode list page size (default: 25)")
     ap.add_argument("--max-pages", type=int, default=None,
-                    help="cap list pages (default: page to exhaustion)")
+                    help="cap list pages per source (default: page to exhaustion)")
+    ap.add_argument("--reddit-subs", default=",".join(REDDIT_SUBS),
+                    help=f'subreddits to search (default: {",".join(REDDIT_SUBS)})')
     ap.add_argument("--no-comments", action="store_true",
                     help="skip comment fetching (much faster, but comments are where the "
                          "actual questions usually are)")
@@ -492,58 +869,43 @@ def main():
     ap.add_argument("--refresh-index", action="store_true",
                     help="re-download the LeetCode problem index")
     args = ap.parse_args()
+    # Runs take hours; keep progress visible when stdout is a pipe or a log file.
+    sys.stdout.reconfigure(line_buffering=True)
 
-    cache_dir = args.cache_dir or os.path.join(REPO_ROOT, "data", ".lc_discuss_cache", args.tag)
-    os.makedirs(cache_dir, exist_ok=True)
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+    unknown = [s for s in sources if s not in SOURCES]
+    if unknown:
+        sys.exit(f'unknown source(s): {",".join(unknown)} — pick from {",".join(SOURCES)}')
+    args.reddit_subs = [s.strip() for s in args.reddit_subs.split(",") if s.strip()]
+
+    root = args.cache_dir or os.path.join(REPO_ROOT, "data", ".lc_discuss_cache", args.tag)
     default_name = "g_recent_asked.md" if args.tag == "google" else f"{args.tag}_recent_asked.md"
     out_path = args.out or os.path.join(REPO_ROOT, "doc", default_name)
+    ctx = Ctx(args, root)
 
-    if args.build_only:
-        posts_file = os.path.join(cache_dir, "posts.json")
-        if not os.path.exists(posts_file):
-            sys.exit(f"no cache at {cache_dir} — run without --build-only first")
-        posts = {n["uuid"]: n for n in json.load(open(posts_file))}
-        print(f"[build-only] {len(posts)} posts from cache")
-    else:
-        print(f"[1/3] listing `{args.tag}` discuss posts")
-        posts = fetch_post_list(args.tag, cache_dir, args.delay, args.per_page, args.max_pages)
-        if not posts:
-            sys.exit("no posts found — check the tag slug, or the API/WAF may be blocking")
-        print(f"[2/3] fetching post bodies")
-        fetch_bodies(posts, cache_dir, args.delay)
-        if args.no_comments:
-            print("[3/3] skipping comments (--no-comments)")
-        else:
-            print(f"[3/3] fetching comments")
-            fetch_comments(posts, cache_dir, args.delay)
+    posts = []
+    for i, name in enumerate(sources, 1):
+        print(f"[{i}/{len(sources)}] {LABELS[name]}"
+              f'{" (cache only)" if args.build_only else ""}')
+        got = SOURCES[name](ctx) or []
+        print(f"  -> {len(got)} posts")
+        posts.extend(got)
+    if not posts:
+        sys.exit("no posts found — check the tag, or the sites may be blocking us")
 
-    # Merge cached bodies + comments into the post records.
-    body_dir = os.path.join(cache_dir, "bodies")
-    if os.path.isdir(body_dir):
-        for name in os.listdir(body_dir):
-            node = json.load(open(os.path.join(body_dir, name)))
-            uuid = name[:-5]
-            if uuid in posts and node.get("content"):
-                posts[uuid]["content"] = node["content"]
-    comments = {}
-    comment_dir = os.path.join(cache_dir, "comments")
-    if os.path.isdir(comment_dir):
-        for name in os.listdir(comment_dir):
-            entry = json.load(open(os.path.join(comment_dir, name)))
-            comments[entry["uuid"]] = entry["comments"]
-
-    by_slug, by_num, by_title = load_problem_index(cache_dir, args.refresh_index)
-    ranked = extract(posts, comments, by_slug, by_num, by_title)
-    generated_on = time.strftime("%Y-%m-%d")
-    render(args.tag, posts, comments, ranked, load_repo_solved(), out_path, generated_on)
+    by_slug, by_num, by_title = load_problem_index(
+        Cache(root), args.refresh_index, ctx.delay("leetcode"))
+    ranked = extract(posts, by_slug, by_num, by_title)
+    render(ctx, posts, ranked, load_repo_solved(), out_path, sources,
+           time.strftime("%Y-%m-%d"))
 
     method_counts = collections.Counter(
         "url" if h["methods"]["url"] else "num" if h["methods"]["number"] else "title"
         for h in ranked)
     shown = os.path.relpath(out_path, REPO_ROOT)
+    per_source = collections.Counter(p["source"] for p in posts)
     print(f"\nwrote {out_path if shown.startswith('..') else shown}")
-    print(f"  posts={len(posts)} bodies={sum(1 for n in posts.values() if n.get('content'))} "
-          f"comments={sum(len(v) for v in comments.values())}")
+    print(f"  posts={len(posts)} {dict(per_source)}")
     print(f"  problems={len(ranked)} by strongest match: {dict(method_counts)}")
 
 


### PR DESCRIPTION
The scraper only read LeetCode Discuss, which is the narrowest of the public sources — most recent Google/FAANG interview reports land on Reddit or Blind instead. Add three sources behind one shared pipeline.

  leetcode  GraphQL Discuss API   threads + bodies + comments  (unchanged)
  reddit    search.rss + post .rss  posts + comment threads
  blind     server-rendered HTML    search cards + full bodies
  hn        Algolia search API      stories + comments

Sources are now interchangeable: each is one function returning record()s that honours ctx.build_only and registers itself in SOURCES; extraction, ranking and the report never look at where a post came from. Pick a subset with --sources. Per-source delays and caches (LeetCode keeps the old cache layout so existing pulls still resume); comment fetching goes newest-first so an interrupted run keeps the freshest threads.

Two extraction fixes the extra prose surfaced: "leetcode 75/150/169" is a study list, not problem #75, and "leetcode 8+ hrs" is a count, not a problem id. Reddit's RSS footer is stripped so it stops appearing in every evidence quote.

Undocumented behaviour found along the way, all recorded in the module docstring: Reddit 403s .json for anonymous clients but still serves the .rss twin of the same path, and rate-limits on a rolling window that needs ~8s spacing and a ~90s sleep on 429; Blind ignores ?page entirely (20 cards per query, so breadth means asking several), truncates card bodies at ~312 chars, and hides the exact post date in a title="..." attribute next to the human one.

doc/g_recent_asked.md is unchanged — regenerating it needs a full run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded company discussion scraping to support LeetCode, Reddit, Blind, and Hacker News.
  * Added source selection, independent caching, configurable delays, and cached-report rebuilding.
  * Reports now include source statistics, context, cross-source evidence, and interview-focused feeds.
  * Added comment retrieval and filtering for relevant problem links, numbers, and titles while reducing false positives.

* **Documentation**
  * Documented supported sources, usage examples, caching, source-specific options, limitations, and extension guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->