### PR TITLE
feat(leetcode_python): add 98 solutions for LC 2702-2845

### DIFF
--- a/doc/lc-coverage-kamyu/skipped_2001-3000.json
+++ b/doc/lc-coverage-kamyu/skipped_2001-3000.json
@@ -40,6 +40,14 @@
   "skip_reason": "SQL problem, not Python"
  },
  {
+  "num": 2060,
+  "title": "Check if an Original String Exists Given Two Encoded Strings",
+  "slug": "check-if-an-original-string-exists-given-two-encoded-strings",
+  "difficulty": "Hard",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
   "num": 2066,
   "title": "Account Balance",
   "slug": "account-balance",
@@ -608,6 +616,14 @@
   "skip_reason": "JavaScript/TypeScript-only problem, not Python"
  },
  {
+  "num": 2691,
+  "title": "Immutability Helper",
+  "slug": "immutability-helper",
+  "difficulty": "Hard",
+  "premium": true,
+  "skip_reason": "JavaScript-only problem, not Python"
+ },
+ {
   "num": 2692,
   "title": "Make Object Immutable",
   "slug": "make-object-immutable",
@@ -640,6 +656,14 @@
   "skip_reason": "JavaScript/TypeScript-only problem, not Python"
  },
  {
+  "num": 2700,
+  "title": "Differences Between Two Objects",
+  "slug": "differences-between-two-objects",
+  "difficulty": "Medium",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
   "num": 2701,
   "title": "Consecutive Transactions with Increasing Amounts",
   "slug": "consecutive-transactions-with-increasing-amounts",
@@ -648,12 +672,100 @@
   "skip_reason": "SQL problem, not Python"
  },
  {
+  "num": 2703,
+  "title": "Return Length of Arguments Passed",
+  "slug": "return-length-of-arguments-passed",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2704,
+  "title": "To Be Or Not To Be",
+  "slug": "to-be-or-not-to-be",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2705,
+  "title": "Compact Object",
+  "slug": "compact-object",
+  "difficulty": "Medium",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2715,
+  "title": "Timeout Cancellation",
+  "slug": "timeout-cancellation",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
   "num": 2720,
   "title": "Popularity Percentage",
   "slug": "popularity-percentage",
   "difficulty": "Hard",
   "premium": true,
   "skip_reason": "SQL problem, not Python"
+ },
+ {
+  "num": 2721,
+  "title": "Execute Asynchronous Functions in Parallel",
+  "slug": "execute-asynchronous-functions-in-parallel",
+  "difficulty": "Medium",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2722,
+  "title": "Join Two Arrays by ID",
+  "slug": "join-two-arrays-by-id",
+  "difficulty": "Medium",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2723,
+  "title": "Add Two Promises",
+  "slug": "add-two-promises",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2724,
+  "title": "Sort By",
+  "slug": "sort-by",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2725,
+  "title": "Interval Cancellation",
+  "slug": "interval-cancellation",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2726,
+  "title": "Calculator with Method Chaining",
+  "slug": "calculator-with-method-chaining",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2727,
+  "title": "Is Object Empty",
+  "slug": "is-object-empty",
+  "difficulty": "Easy",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
  },
  {
   "num": 2738,
@@ -672,6 +784,86 @@
   "skip_reason": "SQL problem, not Python"
  },
  {
+  "num": 2754,
+  "title": "Bind Function to Context",
+  "slug": "bind-function-to-context",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2755,
+  "title": "Deep Merge of Two Objects",
+  "slug": "deep-merge-of-two-objects",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2756,
+  "title": "Query Batching",
+  "slug": "query-batching",
+  "difficulty": "Hard",
+  "premium": true,
+  "skip_reason": "JavaScript-only problem, not Python"
+ },
+ {
+  "num": 2757,
+  "title": "Generate Circular Array Values",
+  "slug": "generate-circular-array-values",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2758,
+  "title": "Next Day",
+  "slug": "next-day",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2759,
+  "title": "Convert JSON String to Object",
+  "slug": "convert-json-string-to-object",
+  "difficulty": "Hard",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2774,
+  "title": "Array Upper Bound",
+  "slug": "array-upper-bound",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2775,
+  "title": "Undefined to Null",
+  "slug": "undefined-to-null",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2776,
+  "title": "Convert Callback Based Function to Promise Based Function",
+  "slug": "convert-callback-based-function-to-promise-based-function",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2777,
+  "title": "Date Range Generator",
+  "slug": "date-range-generator",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
   "num": 2783,
   "title": "Flight Occupancy and Waitlist Analysis",
   "slug": "flight-occupancy-and-waitlist-analysis",
@@ -688,12 +880,92 @@
   "skip_reason": "SQL problem, not Python"
  },
  {
+  "num": 2794,
+  "title": "Create Object from Two Arrays",
+  "slug": "create-object-from-two-arrays",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2795,
+  "title": "Parallel Execution of Promises for Individual Results Retrieval",
+  "slug": "parallel-execution-of-promises-for-individual-results-retrieval",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2796,
+  "title": "Repeat String",
+  "slug": "repeat-string",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2797,
+  "title": "Partial Function with Placeholders",
+  "slug": "partial-function-with-placeholders",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2803,
+  "title": "Factorial Generator",
+  "slug": "factorial-generator",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2804,
+  "title": "Array Prototype ForEach",
+  "slug": "array-prototype-foreach",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2805,
+  "title": "Custom Interval",
+  "slug": "custom-interval",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
   "num": 2820,
   "title": "Election Results",
   "slug": "election-results",
   "difficulty": "Medium",
   "premium": true,
   "skip_reason": "SQL problem, not Python"
+ },
+ {
+  "num": 2821,
+  "title": "Delay the Resolution of Each Promise",
+  "slug": "delay-the-resolution-of-each-promise",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2822,
+  "title": "Inversion of Object",
+  "slug": "inversion-of-object",
+  "difficulty": "Easy",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
+ },
+ {
+  "num": 2823,
+  "title": "Deep Object Filter",
+  "slug": "deep-object-filter",
+  "difficulty": "Medium",
+  "premium": true,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
  },
  {
   "num": 2837,
@@ -734,6 +1006,14 @@
   "difficulty": "Medium",
   "premium": true,
   "skip_reason": "SQL problem, not Python"
+ },
+ {
+  "num": 2949,
+  "title": "Count Beautiful Substrings II",
+  "slug": "count-beautiful-substrings-ii",
+  "difficulty": "Hard",
+  "premium": false,
+  "skip_reason": "JavaScript/TypeScript-only problem, not Python"
  },
  {
   "num": 2978,

--- a/doc/lc-coverage-kamyu/work_2001-3000.json
+++ b/doc/lc-coverage-kamyu/work_2001-3000.json
@@ -506,17 +506,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2000-2099/2059.Minimum Operations to Convert Number/README_EN.md"
  },
  {
-  "num": 2060,
-  "title": "Check if an Original String Exists Given Two Encoded Strings",
-  "slug": "check-if-an-original-string-exists-given-two-encoded-strings",
-  "difficulty": "Hard",
-  "premium": false,
-  "category": "Dynamic Programming",
-  "target_dir": "Dynamic_Programming",
-  "target_file": "leetcode_python/Dynamic_Programming/check-if-an-original-string-exists-given-two-encoded-strings.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2000-2099/2060.Check if an Original String Exists Given Two Encoded Strings/README_EN.md"
- },
- {
   "num": 2061,
   "title": "Number of Spaces Cleaning Robot Cleaned",
   "slug": "number-of-spaces-cleaning-robot-cleaned",
@@ -738,8 +727,8 @@
  },
  {
   "num": 2086,
-  "title": "Minimum Number of Buckets Required to Collect Rainwater from Houses",
-  "slug": "minimum-number-of-buckets-required-to-collect-rainwater-from-houses",
+  "title": "Minimum Number of Food Buckets to Feed the Hamsters",
+  "slug": "minimum-number-of-food-buckets-to-feed-the-hamsters",
   "difficulty": "Medium",
   "premium": false,
   "category": "Greedy",
@@ -1422,7 +1411,7 @@
   "num": 2156,
   "title": "Find Substring With Given Hash Value",
   "slug": "find-substring-with-given-hash-value",
-  "difficulty": "Medium",
+  "difficulty": "Hard",
   "premium": false,
   "category": "String",
   "target_dir": "String",
@@ -2764,7 +2753,7 @@
   "num": 2293,
   "title": "Min Max Game",
   "slug": "min-max-game",
-  "difficulty": "Medium",
+  "difficulty": "Easy",
   "premium": false,
   "category": "Array",
   "target_dir": "Array",
@@ -4502,7 +4491,7 @@
   "num": 2476,
   "title": "Closest Nodes Queries in a Binary Search Tree",
   "slug": "closest-nodes-queries-in-a-binary-search-tree",
-  "difficulty": "Hard",
+  "difficulty": "Medium",
   "premium": false,
   "category": "Binary Search",
   "target_dir": "Binary_Search",
@@ -4678,7 +4667,7 @@
   "num": 2493,
   "title": "Divide Nodes Into the Maximum Number of Groups",
   "slug": "divide-nodes-into-the-maximum-number-of-groups",
-  "difficulty": "Medium",
+  "difficulty": "Hard",
   "premium": false,
   "category": "Breadth-First Search",
   "target_dir": "Breadth-First-Search",
@@ -4930,12 +4919,12 @@
  {
   "num": 2522,
   "title": "Partition String Into Substrings With Values at Most K",
-  "slug": "minimum-total-cost-to-make-arrays-unequal",
+  "slug": "partition-string-into-substrings-with-values-at-most-k",
   "difficulty": "Medium",
   "premium": false,
   "category": "Greedy",
   "target_dir": "Greedy",
-  "target_file": "leetcode_python/Greedy/minimum-total-cost-to-make-arrays-unequal.py",
+  "target_file": "leetcode_python/Greedy/partition-string-into-substrings-with-values-at-most-k.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2500-2599/2522.Partition String Into Substrings With Values at Most K/README_EN.md"
  },
  {
@@ -5525,7 +5514,7 @@
   "num": 2582,
   "title": "Pass the Pillow",
   "slug": "pass-the-pillow",
-  "difficulty": "Medium",
+  "difficulty": "Easy",
   "premium": false,
   "category": "Math",
   "target_dir": "Math",
@@ -5569,7 +5558,7 @@
   "num": 2586,
   "title": "Count the Number of Vowel Strings in Range",
   "slug": "count-the-number-of-vowel-strings-in-range",
-  "difficulty": "Medium",
+  "difficulty": "Easy",
   "premium": false,
   "category": "String",
   "target_dir": "String",
@@ -5830,226 +5819,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2613.Beautiful Pairs/README_EN.md"
  },
  {
-  "num": 2618,
-  "title": "Check if Object Instance of Class",
-  "slug": "check-if-object-instance-of-class",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/check-if-object-instance-of-class.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2618.Check if Object Instance of Class/README_EN.md"
- },
- {
-  "num": 2619,
-  "title": "Array Prototype Last",
-  "slug": "array-prototype-last",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/array-prototype-last.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2619.Array Prototype Last/README_EN.md"
- },
- {
-  "num": 2620,
-  "title": "Counter",
-  "slug": "counter",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/counter.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2620.Counter/README_EN.md"
- },
- {
-  "num": 2621,
-  "title": "Sleep",
-  "slug": "sleep",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/sleep.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2621.Sleep/README_EN.md"
- },
- {
-  "num": 2622,
-  "title": "Cache With Time Limit",
-  "slug": "cache-with-time-limit",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/cache-with-time-limit.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2622.Cache With Time Limit/README_EN.md"
- },
- {
-  "num": 2623,
-  "title": "Memoize",
-  "slug": "memoize",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/memoize.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2623.Memoize/README_EN.md"
- },
- {
-  "num": 2624,
-  "title": "Snail traversal",
-  "slug": "snail-traversal",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/snail-traversal.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2624.Snail Traversal/README_EN.md"
- },
- {
-  "num": 2625,
-  "title": "Flatten Deeply Nested Array",
-  "slug": "flatten-deeply-nested-array",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/flatten-deeply-nested-array.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2625.Flatten Deeply Nested Array/README_EN.md"
- },
- {
-  "num": 2626,
-  "title": "Array Reduce Transformation",
-  "slug": "array-reduce-transformation",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/array-reduce-transformation.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2626.Array Reduce Transformation/README_EN.md"
- },
- {
-  "num": 2627,
-  "title": "Debounce",
-  "slug": "debounce",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/debounce.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2627.Debounce/README_EN.md"
- },
- {
-  "num": 2628,
-  "title": "JSON Deep Equal",
-  "slug": "json-deep-equal",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/json-deep-equal.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2628.JSON Deep Equal/README_EN.md"
- },
- {
-  "num": 2629,
-  "title": "Function Composition",
-  "slug": "function-composition",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/function-composition.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2629.Function Composition/README_EN.md"
- },
- {
-  "num": 2630,
-  "title": "Memoize II",
-  "slug": "memoize-ii",
-  "difficulty": "Hard",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/memoize-ii.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2630.Memoize II/README_EN.md"
- },
- {
-  "num": 2631,
-  "title": "Group By",
-  "slug": "group-by",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/group-by.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2631.Group By/README_EN.md"
- },
- {
-  "num": 2632,
-  "title": "Curry",
-  "slug": "curry",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/curry.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2632.Curry/README_EN.md"
- },
- {
-  "num": 2633,
-  "title": "Convert Object to JSON String",
-  "slug": "convert-object-to-json-string",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/convert-object-to-json-string.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2633.Convert Object to JSON String/README_EN.md"
- },
- {
-  "num": 2634,
-  "title": "Filter Elements from Array",
-  "slug": "filter-elements-from-array",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/filter-elements-from-array.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2634.Filter Elements from Array/README_EN.md"
- },
- {
-  "num": 2635,
-  "title": "Apply Transform Over Each Element in Array",
-  "slug": "apply-transform-over-each-element-in-array",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/apply-transform-over-each-element-in-array.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2635.Apply Transform Over Each Element in Array/README_EN.md"
- },
- {
-  "num": 2636,
-  "title": "Promise Pool",
-  "slug": "promise-pool",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/promise-pool.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2636.Promise Pool/README_EN.md"
- },
- {
-  "num": 2637,
-  "title": "Promise Time Limit",
-  "slug": "promise-time-limit",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/promise-time-limit.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2637.Promise Time Limit/README_EN.md"
- },
- {
   "num": 2638,
   "title": "Count the Number of K-Free Subsets",
   "slug": "count-the-number-of-k-free-subsets",
@@ -6070,39 +5839,6 @@
   "target_dir": "Array",
   "target_file": "leetcode_python/Array/color-the-triangle-red.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2647.Color the Triangle Red/README_EN.md"
- },
- {
-  "num": 2648,
-  "title": "Generate Fibonacci Sequence",
-  "slug": "generate-fibonacci-sequence",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/generate-fibonacci-sequence.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2648.Generate Fibonacci Sequence/README_EN.md"
- },
- {
-  "num": 2649,
-  "title": "Nested Array Generator",
-  "slug": "nested-array-generator",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/nested-array-generator.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2649.Nested Array Generator/README_EN.md"
- },
- {
-  "num": 2650,
-  "title": "Design Cancellable Function",
-  "slug": "design-cancellable-function",
-  "difficulty": "Hard",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/design-cancellable-function.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2650.Design Cancellable Function/README_EN.md"
  },
  {
   "num": 2651,
@@ -6163,7 +5899,7 @@
   "num": 2660,
   "title": "Determine the Winner of a Bowling Game",
   "slug": "determine-the-winner-of-a-bowling-game",
-  "difficulty": "Medium",
+  "difficulty": "Easy",
   "premium": false,
   "category": "Array",
   "target_dir": "Array",
@@ -6213,39 +5949,6 @@
   "target_dir": "Backtracking",
   "target_file": "leetcode_python/Backtracking/the-knights-tour.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2664.The Knight\u2019s Tour/README_EN.md"
- },
- {
-  "num": 2665,
-  "title": "Counter II",
-  "slug": "counter-ii",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/counter-ii.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2665.Counter II/README_EN.md"
- },
- {
-  "num": 2666,
-  "title": "Allow One Function Call",
-  "slug": "allow-one-function-call",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/allow-one-function-call.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2666.Allow One Function Call/README_EN.md"
- },
- {
-  "num": 2667,
-  "title": "Create Hello World Function",
-  "slug": "create-hello-world-function",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/create-hello-world-function.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2667.Create Hello World Function/README_EN.md"
  },
  {
   "num": 2670,
@@ -6303,39 +6006,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2674.Split a Circular Linked List/README_EN.md"
  },
  {
-  "num": 2675,
-  "title": "Array of Objects to Matrix",
-  "slug": "array-of-objects-to-matrix",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/array-of-objects-to-matrix.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2675.Array of Objects to Matrix/README_EN.md"
- },
- {
-  "num": 2676,
-  "title": "Throttle",
-  "slug": "throttle",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/throttle.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2676.Throttle/README_EN.md"
- },
- {
-  "num": 2677,
-  "title": "Chunk Array",
-  "slug": "chunk-array",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/chunk-array.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2677.Chunk Array/README_EN.md"
- },
- {
   "num": 2678,
   "title": "Number of Senior Citizens",
   "slug": "number-of-senior-citizens",
@@ -6383,78 +6053,12 @@
   "num": 2689,
   "title": "Extract Kth Character From The Rope Tree",
   "slug": "extract-kth-character-from-the-rope-tree",
-  "difficulty": "Medium",
+  "difficulty": "Easy",
   "premium": true,
   "category": "Binary Search Tree",
   "target_dir": "Binary_Search_Tree",
   "target_file": "leetcode_python/Binary_Search_Tree/extract-kth-character-from-the-rope-tree.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2689.Extract Kth Character From The Rope Tree/README_EN.md"
- },
- {
-  "num": 2690,
-  "title": "Infinite Method Object",
-  "slug": "infinite-method-object",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/infinite-method-object.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2690.Infinite Method Object/README_EN.md"
- },
- {
-  "num": 2691,
-  "title": "Immutability Helper",
-  "slug": "immutability-helper",
-  "difficulty": "Hard",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/immutability-helper.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2691.Immutability Helper/README_EN.md"
- },
- {
-  "num": 2692,
-  "title": "Make Object Immutable",
-  "slug": "make-object-immutable",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/make-object-immutable.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2692.Make Object Immutable/README_EN.md"
- },
- {
-  "num": 2693,
-  "title": "Call Function with Custom Context",
-  "slug": "call-function-with-custom-context",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/call-function-with-custom-context.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2693.Call Function with Custom Context/README_EN.md"
- },
- {
-  "num": 2694,
-  "title": "Event Emitter",
-  "slug": "event-emitter",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/event-emitter.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2694.Event Emitter/README_EN.md"
- },
- {
-  "num": 2695,
-  "title": "Array Wrapper",
-  "slug": "array-wrapper",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/array-wrapper.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2695.Array Wrapper/README_EN.md"
  },
  {
   "num": 2696,
@@ -6501,17 +6105,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2600-2699/2699.Modify Graph Edge Weights/README_EN.md"
  },
  {
-  "num": 2700,
-  "title": "Differences Between Two Objects",
-  "slug": "differences-between-two-objects",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/differences-between-two-objects.py",
-  "doocs_readme": null
- },
- {
   "num": 2702,
   "title": "Minimum Operations to Make Numbers Non-positive",
   "slug": "minimum-operations-to-make-numbers-non-positive",
@@ -6521,39 +6114,6 @@
   "target_dir": "Binary_Search",
   "target_file": "leetcode_python/Binary_Search/minimum-operations-to-make-numbers-non-positive.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2702.Minimum Operations to Make Numbers Non-positive/README_EN.md"
- },
- {
-  "num": 2703,
-  "title": "Return Length of Arguments Passed",
-  "slug": "return-length-of-arguments-passed",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/return-length-of-arguments-passed.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2703.Return Length of Arguments Passed/README_EN.md"
- },
- {
-  "num": 2704,
-  "title": "To Be Or Not To Be",
-  "slug": "to-be-or-not-to-be",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/to-be-or-not-to-be.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2704.To Be Or Not To Be/README_EN.md"
- },
- {
-  "num": 2705,
-  "title": "Compact Object",
-  "slug": "compact-object",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/compact-object.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2705.Compact Object/README_EN.md"
  },
  {
   "num": 2708,
@@ -6622,17 +6182,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2714.Find Shortest Path with K Hops/README_EN.md"
  },
  {
-  "num": 2715,
-  "title": "Execute Cancellable Function With Delay",
-  "slug": "execute-cancellable-function-with-delay",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/execute-cancellable-function-with-delay.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2715.Timeout Cancellation/README_EN.md"
- },
- {
   "num": 2716,
   "title": "Minimize String Length",
   "slug": "minimize-string-length",
@@ -6675,83 +6224,6 @@
   "target_dir": "Dynamic_Programming",
   "target_file": "leetcode_python/Dynamic_Programming/count-of-integers.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2719.Count of Integers/README_EN.md"
- },
- {
-  "num": 2721,
-  "title": "Execute Asynchronous Functions in Parallel",
-  "slug": "execute-asynchronous-functions-in-parallel",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/execute-asynchronous-functions-in-parallel.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2721.Execute Asynchronous Functions in Parallel/README_EN.md"
- },
- {
-  "num": 2722,
-  "title": "Join Two Arrays by ID",
-  "slug": "join-two-arrays-by-id",
-  "difficulty": "Medium",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/join-two-arrays-by-id.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2722.Join Two Arrays by ID/README_EN.md"
- },
- {
-  "num": 2723,
-  "title": "Add Two Promises",
-  "slug": "add-two-promises",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/add-two-promises.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2723.Add Two Promises/README_EN.md"
- },
- {
-  "num": 2724,
-  "title": "Sort By",
-  "slug": "sort-by",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/sort-by.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2724.Sort By/README_EN.md"
- },
- {
-  "num": 2725,
-  "title": "Interval Cancellation",
-  "slug": "interval-cancellation",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/interval-cancellation.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2725.Interval Cancellation/README_EN.md"
- },
- {
-  "num": 2726,
-  "title": "Calculator with Method Chaining",
-  "slug": "calculator-with-method-chaining",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/calculator-with-method-chaining.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2726.Calculator with Method Chaining/README_EN.md"
- },
- {
-  "num": 2727,
-  "title": "Is Object Empty",
-  "slug": "is-object-empty",
-  "difficulty": "Easy",
-  "premium": false,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/is-object-empty.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2727.Is Object Empty/README_EN.md"
  },
  {
   "num": 2728,
@@ -6955,7 +6427,7 @@
   "num": 2747,
   "title": "Count Zero Request Servers",
   "slug": "count-zero-request-servers",
-  "difficulty": "Hard",
+  "difficulty": "Medium",
   "premium": false,
   "category": "Two Pointers",
   "target_dir": "Two_Pointers",
@@ -7016,72 +6488,6 @@
   "target_dir": "Array",
   "target_file": "leetcode_python/Array/count-houses-in-a-circular-street-ii.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2753.Count Houses in a Circular Street II/README_EN.md"
- },
- {
-  "num": 2754,
-  "title": "Bind Function to Context",
-  "slug": "bind-function-to-context",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/bind-function-to-context.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2754.Bind Function to Context/README_EN.md"
- },
- {
-  "num": 2755,
-  "title": "Deep Merge of Two Objects",
-  "slug": "deep-merge-of-two-objects",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/deep-merge-of-two-objects.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2755.Deep Merge of Two Objects/README_EN.md"
- },
- {
-  "num": 2756,
-  "title": "Query Batching",
-  "slug": "query-batching",
-  "difficulty": "Hard",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/query-batching.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2756.Query Batching/README_EN.md"
- },
- {
-  "num": 2757,
-  "title": "Generate Circular Array Values",
-  "slug": "generate-circular-array-values",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/generate-circular-array-values.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2757.Generate Circular Array Values/README_EN.md"
- },
- {
-  "num": 2758,
-  "title": "Next Day",
-  "slug": "next-day",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/next-day.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2758.Next Day/README_EN.md"
- },
- {
-  "num": 2759,
-  "title": "Convert JSON String to Object",
-  "slug": "convert-json-string-to-object",
-  "difficulty": "Hard",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/convert-json-string-to-object.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2759.Convert JSON String to Object/README_EN.md"
  },
  {
   "num": 2760,
@@ -7192,50 +6598,6 @@
   "target_dir": "Depth-First-Search",
   "target_file": "leetcode_python/Depth-First-Search/height-of-special-binary-tree.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2773.Height of Special Binary Tree/README_EN.md"
- },
- {
-  "num": 2774,
-  "title": "Array Upper Bound",
-  "slug": "array-upper-bound",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/array-upper-bound.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2774.Array Upper Bound/README_EN.md"
- },
- {
-  "num": 2775,
-  "title": "Undefined to Null",
-  "slug": "undefined-to-null",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/undefined-to-null.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2775.Undefined to Null/README_EN.md"
- },
- {
-  "num": 2776,
-  "title": "Convert Callback Based Function to Promise Based Function",
-  "slug": "convert-callback-based-function-to-promise-based-function",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/convert-callback-based-function-to-promise-based-function.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2776.Convert Callback Based Function to Promise Based Function/README_EN.md"
- },
- {
-  "num": 2777,
-  "title": "Date Range Generator",
-  "slug": "date-range-generator",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/date-range-generator.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2777.Date Range Generator/README_EN.md"
  },
  {
   "num": 2778,
@@ -7392,50 +6754,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2792.Count Nodes That Are Great Enough/README_EN.md"
  },
  {
-  "num": 2794,
-  "title": "Create Object from Two Arrays",
-  "slug": "create-object-from-two-arrays",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/create-object-from-two-arrays.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2794.Create Object from Two Arrays/README_EN.md"
- },
- {
-  "num": 2795,
-  "title": "Parallel Execution of Promises for Individual Results Retrieval",
-  "slug": "parallel-execution-of-promises-for-individual-results-retrieval",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/parallel-execution-of-promises-for-individual-results-retrieval.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2795.Parallel Execution of Promises for Individual Results Retrieval/README_EN.md"
- },
- {
-  "num": 2796,
-  "title": "Repeat String",
-  "slug": "repeat-string",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/repeat-string.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2796.Repeat String/README_EN.md"
- },
- {
-  "num": 2797,
-  "title": "Partial Function with Placeholders",
-  "slug": "partial-function-with-placeholders",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/partial-function-with-placeholders.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2700-2799/2797.Partial Function with Placeholders/README_EN.md"
- },
- {
   "num": 2798,
   "title": "Number of Employees Who Met the Target",
   "slug": "number-of-employees-who-met-the-target",
@@ -7489,39 +6807,6 @@
   "target_dir": "Math",
   "target_file": "leetcode_python/Math/find-the-k-th-lucky-number.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2802.Find The K-th Lucky Number/README_EN.md"
- },
- {
-  "num": 2803,
-  "title": "Factorial Generator",
-  "slug": "factorial-generator",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/factorial-generator.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2803.Factorial Generator/README_EN.md"
- },
- {
-  "num": 2804,
-  "title": "Array Prototype ForEach",
-  "slug": "array-prototype-foreach",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/array-prototype-foreach.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2804.Array Prototype ForEach/README_EN.md"
- },
- {
-  "num": 2805,
-  "title": "Custom Interval",
-  "slug": "custom-interval",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/custom-interval.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2805.Custom Interval/README_EN.md"
  },
  {
   "num": 2806,
@@ -7665,39 +6950,6 @@
   "target_dir": "Greedy",
   "target_file": "leetcode_python/Greedy/minimum-relative-loss-after-buying-chocolates.py",
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2819.Minimum Relative Loss After Buying Chocolates/README_EN.md"
- },
- {
-  "num": 2821,
-  "title": "Delay the Resolution of Each Promise",
-  "slug": "delay-the-resolution-of-each-promise",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/delay-the-resolution-of-each-promise.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2821.Delay the Resolution of Each Promise/README_EN.md"
- },
- {
-  "num": 2822,
-  "title": "Inversion of Object",
-  "slug": "inversion-of-object",
-  "difficulty": "Easy",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/inversion-of-object.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2822.Inversion of Object/README_EN.md"
- },
- {
-  "num": 2823,
-  "title": "Deep Object Filter",
-  "slug": "deep-object-filter",
-  "difficulty": "Medium",
-  "premium": true,
-  "category": "JS",
-  "target_dir": "Array",
-  "target_file": "leetcode_python/Array/deep-object-filter.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2800-2899/2823.Deep Object Filter/README_EN.md"
  },
  {
   "num": 2824,
@@ -8176,7 +7428,7 @@
   "num": 2874,
   "title": "Maximum Value of an Ordered Triplet II",
   "slug": "maximum-value-of-an-ordered-triplet-ii",
-  "difficulty": "Easy",
+  "difficulty": "Medium",
   "premium": false,
   "category": "Array",
   "target_dir": "Array",
@@ -8451,7 +7703,7 @@
   "num": 2900,
   "title": "Longest Unequal Adjacent Groups Subsequence I",
   "slug": "longest-unequal-adjacent-groups-subsequence-i",
-  "difficulty": "Medium",
+  "difficulty": "Easy",
   "premium": false,
   "category": "Greedy",
   "target_dir": "Greedy",
@@ -8627,7 +7879,7 @@
   "num": 2916,
   "title": "Subarrays Distinct Element Sum of Squares II",
   "slug": "subarrays-distinct-element-sum-of-squares-ii",
-  "difficulty": "Easy",
+  "difficulty": "Hard",
   "premium": false,
   "category": "Dynamic Programming",
   "target_dir": "Dynamic_Programming",
@@ -8976,17 +8228,6 @@
   "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2900-2999/2948.Make Lexicographically Smallest Array by Swapping Elements/README_EN.md"
  },
  {
-  "num": 2949,
-  "title": "Count Beautiful Substrings II",
-  "slug": "count-beautiful-substrings-ii",
-  "difficulty": "Hard",
-  "premium": false,
-  "category": "Hash Table",
-  "target_dir": "Hash_table",
-  "target_file": "leetcode_python/Hash_table/count-beautiful-substrings-ii.py",
-  "doocs_readme": "/private/tmp/claude-501/-Users-jliu-CS-basics--claude-worktrees-cheatsheet-review/9cf75c8b-7409-4867-be0d-d5f5590e9e4d/scratchpad/doocs/solution/2900-2999/2949.Count Beautiful Substrings II/README_EN.md"
- },
- {
   "num": 2950,
   "title": "Number of Divisible Substrings",
   "slug": "number-of-divisible-substrings",
@@ -9023,7 +8264,7 @@
   "num": 2953,
   "title": "Count Complete Substrings",
   "slug": "count-complete-substrings",
-  "difficulty": "Medium",
+  "difficulty": "Hard",
   "premium": false,
   "category": "Two Pointers",
   "target_dir": "Two_Pointers",
@@ -9089,7 +8330,7 @@
   "num": 2959,
   "title": "Number of Possible Sets of Closing Branches",
   "slug": "number-of-possible-sets-of-closing-branches",
-  "difficulty": "Medium",
+  "difficulty": "Hard",
   "premium": false,
   "category": "Graph",
   "target_dir": "Graph",

--- a/leetcode_python/Array/check-if-it-is-possible-to-split-array.py
+++ b/leetcode_python/Array/check-if-it-is-possible-to-split-array.py
@@ -1,0 +1,87 @@
+"""
+
+2811. Check if it is Possible to Split Array
+Medium
+
+You are given an array nums of length n and an integer m. You need to determine if it is possible to split the array into n arrays of size 1 by performing a series of steps.
+
+An array is called good if:
+
+The length of the array is one, or
+The sum of the elements of the array is greater than or equal to m.
+
+In each step, you can select an existing array (which may be the result of previous steps) with a length of at least two and split it into two arrays, if both resulting arrays are good.
+
+Return true if you can split the given array into n arrays, otherwise return false.
+
+
+Example 1:
+
+Input: nums = [2, 2, 1], m = 4
+Output: true
+Explanation:
+Split [2, 2, 1] to [2, 2] and [1]. The array [1] has a length of one, and the array [2, 2] has the sum of its elements equal to 4 >= m, so both are good arrays.
+Split [2, 2] to [2] and [2]. both arrays have the length of one, so both are good arrays.
+
+Example 2:
+
+Input: nums = [2, 1, 3], m = 5
+Output: false
+Explanation:
+The first move has to be either of the following:
+Split [2, 1, 3] to [2, 1] and [3]. The array [2, 1] has neither length of one nor sum of elements greater than or equal to m.
+Split [2, 1, 3] to [2] and [1, 3]. The array [1, 3] has neither length of one nor sum of elements greater than or equal to m.
+So as both moves are invalid (they do not divide the array into two good arrays), we are unable to split nums into n arrays of size 1.
+
+Example 3:
+
+Input: nums = [2, 3, 3, 2, 3], m = 6
+Output: true
+Explanation:
+Split [2, 3, 3, 2, 3] to [2] and [3, 3, 2, 3].
+Split [3, 3, 2, 3] to [3, 3, 2] and [3].
+Split [3, 3, 2] to [3, 3] and [2].
+Split [3, 3] to [3] and [3].
+
+
+Constraints:
+
+1 <= n == nums.length <= 100
+1 <= nums[i] <= 100
+1 <= m <= 200
+
+"""
+
+# V0
+# IDEA : GREEDY / OBSERVATION ON THE LAST SPLIT
+#
+#   Peeling elements off one at a time is always legal as long as the
+#   *remaining* block stays good, so the whole problem collapses to a single
+#   local question.
+#
+#   Think backwards: the very last split we ever perform acts on some block of
+#   length exactly 2 (every block eventually shrinks to singletons, and the
+#   final cut must turn a 2-block into two 1-blocks). That 2-block is a pair of
+#   ADJACENT elements of the original array, and every ancestor block that
+#   contains it has a sum >= its sum (values are positive), so every ancestor
+#   is automatically good too.
+#
+#   Conversely, if some adjacent pair nums[i-1] + nums[i] >= m, we can always
+#   strip singletons from the two ends one by one: each strip leaves a
+#   [1] piece (good by length) plus a shrinking block that still contains that
+#   heavy pair, hence still has sum >= m (good by sum).
+#
+#   NOTE : n <= 2 needs no split at all (a length-1 array is already done, and
+#          a length-2 array splits into two singletons which are both good by
+#          length regardless of m) -> always True.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def canSplitArray(self, nums, m):
+        n = len(nums)
+        if n <= 2:
+            return True
+        for i in range(1, n):
+            if nums[i - 1] + nums[i] >= m:
+                return True
+        return False

--- a/leetcode_python/Array/construct-the-longest-new-string.py
+++ b/leetcode_python/Array/construct-the-longest-new-string.py
@@ -1,0 +1,68 @@
+"""
+
+2745. Construct the Longest New String
+Medium
+
+You are given three integers x, y, and z.
+
+You have x strings equal to "AA", y strings equal to "BB", and z strings equal to "AB". You want to choose some (possibly all or none) of these strings and concatenate them in some order to form a new string. This new string must not contain "AAA" or "BBB" as a substring.
+
+Return the maximum possible length of the new string.
+
+A substring is a contiguous non-empty sequence of characters within a string.
+
+
+Example 1:
+
+Input: x = 2, y = 5, z = 1
+Output: 12
+Explanation: We can concatenate the strings "BB", "AA", "BB", "AA", "BB", and "AB" in that order. Then, our new string is "BBAABBAABBAB".
+That string has length 12, and we can show that it is impossible to construct a string of longer length.
+
+Example 2:
+
+Input: x = 3, y = 2, z = 2
+Output: 14
+Explanation: We can concatenate the strings "AB", "AB", "AA", "BB", "AA", "BB", and "AA" in that order. Then, our new string is "ABABAABBAABBAA".
+That string has length 14, and we can show that it is impossible to construct a string of longer length.
+
+
+Constraints:
+
+1 <= x, y, z <= 50
+
+"""
+
+# V0
+# IDEA : GREEDY / CASE ANALYSIS ON THE "AA" vs "BB" ALTERNATION
+#
+#   Think of each block by the letter it starts and ends with:
+#       "AA" -> A..A, "BB" -> B..B, "AB" -> A..B
+#   Concatenating two blocks that touch with the same letter on both sides
+#   makes 3+ of that letter in a row ("AAA" / "BBB"). So in the final string
+#   the "AA" and "BB" blocks MUST strictly alternate: AA BB AA BB ...
+#
+#   Consequences :
+#     - if x == y  : use all of them, "AABBAABB..." works.
+#     - if x != y  : the alternation caps the bigger pile at min(x, y) + 1
+#                    (start and end with the majority letter), so we place
+#                    min(x, y) of each plus one extra of the majority.
+#
+#   Every "AB" block is A..B, so a run of "AB"s ("ABABAB...") is always safe,
+#   and it can be prefixed to a chain that STARTS with A (because the run
+#   ends in B) — that is, all z of them are always usable, for free.
+#
+#   NOTE : the whole layout ends up as  (AB)*z + [AA BB AA ...]  when the
+#          chain starts with "AA", or  [BB AA ...] + (AB)*z  when it starts
+#          with "BB". Either way no "AB" is ever wasted.
+#
+#   NOTE : each block contributes 2 characters, hence the final "* 2".
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def longestString(self, x, y, z):
+        if x == y:
+            blocks = x + y + z
+        else:
+            blocks = 2 * min(x, y) + 1 + z
+        return blocks * 2

--- a/leetcode_python/Array/count-houses-in-a-circular-street-ii.py
+++ b/leetcode_python/Array/count-houses-in-a-circular-street-ii.py
@@ -1,0 +1,91 @@
+"""
+
+2753. Count Houses in a Circular Street II
+Hard
+
+You are given an object street of class Street that represents a circular street and a positive integer k which represents a maximum bound for the number of houses in that street (in other words, the number of houses is less than or equal to k). Houses' doors could be open or closed initially (at least one is open).
+
+Initially, you are standing in front of a door to a house on this street. Your task is to count the number of houses in the street.
+
+The class Street contains the following functions which may help you:
+
+void closeDoor(): Close the door of the house you are in front of.
+boolean isDoorOpen(): Returns true if the door of the current house is open and false otherwise.
+void moveRight(): Move to the right house.
+
+Note that by circular street, we mean if you number the houses from 1 to n, then the right house of house_i is house_(i+1) for i < n, and the right house of house_n is house_1.
+
+Return ans which represents the number of houses on this street.
+
+
+Example 1:
+
+Input: street = [1,1,1,1], k = 10
+Output: 4
+Explanation: There are 4 houses, and all their doors are open.
+The number of houses is less than k, which is 10.
+
+Example 2:
+
+Input: street = [1,0,1,1,0], k = 5
+Output: 5
+Explanation: There are 5 houses, and the doors of the 1st, 3rd, and 4th house (moving in the right direction) are open, and the rest are closed.
+The number of houses is equal to k, which is 5.
+
+
+Constraints:
+
+n == number of houses
+1 <= n <= k <= 10^5
+street is circular by definition provided in the statement.
+The input is generated such that at least one of the doors is open.
+
+"""
+
+# V0
+# IDEA : INTERACTIVE / BRAIN TEASER -- use one open door as an anchor
+#
+#  we cannot see n, we can only feel the street through 3 calls. The trick is
+#  to leave ONE open door untouched and use it as a marker of "one full lap".
+#
+#  step 1 : walk right until we stand on an open door -- that is our anchor.
+#           (guaranteed to exist, and reached within n <= k steps)
+#  step 2 : from there take up to k more steps to the right. Every time we
+#           land on an open door we record the step counter and CLOSE that
+#           door.
+#
+#  why the LAST recorded counter is n:
+#     - during steps 1..n we sweep the whole street once and close every open
+#       door we meet; at step exactly n we are back on the anchor, which is
+#       still open -> the counter n gets recorded.
+#     - after that every door on the street is closed, so no further step can
+#       overwrite the answer.
+#   -> the last recorded value is exactly n.
+#
+#   NOTE : do NOT close the anchor before starting -- it is the only thing
+#          that tells us a lap is complete.
+#   NOTE : k >= n is promised, so the loop is long enough to reach step n.
+#
+# time = O(k), space = O(1)
+#
+# Definition for a street.
+# class Street(object):
+#     def closeDoor(self):
+#         pass
+#     def isDoorOpen(self):
+#         pass
+#     def moveRight(self):
+#         pass
+class Solution(object):
+    def houseCount(self, street, k):
+        # step 1 : park on an open door (the anchor)
+        while not street.isDoorOpen():
+            street.moveRight()
+        # step 2 : one guarded lap, closing every open door we pass
+        res = 0
+        for i in range(1, k + 1):
+            street.moveRight()
+            if street.isDoorOpen():
+                res = i
+                street.closeDoor()
+        return res

--- a/leetcode_python/Array/count-houses-in-a-circular-street.py
+++ b/leetcode_python/Array/count-houses-in-a-circular-street.py
@@ -1,0 +1,72 @@
+"""
+
+2728. Count Houses in a Circular Street
+Easy
+
+You are given an object street of class Street that represents a circular street and a positive integer k which represents a maximum bound for the number of houses in that street (in other words, the number of houses is less than or equal to k). Houses' doors could be open or closed initially.
+
+Initially, you are standing in front of a door to a house on this street. Your task is to count the number of houses in the street.
+
+The class Street contains the following functions which may help you:
+
+void openDoor(): Open the door of the house you are in front of.
+void closeDoor(): Close the door of the house you are in front of.
+boolean isDoorOpen(): Returns true if the door of the current house is open and false otherwise.
+void moveRight(): Move to the right house.
+void moveLeft(): Move to the left house.
+
+Return ans which represents the number of houses on this street.
+
+
+Example 1:
+
+Input: street = [0,0,0,0], k = 10
+Output: 4
+Explanation: There are 4 houses, and all their doors are closed.
+The number of houses is less than k, which is 10.
+
+Example 2:
+
+Input: street = [1,0,1,1,0], k = 5
+Output: 5
+Explanation: There are 5 houses, and the doors of the 1st, 3rd, and 4th house (moving in the right direction) are open, and the rest are closed.
+The number of houses is equal to k, which is 5.
+
+
+Constraints:
+
+n == number of houses
+1 <= n <= k <= 10^3
+
+"""
+
+# V0
+# IDEA : INTERACTIVE - NORMALIZE THE STREET, THEN CLOSE-AND-COUNT ONE LAP
+#
+#   the initial door states are arbitrary, so we cannot use them as markers.
+#   phase 1 : walk k steps (k >= n, so we cover every house at least once)
+#             opening every door -> the whole street is now known to be OPEN.
+#   phase 2 : from wherever we stand, keep closing the current door and
+#             stepping on, counting each house. The moment we meet a door that
+#             is ALREADY closed we have come back to the very first house we
+#             closed, i.e. we walked exactly one full lap -> that count is n.
+#
+#   NOTE : phase 1 must move in the SAME direction as phase 2 (here: left),
+#          but any consistent direction works since the street is circular.
+#   NOTE : the door must be closed BEFORE moving on, otherwise the loop guard
+#          never sees the marker again and it spins forever.
+#
+# time = O(k), space = O(1)
+class Solution(object):
+    def houseCount(self, street, k):
+        # phase 1 : open every door
+        for _ in range(k):
+            street.openDoor()
+            street.moveLeft()
+        # phase 2 : close doors until we hit the first one we closed
+        res = 0
+        while street.isDoorOpen():
+            street.closeDoor()
+            street.moveLeft()
+            res += 1
+        return res

--- a/leetcode_python/Array/determine-the-minimum-sum-of-a-k-avoiding-array.py
+++ b/leetcode_python/Array/determine-the-minimum-sum-of-a-k-avoiding-array.py
@@ -1,0 +1,66 @@
+"""
+
+2829. Determine the Minimum Sum of a k-avoiding Array
+Medium
+
+You are given two integers, n and k.
+
+An array of distinct positive integers is called a k-avoiding array if there does not exist any pair of distinct elements that sum to k.
+
+Return the minimum possible sum of a k-avoiding array of length n.
+
+
+Example 1:
+
+Input: n = 5, k = 4
+Output: 18
+Explanation: Consider the k-avoiding array [1,2,4,5,6], which has a sum of 18.
+It can be proven that there is no k-avoiding array with a sum less than 18.
+
+Example 2:
+
+Input: n = 2, k = 6
+Output: 3
+Explanation: We can construct the array [1,2], which has a sum of 3.
+It can be proven that there is no k-avoiding array with a sum less than 3.
+
+
+Constraints:
+
+1 <= n, k <= 50
+
+"""
+
+# V0
+# IDEA : GREEDY (take the smallest still-legal integer each time)
+#
+#   Scan i = 1, 2, 3, ... and take i whenever it is not banned. Taking i bans
+#   its partner k - i (that pair is the only way i can ever create the sum k).
+#
+#   NOTE : greedy is optimal because the integers pair up as
+#          {1, k-1}, {2, k-2}, ... — at most one member of each pair may be
+#          used, and the banned partner k - i is always LARGER than the i we
+#          took (we meet i first), so we never trade a small number away for
+#          a bigger one.
+#
+#   NOTE : i == k - i (i.e. k even, i = k/2) is not a conflict: the pair must
+#          use two DISTINCT elements and all elements are distinct, so k/2
+#          alone is fine. Marking k - i == i as banned after we already took
+#          i is harmless since i is never revisited.
+#
+#   NOTE : once i passes k every later integer is free, so the loop always
+#          terminates after at most n + k steps.
+#
+# time = O(n + k), space = O(n + k)
+class Solution(object):
+    def minimumSum(self, n, k):
+        banned = set()
+        total = 0
+        i = 1
+        for _ in range(n):
+            while i in banned:
+                i += 1
+            total += i
+            banned.add(k - i)
+            i += 1
+        return total

--- a/leetcode_python/Array/difference-of-number-of-distinct-values-on-diagonals.py
+++ b/leetcode_python/Array/difference-of-number-of-distinct-values-on-diagonals.py
@@ -1,0 +1,101 @@
+"""
+
+2711. Difference of Number of Distinct Values on Diagonals
+Medium
+
+Given a 2D grid of size m x n, you should find the matrix answer of size m x n.
+
+The cell answer[r][c] is calculated by looking at the diagonal values of the cell grid[r][c]:
+
+Let leftAbove[r][c] be the number of distinct values on the diagonal to the left and above the cell grid[r][c] not including the cell grid[r][c] itself.
+Let rightBelow[r][c] be the number of distinct values on the diagonal to the right and below the cell grid[r][c], not including the cell grid[r][c] itself.
+Then answer[r][c] = |leftAbove[r][c] - rightBelow[r][c]|.
+
+A matrix diagonal is a diagonal line of cells starting from some cell in either the topmost row or leftmost column and going in the bottom-right direction until the end of the matrix is reached.
+
+For example, for the cell with indices (2, 3):
+  - Red-colored cells are left and above the cell.
+  - Blue-colored cells are right and below the cell.
+
+Return the matrix answer.
+
+
+Example 1:
+
+Input: grid = [[1,2,3],[3,1,5],[3,2,1]]
+Output: [[1,1,0],[1,0,1],[0,1,1]]
+Explanation:
+To calculate the answer cells:
+
+answer  | left-above elements    | leftAbove   | right-below elements   | rightBelow  | |leftAbove - rightBelow|
+[0][0]  | []                     | 0           | [grid[1][1], grid[2][2]] | |{1, 1}| = 1 | 1
+[0][1]  | []                     | 0           | [grid[1][2]]           | |{5}| = 1    | 1
+[0][2]  | []                     | 0           | []                     | 0           | 0
+[1][0]  | []                     | 0           | [grid[2][1]]           | |{2}| = 1    | 1
+[1][1]  | [grid[0][0]]           | |{1}| = 1   | [grid[2][2]]           | |{1}| = 1    | 0
+[1][2]  | [grid[0][1]]           | |{2}| = 1   | []                     | 0           | 1
+[2][0]  | []                     | 0           | []                     | 0           | 0
+[2][1]  | [grid[1][0]]           | |{3}| = 1   | []                     | 0           | 1
+[2][2]  | [grid[0][0], grid[1][1]] | |{1, 1}| = 1 | []                   | 0           | 1
+
+Example 2:
+
+Input: grid = [[1]]
+Output: [[0]]
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m, n, grid[i][j] <= 50
+
+"""
+
+# V0
+# IDEA : DIAGONAL SWEEP + PREFIX / SUFFIX DISTINCT COUNTS
+#
+#   every cell belongs to exactly one top-left -> bottom-right diagonal, and
+#   the diagonals are the ones starting at (i, 0) for each row i and at (0, j)
+#   for each column j > 0. So flatten each diagonal into a list once, then:
+#
+#     - sweep forward keeping a running set -> pre[t] = #distinct STRICTLY
+#       before position t on that diagonal (the "left & above" part)
+#     - sweep backward the same way      -> suf[t] = #distinct STRICTLY
+#       after position t (the "right & below" part)
+#
+#   answer at that cell = abs(pre[t] - suf[t]).
+#
+#   NOTE : the running set must be updated AFTER reading the count for the
+#          current cell, since the cell itself is excluded from both sides.
+#   NOTE : this is O(m * n) overall - each cell is touched a constant number
+#          of times - vs the O(m * n * min(m, n)) naive re-walk per cell.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def differenceOfDistinctValues(self, grid):
+        m, n = len(grid), len(grid[0])
+        ans = [[0] * n for _ in range(m)]
+
+        starts = [(i, 0) for i in range(m)] + [(0, j) for j in range(1, n)]
+        for r, c in starts:
+            cells = []
+            x, y = r, c
+            while x < m and y < n:
+                cells.append((x, y))
+                x, y = x + 1, y + 1
+
+            k = len(cells)
+            pre = [0] * k
+            seen = set()
+            for t in range(k):
+                pre[t] = len(seen)
+                seen.add(grid[cells[t][0]][cells[t][1]])
+
+            seen = set()
+            for t in range(k - 1, -1, -1):
+                x, y = cells[t]
+                ans[x][y] = abs(pre[t] - len(seen))
+                seen.add(grid[x][y])
+
+        return ans

--- a/leetcode_python/Array/find-a-good-subset-of-the-matrix.py
+++ b/leetcode_python/Array/find-a-good-subset-of-the-matrix.py
@@ -1,0 +1,101 @@
+"""
+
+2732. Find a Good Subset of the Matrix
+Hard
+
+You are given a 0-indexed m x n binary matrix grid.
+
+Let us call a non-empty subset of rows good if the sum of each column of the subset is at most half of the length of the subset.
+
+More formally, if the length of the chosen subset of rows is k, then the sum of each column should be at most floor(k / 2).
+
+Return an integer array that contains row indices of a good subset sorted in ascending order.
+
+If there are multiple good subsets, you can return any of them. If there are no good subsets, return an empty array.
+
+A subset of rows of the matrix grid is any matrix that can be obtained by deleting some (possibly none or all) rows from grid.
+
+
+Example 1:
+
+Input: grid = [[0,1,1,0],[0,0,0,1],[1,1,1,1]]
+Output: [0,1]
+Explanation: We can choose the 0th and 1st rows to create a good subset of rows.
+The length of the chosen subset is 2.
+- The sum of the 0th column is 0 + 0 = 0, which is at most half of the length of the subset.
+- The sum of the 1st column is 1 + 0 = 1, which is at most half of the length of the subset.
+- The sum of the 2nd column is 1 + 0 = 1, which is at most half of the length of the subset.
+- The sum of the 3rd column is 0 + 1 = 1, which is at most half of the length of the subset.
+
+Example 2:
+
+Input: grid = [[0]]
+Output: [0]
+Explanation: We can choose the 0th row to create a good subset of rows.
+The length of the chosen subset is 1.
+- The sum of the 0th column is 0, which is at most half of the length of the subset.
+
+Example 3:
+
+Input: grid = [[1,1,1],[1,1,1]]
+Output: []
+Explanation: It is impossible to choose any subset of rows to create a good subset.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m <= 10^4
+1 <= n <= 5
+grid[i][j] is either 0 or 1.
+
+"""
+
+# V0
+# IDEA : BITMASK ROWS + PROOF THAT ONLY k = 1 OR k = 2 CAN EVER WIN
+#
+#   encode each row as a bitmask over its <= 5 columns.
+#
+#   why only k in {1, 2} matters:
+#     k = 1 -> every column sum must be <= 0  => an all-zero row.
+#     k = 2 -> every column sum must be <= 1  => two rows whose AND is 0.
+#     k = 3 -> cap is still floor(3/2) = 1, so any 2 of the 3 rows already
+#              form a valid k = 2 subset. Nothing new. Same for every odd k.
+#     k = 4 -> cap is 2. If no valid pair exists, EVERY one of the C(4,2) = 6
+#              pairs shares a column where both are 1, so by pigeonhole some
+#              column is shared by >= 2 pairs among n <= 5 columns, which
+#              forces that column's sum to be >= 3 > 2. Contradiction.
+#              The same counting kills every larger even k.
+#
+#   so: scan for an all-zero row; otherwise test every pair of DISTINCT masks
+#   for mask_a & mask_b == 0.
+#
+#   NOTE : keeping one representative index per mask is enough (any row with
+#          the same mask is interchangeable) -> at most 2^n = 32 candidates,
+#          so the pair loop is O(4^n), not O(m^2).
+#   NOTE : a & b == 0 with a == b would force a == 0, which the all-zero check
+#          already returned on — so a pair from the dict is never one row
+#          matched against itself.
+#   NOTE : the two indices must be returned in ASCENDING order.
+#
+# time = O(m * n + 4^n), space = O(2^n)
+class Solution(object):
+    def goodSubsetofBinaryMatrix(self, grid):
+        seen = {}
+        for i, row in enumerate(grid):
+            mask = 0
+            for j, v in enumerate(row):
+                if v:
+                    mask |= 1 << j
+            if mask == 0:
+                return [i]
+            if mask not in seen:
+                seen[mask] = i
+        masks = list(seen.keys())
+        for p in range(len(masks)):
+            for q in range(p + 1, len(masks)):
+                if masks[p] & masks[q] == 0:
+                    i, j = seen[masks[p]], seen[masks[q]]
+                    return [min(i, j), max(i, j)]
+        return []

--- a/leetcode_python/Array/find-the-minimum-possible-sum-of-a-beautiful-array.py
+++ b/leetcode_python/Array/find-the-minimum-possible-sum-of-a-beautiful-array.py
@@ -1,0 +1,87 @@
+"""
+
+2834. Find the Minimum Possible Sum of a Beautiful Array
+Medium
+
+You are given positive integers n and target.
+
+An array nums is beautiful if it meets the following conditions:
+
+nums.length == n.
+nums consists of pairwise distinct positive integers.
+There doesn't exist two distinct indices, i and j, in the range [0, n - 1], such that nums[i] + nums[j] == target.
+
+Return the minimum possible sum that a beautiful array could have modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: n = 2, target = 3
+Output: 4
+Explanation: We can see that nums = [1,3] is beautiful.
+- The array nums has length n = 2.
+- The array nums consists of pairwise distinct positive integers.
+- There doesn't exist two distinct indices, i and j, with nums[i] + nums[j] == 3.
+It can be proven that 4 is the minimum possible sum that a beautiful array could have.
+
+Example 2:
+
+Input: n = 3, target = 3
+Output: 8
+Explanation: We can see that nums = [1,3,4] is beautiful.
+- The array nums has length n = 3.
+- The array nums consists of pairwise distinct positive integers.
+- There doesn't exist two distinct indices, i and j, with nums[i] + nums[j] == 3.
+It can be proven that 8 is the minimum possible sum that a beautiful array could have.
+
+Example 3:
+
+Input: n = 1, target = 1
+Output: 1
+Explanation: We can see, that nums = [1] is beautiful.
+
+
+Constraints:
+
+1 <= n <= 10^9
+1 <= target <= 10^9
+
+"""
+
+# V0
+# IDEA : GREEDY + ARITHMETIC SERIES (closed form, no loop)
+#
+#   Same pairing idea as LC 2829, but n reaches 10^9 so the greedy has to be
+#   summed in closed form rather than simulated.
+#
+#   Take the smallest integers 1, 2, ..., m where m = target // 2. Picking x
+#   in that range bans target - x, which is > m, i.e. strictly larger than
+#   anything else in the cheap block — so the whole block 1..m is safe and
+#   obviously optimal to take first.
+#
+#   NOTE : m = target // 2 (floor), not (target - 1) // 2. When target is
+#          even, target/2 pairs only with ITSELF, and the two indices must be
+#          distinct while the values are distinct — so target/2 can never
+#          form the forbidden sum and is legal to include.
+#
+#   Everything in (m, target) is banned by a partner we already took, so the
+#   remaining n - m elements are target, target + 1, ..., target + n - m - 1.
+#
+#       sum = m(m + 1) / 2  +  (n - m) * target + (n - m)(n - m - 1) / 2
+#
+#   NOTE : if n <= m we only need 1..n and stop there.
+#
+#   NOTE : take the modulo only at the very end — Python ints are arbitrary
+#          precision, so the intermediate products (up to ~10^18) are exact.
+#          A fixed-width language must reduce mid-way or use 64-bit + care.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def minimumPossibleSum(self, n, target):
+        MOD = 10 ** 9 + 7
+        m = target // 2
+        if n <= m:
+            return (n * (n + 1) // 2) % MOD
+        rest = n - m
+        total = m * (m + 1) // 2 + rest * target + rest * (rest - 1) // 2
+        return total % MOD

--- a/leetcode_python/Array/longest-even-odd-subarray-with-threshold.py
+++ b/leetcode_python/Array/longest-even-odd-subarray-with-threshold.py
@@ -1,0 +1,82 @@
+"""
+
+2760. Longest Even Odd Subarray With Threshold
+Easy
+
+You are given a 0-indexed integer array nums and an integer threshold.
+
+Find the length of the longest subarray of nums starting at index l and ending at index r (0 <= l <= r < nums.length) that satisfies the following conditions:
+
+nums[l] % 2 == 0
+For all indices i in the range [l, r - 1], nums[i] % 2 != nums[i + 1] % 2
+For all indices i in the range [l, r], nums[i] <= threshold
+
+Return an integer denoting the length of the longest such subarray.
+
+Note: A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [3,2,5,4], threshold = 5
+Output: 3
+Explanation: In this example, we can select the subarray that starts at l = 1 and ends at r = 3 => [2,5,4]. This subarray satisfies the conditions.
+Hence, the answer is the length of the subarray, 3. We can show that 3 is the maximum possible achievable length.
+
+Example 2:
+
+Input: nums = [1,2], threshold = 2
+Output: 1
+Explanation: In this example, we can select the subarray that starts at l = 1 and ends at r = 1 => [2].
+It satisfies all the conditions and we can show that 1 is the maximum possible achievable length.
+
+Example 3:
+
+Input: nums = [2,3,4,5], threshold = 4
+Output: 3
+Explanation: In this example, we can select the subarray that starts at l = 0 and ends at r = 2 => [2,3,4].
+It satisfies all the conditions.
+Hence, the answer is the length of the subarray, 3. We can show that 3 is the maximum possible achievable length.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= nums[i] <= 100
+1 <= threshold <= 100
+
+"""
+
+# V0
+# IDEA : GREEDY SCAN WITHOUT BACKTRACKING (two pointers)
+#
+#  from a valid start l we extend r as far as the alternating-parity rule and
+#  the threshold rule allow -- and that maximal stretch is unique.
+#
+#  the key observation that turns the O(n^2) brute force into O(n): once a
+#  stretch [l, r) stops at r, NO index strictly inside (l, r) can be a better
+#  start. Any such index either has odd value (illegal start) or, if even, its
+#  own stretch is a suffix of [l, r) and hence shorter. So we may jump
+#  l = r directly instead of restarting at l + 1.
+#
+#   NOTE : a start needs BOTH nums[l] % 2 == 0 AND nums[l] <= threshold;
+#          if either fails we just move on by one.
+#   NOTE : the parity test compares nums[r] with nums[r-1], so the very first
+#          extension already checks against the (even) start element.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def longestAlternatingSubarray(self, nums, threshold):
+        n = len(nums)
+        res = 0
+        l = 0
+        while l < n:
+            if nums[l] % 2 != 0 or nums[l] > threshold:
+                l += 1
+                continue
+            r = l + 1
+            while r < n and nums[r] <= threshold and nums[r] % 2 != nums[r - 1] % 2:
+                r += 1
+            res = max(res, r - l)
+            l = r
+        return res

--- a/leetcode_python/Array/neither-minimum-nor-maximum.py
+++ b/leetcode_python/Array/neither-minimum-nor-maximum.py
@@ -1,0 +1,55 @@
+"""
+
+2733. Neither Minimum nor Maximum
+Easy
+
+Given an integer array nums containing distinct positive integers, find and return any number from the array that is neither the minimum nor the maximum value in the array, or -1 if there is no such number.
+
+Return the selected integer.
+
+
+Example 1:
+
+Input: nums = [3,2,1,4]
+Output: 2
+Explanation: In this example, the minimum value is 1 and the maximum value is 4. Therefore, either 2 or 3 can be valid answers.
+
+Example 2:
+
+Input: nums = [1,2]
+Output: -1
+Explanation: Since there is no number in nums that is neither the maximum nor the minimum, we cannot select a number that satisfies the given condition. Therefore, there is no answer.
+
+Example 3:
+
+Input: nums = [2,1,3]
+Output: 2
+Explanation: Since 2 is neither the maximum nor the minimum value in nums, it is the only valid answer.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= nums[i] <= 100
+All values in nums are distinct
+
+"""
+
+# V0
+# IDEA : MIN / MAX THEN FIRST SURVIVOR
+#
+#   grab the global min and max, then return the first element that is
+#   neither. Since the values are DISTINCT, exactly one element equals the min
+#   and one equals the max, so any survivor is a valid answer.
+#
+#   NOTE : len(nums) <= 2 has no survivor -> -1 falls out naturally (for
+#          len == 1 the single element is both the min and the max).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def findNonMinOrMax(self, nums):
+        lo, hi = min(nums), max(nums)
+        for x in nums:
+            if x != lo and x != hi:
+                return x
+        return -1

--- a/leetcode_python/Array/number-of-employees-who-met-the-target.py
+++ b/leetcode_python/Array/number-of-employees-who-met-the-target.py
@@ -1,0 +1,59 @@
+"""
+
+2798. Number of Employees Who Met the Target
+Easy
+
+There are n employees in a company, numbered from 0 to n - 1. Each employee i has worked for hours[i] hours in the company.
+
+The company requires each employee to work for at least target hours.
+
+You are given a 0-indexed array of non-negative integers hours of length n and a non-negative integer target.
+
+Return the integer denoting the number of employees who worked at least target hours.
+
+
+Example 1:
+
+Input: hours = [0,1,2,3,4], target = 2
+Output: 3
+Explanation: The company wants each employee to work for at least 2 hours.
+- Employee 0 worked for 0 hours and didn't meet the target.
+- Employee 1 worked for 1 hours and didn't meet the target.
+- Employee 2 worked for 2 hours and met the target.
+- Employee 3 worked for 3 hours and met the target.
+- Employee 4 worked for 4 hours and met the target.
+There are 3 employees who met the target.
+
+Example 2:
+
+Input: hours = [5,1,4,2,2], target = 6
+Output: 0
+Explanation: The company wants each employee to work for at least 6 hours.
+There are 0 employees who met the target.
+
+
+Constraints:
+
+1 <= n == hours.length <= 50
+0 <= hours[i], target <= 10^5
+
+"""
+
+# V0
+# IDEA : LINEAR COUNT
+#
+#   each employee is judged independently, so a single pass counting the
+#   entries with hours[i] >= target is enough. no ordering or grouping is
+#   involved.
+#
+#   NOTE : the bar is "at least" target, so the comparison is >= and NOT >.
+#          an employee working exactly `target` hours does meet it.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def numberOfEmployeesWhoMetTarget(self, hours, target):
+        res = 0
+        for h in hours:
+            if h >= target:
+                res += 1
+        return res

--- a/leetcode_python/Array/number-of-unique-categories.py
+++ b/leetcode_python/Array/number-of-unique-categories.py
@@ -1,0 +1,75 @@
+"""
+
+2782. Number of Unique Categories
+Medium
+
+You are given an integer n and an object categoryHandler of class CategoryHandler.
+
+There are n elements, numbered from 0 to n - 1. Each element has a category, and your task is to find the number of unique categories.
+
+The class CategoryHandler contains the following function, which may help you:
+
+boolean haveSameCategory(integer a, integer b): Returns true if a and b are in the same category and false otherwise. Also, if either a or b is not a valid number (i.e. it's greater than or equal to n or less than 0), it returns false.
+
+Return the number of unique categories.
+
+
+Example 1:
+
+Input: n = 6, categoryHandler = [1,1,2,2,3,3]
+Output: 3
+Explanation: There are 6 elements in this example. The first two elements belong to category 1, the second two belong to category 2, and the last two elements belong to category 3. So there are 3 unique categories.
+
+Example 2:
+
+Input: n = 5, categoryHandler = [1,2,3,4,5]
+Output: 5
+Explanation: There are 5 elements in this example. Each element belongs to a unique category. So there are 5 unique categories.
+
+Example 3:
+
+Input: n = 3, categoryHandler = [1,1,1]
+Output: 1
+Explanation: There are 3 elements in this example. All of them belong to one category. So there is only 1 unique category.
+
+
+Constraints:
+
+1 <= n <= 100
+
+"""
+
+# V0
+# IDEA : REPRESENTATIVE SCAN (INTERACTIVE)
+#
+#   "same category" is an equivalence relation, so the elements are already
+#   partitioned into groups; we only need to count the groups.
+#
+#   NOTE : we do NOT need a full union-find here. Keep one representative per
+#          category discovered so far; for a new element i, compare it against
+#          the representatives only. If it matches one, it joins that group;
+#          if it matches none, it opens a brand new category.
+#
+#   NOTE : this is correct precisely because of transitivity - matching any
+#          member of a group is the same as matching its representative.
+#
+#   n <= 100, so the O(n^2) worst case (all categories distinct) is fine.
+#
+#   Definition for a category handler (provided by LeetCode):
+#     class CategoryHandler(object):
+#         def haveSameCategory(self, a, b):  # -> bool
+#             ...
+#
+# time = O(n^2) haveSameCategory calls, space = O(n)
+class Solution(object):
+    def numberOfCategories(self, n, categoryHandler):
+        reps = []
+        for i in range(n):
+            found = False
+            for r in reps:
+                if categoryHandler.haveSameCategory(r, i):
+                    found = True
+                    break
+            if not found:
+                reps.append(i)
+        return len(reps)

--- a/leetcode_python/Array/robot-collisions.py
+++ b/leetcode_python/Array/robot-collisions.py
@@ -1,0 +1,97 @@
+"""
+
+2751. Robot Collisions
+Hard
+
+There are n 1-indexed robots, each having a position on a line, health, and movement direction.
+
+You are given 0-indexed integer arrays positions, healths, and a string directions (directions[i] is either 'L' for left or 'R' for right). All integers in positions are unique.
+
+All robots start moving on the line simultaneously at the same speed in their given directions. If two robots ever share the same position while moving, they will collide.
+
+If two robots collide, the robot with lower health is removed from the line, and the health of the other robot decreases by one. The surviving robot continues in the same direction it was going. If both robots have the same health, they are both removed from the line.
+
+Your task is to determine the health of the robots that survive the collisions, in the same order that the robots were given, i.e. final health of robot 1 (if survived), final health of robot 2 (if survived), and so on. If there are no survivors, return an empty array.
+
+Return an array containing the health of the remaining robots (in the order they were given in the input), after no further collisions can occur.
+
+Note: The positions may be unsorted.
+
+
+Example 1:
+
+Input: positions = [5,4,3,2,1], healths = [2,17,9,15,10], directions = "RRRRR"
+Output: [2,17,9,15,10]
+Explanation: No collision occurs in this example, since all robots are moving in the same direction. So, the health of the robots in order from the first robot is returned, [2, 17, 9, 15, 10].
+
+Example 2:
+
+Input: positions = [3,5,2,6], healths = [10,10,15,12], directions = "RLRL"
+Output: [14]
+Explanation: There are 2 collisions in this example. Firstly, robot 1 and robot 2 will collide, and since both have the same health, they will be removed from the line. Next, robot 3 and robot 4 will collide and since robot 4's health is smaller, it gets removed, and robot 3's health becomes 15 - 1 = 14. Only robot 3 remains, so we return [14].
+
+Example 3:
+
+Input: positions = [1,2,5,6], healths = [10,10,11,11], directions = "RLRL"
+Output: []
+Explanation: Robot 1 and robot 2 will collide and since both have the same health, they are both removed. Robot 3 and 4 will collide and since both have the same health, they are both removed. So, we return an empty array, [].
+
+
+Constraints:
+
+1 <= positions.length == healths.length == directions.length == n <= 10^5
+1 <= positions[i], healths[i] <= 10^9
+directions[i] == 'L' or directions[i] == 'R'
+All values in positions are distinct
+
+"""
+
+# V0
+# IDEA : SORT BY POSITION + MONOTONIC STACK SIMULATION ("asteroid collision")
+#
+#  a collision can only happen between an 'R' robot and an 'L' robot that is
+#  currently to its RIGHT. So walk the robots in increasing position order:
+#
+#     - 'R' robot -> it may still be hit later, push its index on the stack
+#     - 'L' robot -> it fights the stack top (the nearest 'R' robot on its
+#                    left), repeatedly, until it dies or the stack is empty
+#
+#  the stack therefore holds exactly the still-alive right-movers, in
+#  increasing position -> nearest opponent is always the top.
+#
+#  one duel (stack top j vs current i):
+#     health[j] > health[i] : i dies,  health[j] -= 1   -> stop
+#     health[j] < health[i] : j dies (pop), health[i] -= 1 -> keep fighting
+#     equal                 : both die (pop)            -> stop
+#
+#   NOTE : the answer must be in ORIGINAL index order, so work on indices and
+#          just zero out the health of a dead robot, then filter at the end.
+#   NOTE : positions are NOT sorted in the input -- sorting the indices (not
+#          the arrays) is what keeps the original order recoverable.
+#   NOTE : we copy `healths` so the caller's array is left untouched.
+#
+# time = O(n * log n), space = O(n)
+class Solution(object):
+    def survivedRobotsHealths(self, positions, healths, directions):
+        hp = list(healths)
+        order = sorted(range(len(positions)), key=lambda i: positions[i])
+
+        stack = []                      # indices of alive right-moving robots
+        for i in order:
+            if directions[i] == 'R':
+                stack.append(i)
+                continue
+            # a left-mover: fight everything on the stack until it dies
+            while stack and hp[i] > 0:
+                j = stack[-1]
+                if hp[j] > hp[i]:
+                    hp[j] -= 1
+                    hp[i] = 0
+                elif hp[j] < hp[i]:
+                    hp[i] -= 1
+                    hp[j] = 0
+                    stack.pop()
+                else:
+                    hp[i] = hp[j] = 0
+                    stack.pop()
+        return [h for h in hp if h > 0]

--- a/leetcode_python/Array/semi-ordered-permutation.py
+++ b/leetcode_python/Array/semi-ordered-permutation.py
@@ -1,0 +1,71 @@
+"""
+
+2717. Semi-Ordered Permutation
+Easy
+
+You are given a 0-indexed permutation of n integers nums.
+
+A permutation is called semi-ordered if the first number equals 1 and the last number equals n. You can perform the below operation as many times as you want until you make nums a semi-ordered permutation:
+
+Pick two adjacent elements in nums, then swap them.
+
+Return the minimum number of operations to make nums a semi-ordered permutation.
+
+A permutation is a sequence of integers from 1 to n of length n containing each number exactly once.
+
+
+Example 1:
+
+Input: nums = [2,1,4,3]
+Output: 2
+Explanation: We can make the permutation semi-ordered using these sequence of operations:
+1 - swap i = 0 and j = 1. The permutation becomes [1,2,4,3].
+2 - swap i = 2 and j = 3. The permutation becomes [1,2,3,4].
+It can be proved that there is no sequence of less than two operations that make nums a semi-ordered permutation.
+
+Example 2:
+
+Input: nums = [2,4,1,3]
+Output: 3
+Explanation: We can make the permutation semi-ordered using these sequence of operations:
+1 - swap i = 1 and j = 2. The permutation becomes [2,1,4,3].
+2 - swap i = 0 and j = 1. The permutation becomes [1,2,4,3].
+3 - swap i = 2 and j = 3. The permutation becomes [1,2,3,4].
+It can be proved that there is no sequence of less than three operations that make nums a semi-ordered permutation.
+
+Example 3:
+
+Input: nums = [1,3,4,2,5]
+Output: 0
+Explanation: The permutation is already a semi-ordered permutation.
+
+
+Constraints:
+
+2 <= nums.length == n <= 50
+1 <= nums[i] <= 50
+nums is a permutation.
+
+"""
+
+# V0
+# IDEA : MATH (only the positions of 1 and n matter)
+#
+#   moving 1 to the front costs i adjacent swaps (i = index of 1);
+#   moving n to the back costs n - 1 - j swaps (j = index of n).
+#   the two journeys are independent, so the total is i + (n - 1 - j)...
+#
+#   NOTE : ...unless 1 sits to the RIGHT of n (i > j). Then the two values
+#          must cross each other, and one single swap moves BOTH of them one
+#          step closer to their targets -> that shared swap is double counted
+#          and we subtract 1 more.
+#
+#   so : answer = i + n - j - (1 if i < j else 2)
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def semiOrderedPermutation(self, nums):
+        n = len(nums)
+        i = nums.index(1)
+        j = nums.index(n)
+        return i + n - j - (1 if i < j else 2)

--- a/leetcode_python/Backtracking/special-permutations.py
+++ b/leetcode_python/Backtracking/special-permutations.py
@@ -1,0 +1,93 @@
+"""
+
+2741. Special Permutations
+Medium
+
+You are given a 0-indexed integer array nums containing n distinct positive integers. A permutation of nums is called special if:
+
+For all indexes 0 <= i < n - 1, either nums[i] % nums[i+1] == 0 or nums[i+1] % nums[i] == 0.
+
+Return the total number of special permutations. As the answer could be large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [2,3,6]
+Output: 2
+Explanation: [3,6,2] and [2,6,3] are the two special permutations of nums.
+
+Example 2:
+
+Input: nums = [1,4,3]
+Output: 2
+Explanation: [3,1,4] and [4,1,3] are the two special permutations of nums.
+
+
+Constraints:
+
+2 <= nums.length <= 14
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : BACKTRACKING COMPRESSED INTO BITMASK DP (STATE COMPRESSION)
+#
+#   Plain backtracking over all n! orders is 14! ~ 8.7e10 — way too slow.
+#   But the count of ways to FINISH a permutation only depends on:
+#       (1) WHICH numbers are already used  -> a 14-bit mask
+#       (2) WHICH number was placed LAST    -> an index
+#   The actual order of the used prefix is irrelevant. So memoizing on
+#   (mask, last) collapses n! branches into n * 2^n states.
+#
+#   dp[mask][last] = number of ways to extend a prefix that used exactly the
+#                    numbers in `mask` and ended with nums[last].
+#
+#   Transition : append any unused j whose value divides / is divided by
+#   nums[last]. Base case : mask == full -> 1 (one complete permutation).
+#
+#   NOTE : the answer sums over EVERY possible starting index, since any
+#          number may open the permutation.
+#
+#   NOTE : take the modulo on every accumulation; the raw count of a 14
+#          element permutation set can exceed 10^9.
+#
+#   NOTE : precompute the divisibility adjacency as bitmasks so the inner
+#          loop is a single `ok[last] & ~mask` scan instead of n modulos.
+#
+# time = O(n^2 * 2^n), space = O(n * 2^n)
+class Solution(object):
+    def specialPerm(self, nums):
+        MOD = 10 ** 9 + 7
+        n = len(nums)
+        full = (1 << n) - 1
+
+        # ok[i] = bitmask of the j that may directly follow / precede i
+        ok = [0] * n
+        for i in range(n):
+            for j in range(n):
+                if i != j and (nums[i] % nums[j] == 0 or nums[j] % nums[i] == 0):
+                    ok[i] |= 1 << j
+
+        # dp[mask][last]; iterate masks descending so dp[bigger mask] is ready
+        dp = [[0] * n for _ in range(1 << n)]
+        for last in range(n):
+            dp[full][last] = 1
+
+        for mask in range(full - 1, 0, -1):
+            free = full ^ mask
+            for last in range(n):
+                if not (mask >> last) & 1:
+                    continue
+                cand = ok[last] & free
+                total = 0
+                while cand:
+                    j = (cand & -cand).bit_length() - 1
+                    total += dp[mask | (1 << j)][j]
+                    cand &= cand - 1
+                dp[mask][last] = total % MOD
+
+        res = 0
+        for i in range(n):
+            res += dp[1 << i][i]
+        return res % MOD

--- a/leetcode_python/Binary_Search/minimum-operations-to-make-numbers-non-positive.py
+++ b/leetcode_python/Binary_Search/minimum-operations-to-make-numbers-non-positive.py
@@ -1,0 +1,83 @@
+"""
+
+2702. Minimum Operations to Make Numbers Non-positive
+Hard
+
+You are given a 0-indexed integer array nums and two integers x and y. In one operation, you must choose an index i such that 0 <= i < nums.length and perform the following:
+
+Decrement nums[i] by x.
+Decrement values by y at all indices except the ith one.
+
+Return the minimum number of operations to make all the integers in nums less than or equal to zero.
+
+
+Example 1:
+
+Input: nums = [3,4,1,7,6], x = 4, y = 2
+Output: 3
+Explanation: You will need three operations. One of the optimal sequence of operations is:
+Operation 1: Choose i = 3. Then, nums = [1,2,-1,3,4].
+Operation 2: Choose i = 3. Then, nums = [-1,0,-3,-1,2].
+Operation 3: Choose i = 4. Then, nums = [-3,-2,-5,-3,-2].
+Now all the numbers in nums are non-positive. Therefore, we return 3.
+
+Example 2:
+
+Input: nums = [1,2,1], x = 2, y = 1
+Output: 1
+Explanation: We can perform the operation once on i = 1. Then, nums becomes [0,0,0].
+All the positive numbers are removed, and therefore, we return 1.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+1 <= y < x <= 10^9
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH ON THE ANSWER
+#
+#   suppose we commit to exactly t operations. Every element is hit by y on
+#   every operation it is NOT chosen for, so after t operations an element v
+#   that was chosen c times ends at  v - c*x - (t - c)*y  =  v - t*y - c*(x-y).
+#
+#   so with a budget of t operations, element v needs
+#       c_v = ceil((v - t*y) / (x - y))     if v > t*y   else   0
+#   picks of its own (x > y so x - y > 0). The t picks are shared across all
+#   elements, so t operations suffice  <=>  sum(c_v) <= t.
+#
+#   that predicate is MONOTONE in t (more operations never hurt: t*y grows and
+#   x - y is fixed), so binary search the smallest feasible t on [0, max(nums)].
+#
+#   NOTE : t = max(nums) is always feasible since y >= 1 => t*y >= max(nums),
+#          so it is a valid right boundary.
+#   NOTE : the reference Python uses float ceil() here - with v, x, y up to
+#          10^9 the intermediate t*y reaches ~10^18 and float64 silently loses
+#          precision. Use INTEGER ceil-division instead: (a + b - 1) // b.
+#
+# time = O(n * log(max(nums))), space = O(1)
+class Solution(object):
+    def minOperations(self, nums, x, y):
+        d = x - y
+
+        def feasible(t):
+            need = 0
+            budget = t * y
+            for v in nums:
+                if v > budget:
+                    need += (v - budget + d - 1) // d
+                    if need > t:
+                        return False
+            return need <= t
+
+        lo, hi = 0, max(nums)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if feasible(mid):
+                hi = mid
+            else:
+                lo = mid + 1
+        return lo

--- a/leetcode_python/Binary_Search_Tree/minimum-absolute-difference-between-elements-with-constraint.py
+++ b/leetcode_python/Binary_Search_Tree/minimum-absolute-difference-between-elements-with-constraint.py
@@ -1,0 +1,136 @@
+"""
+
+2817. Minimum Absolute Difference Between Elements With Constraint
+Medium
+
+You are given a 0-indexed integer array nums and an integer x.
+
+Find the minimum absolute difference between two elements in the array that are at least x indices apart.
+
+In other words, find two indices i and j such that abs(i - j) >= x and abs(nums[i] - nums[j]) is minimized.
+
+Return an integer denoting the minimum absolute difference between two elements that are at least x indices apart.
+
+
+Example 1:
+
+Input: nums = [4,3,2,4], x = 2
+Output: 0
+Explanation: We can select nums[0] = 4 and nums[3] = 4.
+They are at least 2 indices apart, and their absolute difference is the minimum, 0.
+It can be shown that 0 is the optimal answer.
+
+Example 2:
+
+Input: nums = [5,3,2,10,15], x = 1
+Output: 1
+Explanation: We can select nums[1] = 3 and nums[2] = 2.
+They are at least 1 index apart, and their absolute difference is the minimum, 1.
+It can be shown that 1 is the optimal answer.
+
+Example 3:
+
+Input: nums = [1,2,3,4], x = 3
+Output: 3
+Explanation: We can select nums[0] = 1 and nums[3] = 4.
+They are at least 3 indices apart, and their absolute difference is the minimum, 3.
+It can be shown that 3 is the optimal answer.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+0 <= x < nums.length
+
+"""
+
+# V0
+# IDEA : SLIDING "ORDERED SET" OF ELIGIBLE PARTNERS (BST-STYLE PREDECESSOR /
+#        SUCCESSOR QUERIES, IMPLEMENTED ON A BIT WITH BINARY LIFTING)
+#
+#   Sweep j = x, x+1, ... and just before handling j insert nums[j - x] into
+#   an ordered multiset S. By construction S holds exactly the values whose
+#   index is <= j - x, i.e. every partner that is >= x indices away from j
+#   (pairs with i > j are covered symmetrically when the roles swap, so one
+#   forward sweep is enough).
+#
+#   The best partner for nums[j] inside S is its PREDECESSOR (largest value
+#   <= nums[j]) or its SUCCESSOR (smallest value >= nums[j]) - anything
+#   further away in value is strictly worse. Two ordered-set queries per step.
+#
+#   NOTE : x == 0 is legal and means "any two indices, including i == j", so
+#          the sweep must insert nums[j] itself before querying j -> answer 0.
+#          Starting the loop at j = x with the insert-then-query order gets
+#          this right automatically.
+#
+#   NOTE : Python has no built-in balanced BST. Instead of an O(n) per-insert
+#          `bisect.insort` (which degrades to ~O(n^2) memmove at n = 10^5),
+#          the ordered set here is a Fenwick tree over COMPRESSED values:
+#          add() is O(log n), and predecessor / successor are answered by
+#          "count how many are <= v" plus a binary-lifting select of the k-th
+#          smallest, also O(log n).
+#
+# time = O(n * log n), space = O(n)
+class Solution(object):
+    def minAbsoluteDifference(self, nums, x):
+        n = len(nums)
+
+        # coordinate compression: value -> rank in 1..m
+        vals = sorted(set(nums))
+        m = len(vals)
+        rank = {}
+        for i, v in enumerate(vals):
+            rank[v] = i + 1
+
+        tree = [0] * (m + 1)
+        size = 0
+
+        # highest power of two <= m, used by the binary-lifting select
+        log = 1
+        while (log << 1) <= m:
+            log <<= 1
+
+        def add(i):
+            while i <= m:
+                tree[i] += 1
+                i += i & (-i)
+
+        def count_le(i):
+            # how many inserted values have rank <= i
+            s = 0
+            while i > 0:
+                s += tree[i]
+                i -= i & (-i)
+            return s
+
+        def select(k):
+            # rank of the k-th smallest inserted value (1 <= k <= size)
+            pos, rest = 0, k
+            step = log
+            while step:
+                nxt = pos + step
+                if nxt <= m and tree[nxt] < rest:
+                    pos = nxt
+                    rest -= tree[pos]
+                step >>= 1
+            return pos + 1
+
+        ans = float('inf')
+        for j in range(x, n):
+            add(rank[nums[j - x]])
+            size += 1
+
+            r = rank[nums[j]]
+            c = count_le(r)
+            if c > 0:                          # predecessor (value <= nums[j])
+                d = nums[j] - vals[select(c) - 1]
+                if d < ans:
+                    ans = d
+            if c < size:                       # successor (value > nums[j])
+                d = vals[select(c + 1) - 1] - nums[j]
+                if d < ans:
+                    ans = d
+            if ans == 0:
+                return 0
+        return ans

--- a/leetcode_python/Breadth-First-Search/find-the-safest-path-in-a-grid.py
+++ b/leetcode_python/Breadth-First-Search/find-the-safest-path-in-a-grid.py
@@ -1,0 +1,122 @@
+"""
+
+2812. Find the Safest Path in a Grid
+Medium
+
+You are given a 0-indexed 2D matrix grid of size n x n, where (r, c) represents:
+
+A cell containing a thief if grid[r][c] = 1
+An empty cell if grid[r][c] = 0
+
+You are initially positioned at cell (0, 0). In one move, you can move to any adjacent cell in the grid, including cells containing thieves.
+
+The safeness factor of a path on the grid is defined as the minimum manhattan distance from any cell in the path to any thief in the grid.
+
+Return the maximum safeness factor of all paths leading to cell (n - 1, n - 1).
+
+An adjacent cell of cell (r, c), is one of the cells (r, c + 1), (r, c - 1), (r + 1, c) and (r - 1, c) if it exists.
+
+The Manhattan distance between two cells (a, b) and (x, y) is equal to |a - x| + |b - y|, where |val| denotes the absolute value of val.
+
+
+Example 1:
+
+Input: grid = [[1,0,0],[0,0,0],[0,0,1]]
+Output: 0
+Explanation: All paths from (0, 0) to (n - 1, n - 1) go through the thieves in cells (0, 0) and (n - 1, n - 1).
+
+Example 2:
+
+Input: grid = [[0,0,1],[0,0,0],[0,0,0]]
+Output: 2
+Explanation: The path depicted in the picture above has a safeness factor of 2 since:
+- The closest cell of the path to the thief at cell (0, 2) is cell (0, 0). The distance between them is | 0 - 0 | + | 0 - 2 | = 2.
+It can be shown that there are no other paths with a higher safeness factor.
+
+Example 3:
+
+Input: grid = [[0,0,0,1],[0,0,0,0],[0,0,0,0],[1,0,0,0]]
+Output: 2
+Explanation: The path depicted in the picture above has a safeness factor of 2 since:
+- The closest cell of the path to the thief at cell (0, 3) is cell (1, 2). The distance between them is | 0 - 1 | + | 3 - 2 | = 2.
+- The closest cell of the path to the thief at cell (3, 0) is cell (3, 2). The distance between them is | 3 - 3 | + | 0 - 2 | = 2.
+It can be shown that there are no other paths with a higher safeness factor.
+
+
+Constraints:
+
+1 <= grid.length == n <= 400
+grid[i].length == n
+grid[i][j] is either 0 or 1.
+There is at least one thief in the grid.
+
+"""
+
+# V0
+# IDEA : MULTI-SOURCE BFS + MAX-MIN (WIDEST PATH) DIJKSTRA
+#
+#   Step 1 : multi-source BFS starting from EVERY thief at once gives
+#            dist[r][c] = manhattan distance from (r, c) to the nearest thief.
+#            (On a 4-neighbour grid with no obstacles, BFS layers == manhattan
+#             distance, so no extra work is needed.)
+#
+#   Step 2 : we now want the path (0,0) -> (n-1,n-1) whose MINIMUM dist value
+#            is as large as possible - the classic "widest path" / bottleneck
+#            shortest path problem. Run a Dijkstra variant with a max-heap
+#            where the cost of a path is min(cost so far, dist[next]) and we
+#            always expand the currently best (largest) bottleneck.
+#            The first time we pop the destination, its bottleneck is optimal.
+#
+#   NOTE : the endpoints count too - if (0,0) or (n-1,n-1) holds a thief its
+#          dist is 0 and the answer is 0. Seeding the heap with dist[0][0]
+#          handles that for free.
+#
+#   NOTE : `best` doubles as the visited marker; a cell is only pushed when we
+#          strictly improve its bottleneck, so each cell is finalised once.
+#
+# time = O(n^2 * log n), space = O(n^2)
+import heapq
+from collections import deque
+
+
+class Solution(object):
+    def maximumSafenessFactor(self, grid):
+        n = len(grid)
+        dirs = ((-1, 0), (1, 0), (0, -1), (0, 1))
+
+        # --- step 1 : multi-source BFS from all thieves ---
+        dist = [[-1] * n for _ in range(n)]
+        q = deque()
+        for i in range(n):
+            for j in range(n):
+                if grid[i][j] == 1:
+                    dist[i][j] = 0
+                    q.append((i, j))
+        while q:
+            i, j = q.popleft()
+            d = dist[i][j] + 1
+            for di, dj in dirs:
+                x, y = i + di, j + dj
+                if 0 <= x < n and 0 <= y < n and dist[x][y] == -1:
+                    dist[x][y] = d
+                    q.append((x, y))
+
+        # --- step 2 : bottleneck (max-min) Dijkstra with a max-heap ---
+        best = [[-1] * n for _ in range(n)]
+        best[0][0] = dist[0][0]
+        heap = [(-dist[0][0], 0, 0)]
+        while heap:
+            negd, i, j = heapq.heappop(heap)
+            d = -negd
+            if d < best[i][j]:
+                continue
+            if i == n - 1 and j == n - 1:
+                return d
+            for di, dj in dirs:
+                x, y = i + di, j + dj
+                if 0 <= x < n and 0 <= y < n:
+                    nd = d if d < dist[x][y] else dist[x][y]
+                    if nd > best[x][y]:
+                        best[x][y] = nd
+                        heapq.heappush(heap, (-nd, x, y))
+        return 0

--- a/leetcode_python/Breadth-First-Search/minimum-time-takes-to-reach-destination-without-drowning.py
+++ b/leetcode_python/Breadth-First-Search/minimum-time-takes-to-reach-destination-without-drowning.py
@@ -1,0 +1,130 @@
+"""
+
+2814. Minimum Time Takes to Reach Destination Without Drowning
+Hard
+
+You are given an n * m 0-indexed grid of string land. Right now, you are standing at the cell that contains "S", and you want to get to the cell containing "D". There are three other types of cells in this land:
+
+".": These cells are empty.
+"X": These cells are stone.
+"*": These cells are flooded.
+
+At each second, you can move to a cell that shares a side with your current cell (if it exists). Also, at each second, every empty cell that shares a side with a flooded cell becomes flooded as well.
+
+There are two problems ahead of your journey:
+
+You can't step on stone cells.
+You can't step on flooded cells since you will drown (also, you can't step on a cell that will be flooded at the same time as you step on it).
+
+Return the minimum time it takes you to reach the destination in seconds, or -1 if it is impossible.
+
+Note that the destination will never be flooded.
+
+
+Example 1:
+
+Input: land = [["D",".","*"],[".",".","."],[".","S","."]]
+Output: 3
+Explanation: The picture below shows the simulation of the land second by second. The blue cells are flooded, and the gray cells are stone.
+Picture (0) shows the initial state and picture (3) shows the final state when we reach destination. As you see, it takes us 3 second to reach destination and the answer would be 3.
+It can be shown that 3 is the minimum time needed to reach from S to D.
+
+Example 2:
+
+Input: land = [["D","X","*"],[".",".","."],[".",".","S"]]
+Output: -1
+Explanation: The picture below shows the simulation of the land second by second. The blue cells are flooded, and the gray cells are stone.
+Picture (0) shows the initial state. As you see, no matter which paths we choose, we will drown at the 3rd second. Also the minimum path takes us 4 seconds to reach from S to D.
+So the answer would be -1.
+
+Example 3:
+
+Input: land = [["D",".",".",".","*","."],[".","X",".","X",".","."],[".",".",".",".","S","."]]
+Output: 6
+Explanation: It can be shown that we can reach destination in 6 seconds. Also it can be shown that 6 is the minimum seconds one need to reach from S to D.
+
+
+Constraints:
+
+2 <= n, m <= 100
+land consists only of "S", "D", ".", "*" and "X".
+Exactly one of the cells is equal to "S".
+Exactly one of the cells is equal to "D".
+
+"""
+
+# V0
+# IDEA : TWO BFS - FLOOD SPREAD FIRST, THEN THE WALKER
+#
+#   The water does not care about us, so precompute it once:
+#     BFS 1 : multi-source BFS from every "*" cell gives
+#             flood[r][c] = the second at which (r, c) becomes flooded
+#             (INF if it never does). Stone "X" blocks the water, and "D" is
+#             stated to never flood, so both are treated as non-floodable.
+#
+#     BFS 2 : ordinary shortest-path BFS for the walker starting at "S" with
+#             t = 0. Stepping into (x, y) happens at second t + 1 and is legal
+#             only when the cell is not stone and flood[x][y] > t + 1.
+#
+#   NOTE : the inequality is STRICT - the statement forbids stepping onto a
+#          cell that floods at the very same second, so flood[x][y] == t + 1
+#          is a drowning move.
+#   NOTE : "D" is exempt from the flood check entirely.
+#   NOTE : BFS 2 visits each cell at most once because the walker's arrival
+#          times are non-decreasing; a later arrival is never more permissive
+#          than the first one, so no re-visits are needed.
+#
+# time = O(n * m), space = O(n * m)
+from collections import deque
+
+
+class Solution(object):
+    def minimumSeconds(self, land):
+        n, m = len(land), len(land[0])
+        dirs = ((-1, 0), (1, 0), (0, -1), (0, 1))
+        INF = float('inf')
+
+        # --- BFS 1 : flood spreading ---
+        flood = [[INF] * m for _ in range(n)]
+        q = deque()
+        start = dest = None
+        for i in range(n):
+            for j in range(m):
+                ch = land[i][j]
+                if ch == '*':
+                    flood[i][j] = 0
+                    q.append((i, j))
+                elif ch == 'S':
+                    start = (i, j)
+                elif ch == 'D':
+                    dest = (i, j)
+        while q:
+            i, j = q.popleft()
+            t = flood[i][j] + 1
+            for di, dj in dirs:
+                x, y = i + di, j + dj
+                if 0 <= x < n and 0 <= y < m and flood[x][y] == INF:
+                    if land[x][y] == 'X' or land[x][y] == 'D':
+                        continue
+                    flood[x][y] = t
+                    q.append((x, y))
+
+        # --- BFS 2 : the walker ---
+        seen = [[False] * m for _ in range(n)]
+        seen[start[0]][start[1]] = True
+        q = deque([(start[0], start[1], 0)])
+        while q:
+            i, j, t = q.popleft()
+            if (i, j) == dest:
+                return t
+            for di, dj in dirs:
+                x, y = i + di, j + dj
+                if not (0 <= x < n and 0 <= y < m) or seen[x][y]:
+                    continue
+                if land[x][y] == 'X':
+                    continue
+                if land[x][y] != 'D' and flood[x][y] <= t + 1:
+                    continue
+                seen[x][y] = True
+                q.append((x, y, t + 1))
+        return -1

--- a/leetcode_python/Depth-First-Search/count-paths-that-can-form-a-palindrome-in-a-tree.py
+++ b/leetcode_python/Depth-First-Search/count-paths-that-can-form-a-palindrome-in-a-tree.py
@@ -1,0 +1,96 @@
+"""
+
+2791. Count Paths That Can Form a Palindrome in a Tree
+Hard
+
+You are given a tree (i.e. a connected, undirected graph that has no cycles) rooted at node 0 consisting of n nodes numbered from 0 to n - 1. The tree is represented by a 0-indexed array parent of size n, where parent[i] is the parent of node i. Since node 0 is the root, parent[0] == -1.
+
+You are also given a string s of length n, where s[i] is the character assigned to the edge between i and parent[i]. s[0] can be ignored.
+
+Return the number of pairs of nodes (u, v) such that u < v and the characters assigned to edges on the path from u to v can be rearranged to form a palindrome.
+
+A string is a palindrome when it reads the same backwards as forwards.
+
+
+Example 1:
+
+Input: parent = [-1,0,0,1,1,2], s = "acaabc"
+Output: 8
+Explanation: The valid pairs are:
+- All the pairs (0,1), (0,2), (1,3), (1,4) and (2,5) result in one character which is always a palindrome.
+- The pair (2,3) result in the string "aca" which is a palindrome.
+- The pair (1,5) result in the string "cac" which is a palindrome.
+- The pair (3,5) result in the string "acac" which can be rearranged into the palindrome "acca".
+
+Example 2:
+
+Input: parent = [-1,0,0,0,0], s = "aaaaa"
+Output: 10
+Explanation: Any pair of nodes (u,v) where u < v is valid.
+
+
+Constraints:
+
+n == parent.length == s.length
+1 <= n <= 10^5
+0 <= parent[i] <= n - 1 for all i >= 1
+parent[0] == -1
+parent represents a valid tree.
+s consists of only lowercase English letters.
+
+"""
+
+# V0
+# IDEA : ROOT-TO-NODE XOR BITMASK + PAIR COUNTING
+#
+#   a multiset of letters can be rearranged into a palindrome iff AT MOST ONE
+#   letter has an odd count. Encode "parity of each of the 26 letters" as a
+#   26-bit mask -> the condition becomes popcount(mask) <= 1.
+#
+#   let mask[v] = xor of the edge letters on the path root -> v. For any pair
+#   (u, v) the shared prefix down to their LCA cancels out, so
+#       mask(path u..v) = mask[u] ^ mask[v]
+#   and we never have to find the LCA at all.
+#
+#   so: count pairs (u, v) with popcount(mask[u] ^ mask[v]) <= 1, i.e.
+#   mask[v] equals mask[u] or mask[u] ^ (1 << k) for one of the 26 letters.
+#
+#   NOTE : one pass with a running counter avoids double counting - for each
+#          node we look up the 27 candidate masks among the nodes ALREADY
+#          inserted, then insert ourselves. Order of the pass is irrelevant
+#          because we are just counting unordered pairs over the mask list.
+#
+#   NOTE : the root itself must take part (mask 0) - pairs (0, v) are real
+#          pairs, as example 1 shows.
+#
+#   NOTE : parent[i] is NOT guaranteed to be smaller than i, so masks are
+#          computed by an explicit top-down traversal, done ITERATIVELY:
+#          n reaches 1e5 and the tree can be a single chain, which would blow
+#          Python's recursion limit.
+#
+# time = O(26 * n), space = O(n)
+class Solution(object):
+    def countPalindromePaths(self, parent, s):
+        n = len(parent)
+        children = [[] for _ in range(n)]
+        for i in range(1, n):
+            children[parent[i]].append(i)
+
+        # iterative top-down walk: mask[child] = mask[node] ^ bit(s[child])
+        mask = [0] * n
+        stack = [0]
+        while stack:
+            node = stack.pop()
+            base = mask[node]
+            for child in children[node]:
+                mask[child] = base ^ (1 << (ord(s[child]) - ord('a')))
+                stack.append(child)
+
+        res = 0
+        cnt = {}
+        for m in mask:
+            res += cnt.get(m, 0)
+            for k in range(26):
+                res += cnt.get(m ^ (1 << k), 0)
+            cnt[m] = cnt.get(m, 0) + 1
+        return res

--- a/leetcode_python/Depth-First-Search/height-of-special-binary-tree.py
+++ b/leetcode_python/Depth-First-Search/height-of-special-binary-tree.py
@@ -1,0 +1,92 @@
+"""
+
+2773. Height of Special Binary Tree
+Medium
+
+You are given a root, which is the root of a special binary tree with n nodes. The nodes of the special binary tree are numbered from 1 to n. Suppose the tree has k leaves in the following order: b1 < b2 < ... < bk.
+
+The leaves of this tree have a special property! That is, for every leaf bi, the following conditions hold:
+
+The right child of bi is bi + 1 if i < k, and b1 otherwise.
+The left child of bi is bi - 1 if i > 1, and bk otherwise.
+
+Return the height of the given tree.
+
+Note: The height of a binary tree is the length of the longest path from the root to any other node.
+
+
+Example 1:
+
+Input: root = [1,2,3,null,null,4,5]
+Output: 2
+Explanation: The given tree is shown in the following picture. Each leaf's left child is the leaf to its left (shown with the blue edges). Each leaf's right child is the leaf to its right (shown with the red edges). We can see that the graph has a height of 2.
+
+Example 2:
+
+Input: root = [1,2]
+Output: 1
+Explanation: The given tree is shown in the following picture. There is only one leaf, so it doesn't have any left or right child. We can see that the graph has a height of 1.
+
+Example 3:
+
+Input: root = [1,2,3,null,null,4,null,5,6]
+Output: 3
+Explanation: The given tree is shown in the following picture. Each leaf's left child is the leaf to its left (shown with the blue edges). Each leaf's right child is the leaf to its right (shown with the red edges). We can see that the graph has a height of 3.
+
+
+Constraints:
+
+n == number of nodes in the tree
+2 <= n <= 10^4
+1 <= node.val <= n
+The input is generated such that each node.val is unique.
+
+"""
+
+# V0
+# IDEA : DFS THAT FILTERS OUT THE FAKE LEAF-TO-LEAF LINKS
+#
+#   the extra pointers only ever join two LEAVES, and they always come in a
+#   mirrored pair: if leaf u's right pointer is leaf v, then v's left pointer
+#   points straight back at u. That back-pointer is the tell:
+#
+#       u.left  is fake  <=>  u.left.right  is u
+#       u.right is fake  <=>  u.right.left  is u
+#
+#   NOTE : a genuine parent-child edge can never satisfy this — it would make a
+#          2-cycle inside a real tree — so the test never discards a real edge.
+#   NOTE : the k == 1 case still works: the lone leaf points at ITSELF both
+#          ways, so u.left is u and u.left.right is u -> fake, as wanted.
+#
+#   With the fake edges filtered the shape is an ordinary tree, and the height
+#   is the deepest node's depth in edges.
+#
+#   NOTE : n reaches 1e4 and the tree may be a chain, so the walk uses an
+#          explicit stack rather than recursion (Python's default limit is
+#          ~1000 frames).
+#
+# time = O(n), space = O(n)
+# Definition for a binary tree node.
+# class TreeNode(object):
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution(object):
+    def heightOfTree(self, root):
+        if not root:
+            return 0
+
+        res = 0
+        stack = [(root, 0)]
+        while stack:
+            node, depth = stack.pop()
+            if depth > res:
+                res = depth
+            left, right = node.left, node.right
+            if left is not None and left.right is not node:
+                stack.append((left, depth + 1))
+            if right is not None and right.left is not node:
+                stack.append((right, depth + 1))
+
+        return res

--- a/leetcode_python/Dynamic_Programming/count-of-integers.py
+++ b/leetcode_python/Dynamic_Programming/count-of-integers.py
@@ -1,0 +1,82 @@
+"""
+
+2719. Count of Integers
+Hard
+
+You are given two numeric strings num1 and num2 and two integers max_sum and min_sum. We denote an integer x to be good if:
+
+num1 <= x <= num2
+min_sum <= digit_sum(x) <= max_sum.
+
+Return the number of good integers. Since the answer may be large, return it modulo 10^9 + 7.
+
+Note that digit_sum(x) denotes the sum of the digits of x.
+
+
+Example 1:
+
+Input: num1 = "1", num2 = "12", min_sum = 1, max_sum = 8
+Output: 11
+Explanation: There are 11 integers whose sum of digits lies between 1 and 8 are 1,2,3,4,5,6,7,8,10,11, and 12. Thus, we return 11.
+
+Example 2:
+
+Input: num1 = "1", num2 = "5", min_sum = 1, max_sum = 5
+Output: 5
+Explanation: The 5 integers whose sum of digits lies between 1 and 5 are 1,2,3,4, and 5. Thus, we return 5.
+
+
+Constraints:
+
+1 <= num1 <= num2 <= 10^22
+1 <= min_sum <= max_sum <= 400
+
+"""
+
+# V0
+# IDEA : DIGIT DP (count [0, hi] then subtract via prefix difference)
+#
+#   answer = f(num2) - f(num1 - 1), where f(hi) counts x in [0, hi] whose
+#   digit sum falls inside [min_sum, max_sum].
+#
+#   f(hi) is a classic digit DP: scan the decimal digits left -> right,
+#   carrying (pos, running digit sum, tight?) where `tight` means every digit
+#   placed so far equals hi's prefix, so the current digit is capped by hi[pos].
+#
+#   NOTE : only the NON-tight states are memoizable — a tight state depends on
+#          the actual prefix of hi, so it is visited at most once per pos anyway.
+#   NOTE : leading zeros are harmless here, they add 0 to the digit sum, so no
+#          separate "started" flag is needed (min_sum >= 1 already excludes 0).
+#   NOTE : num1 - 1 must be done on the integer (num1 can be 10^22, way past
+#          64-bit, but Python ints are unbounded so int(num1) - 1 is exact).
+#   NOTE : prune s > max_sum early, it keeps the state space at ~n * max_sum.
+#
+# time = O(10 * n * max_sum), space = O(n * max_sum)   (n = len(num2) <= 23)
+class Solution(object):
+    def count(self, num1, num2, min_sum, max_sum):
+        MOD = 10 ** 9 + 7
+
+        def count_upto(num):
+            n = len(num)
+            memo = {}
+
+            def dfs(pos, s, tight):
+                if s > max_sum:
+                    return 0
+                if pos == n:
+                    return 1 if s >= min_sum else 0
+                if not tight and (pos, s) in memo:
+                    return memo[(pos, s)]
+                up = int(num[pos]) if tight else 9
+                res = 0
+                for d in range(up + 1):
+                    res += dfs(pos + 1, s + d, tight and d == up)
+                res %= MOD
+                if not tight:
+                    memo[(pos, s)] = res
+                return res
+
+            return dfs(0, 0, True)
+
+        lo = str(int(num1) - 1)
+        return (count_upto(num2) - count_upto(lo)) % MOD

--- a/leetcode_python/Dynamic_Programming/count-stepping-numbers-in-range.py
+++ b/leetcode_python/Dynamic_Programming/count-stepping-numbers-in-range.py
@@ -1,0 +1,111 @@
+"""
+
+2801. Count Stepping Numbers in Range
+Hard
+
+Given two positive integers low and high represented as strings, find the count of stepping numbers in the inclusive range [low, high].
+
+A stepping number is an integer such that all of its adjacent digits have an absolute difference of exactly 1.
+
+Return an integer denoting the count of stepping numbers in the inclusive range [low, high].
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+Note: A stepping number should not have a leading zero.
+
+
+Example 1:
+
+Input: low = "1", high = "11"
+Output: 10
+Explanation: The stepping numbers in the range [1,11] are 1, 2, 3, 4, 5, 6, 7, 8, 9 and 10. There are a total of 10 stepping numbers in the range. Hence, the output is 10.
+
+Example 2:
+
+Input: low = "90", high = "101"
+Output: 2
+Explanation: The stepping numbers in the range [90,101] are 98 and 101. There are a total of 2 stepping numbers in the range. Hence, the output is 2.
+
+
+Constraints:
+
+1 <= int(low) <= int(high) < 10^100
+1 <= low.length, high.length <= 100
+low and high consist of only digits.
+low and high don't have any leading zeros.
+
+"""
+
+# V0
+# IDEA : DIGIT DP (COUNT [1, high] - COUNT [1, low - 1])
+#
+#   the numbers are up to 100 digits long, so we can never enumerate them.
+#   but "stepping" only constrains ADJACENT digits, so a digit-by-digit dp
+#   carrying just the previous digit is enough.
+#
+#   classic range trick : f(x) = count of stepping numbers in [1, x], and
+#   the answer is f(high) - f(low - 1).
+#
+#   state dfs(pos, pre, lead, limit) :
+#     pos   - index of the digit we are choosing
+#     pre   - digit chosen at pos-1 (-1 while still in leading zeros)
+#     lead  - we have not placed a non-zero digit yet
+#     limit - every digit so far equals high's prefix, so this digit is
+#             capped by num[pos]
+#
+#   NOTE : `lead` is what forbids leading zeros. while lead is on, a chosen
+#          0 keeps us in the "nothing written yet" state instead of becoming
+#          a real digit with a stepping constraint. reaching the end still
+#          in lead means we built the empty number -> contributes 0, which
+#          is exactly why 0 itself is never counted.
+#
+#   NOTE : memoization is only legal for states with lead=False and
+#          limit=False. a limited state depends on the actual bound prefix,
+#          and a leading state has no meaningful `pre`. the cache must also
+#          be reset between the two bounds since `num` changes.
+#
+#   NOTE : low - 1 is computed with python's arbitrary-precision int, so no
+#          manual borrow-subtraction on the digit string is needed. when
+#          low == "1" this yields "0", and dfs correctly returns 0 for it.
+#
+#   NOTE : take the final difference modulo 10^9+7 - the two counts are
+#          already reduced, so a - b can go negative before the mod.
+#
+# time = O(L * 10 * 10), space = O(L * 10)   L = len(high) <= 100
+class Solution(object):
+    def countSteppingNumbers(self, low, high):
+        MOD = 10 ** 9 + 7
+
+        def count(num):
+            memo = {}
+
+            def dfs(pos, pre, lead, limit):
+                if pos == len(num):
+                    # still `lead` -> we placed nothing at all, not a number
+                    return 0 if lead else 1
+                if not lead and not limit and (pos, pre) in memo:
+                    return memo[(pos, pre)]
+
+                up = int(num[pos]) if limit else 9
+                res = 0
+                for d in range(up + 1):
+                    nxt_limit = limit and d == up
+                    if lead:
+                        if d == 0:
+                            res += dfs(pos + 1, -1, True, nxt_limit)
+                        else:
+                            # first real digit : no stepping constraint yet
+                            res += dfs(pos + 1, d, False, nxt_limit)
+                    elif abs(d - pre) == 1:
+                        res += dfs(pos + 1, d, False, nxt_limit)
+                res %= MOD
+
+                if not lead and not limit:
+                    memo[(pos, pre)] = res
+                return res
+
+            return dfs(0, -1, True, True)
+
+        a = count(high)
+        b = count(str(int(low) - 1))
+        return (a - b) % MOD

--- a/leetcode_python/Dynamic_Programming/decremental-string-concatenation.py
+++ b/leetcode_python/Dynamic_Programming/decremental-string-concatenation.py
@@ -1,0 +1,117 @@
+"""
+
+2746. Decremental String Concatenation
+Medium
+
+You are given a 0-indexed array words containing n strings.
+
+Let's define a join operation join(x, y) between two strings x and y as concatenating them into xy. However, if the last character of x is equal to the first character of y, one of them is deleted.
+
+For example join("ab", "ba") = "aba" and join("ab", "cde") = "abcde".
+
+You are to perform n - 1 join operations. Let str0 = words[0]. Starting from i = 1 up to i = n - 1, for the ith operation, you can do one of the following:
+
+Make stri = join(stri - 1, words[i])
+Make stri = join(words[i], stri - 1)
+
+Your task is to minimize the length of strn - 1.
+
+Return an integer denoting the minimum possible length of strn - 1.
+
+
+Example 1:
+
+Input: words = ["aa","ab","bc"]
+Output: 4
+Explanation: In this example, we can perform join operations in the following order to minimize the length of str2:
+str0 = "aa"
+str1 = join(str0, "ab") = "aab"
+str2 = join(str1, "bc") = "aabc"
+It can be shown that the minimum possible length of str2 is 4.
+
+Example 2:
+
+Input: words = ["ab","b"]
+Output: 2
+Explanation: In this example, str0 = "ab", there are two ways to get str1:
+join(str0, "b") = "ab" or join("b", str0) = "bab".
+The first string, "ab", has the minimum length. Hence, the answer is 2.
+
+Example 3:
+
+Input: words = ["aaa","c","aba"]
+Output: 6
+Explanation: In this example, we can perform join operations in the following order to minimize the length of str2:
+str0 = "aaa"
+str1 = join(str0, "c") = "aaac"
+str2 = join("aba", str1) = "abaaac"
+It can be shown that the minimum possible length of str2 is 6.
+
+
+Constraints:
+
+1 <= words.length <= 1000
+1 <= words[i].length <= 50
+Each character in words[i] is an English lowercase letter
+
+"""
+
+# V0
+# IDEA : DP OVER (FIRST CHAR, LAST CHAR) OF THE ACCUMULATED STRING
+#
+#   The only thing about the accumulated string that ever matters for a
+#   FUTURE join is its first character and its last character — the middle is
+#   never touched again. So the state is just (first, last), 26 * 26 = 676
+#   possibilities, and we keep the minimum length reached for each state.
+#
+#   Processing words[i] (call it s, with head = s[0], tail = s[-1]) from a
+#   state (a, b) of length L :
+#     - append  : join(acc, s) -> new state (a, tail),
+#                 length L + len(s) - (1 if head == b else 0)
+#     - prepend : join(s, acc) -> new state (head, b),
+#                 length L + len(s) - (1 if tail == a else 0)
+#
+#   NOTE : the saving is 1 character and only when the touching characters
+#          match — that is the whole "decremental" part of the problem.
+#
+#   NOTE : for a SINGLE-character word, head == tail; appending it after a
+#          string that ends with the same letter still just saves 1 (the
+#          word itself is not consumed), which the formula already gives.
+#
+#   NOTE : this is written BOTTOM-UP on purpose. n can be 1000, so the
+#          natural top-down dfs(i, a, b) would recurse 1000 deep and risk
+#          hitting Python's default recursion limit.
+#
+# time = O(n * 26^2), space = O(26^2)
+class Solution(object):
+    def minimizeConcatenatedLength(self, words):
+        INF = float('inf')
+        # dp[a][b] = min length of an accumulated string starting with 'a'+a
+        #            and ending with 'a'+b
+        dp = [[INF] * 26 for _ in range(26)]
+        first = ord(words[0][0]) - 97
+        last = ord(words[0][-1]) - 97
+        dp[first][last] = len(words[0])
+
+        for s in words[1:]:
+            head = ord(s[0]) - 97
+            tail = ord(s[-1]) - 97
+            size = len(s)
+            nxt = [[INF] * 26 for _ in range(26)]
+            for a in range(26):
+                row = dp[a]
+                for b in range(26):
+                    cur = row[b]
+                    if cur == INF:
+                        continue
+                    # acc + s
+                    cand = cur + size - (1 if head == b else 0)
+                    if cand < nxt[a][tail]:
+                        nxt[a][tail] = cand
+                    # s + acc
+                    cand = cur + size - (1 if tail == a else 0)
+                    if cand < nxt[head][b]:
+                        nxt[head][b] = cand
+            dp = nxt
+
+        return min(min(row) for row in dp)

--- a/leetcode_python/Dynamic_Programming/longest-non-decreasing-subarray-from-two-arrays.py
+++ b/leetcode_python/Dynamic_Programming/longest-non-decreasing-subarray-from-two-arrays.py
@@ -1,0 +1,90 @@
+"""
+
+2771. Longest Non-decreasing Subarray From Two Arrays
+Medium
+
+You are given two 0-indexed integer arrays nums1 and nums2 of length n.
+
+Let's define another 0-indexed integer array, nums3, of length n. For each index i in the range [0, n - 1], you can assign either nums1[i] or nums2[i] to nums3[i].
+
+Your task is to maximize the length of the longest non-decreasing subarray in nums3 by choosing its values optimally.
+
+Return an integer representing the length of the longest non-decreasing subarray in nums3.
+
+Note: A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums1 = [2,3,1], nums2 = [1,2,1]
+Output: 2
+Explanation: One way to construct nums3 is:
+nums3 = [nums1[0], nums2[1], nums2[2]] => [2,2,1].
+The subarray starting from index 0 and ending at index 1, [2,2], forms a non-decreasing subarray of length 2.
+We can show that 2 is the maximum achievable length.
+
+Example 2:
+
+Input: nums1 = [1,3,2,1], nums2 = [2,2,3,4]
+Output: 4
+Explanation: One way to construct nums3 is:
+nums3 = [nums1[0], nums2[1], nums2[2], nums2[3]] => [1,2,3,4].
+The entire array forms a non-decreasing subarray of length 4, making it the maximum achievable length.
+
+Example 3:
+
+Input: nums1 = [1,1], nums2 = [2,2]
+Output: 2
+Explanation: One way to construct nums3 is:
+nums3 = [nums1[0], nums1[1]] => [1,1].
+The entire array forms a non-decreasing subarray of length 2, making it the maximum achievable length.
+
+
+Constraints:
+
+1 <= nums1.length == nums2.length == n <= 10^5
+1 <= nums1[i], nums2[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : DP KEYED ON "WHICH ARRAY DID I TAKE AT i"
+#
+#   the choice at index i only interacts with index i - 1 through the VALUE
+#   actually placed there, and that value is one of two known candidates. So
+#   two states per index suffice:
+#
+#       f[i] = longest non-decreasing run ENDING at i having taken nums1[i]
+#       g[i] = longest non-decreasing run ENDING at i having taken nums2[i]
+#
+#       f[i] = 1 + max( f[i-1] if nums1[i] >= nums1[i-1],
+#                       g[i-1] if nums1[i] >= nums2[i-1] )   (0 if neither)
+#       g[i] = 1 + max( f[i-1] if nums2[i] >= nums1[i-1],
+#                       g[i-1] if nums2[i] >= nums2[i-1] )
+#
+#   NOTE : "ending at i" is the whole trick — a run that ends at i is either
+#          length 1 or extends a run ending at i - 1, so the recurrence is
+#          local and the answer is max over ALL i (not just the last one).
+#   NOTE : n is up to 1e5 -> rolling two scalars instead of two arrays.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maxNonDecreasingLength(self, nums1, nums2):
+        n = len(nums1)
+        f = g = 1                      # runs ending at index 0
+        res = 1
+
+        for i in range(1, n):
+            nf = ng = 1
+            if nums1[i] >= nums1[i - 1]:
+                nf = max(nf, f + 1)
+            if nums1[i] >= nums2[i - 1]:
+                nf = max(nf, g + 1)
+            if nums2[i] >= nums1[i - 1]:
+                ng = max(ng, f + 1)
+            if nums2[i] >= nums2[i - 1]:
+                ng = max(ng, g + 1)
+            f, g = nf, ng
+            res = max(res, f, g)
+
+        return res

--- a/leetcode_python/Dynamic_Programming/maximize-the-profit-as-the-salesman.py
+++ b/leetcode_python/Dynamic_Programming/maximize-the-profit-as-the-salesman.py
@@ -1,0 +1,81 @@
+"""
+
+2830. Maximize the Profit as the Salesman
+Medium
+
+You are given an integer n representing the number of houses on a number line, numbered from 0 to n - 1.
+
+Additionally, you are given a 2D integer array offers where offers[i] = [start_i, end_i, gold_i], indicating that i-th buyer wants to buy all the houses from start_i to end_i for gold_i amount of gold.
+
+As a salesman, your goal is to maximize your earnings by strategically selecting and selling houses to buyers.
+
+Return the maximum amount of gold you can earn.
+
+Note that different buyers can't buy the same house, and some houses may remain unsold.
+
+
+Example 1:
+
+Input: n = 5, offers = [[0,0,1],[0,2,2],[1,3,2]]
+Output: 3
+Explanation: There are 5 houses numbered from 0 to 4 and there are 3 purchase offers.
+We sell houses in the range [0,0] to 1st buyer for 1 gold and houses in the range [1,3] to 3rd buyer for 2 golds.
+It can be proven that 3 is the maximum amount of gold we can achieve.
+
+Example 2:
+
+Input: n = 5, offers = [[0,0,1],[0,2,10],[1,3,2]]
+Output: 10
+Explanation: There are 5 houses numbered from 0 to 4 and there are 3 purchase offers.
+We sell houses in the range [0,2] to 2nd buyer for 10 golds.
+It can be proven that 10 is the maximum amount of gold we can achieve.
+
+
+Constraints:
+
+1 <= n <= 10^5
+1 <= offers.length <= 10^5
+offers[i].length == 3
+0 <= start_i <= end_i <= n - 1
+1 <= gold_i <= 10^3
+
+"""
+
+# V0
+# IDEA : DP OVER HOUSES (weighted interval scheduling, bucketed by end)
+#
+#   This is weighted interval scheduling. Instead of sorting the offers and
+#   binary-searching the previous compatible one, index the DP by HOUSE,
+#   which is O(n + m) and avoids the log factor entirely:
+#
+#       dp[j] = max gold obtainable using only houses 0 .. j-1
+#       dp[j] = max( dp[j - 1],                          # house j-1 unsold
+#                    max over offers ending at j-1 of
+#                        dp[start] + gold )              # take that offer
+#
+#   NOTE : dp is 1-indexed over houses so dp[start] means "everything strictly
+#          before start", which is exactly the region an offer [start, end]
+#          leaves free. No off-by-one adjustment is needed.
+#
+#   NOTE : bucket the offers by their end house first, so each offer is
+#          examined exactly once as the sweep passes its end.
+#
+#   NOTE : iteration only, no recursion — n and offers.length both reach 10^5.
+#
+# time = O(n + m), space = O(n + m)
+class Solution(object):
+    def maximizeTheProfit(self, n, offers):
+        # by_end[e] = list of (start, gold) for offers finishing at house e
+        by_end = [[] for _ in range(n)]
+        for s, e, g in offers:
+            by_end[e].append((s, g))
+
+        dp = [0] * (n + 1)
+        for j in range(1, n + 1):
+            best = dp[j - 1]
+            for s, g in by_end[j - 1]:
+                cand = dp[s] + g
+                if cand > best:
+                    best = cand
+            dp[j] = best
+        return dp[n]

--- a/leetcode_python/Dynamic_Programming/maximum-number-of-jumps-to-reach-the-last-index.py
+++ b/leetcode_python/Dynamic_Programming/maximum-number-of-jumps-to-reach-the-last-index.py
@@ -1,0 +1,89 @@
+"""
+
+2770. Maximum Number of Jumps to Reach the Last Index
+Medium
+
+You are given a 0-indexed array nums of n integers and an integer target.
+
+You are initially positioned at index 0. In one step, you can jump from index i to any index j such that:
+
+0 <= i < j < n
+-target <= nums[j] - nums[i] <= target
+
+Return the maximum number of jumps you can make to reach index n - 1.
+
+If there is no way to reach index n - 1, return -1.
+
+
+Example 1:
+
+Input: nums = [1,3,6,4,1,2], target = 2
+Output: 3
+Explanation: To go from index 0 to index n - 1 with the maximum number of jumps, you can perform the following jumping sequence:
+- Jump from index 0 to index 1.
+- Jump from index 1 to index 3.
+- Jump from index 3 to index 5.
+It can be proven that there is no other jumping sequence that goes from 0 to n - 1 with more than 3 jumps. Hence, the answer is 3.
+
+Example 2:
+
+Input: nums = [1,3,6,4,1,2], target = 3
+Output: 5
+Explanation: To go from index 0 to index n - 1 with the maximum number of jumps, you can perform the following jumping sequence:
+- Jump from index 0 to index 1.
+- Jump from index 1 to index 2.
+- Jump from index 2 to index 3.
+- Jump from index 3 to index 4.
+- Jump from index 4 to index 5.
+It can be proven that there is no other jumping sequence that goes from 0 to n - 1 with more than 5 jumps. Hence, the answer is 5.
+
+Example 3:
+
+Input: nums = [1,3,6,4,1,2], target = 0
+Output: -1
+Explanation: It can be proven that there is no jumping sequence that goes from 0 to n - 1. Hence, the answer is -1.
+
+
+Constraints:
+
+2 <= nums.length == n <= 1000
+-10^9 <= nums[i] <= 10^9
+0 <= target <= 2 * 10^9
+
+"""
+
+# V0
+# IDEA : LONGEST-PATH DP ON A DAG (jumps only go forward, so index order works)
+#
+#   dp[j] = max number of jumps to land on index j starting from index 0
+#
+#       dp[0] = 0
+#       dp[j] = 1 + max{ dp[i] : i < j and |nums[j] - nums[i]| <= target }
+#
+#   NOTE : we want the MAXIMUM number of jumps, so unreachable states must not
+#          be allowed to seed anything — mark them -1 (here -inf via a guard)
+#          and skip them when relaxing.
+#   NOTE : edges always point from a smaller index to a larger one, so scanning
+#          j left to right is already a topological order — no recursion needed.
+#
+#   answer = dp[n - 1] (or -1 if the last index is unreachable)
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def maximumJumps(self, nums, target):
+        n = len(nums)
+        NEG = -1                       # sentinel: index not reachable yet
+        dp = [NEG] * n
+        dp[0] = 0
+
+        for j in range(1, n):
+            best = NEG
+            for i in range(j):
+                if dp[i] == NEG:
+                    continue
+                if abs(nums[j] - nums[i]) <= target:
+                    if dp[i] + 1 > best:
+                        best = dp[i] + 1
+            dp[j] = best
+
+        return dp[n - 1]

--- a/leetcode_python/Dynamic_Programming/maximum-strictly-increasing-cells-in-a-matrix.py
+++ b/leetcode_python/Dynamic_Programming/maximum-strictly-increasing-cells-in-a-matrix.py
@@ -1,0 +1,93 @@
+"""
+
+2713. Maximum Strictly Increasing Cells in a Matrix
+Hard
+
+Given a 1-indexed m x n integer matrix mat, you can select any cell in the matrix as your starting cell.
+
+From the starting cell, you can move to any other cell in the same row or column, but only if the value of the destination cell is strictly greater than the value of the current cell. You can repeat this process as many times as possible, moving from cell to cell until you can no longer make any moves.
+
+Your task is to find the maximum number of cells that you can visit in the matrix by starting from some cell.
+
+Return an integer denoting the maximum number of cells that can be visited.
+
+
+Example 1:
+
+Input: mat = [[3,1],[3,4]]
+Output: 2
+Explanation: The image shows how we can visit 2 cells starting from row 1, column 2. It can be shown that we cannot visit more than 2 cells no matter where we start from, so the answer is 2.
+
+Example 2:
+
+Input: mat = [[1,1],[1,1]]
+Output: 1
+Explanation: Since the cells must be strictly increasing, we can only visit one cell in this example.
+
+Example 3:
+
+Input: mat = [[3,1,6],[-9,5,7]]
+Output: 4
+Explanation: The image above shows how we can visit 4 cells starting from row 2, column 1. It can be shown that we cannot visit more than 4 cells no matter where we start from, so the answer is 4.
+
+
+Constraints:
+
+m == mat.length
+n == mat[i].length
+1 <= m, n <= 10^5
+1 <= m * n <= 10^5
+-10^5 <= mat[i][j] <= 10^5
+
+"""
+
+# V0
+# IDEA : SORT BY VALUE + DP with PER-ROW / PER-COLUMN MAXIMA
+#
+#   let f[i][j] = longest strictly increasing path ENDING at cell (i, j).
+#   a predecessor must sit in row i or column j with a strictly smaller value,
+#   so
+#       f[i][j] = 1 + max( best f over row i with smaller value,
+#                          best f over col j with smaller value )
+#
+#   process the cells in INCREASING value order and keep
+#       rowMax[i] = max f over the cells of row i already processed
+#       colMax[j] = max f over the cells of col j already processed
+#   then the two maxima above are exactly rowMax[i] and colMax[j].
+#
+#   NOTE : "strictly" greater is the whole trick for EQUAL values. All cells
+#          sharing one value must be handled as a BATCH: first READ
+#          rowMax/colMax for every cell of the batch, only THEN write the
+#          results back. Interleaving read and write would let one cell use
+#          another cell of the same value as its predecessor.
+#   NOTE : m * n <= 10^5 but m (or n) alone can be 10^5, so allocate
+#          rowMax/colMax by their own lengths, and iterate (no recursion).
+#
+# time = O(m * n * log(m * n)), space = O(m * n)
+class Solution(object):
+    def maxIncreasingCells(self, mat):
+        m, n = len(mat), len(mat[0])
+
+        groups = {}
+        for i in range(m):
+            row = mat[i]
+            for j in range(n):
+                groups.setdefault(row[j], []).append((i, j))
+
+        row_max = [0] * m
+        col_max = [0] * n
+        ans = 0
+        for v in sorted(groups):
+            cells = groups[v]
+            # pass 1 : read only
+            cur = [1 + max(row_max[i], col_max[j]) for i, j in cells]
+            # pass 2 : write back
+            for k in range(len(cells)):
+                i, j = cells[k]
+                if cur[k] > row_max[i]:
+                    row_max[i] = cur[k]
+                if cur[k] > col_max[j]:
+                    col_max[j] = cur[k]
+                if cur[k] > ans:
+                    ans = cur[k]
+        return ans

--- a/leetcode_python/Dynamic_Programming/minimum-time-to-make-array-sum-at-most-x.py
+++ b/leetcode_python/Dynamic_Programming/minimum-time-to-make-array-sum-at-most-x.py
@@ -1,0 +1,98 @@
+"""
+
+2809. Minimum Time to Make Array Sum At Most x
+Hard
+
+You are given two 0-indexed integer arrays nums1 and nums2 of equal length. Every second, for all indices 0 <= i < nums1.length, value of nums1[i] is incremented by nums2[i]. After this is done, you can do the following operation:
+
+Choose an index 0 <= i < nums1.length and make nums1[i] = 0.
+
+You are also given an integer x.
+
+Return the minimum time in which you can make the sum of all elements of nums1 to be less than or equal to x, or -1 if this is not possible.
+
+
+Example 1:
+
+Input: nums1 = [1,2,3], nums2 = [1,2,3], x = 4
+Output: 3
+Explanation:
+For the 1st second, we apply the operation on i = 0. Therefore nums1 = [0,2+2,3+3] = [0,4,6].
+For the 2nd second, we apply the operation on i = 1. Therefore nums1 = [0+1,0,6+3] = [1,0,9].
+For the 3rd second, we apply the operation on i = 2. Therefore nums1 = [1+1,0+2,0] = [2,2,0].
+Now sum of nums1 = 4. It can be shown that these operations are optimal, so we return 3.
+
+Example 2:
+
+Input: nums1 = [1,2,3], nums2 = [3,3,3], x = 4
+Output: -1
+Explanation: It can be shown that the sum of nums1 will always be greater than x, no matter which operations are performed.
+
+
+Constraints:
+
+1 <= nums1.length <= 10^3
+1 <= nums1[i] <= 10^3
+0 <= nums2[i] <= 10^3
+nums1.length == nums2.length
+0 <= x <= 10^6
+
+"""
+
+# V0
+# IDEA : SORT BY nums2 + KNAPSACK-STYLE DP OVER "HOW MANY WE ZERO OUT"
+#
+#   after t seconds with NO operation the sum would be
+#       s1 + s2 * t          (s1 = sum(nums1), s2 = sum(nums2))
+#   each index we zero out at second j removes, from the final sum,
+#       nums1[i] + nums2[i] * j
+#   (its own start value plus the j increments it accumulated by then).
+#
+#   two structural facts :
+#     - zeroing the same index twice is wasted : only the last reset counts,
+#       so we reset at most n distinct indices and the answer t is in [0, n]
+#     - GREEDY ORDER : if we decide to reset a set of indices, the one with
+#       the LARGER nums2 should be reset LATER (bigger multiplier j on a
+#       bigger growth rate). so sorting by nums2 ascending fixes an optimal
+#       order and turns the problem into a subset-selection dp.
+#
+#   dp : after considering the first i sorted items, f[j] = the maximum
+#   total reduction achievable by resetting exactly j of them
+#       f[j] = max(f[j], f[j-1] + a + b * j)
+#   where the j-th reset happens at second j.
+#
+#   then the smallest t with  s1 + s2 * t - f[t] <= x  is the answer;
+#   if no t in [0, n] works, return -1.
+#
+#   NOTE : the inner loop must run j from n DOWN to 1 for the 1-D rolling
+#          array, otherwise f[j-1] would already be this item's value and
+#          the item could be reset twice.
+#
+#   NOTE : t is never worth pushing beyond n - past that point every index
+#          has already been reset once and extra seconds only add growth.
+#
+#   NOTE : sort the PAIRS by nums2, not the two arrays independently - the
+#          (nums1[i], nums2[i]) pairing must be preserved.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def minimumTime(self, nums1, nums2, x):
+        n = len(nums1)
+
+        # larger growth rate -> reset later -> larger multiplier
+        pairs = sorted(zip(nums1, nums2), key=lambda p: p[1])
+
+        f = [0] * (n + 1)
+        for a, b in pairs:
+            # descending j : each item usable at most once
+            for j in range(n, 0, -1):
+                cand = f[j - 1] + a + b * j
+                if cand > f[j]:
+                    f[j] = cand
+
+        s1 = sum(nums1)
+        s2 = sum(nums2)
+        for t in range(n + 1):
+            if s1 + s2 * t - f[t] <= x:
+                return t
+        return -1

--- a/leetcode_python/Dynamic_Programming/number-of-beautiful-integers-in-the-range.py
+++ b/leetcode_python/Dynamic_Programming/number-of-beautiful-integers-in-the-range.py
@@ -1,0 +1,114 @@
+"""
+
+2827. Number of Beautiful Integers in the Range
+Hard
+
+You are given positive integers low, high, and k.
+
+A number is beautiful if it meets both of the following conditions:
+
+The count of even digits in the number is equal to the count of odd digits.
+The number is divisible by k.
+
+Return the number of beautiful integers in the range [low, high].
+
+
+Example 1:
+
+Input: low = 10, high = 20, k = 3
+Output: 2
+Explanation: There are 2 beautiful integers in the given range: [12,18].
+- 12 is beautiful because it contains 1 odd digit and 1 even digit, and is divisible by k = 3.
+- 18 is beautiful because it contains 1 odd digit and 1 even digit, and is divisible by k = 3.
+Additionally we can see that:
+- 16 is not beautiful because it is not divisible by k = 3.
+- 15 is not beautiful because it does not contain equal counts even and odd digits.
+It can be shown that there are only 2 beautiful integers in the given range.
+
+Example 2:
+
+Input: low = 1, high = 10, k = 1
+Output: 1
+Explanation: There is 1 beautiful integer in the given range: [10].
+- 10 is beautiful because it contains 1 odd digit and 1 even digit, and is divisible by k = 1.
+It can be shown that there is only 1 beautiful integer in the given range.
+
+Example 3:
+
+Input: low = 5, high = 5, k = 2
+Output: 0
+Explanation: There are 0 beautiful integers in the given range.
+- 5 is not beautiful because it is not divisible by k = 2 and it does not contain equal even and odd digits.
+
+
+Constraints:
+
+0 < low <= high <= 10^9
+0 < k <= 20
+
+"""
+
+# V0
+# IDEA : DIGIT DP + PREFIX SUBTRACTION
+#
+#   count(x) = number of beautiful integers in [1, x], so the answer is
+#   count(high) - count(low - 1).
+#
+#   Build x digit by digit, carrying 4 pieces of state:
+#     pos   : index into str(x) we are about to fill
+#     mod   : value built so far, modulo k  (k <= 20, so <= 20 states)
+#     diff  : (#odd digits) - (#even digits) placed so far; "beautiful"
+#             means diff == 0 at the end. Range is [-10, 10] for 10 digits.
+#     lead  : still in the leading-zero run, i.e. no significant digit yet
+#     limit : the prefix so far exactly matches str(x)'s prefix, so the next
+#             digit is capped at str(x)[pos]
+#
+#   NOTE : leading zeros must NOT be counted as even digits — "12" has one
+#          even and one odd digit, not nine extra evens. While lead is true
+#          we place a 0 without touching mod/diff.
+#
+#   NOTE : a number that is ALL leading zeros is the integer 0, which is not
+#          in [1, x]. Hence the explicit `not lead` guard at pos == n, and
+#          count(x) returning 0 for x <= 0 (low - 1 can be 0).
+#
+#   NOTE : memoizing on the full 5-tuple is safe (not just on the
+#          lead=limit=False states): for a fixed pos there is exactly one
+#          prefix with limit=True and exactly one with lead=True, so those
+#          keys are never shared between different prefixes.
+#
+#   NOTE : the memo must be rebuilt per call to count() — it is keyed by
+#          position within a specific str(x).
+#
+# time = O(log(x) * k * d * 10) per bound, space = O(log(x) * k * d)
+class Solution(object):
+    def numberOfBeautifulIntegers(self, low, high, k):
+        return self._count(high, k) - self._count(low - 1, k)
+
+    def _count(self, x, k):
+        if x <= 0:
+            return 0
+        s = str(x)
+        n = len(s)
+        memo = {}
+
+        def dfs(pos, mod, diff, lead, limit):
+            if pos == n:
+                if lead:
+                    return 0
+                return 1 if (mod == 0 and diff == 0) else 0
+            key = (pos, mod, diff, lead, limit)
+            if key in memo:
+                return memo[key]
+            up = int(s[pos]) if limit else 9
+            res = 0
+            for d in range(up + 1):
+                nxt_limit = limit and (d == up)
+                if d == 0 and lead:
+                    res += dfs(pos + 1, 0, 0, True, nxt_limit)
+                else:
+                    nxt_diff = diff + (1 if d % 2 else -1)
+                    res += dfs(pos + 1, (mod * 10 + d) % k, nxt_diff, False, nxt_limit)
+            memo[key] = res
+            return res
+
+        return dfs(0, 0, 0, True, True)

--- a/leetcode_python/Dynamic_Programming/painting-the-walls.py
+++ b/leetcode_python/Dynamic_Programming/painting-the-walls.py
@@ -1,0 +1,78 @@
+"""
+
+2742. Painting the Walls
+Hard
+
+You are given two 0-indexed integer arrays, cost and time, of size n representing the costs and the time taken to paint n different walls respectively. There are two painters available:
+
+A paid painter that paints the ith wall in time[i] units of time and takes cost[i] units of money.
+A free painter that paints any wall in 1 unit of time at a cost of 0. But the free painter can only be used if the paid painter is already occupied.
+
+Return the minimum amount of money required to paint the n walls.
+
+
+Example 1:
+
+Input: cost = [1,2,3,2], time = [1,2,3,2]
+Output: 3
+Explanation: The walls at index 0 and 1 will be painted by the paid painter, and it will take 3 units of time; meanwhile, the free painter will paint the walls at index 2 and 3, free of cost in 2 units of time. Thus, the total cost is 1 + 2 = 3.
+
+Example 2:
+
+Input: cost = [2,3,4,2], time = [1,1,1,1]
+Output: 4
+Explanation: The walls at index 0 and 3 will be painted by the paid painter, and it will take 2 units of time; meanwhile, the free painter will paint the walls at index 1 and 2, free of cost in 2 units of time. Thus, the total cost is 2 + 2 = 4.
+
+
+Constraints:
+
+1 <= cost.length <= 500
+cost.length == time.length
+1 <= cost[i] <= 10^6
+1 <= time[i] <= 500
+
+"""
+
+# V0
+# IDEA : REPHRASE AS A 0/1 KNAPSACK ("BUY ENOUGH TIME TO COVER n WALLS")
+#
+#   Say S is the set of walls given to the PAID painter. He is busy for
+#   sum(time[i] for i in S) units of time, and during every one of those
+#   units the free painter finishes exactly 1 wall. So the free painter can
+#   handle at most sum(time[i]) walls, while |S| walls are already done by
+#   the paid painter. The choice S is feasible iff
+#
+#       sum(time[i] for i in S) + |S| >= n
+#       <=> sum(time[i] + 1 for i in S) >= n
+#
+#   So each wall i is an item of "weight" time[i] + 1 and "value" cost[i],
+#   and we want the CHEAPEST subset whose weight reaches n. That is a 0/1
+#   knapsack with a >= target, i.e. a covering knapsack.
+#
+#   dp[j] = min cost to accumulate j units of coverage.
+#
+#   NOTE : coverage is CAPPED at n via max(0, j - w) — overshooting the
+#          target is fine and must not fall off the array.
+#
+#   NOTE : the inner loop must go DOWNWARD so each wall is used at most once
+#          (standard 0/1 knapsack in-place trick).
+#
+#   NOTE : dp[n] is always reachable — hiring the paid painter for every wall
+#          gives coverage >= n — so no INF ever survives at the answer.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def paintWalls(self, cost, time):
+        n = len(cost)
+        INF = float('inf')
+        dp = [INF] * (n + 1)
+        dp[0] = 0
+
+        for c, t in zip(cost, time):
+            w = t + 1
+            for j in range(n, 0, -1):
+                prev = dp[j - w] if j - w > 0 else dp[0]
+                if prev + c < dp[j]:
+                    dp[j] = prev + c
+
+        return dp[n]

--- a/leetcode_python/Dynamic_Programming/sorting-three-groups.py
+++ b/leetcode_python/Dynamic_Programming/sorting-three-groups.py
@@ -1,0 +1,71 @@
+"""
+
+2826. Sorting Three Groups
+Medium
+
+You are given an integer array nums. Each element in nums is 1, 2 or 3. In each operation, you can remove an element from nums. Return the minimum number of operations to make nums non-decreasing.
+
+
+Example 1:
+
+Input: nums = [2,1,3,2,1]
+Output: 3
+Explanation:
+One of the optimal solutions is to remove nums[0], nums[2] and nums[3].
+
+Example 2:
+
+Input: nums = [1,3,2,1,3,3]
+Output: 2
+Explanation:
+One of the optimal solutions is to remove nums[1] and nums[2].
+
+Example 3:
+
+Input: nums = [2,2,2,2,3,3]
+Output: 0
+Explanation:
+nums is already non-decreasing.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= nums[i] <= 3
+
+Follow-up: Can you come up with an algorithm that runs in O(n) time complexity?
+
+"""
+
+# V0
+# IDEA : DP (removals = n - longest non-decreasing subsequence)
+#
+#   Whatever we keep must itself be non-decreasing, and anything
+#   non-decreasing can be kept, so the minimum number of removals is
+#   n - LNDS(nums). Because values are only 1..3, the usual O(n log n)
+#   LNDS collapses to an O(n) scan over 3 buckets.
+#
+#   Let f[j] = length of the longest non-decreasing subsequence built so far
+#   whose LAST value is <= j + 1  (j = 0, 1, 2). f is non-decreasing by
+#   construction, so max(f[:x]) is simply f[x - 1].
+#
+#   On seeing value x we may append it to any subsequence ending in <= x:
+#       f[x - 1] = f[x - 1] + 1
+#   and then restore the "<=" prefix-max invariant for the buckets above it.
+#
+#   NOTE : the answer is len(nums) - f[2], not f[2] itself.
+#
+#   NOTE : this is the O(n) / O(1) follow-up answer — no per-element loop
+#          over all previous indices is needed.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumOperations(self, nums):
+        # f[j] : LNDS length whose last kept value is <= j + 1
+        f = [0, 0, 0]
+        for x in nums:
+            f[x - 1] += 1
+            for j in range(x, 3):
+                if f[j] < f[j - 1]:
+                    f[j] = f[j - 1]
+        return len(nums) - f[2]

--- a/leetcode_python/Dynamic_Programming/visit-array-positions-to-maximize-score.py
+++ b/leetcode_python/Dynamic_Programming/visit-array-positions-to-maximize-score.py
@@ -1,0 +1,75 @@
+"""
+
+2786. Visit Array Positions to Maximize Score
+Medium
+
+You are given a 0-indexed integer array nums and a positive integer x.
+
+You are initially at position 0 in the array and you can visit other positions according to the following rules:
+
+If you are currently in position i, then you can move to any position j such that i < j.
+For each position i that you visit, you get a score of nums[i].
+If you move from a position i to a position j and the parities of nums[i] and nums[j] differ, then you lose a score of x.
+
+Return the maximum total score you can get.
+
+Note that initially you have nums[0] points.
+
+
+Example 1:
+
+Input: nums = [2,3,6,1,9,2], x = 5
+Output: 13
+Explanation: We can visit the following positions in the array: 0 -> 2 -> 3 -> 4.
+The corresponding values are 2, 6, 1 and 9. Since the integers 6 and 1 have different parities, the move 2 -> 3 will make you lose a score of x = 5.
+The total score will be: 2 + 6 + 1 + 9 - 5 = 13.
+
+Example 2:
+
+Input: nums = [2,4,6,8], x = 3
+Output: 20
+Explanation: All the integers in the array have the same parities, so we can visit all of them without losing any score.
+The total score is: 2 + 4 + 6 + 8 = 20.
+
+
+Constraints:
+
+2 <= nums.length <= 10^5
+1 <= nums[i], x <= 10^6
+
+"""
+
+# V0
+# IDEA : DP ON PARITY (2 ROLLING STATES)
+#
+#   the penalty depends only on the PARITY of the previous visited value, not
+#   on which index it was. So the whole history collapses into 2 numbers:
+#     dp[0] = best score of a path whose last visited value is even
+#     dp[1] = best score of a path whose last visited value is odd
+#
+#   for each value v (left to right), with p = v & 1:
+#     dp[p] = max(dp[p], dp[p ^ 1] - x) + v
+#   i.e. either continue from a same-parity tail (free) or from the opposite
+#   parity tail (pay x), then collect v.
+#
+#   NOTE : we ALWAYS take v when we update dp[p]; skipping position i is
+#          modelled by simply not letting it overwrite a better dp[p].
+#          Since nums[i] >= 1, extending is never harmful within the same
+#          parity, and max() keeps the better of the two options anyway.
+#
+#   NOTE : position 0 is mandatory -> seed dp[nums[0] & 1] = nums[0] and set
+#          the OTHER parity to -inf so no path can start off-index-0.
+#
+#   NOTE : forced iteration (n up to 1e5); no recursion.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maxScore(self, nums, x):
+        NEG = float('-inf')
+        dp = [NEG, NEG]
+        dp[nums[0] & 1] = nums[0]
+        for i in range(1, len(nums)):
+            v = nums[i]
+            p = v & 1
+            dp[p] = max(dp[p], dp[p ^ 1] - x) + v
+        return max(dp)

--- a/leetcode_python/Dynamic_Programming/ways-to-express-an-integer-as-sum-of-powers.py
+++ b/leetcode_python/Dynamic_Programming/ways-to-express-an-integer-as-sum-of-powers.py
@@ -1,0 +1,68 @@
+"""
+
+2787. Ways to Express an Integer as Sum of Powers
+Medium
+
+Given two positive integers n and x.
+
+Return the number of ways n can be expressed as the sum of the xth power of unique positive integers, in other words, the number of sets of unique integers [n1, n2, ..., nk] where n = n1^x + n2^x + ... + nk^x.
+
+Since the result can be very large, return it modulo 10^9 + 7.
+
+For example, if n = 160 and x = 3, one way to express n is n = 2^3 + 3^3 + 5^3.
+
+
+Example 1:
+
+Input: n = 10, x = 2
+Output: 1
+Explanation: We can express n as the following: n = 3^2 + 1^2 = 10.
+It can be shown that it is the only way to express 10 as the sum of the 2nd power of unique integers.
+
+Example 2:
+
+Input: n = 4, x = 1
+Output: 2
+Explanation: We can express n in the following ways:
+- n = 4^1 = 4.
+- n = 3^1 + 1^1 = 4.
+
+
+Constraints:
+
+1 <= n <= 300
+1 <= x <= 5
+
+"""
+
+# V0
+# IDEA : 0/1 KNAPSACK (COUNT SUBSETS SUMMING TO n)
+#
+#   each base integer i contributes the item weight i^x and may be used AT
+#   MOST ONCE ("unique positive integers") -> classic 0/1 knapsack counting.
+#
+#   dp[j] = number of subsets of the bases processed so far whose powers
+#           sum to exactly j.   dp[0] = 1 (the empty subset).
+#
+#   NOTE : the inner loop MUST run downward (j from n to k). Iterating upward
+#          would let the same base be reused, which turns this into unbounded
+#          knapsack and over-counts.
+#
+#   NOTE : we only need bases i with i^x <= n, so the loop stops as soon as
+#          i^x exceeds n (for x = 5 and n = 300 that is just i <= 3).
+#
+#   NOTE : take the answer mod 1e9+7 as we go.
+#
+# time = O(n * n^(1/x)), space = O(n)
+class Solution(object):
+    def numberOfWays(self, n, x):
+        MOD = 10 ** 9 + 7
+        dp = [0] * (n + 1)
+        dp[0] = 1
+        i = 1
+        while i ** x <= n:
+            k = i ** x
+            for j in range(n, k - 1, -1):
+                dp[j] = (dp[j] + dp[j - k]) % MOD
+            i += 1
+        return dp[n]

--- a/leetcode_python/Graph/find-shortest-path-with-k-hops.py
+++ b/leetcode_python/Graph/find-shortest-path-with-k-hops.py
@@ -1,0 +1,93 @@
+"""
+
+2714. Find Shortest Path with K Hops
+Hard
+
+You are given a positive integer n which is the number of nodes of a 0-indexed undirected weighted connected graph and a 0-indexed 2D array edges where edges[i] = [ui, vi, wi] indicates that there is an edge between nodes ui and vi with weight wi.
+
+You are also given two nodes s and d, and a positive integer k, your task is to find the shortest path from s to d, but you can hop over at most k edges. In other words, make the weight of at most k edges 0 and then find the shortest path from s to d.
+
+Return the length of the shortest path from s to d with the given condition.
+
+
+Example 1:
+
+Input: n = 4, edges = [[0,1,4],[0,2,2],[2,3,6]], s = 1, d = 3, k = 2
+Output: 2
+Explanation: In this example there is only one path from node 1 (the green node) to node 3 (the red node), which is (1->0->2->3) and the length of it is 4 + 2 + 6 = 12. Now we can make weight of two edges 0, we make weight of the blue edges 0, then we have 0 + 2 + 0 = 2. It can be shown that 2 is the minimum length of a path we can achieve with the given condition.
+
+Example 2:
+
+Input: n = 7, edges = [[3,1,9],[3,2,4],[4,0,9],[0,5,6],[3,6,2],[6,0,4],[1,2,4]], s = 4, d = 1, k = 2
+Output: 6
+Explanation: In this example there are 2 paths from node 4 (the green node) to node 1 (the red node), which are (4->0->6->3->2->1) and (4->0->6->3->1). The first one has the length 9 + 4 + 2 + 4 + 4 = 23, and the second one has the length 9 + 4 + 2 + 9 = 24. Now if we make weight of the blue edges 0, we get the shortest path with the length 0 + 4 + 2 + 0 = 6. It can be shown that 6 is the minimum length of a path we can achieve with the given condition.
+
+Example 3:
+
+Input: n = 5, edges = [[0,4,2],[0,1,3],[0,2,1],[2,1,4],[1,3,4],[3,4,7]], s = 2, d = 3, k = 1
+Output: 3
+Explanation: In this example there are 4 paths from node 2 (the green node) to node 3 (the red node), which are (2->1->3), (2->0->1->3), (2->1->0->4->3) and (2->0->4->3). The first two have the length 4 + 4 = 1 + 3 + 4 = 8, the third one has the length 4 + 3 + 2 + 7 = 16 and the last one has the length 1 + 2 + 7 = 10. Now if we make weight of the blue edge 0, we get the shortest path with the length 1 + 2 + 0 = 3. It can be shown that 3 is the minimum length of a path we can achieve with the given condition.
+
+
+Constraints:
+
+2 <= n <= 500
+n - 1 <= edges.length <= min(10^4, n * (n - 1) / 2)
+edges[i].length = 3
+0 <= edges[i][0], edges[i][1] <= n - 1
+1 <= edges[i][2] <= 10^6
+0 <= s, d, k <= n - 1
+s != d
+The input is generated such that the graph is connected and has no repeated edges or self-loops
+
+"""
+
+import heapq
+
+# V0
+# IDEA : DIJKSTRA on the LAYERED STATE GRAPH (node, #hops used so far)
+#
+#   the choice "which edges do I zero out" cannot be made up front, so we fold
+#   it into the state: dist[u][t] = cheapest way to reach node u having already
+#   spent t of the k free hops. From a state (u, t) each incident edge (u,v,w)
+#   offers two transitions:
+#
+#       pay the edge  ->  (v, t)     with cost dis + w
+#       hop the edge  ->  (v, t + 1) with cost dis      (only if t < k)
+#
+#   all transition costs are >= 0, so plain Dijkstra over the n * (k + 1)
+#   states is correct. The answer is min(dist[d][0..k]).
+#
+#   NOTE : spending FEWER hops is never forced to be better or worse, so we
+#          must take the min over ALL t at the destination, not just t == k.
+#   NOTE : the heap can hold stale entries (a state re-pushed with a smaller
+#          key); skip a popped entry whose distance no longer matches the best
+#          known one, otherwise each state gets expanded many times.
+#   NOTE : the graph is UNDIRECTED - insert both directions.
+#
+# time = O(E * k * log(V * k)), space = O(n * k)
+class Solution(object):
+    def shortestPathWithHops(self, n, edges, s, d, k):
+        g = [[] for _ in range(n)]
+        for u, v, w in edges:
+            g[u].append((v, w))
+            g[v].append((u, w))
+
+        INF = float('inf')
+        dist = [[INF] * (k + 1) for _ in range(n)]
+        dist[s][0] = 0
+        pq = [(0, s, 0)]
+        while pq:
+            dis, u, t = heapq.heappop(pq)
+            if dis > dist[u][t]:
+                continue          # stale heap entry
+            if u == d:
+                return dis        # first pop of d is already optimal
+            for v, w in g[u]:
+                if dis + w < dist[v][t]:
+                    dist[v][t] = dis + w
+                    heapq.heappush(pq, (dis + w, v, t))
+                if t < k and dis < dist[v][t + 1]:
+                    dist[v][t + 1] = dis
+                    heapq.heappush(pq, (dis, v, t + 1))
+        return min(dist[d])

--- a/leetcode_python/Graph/find-the-closest-marked-node.py
+++ b/leetcode_python/Graph/find-the-closest-marked-node.py
@@ -1,0 +1,93 @@
+"""
+
+2737. Find the Closest Marked Node
+Medium
+
+You are given a positive integer n which is the number of nodes of a 0-indexed directed weighted graph and a 0-indexed 2D array edges where edges[i] = [ui, vi, wi] indicates that there is an edge from node ui to node vi with weight wi.
+
+You are also given a node s and a node array marked; your task is to find the minimum distance from s to any of the nodes in marked.
+
+Return an integer denoting the minimum distance from s to any node in marked or -1 if there are no paths from s to any of the marked nodes.
+
+
+Example 1:
+
+Input: n = 4, edges = [[0,1,1],[1,2,3],[2,3,2],[0,3,4]], s = 0, marked = [2,3]
+Output: 4
+Explanation: There is one path from node 0 (the green node) to node 2 (a red node), which is 0->1->2, and has a distance of 1 + 3 = 4.
+There are two paths from node 0 to node 3 (a red node), which are 0->1->2->3 and 0->3, the first one has a distance of 1 + 3 + 2 = 6 and the second one has a distance of 4.
+The minimum of them is 4.
+
+Example 2:
+
+Input: n = 5, edges = [[0,1,2],[0,2,4],[1,3,1],[2,3,3],[3,4,2]], s = 1, marked = [0,4]
+Output: 3
+Explanation: There are no paths from node 1 (the green node) to node 0 (a red node).
+There is one path from node 1 to node 4 (a red node), which is 1->3->4, and has a distance of 1 + 2 = 3.
+So the answer is 3.
+
+Example 3:
+
+Input: n = 4, edges = [[0,1,1],[1,2,3],[2,3,2]], s = 3, marked = [0,1]
+Output: -1
+Explanation: There are no paths from node 3 (the green node) to any of the marked nodes (the red nodes), so the answer is -1.
+
+
+Constraints:
+
+2 <= n <= 500
+1 <= edges.length <= 10^4
+edges[i].length = 3
+0 <= edges[i][0], edges[i][1] <= n - 1
+1 <= edges[i][2] <= 10^6
+1 <= marked.length <= n - 1
+0 <= s, marked[i] <= n - 1
+s != marked[i]
+marked[i] != marked[j] for every i != j
+The graph might have repeated edges.
+The graph is generated such that it has no self-loops.
+
+"""
+
+import heapq
+
+# V0
+# IDEA : DIJKSTRA (SINGLE SOURCE) + MIN OVER THE MARKED SET
+#
+#   All weights are positive, so a single Dijkstra run from s gives the
+#   shortest distance to EVERY node. The answer is then just the smallest
+#   dist[v] over v in marked (or -1 when they are all unreachable).
+#
+#   NOTE : the graph is DIRECTED — only add u -> v, never the reverse.
+#
+#   NOTE : the graph may contain REPEATED edges between the same pair. That
+#          is harmless for Dijkstra (the heavier duplicate simply never
+#          improves anything), so no de-duplication is needed.
+#
+#   NOTE : we early-exit as soon as a marked node is popped from the heap.
+#          Dijkstra pops nodes in non-decreasing distance order, so the first
+#          marked node popped is already the closest one.
+#
+# time = O(E * log E), space = O(V + E)
+class Solution(object):
+    def minimumDistance(self, n, edges, s, marked):
+        graph = [[] for _ in range(n)]
+        for u, v, w in edges:
+            graph[u].append((v, w))
+
+        target = set(marked)
+        dist = [-1] * n            # -1 == not settled yet
+        pq = [(0, s)]
+
+        while pq:
+            d, u = heapq.heappop(pq)
+            if dist[u] != -1:      # already settled with a smaller d
+                continue
+            dist[u] = d
+            if u in target:
+                return d
+            for v, w in graph[u]:
+                if dist[v] == -1:
+                    heapq.heappush(pq, (d + w, v))
+
+        return -1

--- a/leetcode_python/Graph/maximize-value-of-function-in-a-ball-passing-game.py
+++ b/leetcode_python/Graph/maximize-value-of-function-in-a-ball-passing-game.py
@@ -1,0 +1,99 @@
+"""
+
+2836. Maximize Value of Function in a Ball Passing Game
+Hard
+
+You are given an integer array receiver of length n and an integer k. n players are playing a ball-passing game.
+
+You choose the starting player, i. The game proceeds as follows: player i passes the ball to player receiver[i], who then passes it to receiver[receiver[i]], and so on, for k passes in total. The game's score is the sum of the indices of the players who touched the ball, including repetitions, i.e. i + receiver[i] + receiver[receiver[i]] + ... + receiver^(k)[i].
+
+Return the maximum possible score.
+
+Notes:
+
+- receiver may contain duplicates.
+- receiver[i] may be equal to i.
+
+
+Example 1:
+
+Input: receiver = [2,0,1], k = 4
+Output: 6
+Explanation: Starting with player i = 2 the initial score is 2:
+Pass 1: player 2 passes to player 1, score 3
+Pass 2: player 1 passes to player 0, score 3
+Pass 3: player 0 passes to player 2, score 5
+Pass 4: player 2 passes to player 1, score 6
+
+Example 2:
+
+Input: receiver = [1,1,1,2,3], k = 3
+Output: 10
+Explanation: Starting with player i = 4 the initial score is 4:
+Pass 1: player 4 passes to player 3, score 7
+Pass 2: player 3 passes to player 2, score 9
+Pass 3: player 2 passes to player 1, score 10
+
+
+Constraints:
+
+1 <= receiver.length == n <= 10^5
+0 <= receiver[i] <= n - 1
+1 <= k <= 10^10
+
+"""
+
+# V0
+# IDEA : BINARY LIFTING (a.k.a. sparse table on the functional graph)
+#
+#   k can be 10^10, so simulating every pass is hopeless. `receiver` is a
+#   functional graph (exactly one outgoing edge per node), so jumping is
+#   composable and we can pre-compute power-of-two jumps.
+#
+#   up[j][i] = player reached after 2^j passes starting at i
+#   sm[j][i] = sum of the indices TOUCHED on those 2^j passes, counting the
+#              start i but NOT the final landing player
+#
+#   base (j = 0, one pass): up[0][i] = receiver[i], sm[0][i] = i
+#   step: up[j][i]  = up[j-1][ up[j-1][i] ]
+#         sm[j][i]  = sm[j-1][i] + sm[j-1][ up[j-1][i] ]
+#
+#   then for each start i we decompose k into its set bits, chaining the jumps
+#   and accumulating the sums.
+#
+#   NOTE : `sm` excludes the landing player on purpose - that is what makes the
+#          two halves compose without double counting the joint node. the final
+#          answer adds the very last player back once: total = acc + p.
+#   NOTE : answers are big (n * k ~ 10^15) - fine in Python, but a Java/C++
+#          port must use 64-bit.
+#
+# time = O(n * log k), space = O(n * log k)
+class Solution(object):
+    def getMaxFunctionValue(self, receiver, k):
+        n = len(receiver)
+        m = max(1, k.bit_length())
+
+        up = [list(receiver)]
+        sm = [list(range(n))]
+        for j in range(1, m):
+            pu, ps = up[j - 1], sm[j - 1]
+            cu = [0] * n
+            cs = [0] * n
+            for i in range(n):
+                mid = pu[i]
+                cu[i] = pu[mid]
+                cs[i] = ps[i] + ps[mid]
+            up.append(cu)
+            sm.append(cs)
+
+        ans = 0
+        for i in range(n):
+            p = i
+            acc = 0
+            for j in range(m):
+                if (k >> j) & 1:
+                    acc += sm[j][p]
+                    p = up[j][p]
+            if acc + p > ans:
+                ans = acc + p
+        return ans

--- a/leetcode_python/Greedy/apply-operations-to-make-all-array-elements-equal-to-zero.py
+++ b/leetcode_python/Greedy/apply-operations-to-make-all-array-elements-equal-to-zero.py
@@ -1,0 +1,77 @@
+"""
+
+2772. Apply Operations to Make All Array Elements Equal to Zero
+Medium
+
+You are given a 0-indexed integer array nums and a positive integer k.
+
+You can apply the following operation on the array any number of times:
+
+Choose any subarray of size k from the array and decrease all its elements by 1.
+
+Return true if you can make all the array elements equal to 0, or false otherwise.
+
+A subarray is a contiguous non-empty part of an array.
+
+
+Example 1:
+
+Input: nums = [2,2,3,1,1,0], k = 3
+Output: true
+Explanation: We can do the following operations:
+- Choose the subarray [2,2,3]. The resulting array will be nums = [1,1,2,1,1,0].
+- Choose the subarray [2,1,1]. The resulting array will be nums = [1,1,1,0,0,0].
+- Choose the subarray [1,1,1]. The resulting array will be nums = [0,0,0,0,0,0].
+
+Example 2:
+
+Input: nums = [1,3,1,1], k = 2
+Output: false
+Explanation: It is not possible to make all the array elements equal to 0.
+
+
+Constraints:
+
+1 <= k <= nums.length <= 10^5
+0 <= nums[i] <= 10^6
+
+"""
+
+# V0
+# IDEA : LEFT-TO-RIGHT GREEDY + DIFFERENCE ARRAY
+#
+#   scan left to right. Index i can only ever be touched by windows starting at
+#   i - k + 1 .. i, and once we pass i no window starting further right can
+#   reach it. So the number of operations starting AT i is forced: whatever
+#   value is still left at i after earlier windows have been applied.
+#
+#       cur = nums[i] + (sum of window deltas currently covering i)
+#       cur == 0 -> nothing to do
+#       cur  < 0 -> earlier windows overshot     -> False
+#       i + k > n -> no room for a window here   -> False
+#       else start `cur` operations at i, ending after i + k - 1
+#
+#   NOTE : applying `cur` operations one cell at a time is O(n * k); instead a
+#          difference array records "-cur from i, +cur again at i + k", so the
+#          running sum is maintained in O(1) per index.
+#   NOTE : nums[i] can be 1e6 and n 1e5, so the counts are large but Python
+#          ints are unbounded — nothing to mod or clamp here.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def checkArray(self, nums, k):
+        n = len(nums)
+        diff = [0] * (n + 1)           # diff[i] applied when we reach index i
+        running = 0                    # total decrease currently covering i
+
+        for i in range(n):
+            running += diff[i]
+            cur = nums[i] + running
+            if cur == 0:
+                continue
+            if cur < 0 or i + k > n:
+                return False
+            running -= cur             # start `cur` windows at i
+            diff[i + k] += cur         # ... which expire right after i + k - 1
+
+        return True

--- a/leetcode_python/Greedy/count-k-subsequences-of-a-string-with-maximum-beauty.py
+++ b/leetcode_python/Greedy/count-k-subsequences-of-a-string-with-maximum-beauty.py
@@ -1,0 +1,119 @@
+"""
+
+2842. Count K-Subsequences of a String With Maximum Beauty
+Hard
+
+You are given a string s and an integer k.
+
+A k-subsequence is a subsequence of s, having length k, and all its characters are unique, i.e., every character occurs once.
+
+Let f(c) denote the number of times the character c occurs in s.
+
+The beauty of a k-subsequence is the sum of f(c) for every character c in the k-subsequence.
+
+For example, consider s = "abbbdd" and k = 2:
+
+f('a') = 1, f('b') = 3, f('d') = 2
+Some k-subsequences of s are:
+"abbbdd" -> "ab" having a beauty of f('a') + f('b') = 4
+"abbbdd" -> "ad" having a beauty of f('a') + f('d') = 3
+"abbbdd" -> "bd" having a beauty of f('b') + f('d') = 5
+
+Return an integer denoting the number of k-subsequences whose beauty is the maximum among all k-subsequences. Since the answer may be too large, return it modulo 10^9 + 7.
+
+A subsequence of a string is a new string formed from the original string by deleting some (possibly none) of the characters without disturbing the relative positions of the remaining characters.
+
+Notes
+
+- f(c) is the number of times a character c occurs in s, not a k-subsequence.
+- Two k-subsequences are considered different if one is formed by an index that is not present in the other. So, two k-subsequences may form the same string.
+
+
+Example 1:
+
+Input: s = "bcca", k = 2
+Output: 4
+Explanation: From s we have f('a') = 1, f('b') = 1, and f('c') = 2.
+The k-subsequences of s are:
+bcca having a beauty of f('b') + f('c') = 3
+bcca having a beauty of f('b') + f('c') = 3
+bcca having a beauty of f('b') + f('a') = 2
+bcca having a beauty of f('c') + f('a') = 3
+bcca having a beauty of f('c') + f('a') = 3
+There are 4 k-subsequences that have the maximum beauty, 3.
+Hence, the answer is 4.
+
+Example 2:
+
+Input: s = "abbcd", k = 4
+Output: 2
+Explanation: From s we have f('a') = 1, f('b') = 2, f('c') = 1, and f('d') = 1.
+The k-subsequences of s are:
+abbcd having a beauty of f('a') + f('b') + f('c') + f('d') = 5
+abbcd having a beauty of f('a') + f('b') + f('c') + f('d') = 5
+There are 2 k-subsequences that have the maximum beauty, 5.
+Hence, the answer is 2.
+
+
+Constraints:
+
+1 <= s.length <= 2 * 10^5
+1 <= k <= s.length
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : GREEDY (pick the k biggest frequencies) + COMBINATORICS
+#
+#   a k-subsequence uses k DISTINCT letters, so if s has fewer than k distinct
+#   letters the answer is 0. otherwise the beauty is the sum of the chosen
+#   letters' frequencies, and it is maximised by simply taking the k largest
+#   frequencies -> sort the frequencies descending as vs.
+#
+#   counting the ways: a chosen letter c can be realised by ANY one of its f(c)
+#   positions, so each chosen letter contributes a factor f(c).
+#     - letters with frequency STRICTLY greater than val = vs[k-1] are forced
+#       into every optimal pick -> multiply their frequencies together.
+#     - letters with frequency exactly val are interchangeable: if x of them
+#       exist and r = k - (#forced) slots remain, choose which ones with
+#       C(x, r) and pick a position inside each with val^r.
+#
+#   ans = (prod of forced freqs) * C(x, r) * val^r  (mod 1e9+7)
+#
+#   NOTE : distinct letters <= 26, so C(x, r) is tiny - compute it exactly with
+#          an integer loop (no modular inverse / no math.comb needed).
+#   NOTE : take the product modulo as you go; freqs multiply up fast.
+#
+# time = O(n + 26 log 26), space = O(26)
+class Solution(object):
+    def countKSubsequencesWithMaxBeauty(self, s, k):
+        MOD = 10 ** 9 + 7
+
+        freq = {}
+        for ch in s:
+            freq[ch] = freq.get(ch, 0) + 1
+        if len(freq) < k:
+            return 0
+
+        vs = sorted(freq.values(), reverse=True)
+        val = vs[k - 1]
+
+        ans = 1
+        forced = 0
+        while forced < k and vs[forced] > val:
+            ans = ans * vs[forced] % MOD
+            forced += 1
+
+        x = 0
+        for v in vs:
+            if v == val:
+                x += 1
+        r = k - forced
+
+        # C(x, r), exact (x <= 26)
+        c = 1
+        for i in range(r):
+            c = c * (x - i) // (i + 1)
+
+        return ans * (c % MOD) % MOD * pow(val, r, MOD) % MOD

--- a/leetcode_python/Greedy/find-the-maximum-achievable-number.py
+++ b/leetcode_python/Greedy/find-the-maximum-achievable-number.py
@@ -1,0 +1,58 @@
+"""
+
+2769. Find the Maximum Achievable Number
+Easy
+
+Given two integers, num and t. A number x is achievable if it can become equal to num after applying the following operation at most t times:
+
+Increase or decrease x by 1, and simultaneously increase or decrease num by 1.
+
+Return the maximum possible value of x.
+
+
+Example 1:
+
+Input: num = 4, t = 1
+
+Output: 6
+
+Explanation:
+
+Apply the following operation once to make the maximum achievable number equal to num:
+
+Decrease the maximum achievable number by 1, and increase num by 1.
+
+Example 2:
+
+Input: num = 3, t = 2
+
+Output: 7
+
+Explanation:
+
+Apply the following operation twice to make the maximum achievable number equal to num:
+
+Decrease the maximum achievable number by 1, and increase num by 1.
+
+
+Constraints:
+
+1 <= num, t <= 50
+
+"""
+
+# V0
+# IDEA : GREEDY / MATH (each move closes a gap of 2)
+#
+#   one operation may move x and num by +-1 EACH, so the gap |x - num| can
+#   shrink by at most 2 per operation (push num up while pulling x down).
+#
+#   NOTE : "at most t times" — so any x with x - num <= 2 * t is achievable,
+#          and the greedy best is to spend every operation closing the gap:
+#
+#              x_max - num = 2 * t  ->  x_max = num + 2 * t
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def theMaximumAchievableX(self, num, t):
+        return num + 2 * t

--- a/leetcode_python/Greedy/largest-element-in-an-array-after-merge-operations.py
+++ b/leetcode_python/Greedy/largest-element-in-an-array-after-merge-operations.py
@@ -1,0 +1,78 @@
+"""
+
+2789. Largest Element in an Array after Merge Operations
+Medium
+
+You are given a 0-indexed array nums consisting of positive integers.
+
+You can do the following operation on the array any number of times:
+
+Choose an index i such that 0 <= i < nums.length - 1 and nums[i] <= nums[i + 1]. Replace the element nums[i + 1] with nums[i] + nums[i + 1] and delete the element nums[i] from the array.
+
+Return the value of the largest element that you can possibly obtain in the final array.
+
+
+Example 1:
+
+Input: nums = [2,3,7,9,3]
+Output: 21
+Explanation: We can apply the following operations on the array:
+- Choose i = 0. The resulting array will be nums = [5,7,9,3].
+- Choose i = 1. The resulting array will be nums = [5,16,3].
+- Choose i = 0. The resulting array will be nums = [21,3].
+The largest element in the final array is 21. It can be shown that we cannot obtain a larger element.
+
+Example 2:
+
+Input: nums = [5,3,3]
+Output: 11
+Explanation: We can do the following operations on the array:
+- Choose i = 1. The resulting array will be nums = [5,6].
+- Choose i = 0. The resulting array will be nums = [11].
+There is only one element in the final array, which is 11.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^6
+
+"""
+
+# V0
+# IDEA : GREEDY, SCAN FROM THE RIGHT
+#
+#   a merge always pushes the sum RIGHTWARD (nums[i] is absorbed into
+#   nums[i+1]), so any final element is a contiguous suffix-sum of some
+#   segment. Scanning right to left lets each element decide, with full
+#   knowledge of everything already merged to its right, whether it can join.
+#
+#   keep `cur` = value currently accumulated at the right end. For nums[i]:
+#     - nums[i] <= cur  -> it can be absorbed: cur += nums[i]
+#     - nums[i] >  cur  -> the merge is illegal; the chain breaks and nums[i]
+#                          starts a fresh accumulator: cur = nums[i]
+#
+#   NOTE : merging the right side FIRST is what makes this optimal - a bigger
+#          right value can swallow more left neighbours, and merging early on
+#          the right never blocks a later merge.
+#
+#   NOTE : the answer is the max `cur` seen over the whole scan, not just the
+#          final one (e.g. [5,3,3] -> chains restart, best is 11 at i = 0).
+#
+#   NOTE : sums can reach 1e5 * 1e6 = 1e11, beyond 32-bit. Python ints are
+#          unbounded so no overflow here (a Java/C++ port needs long).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maxArrayValue(self, nums):
+        n = len(nums)
+        cur = nums[n - 1]
+        res = cur
+        for i in range(n - 2, -1, -1):
+            if nums[i] <= cur:
+                cur += nums[i]
+            else:
+                cur = nums[i]
+            if cur > res:
+                res = cur
+        return res

--- a/leetcode_python/Greedy/lexicographically-smallest-string-after-substring-operation.py
+++ b/leetcode_python/Greedy/lexicographically-smallest-string-after-substring-operation.py
@@ -1,0 +1,81 @@
+"""
+
+2734. Lexicographically Smallest String After Substring Operation
+Medium
+
+Given a string s consisting of lowercase English letters. Perform the following operation:
+
+Select any non-empty substring then replace every letter of the substring with the preceding letter of the English alphabet. For example, 'b' is converted to 'a', and 'a' is converted to 'z'.
+
+Return the lexicographically smallest string after performing the operation.
+
+
+Example 1:
+
+Input: s = "cbabc"
+Output: "baabc"
+Explanation:
+Perform the operation on the substring starting at index 0, and ending at index 1 inclusive.
+
+Example 2:
+
+Input: s = "aa"
+Output: "az"
+Explanation:
+Perform the operation on the last letter.
+
+Example 3:
+
+Input: s = "acbbc"
+Output: "abaab"
+Explanation:
+Perform the operation on the substring starting at index 1, and ending at index 4 inclusive.
+
+Example 4:
+
+Input: s = "leetcode"
+Output: "kddsbncd"
+Explanation:
+Perform the operation on the entire string.
+
+
+Constraints:
+
+1 <= s.length <= 3 * 10^5
+s consists of lowercase English letters
+
+"""
+
+# V0
+# IDEA : GREEDY - DECREMENT THE FIRST NON-'a' RUN
+#
+#   exactly ONE operation is performed (the substring is non-empty), so we are
+#   picking one interval [i, j) to decrement.
+#
+#   decrementing helps on any letter except 'a' ('a' wraps up to 'z', which is
+#   strictly worse). Lexicographic order is decided by the EARLIEST changed
+#   position, so:
+#     - skip the leading 'a's (touching one of them would raise it to 'z')
+#     - from the first non-'a' at index i, decrement greedily as far as we can
+#       and stop right before the next 'a' — extending past that 'a' would turn
+#       it into 'z' and blow up the string at that position.
+#
+#   NOTE : the all-'a' case is forced — we MUST operate on something, so pick
+#          the single LAST character and pay 'a' -> 'z' at the latest possible
+#          position, i.e. "aaa" -> "aaz".
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def smallestString(self, s):
+        n = len(s)
+        i = 0
+        while i < n and s[i] == 'a':
+            i += 1
+        if i == n:
+            # all 'a' : must operate, sacrifice the last char
+            return s[:n - 1] + 'z'
+        j = i
+        while j < n and s[j] != 'a':
+            j += 1
+        shifted = "".join(chr(ord(c) - 1) for c in s[i:j])
+        return s[:i] + shifted + s[j:]

--- a/leetcode_python/Greedy/make-string-a-subsequence-using-cyclic-increments.py
+++ b/leetcode_python/Greedy/make-string-a-subsequence-using-cyclic-increments.py
@@ -1,0 +1,77 @@
+"""
+
+2825. Make String a Subsequence Using Cyclic Increments
+Medium
+
+You are given two 0-indexed strings str1 and str2.
+
+In an operation, you select a set of indices in str1, and for each index i in the set, increment str1[i] to the next character cyclically. That is 'a' becomes 'b', 'b' becomes 'c', and so on, and 'z' becomes 'a'.
+
+Return true if it is possible to make str2 a subsequence of str1 by performing the operation at most once, and false otherwise.
+
+Note: A subsequence of a string is a new string that is formed from the original string by deleting some (possibly none) of the characters without disturbing the relative positions of the remaining characters.
+
+
+Example 1:
+
+Input: str1 = "abc", str2 = "ad"
+Output: true
+Explanation: Select index 2 in str1.
+Increment str1[2] to become 'd'.
+Hence, str1 becomes "abd" and str2 is now a subsequence. Therefore, true is returned.
+
+Example 2:
+
+Input: str1 = "zc", str2 = "ad"
+Output: true
+Explanation: Select indices 0 and 1 in str1.
+Increment str1[0] to become 'a'.
+Increment str1[1] to become 'd'.
+Hence, str1 becomes "ad" and str2 is now a subsequence. Therefore, true is returned.
+
+Example 3:
+
+Input: str1 = "ab", str2 = "d"
+Output: false
+Explanation: In this example, it can be shown that it is impossible to make str2 a subsequence of str1 using the operation at most once.
+Therefore, false is returned.
+
+
+Constraints:
+
+1 <= str1.length <= 10^5
+1 <= str2.length <= 10^5
+str1 and str2 consist of only lowercase English letters.
+
+"""
+
+# V0
+# IDEA : GREEDY TWO POINTERS (relaxed subsequence match)
+#
+#   The operation picks a SET of indices and bumps each of them exactly once,
+#   and it may be used at most once overall. So every position of str1 ends up
+#   being either its original char c, or its cyclic successor c+1 — the choices
+#   are independent per index, since one operation covers an arbitrary subset.
+#
+#   NOTE : that reduces the whole thing to "is str2 a subsequence of str1"
+#          under a relaxed equality: str1[i] matches str2[j] iff
+#          str2[j] == c or str2[j] == next(c).
+#
+#   NOTE : greedy is safe here — always consuming str2[j] at the earliest
+#          str1 index that can match it never hurts, the classic subsequence
+#          exchange argument (a later match leaves a strictly smaller suffix).
+#
+#   NOTE : 'z' wraps to 'a', so use (ord(c) - ord('a') + 1) % 26.
+#
+# time = O(m + n), space = O(1)
+class Solution(object):
+    def canMakeSubsequence(self, str1, str2):
+        n = len(str2)
+        j = 0
+        for c in str1:
+            if j == n:
+                break
+            nxt = chr((ord(c) - ord('a') + 1) % 26 + ord('a'))
+            if str2[j] == c or str2[j] == nxt:
+                j += 1
+        return j == n

--- a/leetcode_python/Greedy/maximum-elegance-of-a-k-length-subsequence.py
+++ b/leetcode_python/Greedy/maximum-elegance-of-a-k-length-subsequence.py
@@ -1,0 +1,109 @@
+"""
+
+2813. Maximum Elegance of a K-Length Subsequence
+Hard
+
+You are given a 0-indexed 2D integer array items of length n and an integer k.
+
+items[i] = [profit_i, category_i], where profit_i and category_i denote the profit and category of the ith item respectively.
+
+Let's define the elegance of a subsequence of items as total_profit + distinct_categories^2, where total_profit is the sum of all profits in the subsequence, and distinct_categories is the number of distinct categories from all the categories in the selected subsequence.
+
+Your task is to find the maximum elegance from all subsequences of size k in items.
+
+Return an integer denoting the maximum elegance of a subsequence of items with size exactly k.
+
+Note: A subsequence of an array is a new array generated from the original array by deleting some elements (possibly none) without changing the remaining elements' relative order.
+
+
+Example 1:
+
+Input: items = [[3,2],[5,1],[10,1]], k = 2
+Output: 17
+Explanation: In this example, we have to select a subsequence of size 2.
+We can select items[0] = [3,2] and items[2] = [10,1].
+The total profit in this subsequence is 3 + 10 = 13, and the subsequence contains 2 distinct categories [2,1].
+Hence, the elegance is 13 + 2^2 = 17, and we can show that it is the maximum achievable elegance.
+
+Example 2:
+
+Input: items = [[3,1],[3,1],[2,2],[5,3]], k = 3
+Output: 19
+Explanation: In this example, we have to select a subsequence of size 3.
+We can select items[0] = [3,1], items[2] = [2,2], and items[3] = [5,3].
+The total profit in this subsequence is 3 + 2 + 5 = 10, and the subsequence contains 3 distinct categories [1,2,3].
+Hence, the elegance is 10 + 3^2 = 19, and we can show that it is the maximum achievable elegance.
+
+Example 3:
+
+Input: items = [[1,1],[2,1],[3,1]], k = 3
+Output: 7
+Explanation: In this example, we have to select a subsequence of size 3.
+We should select all the items.
+The total profit will be 1 + 2 + 3 = 6, and the subsequence contains 1 distinct category [1].
+Hence, the maximum elegance is 6 + 1^2 = 7.
+
+
+Constraints:
+
+1 <= items.length == n <= 10^5
+items[i].length == 2
+items[i][0] == profit_i
+items[i][1] == category_i
+1 <= profit_i <= 10^9
+1 <= category_i <= n
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : GREEDY (SORT BY PROFIT DESC) + STACK OF "SACRIFICEABLE" DUPLICATES
+#
+#   Sort items by profit descending and take the top k as the starting pick:
+#   that maximises total_profit, so it is optimal for any fixed number of
+#   distinct categories we might end up with.
+#
+#   From there the only useful move is to trade profit for one extra distinct
+#   category. Swapping in an item of a BRAND NEW category means kicking out one
+#   of the currently selected items, and the only item we may safely drop is
+#   one whose category is DUPLICATED inside the selection (otherwise we lose a
+#   category while gaining one - a pure profit loss). Among the duplicates we
+#   drop the cheapest one, i.e. the last duplicate seen while scanning the
+#   sorted prefix -> a LIFO stack `dup` holds exactly those profits in
+#   decreasing order, so `dup.pop()` is the cheapest droppable item.
+#
+#   Scanning the remaining items in profit-descending order, each swap raises
+#   distinct_categories by 1 and lowers total_profit; we record the running
+#   maximum of tot + len(vis)^2 after every swap.
+#
+#   NOTE : skip an item whose category is already selected (no gain), and stop
+#          swapping when `dup` is empty (nothing left we are allowed to drop).
+#   NOTE : the answer is monotone-checked at EVERY step, not only at the end -
+#          the profit loss may outweigh the +(2c+1) category gain at some
+#          point, so the best answer can occur mid-way.
+#
+# time = O(n * log n), space = O(n)
+class Solution(object):
+    def findMaximumElegance(self, items, k):
+        items = sorted(items, key=lambda x: -x[0])
+
+        tot = 0
+        vis = set()
+        dup = []
+        for p, c in items[:k]:
+            tot += p
+            if c in vis:
+                dup.append(p)
+            else:
+                vis.add(c)
+
+        ans = tot + len(vis) ** 2
+        for p, c in items[k:]:
+            if c in vis or not dup:
+                continue
+            vis.add(c)
+            tot += p - dup.pop()
+            cur = tot + len(vis) ** 2
+            if cur > ans:
+                ans = cur
+        return ans

--- a/leetcode_python/Greedy/maximum-number-of-groups-with-increasing-length.py
+++ b/leetcode_python/Greedy/maximum-number-of-groups-with-increasing-length.py
@@ -1,0 +1,95 @@
+"""
+
+2790. Maximum Number of Groups With Increasing Length
+Hard
+
+You are given a 0-indexed array usageLimits of length n.
+
+Your task is to create groups using numbers from 0 to n - 1, ensuring that each number, i, is used no more than usageLimits[i] times in total across all groups. You must also satisfy the following conditions:
+
+Each group must consist of distinct numbers, meaning that no duplicate numbers are allowed within a single group.
+Each group (except the first one) must have a length strictly greater than the previous group.
+
+Return an integer denoting the maximum number of groups you can create while satisfying these conditions.
+
+
+Example 1:
+
+Input: usageLimits = [1,2,5]
+Output: 3
+Explanation: In this example, we can use 0 at most once, 1 at most twice, and 2 at most five times.
+One way of creating the maximum number of groups while satisfying the conditions is:
+Group 1 contains the number [2].
+Group 2 contains the numbers [1,2].
+Group 3 contains the numbers [0,1,2].
+It can be shown that the maximum number of groups is 3.
+So, the output is 3.
+
+Example 2:
+
+Input: usageLimits = [2,1,2]
+Output: 2
+Explanation: In this example, we can use 0 at most twice, 1 at most once, and 2 at most twice.
+One way of creating the maximum number of groups while satisfying the conditions is:
+Group 1 contains the number [0].
+Group 2 contains the numbers [1,2].
+It can be shown that the maximum number of groups is 2.
+So, the output is 2.
+
+Example 3:
+
+Input: usageLimits = [1,1]
+Output: 1
+Explanation: In this example, we can use both 0 and 1 at most once.
+One way of creating the maximum number of groups while satisfying the conditions is:
+Group 1 contains the number [0].
+It can be shown that the maximum number of groups is 1.
+So, the output is 1.
+
+
+Constraints:
+
+1 <= usageLimits.length <= 10^5
+1 <= usageLimits[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : SORT + GREEDY PREFIX BUDGET
+#
+#   the group SIZES can always be taken as 1, 2, 3, ..., k (shrinking any
+#   larger plan to this staircase never hurts). So k groups are feasible iff
+#   we can pay a total of 1 + 2 + ... + k = k(k+1)/2 slots.
+#
+#   key fact: with the limits SORTED ascending, k groups are achievable iff
+#   every prefix satisfies  sum(limits[0..i]) >= 1 + 2 + ... + min(i+1, k).
+#   Intuition - a number can appear at most once per group, so the m smallest
+#   limits can only fill the m smallest group sizes; sorting makes the
+#   binding constraint a simple prefix comparison.
+#
+#   the scan below is that check done incrementally: carry `pool` = leftover
+#   capacity of the prefix seen so far. Adding limit x, if the pool can cover
+#   one more group of size k + 1 (i.e. pool > k), open it and spend k + 1.
+#
+#   NOTE : the test is `pool > k` BEFORE the increment, which is the same as
+#          `pool >= k + 1` - the new group's size.
+#
+#   NOTE : leftovers carry forward. That is legitimate because a spare copy of
+#          a small-limit number can always be shifted into a later, larger
+#          group (groups only grow), so unused capacity is never wasted.
+#
+#   NOTE : limits reach 1e9 and n reaches 1e5 -> the running sum can hit 1e14.
+#          Python ints are unbounded; a Java/C++ port must use long.
+#
+# time = O(n log n), space = O(1) beyond the sort
+class Solution(object):
+    def maxIncreasingGroups(self, usageLimits):
+        usageLimits.sort()
+        k = 0
+        pool = 0
+        for x in usageLimits:
+            pool += x
+            if pool > k:
+                k += 1
+                pool -= k
+        return k

--- a/leetcode_python/Greedy/maximum-strength-of-a-group.py
+++ b/leetcode_python/Greedy/maximum-strength-of-a-group.py
@@ -1,0 +1,69 @@
+"""
+
+2708. Maximum Strength of a Group
+Medium
+
+You are given a 0-indexed integer array nums representing the score of students in an exam. The teacher would like to form one non-empty group of students with maximal strength, where the strength of a group of students of indices i0, i1, i2, ... , ik is defined as nums[i0] * nums[i1] * nums[i2] * ... * nums[ik].
+
+Return the maximum strength of a group the teacher can create.
+
+
+Example 1:
+
+Input: nums = [3,-1,-5,2,5,-9]
+Output: 1350
+Explanation: One way to form a group of maximal strength is to group the students at indices [0,2,3,4,5]. Their strength is 3 * (-5) * 2 * 5 * (-9) = 1350, which we can show is optimal.
+
+Example 2:
+
+Input: nums = [-4,-5,-4]
+Output: 20
+Explanation: Group the students at indices [0, 1] . Then, we'll have a resulting strength of 20. We cannot achieve greater strength.
+
+
+Constraints:
+
+1 <= nums.length <= 13
+-9 <= nums[i] <= 9
+
+"""
+
+# V0
+# IDEA : GREEDY (take every positive, pair up the negatives)
+#
+#   the group is any non-empty SUBSET, so:
+#     - every positive number can only help -> always take it
+#     - zeros never help (they zero the product) -> never take one, unless
+#       nothing else is takeable
+#     - negatives are useful in PAIRS (a product of two negatives is positive),
+#       so take them all; if their count is ODD, drop exactly one - and the one
+#       to drop is the LARGEST negative, i.e. the one closest to 0, since it
+#       contributes the smallest magnitude
+#
+#   NOTE : n == 1 must be answered directly - the group is non-empty, so a
+#          lone -5 (or a lone 0) IS the answer.
+#   NOTE : if the greedy selection ends up empty (e.g. [0, -3] -> the single
+#          negative gets dropped), the best legal group is a single element,
+#          and in that case a 0 must be present, so the answer is 0.
+#   NOTE : an exhaustive 2^n subset scan is also fine here (n <= 13) but this
+#          greedy is O(n log n) and generalises.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def maxStrength(self, nums):
+        if len(nums) == 1:
+            return nums[0]
+
+        pos = [x for x in nums if x > 0]
+        neg = sorted([x for x in nums if x < 0])
+        if len(neg) % 2 == 1:
+            neg.pop()          # drop the negative closest to 0
+
+        picked = pos + neg
+        if not picked:
+            return 0           # only zeros (and at most one dropped negative) left
+
+        ans = 1
+        for x in picked:
+            ans *= x
+        return ans

--- a/leetcode_python/Greedy/minimum-cost-to-make-all-characters-equal.py
+++ b/leetcode_python/Greedy/minimum-cost-to-make-all-characters-equal.py
@@ -1,0 +1,73 @@
+"""
+
+2712. Minimum Cost to Make All Characters Equal
+Medium
+
+You are given a 0-indexed binary string s of length n on which you can apply two types of operations:
+
+Choose an index i and invert all characters from index 0 to index i (both inclusive), with a cost of i + 1
+Choose an index i and invert all characters from index i to index n - 1 (both inclusive), with a cost of n - i
+
+Return the minimum cost to make all characters of the string equal.
+
+Invert a character means if its value is '0' it becomes '1' and vice-versa.
+
+
+Example 1:
+
+Input: s = "0011"
+Output: 2
+Explanation: Apply the second operation with i = 2 to obtain s = "0000" for a cost of 2. It can be shown that 2 is the minimum cost to make all characters equal.
+
+Example 2:
+
+Input: s = "010101"
+Output: 9
+Explanation: Apply the first operation with i = 2 to obtain s = "101101" for a cost of 3.
+Apply the first operation with i = 1 to obtain s = "011101" for a cost of 2.
+Apply the first operation with i = 0 to obtain s = "111101" for a cost of 1.
+Apply the second operation with i = 4 to obtain s = "111110" for a cost of 2.
+Apply the second operation with i = 5 to obtain s = "111111" for a cost of 1.
+The total cost to make all characters equal is 9. It can be shown that 9 is the minimum cost to make all characters equal.
+
+
+Constraints:
+
+1 <= s.length == n <= 10^5
+s[i] is either '0' or '1'
+
+"""
+
+# V0
+# IDEA : GREEDY over the ADJACENT-PAIR BOUNDARIES
+#
+#   think in terms of the n - 1 "boundaries" between neighbours. An operation
+#   at index i flips a PREFIX [0..i] or a SUFFIX [i..n-1], so it toggles the
+#   equality of exactly ONE boundary - the one between i and i + 1 (prefix op)
+#   or between i - 1 and i (suffix op). Every other boundary keeps its state,
+#   because both of its ends flip together or neither does.
+#
+#   so the boundaries are INDEPENDENT: the final string is uniform iff every
+#   boundary ends up "equal", and a boundary that starts unequal must be
+#   toggled an odd number of times -> at least once.
+#
+#   the cheapest single toggle of the boundary between i-1 and i is
+#     min(i, n - i)   ->  prefix op at i-1 costs i, suffix op at i costs n - i
+#
+#   and those choices never conflict, so summing the minimum over every
+#   unequal boundary is both a lower bound and achievable.
+#
+#   NOTE : the target character ('0' vs '1') never has to be decided - it
+#          falls out of whichever ops we picked.
+#   NOTE : n can be 10^5 and the cost sum can exceed 32-bit; Python ints are
+#          unbounded so nothing special is needed here.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumCost(self, s):
+        n = len(s)
+        ans = 0
+        for i in range(1, n):
+            if s[i] != s[i - 1]:
+                ans += min(i, n - i)
+        return ans

--- a/leetcode_python/Greedy/minimum-operations-to-form-subsequence-with-target-sum.py
+++ b/leetcode_python/Greedy/minimum-operations-to-form-subsequence-with-target-sum.py
@@ -1,0 +1,105 @@
+"""
+
+2835. Minimum Operations to Form Subsequence With Target Sum
+Hard
+
+You are given a 0-indexed array nums consisting of non-negative powers of 2, and an integer target.
+
+In one operation, you must apply the following changes to the array:
+
+- Choose any element of the array nums[i] such that nums[i] > 1.
+- Remove nums[i] from the array.
+- Add two occurrences of nums[i] / 2 to the end of nums.
+
+Return the minimum number of operations you need to perform so that nums contains a subsequence whose elements sum to target. If it is impossible to obtain such a subsequence, return -1.
+
+A subsequence is an array that can be derived from another array by deleting some or no elements without changing the order of the remaining elements.
+
+
+Example 1:
+
+Input: nums = [1,2,8], target = 7
+Output: 1
+Explanation: In the first operation, we choose element nums[2]. The array becomes equal to nums = [1,2,4,4].
+At this stage, nums contains the subsequence [1,2,4] which sums up to 7.
+It can be shown that there is no shorter sequence of operations that results in a subsequnce that sums up to 7.
+
+Example 2:
+
+Input: nums = [1,32,1,2], target = 12
+Output: 2
+Explanation: In the first operation, we choose element nums[1]. The array becomes equal to nums = [1,1,2,16,16].
+In the second operation, we choose element nums[3]. The array becomes equal to nums = [1,1,2,16,8,8]
+At this stage, nums contains the subsequence [1,1,2,8] which sums up to 12.
+It can be shown that there is no shorter sequence of operations that results in a subsequence that sums up to 12.
+
+Example 3:
+
+Input: nums = [1,32,1], target = 35
+Output: -1
+Explanation: It can be shown that no sequence of operations results in a subsequence that sums up to 35.
+
+
+Constraints:
+
+1 <= nums.length <= 1000
+1 <= nums[i] <= 2^30
+nums consists only of non-negative powers of two.
+1 <= target < 2^31
+
+"""
+
+# V0
+# IDEA : GREEDY + BIT MANIPULATION (low bit -> high bit, split only on demand)
+#
+#   an operation never changes the total sum, it only moves value from a high
+#   bit down to the next lower bit. so if sum(nums) < target the answer is -1,
+#   and otherwise the target is always reachable.
+#
+#   cnt[i] = how many elements equal 2^i. we walk target's bits from LOW to
+#   HIGH keeping `pool` = total value of the pieces we still own whose size is
+#   <= 2^i (pieces produced by earlier splits land here too).
+#
+#   for a set bit i of target:
+#     - pool >= 2^i  -> pay nothing. (a multiset of powers of two, each <= 2^i,
+#       with total >= 2^i can always hit exactly 2^i by taking the largest
+#       ones first, so no explicit subset construction is needed.)
+#     - otherwise    -> take the SMALLEST element 2^j with j > i and halve it
+#       j - i times. that costs j - i operations, hands us one 2^i, and dumps
+#       the remaining 2^j - 2^i of value back into the pool as small pieces.
+#
+#   NOTE : splitting the smallest available high element is optimal - a bigger
+#          one would cost strictly more halvings to reach the same bit.
+#   NOTE : `pool` only ever holds pieces of size <= 2^i, so adding the whole
+#          2^j (minus the 2^i we consume) to it is safe: every leftover shard
+#          from that split really is <= 2^i.
+#
+# time = O(n + 32 * 32), space = O(32)
+class Solution(object):
+    def minOperations(self, nums, target):
+        if sum(nums) < target:
+            return -1
+
+        B = 32
+        cnt = [0] * (B + 1)
+        for x in nums:
+            cnt[x.bit_length() - 1] += 1
+
+        ops = 0
+        pool = 0
+        for i in range(B):
+            pool += cnt[i] << i
+            if not (target >> i) & 1:
+                continue
+            if pool >= (1 << i):
+                pool -= 1 << i
+                continue
+            j = i + 1
+            while j <= B and cnt[j] == 0:
+                j += 1
+            if j > B:
+                return -1
+            cnt[j] -= 1
+            ops += j - i
+            pool += (1 << j) - (1 << i)
+        return ops

--- a/leetcode_python/Greedy/minimum-operations-to-make-a-special-number.py
+++ b/leetcode_python/Greedy/minimum-operations-to-make-a-special-number.py
@@ -1,0 +1,89 @@
+"""
+
+2844. Minimum Operations to Make a Special Number
+Medium
+
+You are given a 0-indexed string num representing a non-negative integer.
+
+In one operation, you can pick any digit of num and delete it. Note that if you delete all the digits of num, num becomes 0.
+
+Return the minimum number of operations required to make num special.
+
+An integer x is considered special if it is divisible by 25.
+
+
+Example 1:
+
+Input: num = "2245047"
+Output: 2
+Explanation: Delete digits num[5] and num[6]. The resulting number is "22450" which is special since it is divisible by 25.
+It can be shown that 2 is the minimum number of operations required to get a special number.
+
+Example 2:
+
+Input: num = "2908305"
+Output: 3
+Explanation: Delete digits num[3], num[4], and num[6]. The resulting number is "2900" which is special since it is divisible by 25.
+It can be shown that 3 is the minimum number of operations required to get a special number.
+
+Example 3:
+
+Input: num = "10"
+Output: 1
+Explanation: Delete digit num[0]. The resulting number is "0" which is special since it is divisible by 25.
+It can be shown that 1 is the minimum number of operations required to get a special number.
+
+
+Constraints:
+
+1 <= num.length <= 100
+num only consists of digits '0' through '9'.
+num does not contain any leading zeros.
+
+"""
+
+# V0
+# IDEA : GREEDY - only the LAST TWO digits decide divisibility by 25
+#
+#   a number is divisible by 25 iff its last two digits form "00", "25", "50"
+#   or "75" (or the number is the single digit 0, or empty which counts as 0).
+#
+#   deleting digits never reorders them, so the surviving number is a
+#   subsequence. everything before the final pair is free - we keep it all -
+#   which means the cost of ending with the pair (j, i), j < i, is
+#
+#       (digits strictly between j and i) + (digits after i)
+#     = (i - j - 1) + (n - 1 - i)
+#     = n - j - 2
+#
+#   independent of i. so for each of the 4 endings we scan from the RIGHT for
+#   the last digit, then for the nearest matching first digit to its left -
+#   the larger j is, the cheaper.
+#
+#   NOTE : don't forget the degenerate target 0: keeping a single '0' costs
+#          n - 1, and wiping the string costs n. that is the fallback when no
+#          two-digit ending is reachable.
+#   NOTE : leading zeros in the RESULT are fine here - "00" reads as 0, which
+#          is divisible by 25 (the no-leading-zero rule applies to the input).
+#
+# time = O(4 * n), space = O(1)
+class Solution(object):
+    def minimumOperations(self, num):
+        n = len(num)
+
+        # fallback: delete everything (-> 0), or keep exactly one '0'
+        ans = n
+        if '0' in num:
+            ans = n - 1
+
+        for tail in ("00", "25", "50", "75"):
+            i = num.rfind(tail[1])
+            if i <= 0:
+                continue
+            j = num.rfind(tail[0], 0, i)
+            if j < 0:
+                continue
+            cost = n - j - 2
+            if cost < ans:
+                ans = cost
+        return ans

--- a/leetcode_python/Greedy/minimum-relative-loss-after-buying-chocolates.py
+++ b/leetcode_python/Greedy/minimum-relative-loss-after-buying-chocolates.py
@@ -1,0 +1,125 @@
+"""
+
+2819. Minimum Relative Loss After Buying Chocolates
+Hard
+
+You are given an integer array prices, which shows the chocolate prices and a 2D integer array queries, where queries[i] = [ki, mi].
+
+Alice and Bob went to buy some chocolates, and Alice suggested a way to pay for them, and Bob agreed.
+
+The terms for each query are as follows:
+
+If the price of a chocolate is less than or equal to ki, Bob pays for it.
+Otherwise, Bob pays ki of it, and Alice pays the rest.
+
+Bob wants to select exactly mi chocolates such that his relative loss is minimized, more formally, if, in total, Alice has paid ai and Bob has paid bi, Bob wants to minimize bi - ai.
+
+Return an integer array ans where ans[i] is Bob's minimum relative loss possible for queries[i].
+
+
+Example 1:
+
+Input: prices = [1,9,22,10,19], queries = [[18,4],[5,2]]
+Output: [34,-21]
+Explanation: For the 1st query Bob selects the chocolates with prices [1,9,10,22]. He pays 1 + 9 + 10 + 18 = 38 and Alice pays 0 + 0 + 0 + 4 = 4. So Bob's relative loss is 38 - 4 = 34.
+For the 2nd query Bob selects the chocolates with prices [19,22]. He pays 5 + 5 = 10 and Alice pays 14 + 17 = 31. So Bob's relative loss is 10 - 31 = -21.
+It can be shown that these are the minimum possible relative losses.
+
+Example 2:
+
+Input: prices = [1,5,4,3,7,11,9], queries = [[5,4],[5,7],[7,3],[4,5]]
+Output: [4,16,7,1]
+Explanation: For the 1st query Bob selects the chocolates with prices [1,3,9,11]. He pays 1 + 3 + 5 + 5 = 14 and Alice pays 0 + 0 + 4 + 6 = 10. So Bob's relative loss is 14 - 10 = 4.
+For the 2nd query Bob has to select all the chocolates. He pays 1 + 5 + 4 + 3 + 5 + 5 + 5 = 28 and Alice pays 0 + 0 + 0 + 0 + 2 + 6 + 4 = 12. So Bob's relative loss is 28 - 12 = 16.
+For the 3rd query Bob selects the chocolates with prices [1,3,11] and he pays 1 + 3 + 7 = 11 and Alice pays 0 + 0 + 4 = 4. So Bob's relative loss is 11 - 4 = 7.
+For the 4th query Bob selects the chocolates with prices [1,3,7,9,11] and he pays 1 + 3 + 4 + 4 + 4 = 16 and Alice pays 0 + 0 + 3 + 5 + 7 = 15. So Bob's relative loss is 16 - 15 = 1.
+It can be shown that these are the minimum possible relative losses.
+
+Example 3:
+
+Input: prices = [5,6,7], queries = [[10,1],[5,3],[3,3]]
+Output: [5,12,0]
+Explanation: For the 1st query Bob selects the chocolate with price 5 and he pays 5 and Alice pays 0. So Bob's relative loss is 5 - 0 = 5.
+For the 2nd query Bob has to select all the chocolates. He pays 5 + 5 + 5 = 15 and Alice pays 0 + 1 + 2 = 3. So Bob's relative loss is 15 - 3 = 12.
+For the 3rd query Bob has to select all the chocolates. He pays 3 + 3 + 3 = 9 and Alice pays 2 + 3 + 4 = 9. So Bob's relative loss is 9 - 9 = 0.
+It can be shown that these are the minimum possible relative losses.
+
+
+Constraints:
+
+1 <= prices.length == n <= 10^5
+1 <= prices[i] <= 10^9
+1 <= queries.length <= 10^5
+queries[i].length == 2
+1 <= ki <= 10^9
+1 <= mi <= n
+
+"""
+
+# V0
+# IDEA : SORT + PREFIX SUMS + GREEDY SHAPE ("CHEAP PREFIX + EXPENSIVE SUFFIX")
+#        + BINARY SEARCH ON A CONVEX COST CURVE
+#
+#   Write down what one chocolate of price p contributes to (bob - alice):
+#       p <= k :  bob pays p, alice pays 0        -> contribution = p
+#       p >  k :  bob pays k, alice pays p - k    -> contribution = 2*k - p
+#
+#   So on the sorted price array the contribution is INCREASING in p on the
+#   cheap side and DECREASING in p on the expensive side. To pick m items with
+#   the smallest total contribution we therefore always take
+#       - some PREFIX of the cheap group (the cheapest cheap items), and
+#       - some SUFFIX of the expensive group (the priciest expensive items).
+#   Nothing in the middle is ever worth taking.
+#
+#   Let idx = number of prices <= k (binary search on the sorted array). Taking
+#   i cheap items and m - i expensive ones costs
+#       f(i) = pre[i] + 2*k*(m - i) - (suffix sum of the top (m - i) prices)
+#
+#   f is CONVEX : stepping i -> i+1 swaps in prices[i] and swaps out the
+#   cheapest chosen expensive item prices[n-(m-i)], for a delta of
+#       d(i) = prices[i] - (2*k - prices[n - m + i])
+#   whose two terms are both non-decreasing in i. So binary search for the
+#   first i with d(i) >= 0 - that is the minimiser.
+#
+#   NOTE : i is constrained to [max(0, m - (n - idx)), min(m, idx)] - we can
+#          neither take more cheap items than exist nor more expensive ones.
+#   NOTE : Python ints are unbounded, so 2*k*(m-i) up to ~2*10^14 needs no
+#          special care here; a fixed-width language would need 64-bit.
+#
+# time = O((n + q) * log n), space = O(n)
+import bisect
+
+
+class Solution(object):
+    def minimumRelativeLosses(self, prices, queries):
+        prices = sorted(prices)
+        n = len(prices)
+
+        pre = [0] * (n + 1)
+        for i, p in enumerate(prices):
+            pre[i + 1] = pre[i] + p
+        total = pre[n]
+
+        def cost(i, k, m):
+            # i cheap items (prices[0..i-1]) + (m - i) priciest items
+            j = m - i
+            return pre[i] + 2 * k * j - (total - pre[n - j])
+
+        ans = []
+        for k, m in queries:
+            idx = bisect.bisect_right(prices, k)     # count of prices <= k
+            lo = m - (n - idx)
+            if lo < 0:
+                lo = 0
+            hi = idx if idx < m else m
+
+            # first i in [lo, hi) with cost(i + 1) - cost(i) >= 0
+            a, b = lo, hi
+            while a < b:
+                mid = (a + b) // 2
+                if prices[mid] - (2 * k - prices[n - m + mid]) >= 0:
+                    b = mid
+                else:
+                    a = mid + 1
+            ans.append(cost(a, k, m))
+        return ans

--- a/leetcode_python/Hash_table/check-if-array-is-good.py
+++ b/leetcode_python/Hash_table/check-if-array-is-good.py
@@ -1,0 +1,76 @@
+"""
+
+2784. Check if Array is Good
+Easy
+
+You are given an integer array nums. We consider an array good if it is a permutation of an array base[n].
+
+base[n] = [1, 2, ..., n - 1, n, n] (in other words, it is an array of length n + 1 which contains 1 to n - 1 exactly once, plus two occurrences of n). For example, base[1] = [1, 1] and base[3] = [1, 2, 3, 3].
+
+Return true if the given array is good, otherwise return false.
+
+Note: A permutation of integers represents an arrangement of these numbers.
+
+
+Example 1:
+
+Input: nums = [2, 1, 3]
+Output: false
+Explanation: Since the maximum element of the array is 3, the only candidate n for which this array could be a permutation of base[n], is n = 3. However, base[3] has four elements but array nums has three. Therefore, it can not be a permutation of base[3] = [1, 2, 3, 3]. So the answer is false.
+
+Example 2:
+
+Input: nums = [1, 3, 3, 2]
+Output: true
+Explanation: Since the maximum element of the array is 3, the only candidate n for which this array could be a permutation of base[n], is n = 3. It can be seen that nums is a permutation of base[3] = [1, 2, 3, 3] (by swapping the second and fourth elements in nums, we reach base[3]). Therefore, the answer is true.
+
+Example 3:
+
+Input: nums = [1, 1]
+Output: true
+Explanation: Since the maximum element of the array is 1, the only candidate n for which this array could be a permutation of base[n], is n = 1. It can be seen that nums is a permutation of base[1] = [1, 1]. Therefore, the answer is true.
+
+Example 4:
+
+Input: nums = [3, 4, 4, 1, 2, 1]
+Output: false
+Explanation: Since the maximum element of the array is 4, the only candidate n for which this array could be a permutation of base[n], is n = 4. However, base[4] has five elements but array nums has six. Therefore, it can not be a permutation of base[4] = [1, 2, 3, 4, 4]. So the answer is false.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= num[i] <= 200
+
+"""
+
+# V0
+# IDEA : COUNTING
+#
+#   base[n] has exactly n + 1 elements, so a good array of length L must have
+#   n = L - 1. That pins down the ONLY candidate n - no search needed.
+#
+#   NOTE : the check is then purely on the multiset:
+#            cnt[n] == 2, and cnt[i] == 1 for every i in [1, n - 1].
+#          Since the two conditions already account for (n - 1) + 2 = n + 1 = L
+#          elements, nothing else can sneak in (no stray value > n or == 0).
+#
+#   NOTE : n = 1 is the degenerate case -> base[1] = [1, 1], the range
+#          [1, n - 1] is empty and only cnt[1] == 2 is required.
+#
+# time = O(n), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def isGood(self, nums):
+        n = len(nums) - 1
+        if n < 1:
+            return False
+        cnt = Counter(nums)
+        if cnt[n] != 2:
+            return False
+        for i in range(1, n):
+            if cnt[i] != 1:
+                return False
+        return True

--- a/leetcode_python/Hash_table/check-if-strings-can-be-made-equal-with-operations-i.py
+++ b/leetcode_python/Hash_table/check-if-strings-can-be-made-equal-with-operations-i.py
@@ -1,0 +1,55 @@
+"""
+
+2839. Check if Strings Can be Made Equal With Operations I
+Easy
+
+You are given two strings s1 and s2, both of length 4, consisting of lowercase English letters.
+
+You can apply the following operation on any of the two strings any number of times:
+
+- Choose any two indices i and j such that j - i = 2, then swap the two characters at those indices in the string.
+
+Return true if you can make the strings s1 and s2 equal, and false otherwise.
+
+
+Example 1:
+
+Input: s1 = "abcd", s2 = "cdab"
+Output: true
+Explanation: We can do the following operations on s1:
+- Choose the indices i = 0, j = 2. The resulting string is s1 = "cbad".
+- Choose the indices i = 1, j = 3. The resulting string is s1 = "cdab" = s2.
+
+Example 2:
+
+Input: s1 = "abcd", s2 = "dacb"
+Output: false
+Explanation: It is not possible to make the two strings equal.
+
+
+Constraints:
+
+s1.length == s2.length == 4
+s1 and s2 consist only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : PARITY CLASSES + COUNTING
+#
+#   a swap only ever links indices 2 apart, so a character can never move
+#   between an even index and an odd index. the string therefore splits into
+#   two independent groups: {0, 2} and {1, 3}.
+#
+#   inside a group any permutation is reachable (with length 4 each group has
+#   just 2 slots, one swap flips them), so s1 and s2 match iff each group holds
+#   the same MULTISET of characters.
+#
+#   NOTE : compare multisets, not sorted-vs-position - the order inside a group
+#          is free, the group membership is not.
+#
+# time = O(1) (length is fixed at 4), space = O(1)
+class Solution(object):
+    def canBeEqual(self, s1, s2):
+        return (sorted(s1[0::2]) == sorted(s2[0::2])
+                and sorted(s1[1::2]) == sorted(s2[1::2]))

--- a/leetcode_python/Hash_table/check-if-strings-can-be-made-equal-with-operations-ii.py
+++ b/leetcode_python/Hash_table/check-if-strings-can-be-made-equal-with-operations-ii.py
@@ -1,0 +1,65 @@
+"""
+
+2840. Check if Strings Can be Made Equal With Operations II
+Medium
+
+You are given two strings s1 and s2, both of length n, consisting of lowercase English letters.
+
+You can apply the following operation on any of the two strings any number of times:
+
+- Choose any two indices i and j such that i < j and the difference j - i is even, then swap the two characters at those indices in the string.
+
+Return true if you can make the strings s1 and s2 equal, and false otherwise.
+
+
+Example 1:
+
+Input: s1 = "abcdba", s2 = "cabdab"
+Output: true
+Explanation: We can apply the following operations on s1:
+- Choose the indices i = 0, j = 2. The resulting string is s1 = "cbadba".
+- Choose the indices i = 2, j = 4. The resulting string is s1 = "cbbdaa".
+- Choose the indices i = 1, j = 5. The resulting string is s1 = "cabdab" = s2.
+
+Example 2:
+
+Input: s1 = "abe", s2 = "bea"
+Output: false
+Explanation: It is not possible to make the two strings equal.
+
+
+Constraints:
+
+n == s1.length == s2.length
+1 <= n <= 10^5
+s1 and s2 consist only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : PARITY CLASSES + COUNTING (hash table over 2 x 26 counters)
+#
+#   j - i even <=> i and j have the SAME parity. so characters can be shuffled
+#   arbitrarily among even indices, and arbitrarily among odd indices, but can
+#   never cross between the two classes.
+#
+#   => the two strings are convertible iff the even-index multiset of s1 equals
+#      the even-index multiset of s2, and likewise for the odd indices.
+#
+#   one pass with a 2 x 26 counter table: +1 for s1's char, -1 for s2's char at
+#   the same parity bucket; everything must cancel to zero.
+#
+#   NOTE : within one parity class ANY permutation is reachable (adjacent
+#          same-parity indices generate the whole symmetric group), so a plain
+#          count comparison is enough - positions inside a class don't matter.
+#
+# time = O(n + 26), space = O(26)
+class Solution(object):
+    def checkStrings(self, s1, s2):
+        if len(s1) != len(s2):
+            return False
+        cnt = [[0] * 26 for _ in range(2)]
+        for i in range(len(s1)):
+            cnt[i & 1][ord(s1[i]) - 97] += 1
+            cnt[i & 1][ord(s2[i]) - 97] -= 1
+        return all(v == 0 for row in cnt for v in row)

--- a/leetcode_python/Hash_table/count-of-interesting-subarrays.py
+++ b/leetcode_python/Hash_table/count-of-interesting-subarrays.py
@@ -1,0 +1,89 @@
+"""
+
+2845. Count of Interesting Subarrays
+Medium
+
+You are given a 0-indexed integer array nums, an integer modulo, and an integer k.
+
+Your task is to find the count of subarrays that are interesting.
+
+A subarray nums[l..r] is interesting if the following condition holds:
+
+- Let cnt be the number of indices i in the range [l, r] such that nums[i] % modulo == k. Then, cnt % modulo == k.
+
+Return an integer denoting the count of interesting subarrays.
+
+Note: A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [3,2,4], modulo = 2, k = 1
+Output: 3
+Explanation: In this example the interesting subarrays are:
+The subarray nums[0..0] which is [3].
+- There is only one index, i = 0, in the range [0, 0] that satisfies nums[i] % modulo == k.
+- Hence, cnt = 1 and cnt % modulo == k.
+The subarray nums[0..1] which is [3,2].
+- There is only one index, i = 0, in the range [0, 1] that satisfies nums[i] % modulo == k.
+- Hence, cnt = 1 and cnt % modulo == k.
+The subarray nums[0..2] which is [3,2,4].
+- There is only one index, i = 0, in the range [0, 2] that satisfies nums[i] % modulo == k.
+- Hence, cnt = 1 and cnt % modulo == k.
+It can be shown that there are no other interesting subarrays. So, the answer is 3.
+
+Example 2:
+
+Input: nums = [3,1,9,6], modulo = 3, k = 0
+Output: 2
+Explanation: In this example the interesting subarrays are:
+The subarray nums[0..3] which is [3,1,9,6].
+- There are three indices, i = 0, 2, 3, in the range [0, 3] that satisfy nums[i] % modulo == k.
+- Hence, cnt = 3 and cnt % modulo == k.
+The subarray nums[1..1] which is [1].
+- There is no index, i, in the range [1, 1] that satisfies nums[i] % modulo == k.
+- Hence, cnt = 0 and cnt % modulo == k.
+It can be shown that there are no other interesting subarrays. So, the answer is 2.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+1 <= modulo <= 10^9
+0 <= k < modulo
+
+"""
+
+# V0
+# IDEA : PREFIX SUM (mod) + HASH TABLE  -- the "subarray sum equals target" trick
+#
+#   map nums to a 0/1 array: 1 when nums[i] % modulo == k, else 0. then cnt of
+#   a subarray [l..r] is just pre[r+1] - pre[l], and the condition becomes
+#
+#       (pre[r+1] - pre[l]) % modulo == k
+#   <=> pre[l] % modulo == (pre[r+1] - k) % modulo
+#
+#   so sweep r, keep the running prefix sum s, and ask the hash table how many
+#   earlier prefixes had residue (s - k) % modulo. then record s % modulo.
+#
+#   NOTE : seed the table with {0: 1} - the empty prefix - otherwise every
+#          subarray that starts at index 0 is missed.
+#   NOTE : take (s - k) modulo AFTER the subtraction; s - k can go negative,
+#          and a Java/C++ port needs ((s - k) % m + m) % m.
+#   NOTE : store residues, not raw sums - cnt itself is compared modulo.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def countInterestingSubarrays(self, nums, modulo, k):
+        seen = {0: 1}
+        ans = 0
+        s = 0
+        for x in nums:
+            if x % modulo == k:
+                s += 1
+            want = (s - k) % modulo
+            ans += seen.get(want, 0)
+            cur = s % modulo
+            seen[cur] = seen.get(cur, 0) + 1
+        return ans

--- a/leetcode_python/Hash_table/find-maximum-number-of-string-pairs.py
+++ b/leetcode_python/Hash_table/find-maximum-number-of-string-pairs.py
@@ -1,0 +1,81 @@
+"""
+
+2744. Find Maximum Number of String Pairs
+Easy
+
+You are given a 0-indexed array words consisting of distinct strings.
+
+The string words[i] can be paired with the string words[j] if:
+
+The string words[i] is equal to the reversed string of words[j].
+0 <= i < j < words.length.
+
+Return the maximum number of pairs that can be formed from the array words.
+
+Note that each string can belong in at most one pair.
+
+
+Example 1:
+
+Input: words = ["cd","ac","dc","ca","zz"]
+Output: 2
+Explanation: In this example, we can form 2 pair of strings in the following way:
+- We pair the 0th string with the 2nd string, as the reversed string of word[0] is "dc" and is equal to words[2].
+- We pair the 1st string with the 3rd string, as the reversed string of word[1] is "ca" and is equal to words[3].
+It can be proven that 2 is the maximum number of pairs that can be formed.
+
+Example 2:
+
+Input: words = ["ab","ba","cc"]
+Output: 1
+Explanation: In this example, we can form 1 pair of strings in the following way:
+- We pair the 0th string with the 1st string, as the reversed string of words[1] is "ab" and is equal to words[0].
+It can be proven that 1 is the maximum number of pairs that can be formed.
+
+Example 3:
+
+Input: words = ["aa","ab"]
+Output: 0
+Explanation: In this example, we are unable to form any pair of strings.
+
+
+Constraints:
+
+1 <= words.length <= 50
+words[i].length == 2
+words consists of distinct strings.
+words[i] contains only lowercase English letters.
+
+"""
+
+# V0
+# IDEA : HASH SET OF ALREADY-SEEN WORDS (ONE PASS)
+#
+#   Scan left to right keeping a set of the words seen so far. For the
+#   current word w, if its reverse is already in the set then w closes a
+#   pair with that earlier word — count it and REMOVE the partner so it can
+#   never be reused. Otherwise remember w.
+#
+#   NOTE : "each string can belong in at most one pair" is what forces the
+#          removal. It is not actually a constraint here, because the words
+#          are DISTINCT: a palindrome like "aa" is its own reverse but there
+#          is only one copy of it, and any non-palindrome w has at most one
+#          partner reverse(w). So the greedy pairing is trivially maximal.
+#
+#   NOTE : `w in seen` for a palindrome would wrongly self-match, but the
+#          check runs BEFORE w is inserted, so "aa" can only pair with a
+#          second "aa" — which distinctness rules out.
+#
+# time = O(n * L), space = O(n * L)
+class Solution(object):
+    def maximumNumberOfStringPairs(self, words):
+        seen = set()
+        res = 0
+        for w in words:
+            rev = w[::-1]
+            if rev in seen:
+                seen.remove(rev)
+                res += 1
+            else:
+                seen.add(w)
+        return res

--- a/leetcode_python/Hash_table/max-pair-sum-in-an-array.py
+++ b/leetcode_python/Hash_table/max-pair-sum-in-an-array.py
@@ -1,0 +1,89 @@
+"""
+
+2815. Max Pair Sum in an Array
+Easy
+
+You are given an integer array nums. You have to find the maximum sum of a pair of numbers from nums such that the largest digit in both numbers is equal.
+
+For example, 2373 is made up of three distinct digits: 2, 3, and 7, where 7 is the largest among them.
+
+Return the maximum sum or -1 if no such pair exists.
+
+
+Example 1:
+
+Input: nums = [112,131,411]
+
+Output: -1
+
+Explanation:
+
+Each numbers largest digit in order is [2,3,4].
+
+Example 2:
+
+Input: nums = [2536,1613,3366,162]
+
+Output: 5902
+
+Explanation:
+
+All the numbers have 6 as their largest digit, so the answer is 2536 + 3366 = 5902.
+
+Example 3:
+
+Input: nums = [51,71,17,24,42]
+
+Output: 88
+
+Explanation:
+
+Each number's largest digit in order is [5,7,7,4,4].
+
+So we have only two possible pairs, 71 + 17 = 88 and 24 + 42 = 66.
+
+
+Constraints:
+
+2 <= nums.length <= 100
+1 <= nums[i] <= 10^4
+
+"""
+
+# V0
+# IDEA : BUCKET BY LARGEST DIGIT + KEEP THE RUNNING BEST PER BUCKET
+#
+#   Two numbers may be paired iff they share the same "largest digit", which
+#   is a key in 0..9 - only 10 possible buckets. Within one bucket we always
+#   want the two biggest values, so there is no need to store the bucket at
+#   all: keep `best[d]` = the largest number seen so far whose max digit is d,
+#   and while scanning pair each new number with that stored partner.
+#
+#   NOTE : one single pass suffices - a pair (i, j) with i < j is evaluated
+#          exactly when j is scanned, and `best[d]` at that moment is the
+#          maximum over all earlier candidates, which is the best partner j
+#          could have.
+#
+#   NOTE : return -1 when no bucket ever holds two numbers; seeding the answer
+#          with -1 and only overwriting on a real pair covers this, since all
+#          values are positive so any real pair sum is > -1.
+#
+# time = O(n * log10(max(nums))), space = O(1)   # 10 buckets only
+class Solution(object):
+    def maxSum(self, nums):
+        best = [0] * 10          # best[d] = 0 means "nothing seen for digit d"
+        ans = -1
+        for v in nums:
+            d, t = 0, v
+            while t:
+                r = t % 10
+                if r > d:
+                    d = r
+                t //= 10
+            if best[d]:
+                s = best[d] + v
+                if s > ans:
+                    ans = s
+            if v > best[d]:
+                best[d] = v
+        return ans

--- a/leetcode_python/Hash_table/minimize-string-length.py
+++ b/leetcode_python/Hash_table/minimize-string-length.py
@@ -1,0 +1,75 @@
+"""
+
+2716. Minimize String Length
+Easy
+
+Given a string s, you have two types of operation:
+
+1. Choose an index i in the string, and let c be the character in position i. Delete the closest occurrence of c to the left of i (if exists).
+2. Choose an index i in the string, and let c be the character in position i. Delete the closest occurrence of c to the right of i (if exists).
+
+Your task is to minimize the length of s by performing the above operations zero or more times.
+
+Return an integer denoting the length of the minimized string.
+
+
+Example 1:
+
+Input: s = "aaabc"
+Output: 3
+Explanation:
+1. Operation 2: we choose i = 1 so c is 'a', then we remove s[2] as it is closest 'a' character to the right of s[1].
+   s becomes "aabc" after this.
+2. Operation 1: we choose i = 1 so c is 'a', then we remove s[0] as it is closest 'a' character to the left of s[1].
+   s becomes "abc" after this.
+
+Example 2:
+
+Input: s = "cbbd"
+Output: 3
+Explanation:
+1. Operation 1: we choose i = 2 so c is 'b', then we remove s[1] as it is closest 'b' character to the left of s[2].
+   s becomes "cbd" after this.
+
+Example 3:
+
+Input: s = "baadccab"
+Output: 4
+Explanation:
+1. Operation 1: we choose i = 6 so c is 'a', then we remove s[2] as it is closest 'a' character to the left of s[6].
+   s becomes "badccab" after this.
+2. Operation 2: we choose i = 0 so c is 'b', then we remove s[6] as it is closest 'b' character to the right of s[0].
+   s becomes "badcca" after this.
+3. Operation 2: we choose i = 3 so c is 'c', then we remove s[4] as it is closest 'c' character to the right of s[3].
+   s becomes "badca" after this.
+4. Operation 1: we choose i = 4 so c is 'a', then we remove s[1] as it is closest 'a' character to the left of s[4].
+   s becomes "bdca" after this.
+
+
+Constraints:
+
+1 <= s.length <= 100
+s contains only lowercase English letters
+
+"""
+
+# V0
+# IDEA : HASH SET (count of DISTINCT characters)
+#
+#   claim : the answer is exactly the number of distinct characters in s.
+#
+#   - lower bound : an operation only deletes a char c when another c still
+#     remains, so a character that appears in s can never be wiped out
+#     entirely -> every distinct char survives, length >= #distinct.
+#   - upper bound : while some char c appears >= 2 times, pick the LEFTMOST
+#     pair of adjacent-in-order occurrences (i < j with no c in between) and
+#     apply operation 2 at index i to delete the one at j. Each such move
+#     drops the count of c by 1, so we can always reduce every char to a
+#     single occurrence -> length <= #distinct.
+#
+#   NOTE : the operations are just a red herring; no simulation is needed.
+#
+# time = O(n), space = O(|charset|) = O(26)
+class Solution(object):
+    def minimizedStringLength(self, s):
+        return len(set(s))

--- a/leetcode_python/Hash_table/minimum-seconds-to-equalize-a-circular-array.py
+++ b/leetcode_python/Hash_table/minimum-seconds-to-equalize-a-circular-array.py
@@ -1,0 +1,92 @@
+"""
+
+2808. Minimum Seconds to Equalize a Circular Array
+Medium
+
+You are given a 0-indexed array nums containing n integers.
+
+At each second, you perform the following operation on the array:
+
+For every index i in the range [0, n - 1], replace nums[i] with either nums[i], nums[(i - 1 + n) % n], or nums[(i + 1) % n].
+
+Note that all the elements get replaced simultaneously.
+
+Return the minimum number of seconds needed to make all elements in the array nums equal.
+
+
+Example 1:
+
+Input: nums = [1,2,1,2]
+Output: 1
+Explanation: We can equalize the array in 1 second in the following way:
+- At 1st second, replace values at each index with [nums[3],nums[1],nums[3],nums[3]]. After replacement, nums = [2,2,2,2].
+It can be proven that 1 second is the minimum amount of seconds needed for equalizing the array.
+
+Example 2:
+
+Input: nums = [2,1,3,3,2]
+Output: 2
+Explanation: We can equalize the array in 2 seconds in the following way:
+- At 1st second, replace values at each index with [nums[0],nums[2],nums[2],nums[2],nums[3]]. After replacement, nums = [2,3,3,3,3].
+- At 2nd second, replace values at each index with [nums[1],nums[1],nums[2],nums[3],nums[4]]. After replacement, nums = [3,3,3,3,3].
+It can be proven that 2 seconds is the minimum amount of seconds needed for equalizing the array.
+
+Example 3:
+
+Input: nums = [5,5,5,5]
+Output: 0
+Explanation: We don't need to perform any operations as all elements in the initial array are the same.
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^5
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : GROUP INDICES BY VALUE + LARGEST CIRCULAR GAP
+#
+#   the final common value must already exist in the array (the operation
+#   only copies neighbours, it never invents a value).
+#
+#   fix a candidate value x sitting at positions p0 < p1 < ... < pm-1. every
+#   second, each occurrence of x spreads one step left and one step right.
+#   two consecutive occurrences separated by a gap g = p[i+1] - p[i] close
+#   that gap from both ends, so they need floor(g / 2) seconds to cover
+#   everything in between.
+#
+#   the whole array is covered when the WIDEST gap is covered, so the cost
+#   of x is max_gap // 2, and the answer is the min over all candidate x.
+#
+#   NOTE : the array is CIRCULAR, so the wrap-around gap between the last
+#          and the first occurrence must be included :
+#              p[0] + n - p[-1]
+#
+#   NOTE : a value occurring exactly once falls out of the same formula -
+#          its only gap is the wrap-around one, which equals n, giving
+#          n // 2 seconds. no special case needed.
+#
+#   NOTE : if every element is already equal the single group has max gap 1
+#          (or n when n == 1), and 1 // 2 == 0 -> answer 0.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def minimumSeconds(self, nums):
+        n = len(nums)
+
+        pos = {}
+        for i, x in enumerate(nums):
+            if x not in pos:
+                pos[x] = []
+            pos[x].append(i)
+
+        res = n
+        for idx in pos.values():
+            # circular gap : wrap from the last occurrence back to the first
+            gap = idx[0] + n - idx[-1]
+            for i in range(1, len(idx)):
+                gap = max(gap, idx[i] - idx[i - 1])
+            res = min(res, gap // 2)
+        return res

--- a/leetcode_python/Hash_table/number-of-beautiful-pairs.py
+++ b/leetcode_python/Hash_table/number-of-beautiful-pairs.py
@@ -1,0 +1,79 @@
+"""
+
+2748. Number of Beautiful Pairs
+Easy
+
+You are given a 0-indexed integer array nums. A pair of indices i, j where 0 <= i < j < nums.length is called beautiful if the first digit of nums[i] and the last digit of nums[j] are coprime.
+
+Return the total number of beautiful pairs in nums.
+
+Two integers x and y are coprime if there is no integer greater than 1 that divides both of them. In other words, x and y are coprime if gcd(x, y) == 1, where gcd(x, y) is the greatest common divisor of x and y.
+
+
+Example 1:
+
+Input: nums = [2,5,1,4]
+Output: 5
+Explanation: There are 5 beautiful pairs in nums:
+When i = 0 and j = 1: the first digit of nums[0] is 2, and the last digit of nums[1] is 5. We can confirm that 2 and 5 are coprime, since gcd(2,5) == 1.
+When i = 0 and j = 2: the first digit of nums[0] is 2, and the last digit of nums[2] is 1. Indeed, gcd(2,1) == 1.
+When i = 1 and j = 2: the first digit of nums[1] is 5, and the last digit of nums[2] is 1. Indeed, gcd(5,1) == 1.
+When i = 1 and j = 3: the first digit of nums[1] is 5, and the last digit of nums[3] is 4. Indeed, gcd(5,4) == 1.
+When i = 2 and j = 3: the first digit of nums[2] is 1, and the last digit of nums[3] is 4. Indeed, gcd(1,4) == 1.
+Thus, we return 5.
+
+Example 2:
+
+Input: nums = [11,21,12]
+Output: 2
+Explanation: There are 2 beautiful pairs:
+When i = 0 and j = 1: the first digit of nums[0] is 1, and the last digit of nums[1] is 1. Indeed, gcd(1,1) == 1.
+When i = 0 and j = 2: the first digit of nums[0] is 1, and the last digit of nums[2] is 2. Indeed, gcd(1,2) == 1.
+Thus, we return 2.
+
+
+Constraints:
+
+2 <= nums.length <= 100
+1 <= nums[i] <= 9999
+nums[i] % 10 != 0
+
+"""
+
+# V0
+# IDEA : HASH TABLE (bucket counting on the 9 possible leading digits)
+#
+#  a "beautiful" pair only depends on 2 tiny values:
+#     - the FIRST digit of the left element  (1..9)
+#     - the LAST  digit of the right element (1..9, since nums[i] % 10 != 0)
+#
+#  so instead of the O(n^2) double loop we sweep once from left to right and
+#  keep cnt[d] = how many already-seen elements have leading digit d.
+#  For the current element (playing the role of j) we add up cnt[d] over all
+#  d that are coprime with `nums[j] % 10`, then register our own leading digit.
+#
+#   NOTE : register the leading digit AFTER counting, otherwise the element
+#          would pair with itself (i < j must hold strictly).
+#   NOTE : the leading digit is `int(str(x)[0])` -- or repeatedly //= 10,
+#          which avoids the string conversion.
+#
+# time = O(n * 10 * log(10)), space = O(10) = O(1)
+class Solution(object):
+    def countBeautifulPairs(self, nums):
+        def gcd(a, b):
+            while b:
+                a, b = b, a % b
+            return a
+
+        cnt = [0] * 10
+        res = 0
+        for x in nums:
+            last = x % 10
+            for d in range(1, 10):
+                if cnt[d] and gcd(d, last) == 1:
+                    res += cnt[d]
+            first = x
+            while first > 9:
+                first //= 10
+            cnt[first] += 1
+        return res

--- a/leetcode_python/Hash_table/sum-of-matrix-after-queries.py
+++ b/leetcode_python/Hash_table/sum-of-matrix-after-queries.py
@@ -1,0 +1,74 @@
+"""
+
+2718. Sum of Matrix After Queries
+Medium
+
+You are given an integer n and a 0-indexed 2D array queries where queries[i] = [type_i, index_i, val_i].
+
+Initially, there is a 0-indexed n x n matrix filled with 0's. For each query, you must apply one of the following changes:
+
+if type_i == 0, set the values in the row with index_i to val_i, overwriting any previous values.
+if type_i == 1, set the values in the column with index_i to val_i, overwriting any previous values.
+
+Return the sum of integers in the matrix after all queries are applied.
+
+
+Example 1:
+
+Input: n = 3, queries = [[0,0,1],[1,2,2],[0,2,3],[1,0,4]]
+Output: 23
+Explanation: The queries are applied one by one to the matrix. The sum of the matrix after all queries are applied is 23.
+
+Example 2:
+
+Input: n = 3, queries = [[0,0,4],[0,1,2],[1,0,1],[0,2,3],[1,2,1]]
+Output: 17
+Explanation: The queries are applied one by one to the matrix. The sum of the matrix after all queries are applied is 17.
+
+
+Constraints:
+
+1 <= n <= 10^4
+1 <= queries.length <= 5 * 10^4
+queries[i].length == 3
+0 <= type_i <= 1
+0 <= index_i < n
+0 <= val_i <= 10^5
+
+"""
+
+# V0
+# IDEA : HASH SET + REVERSE SCAN
+#
+#   simulating the matrix is impossible (n * n can be 10^8 cells), but note
+#   that the FINAL value of a cell is decided by whichever of "its row" /
+#   "its column" was written LAST.
+#
+#   so walk the queries BACKWARDS: the first time we meet a row (or column)
+#   going backwards is its last write going forwards, hence its final value.
+#
+#   NOTE : when a row is written (going backwards) at a moment where `col`
+#          already holds c distinct columns, those c cells of the row were
+#          already claimed by later column writes -> only (n - c) cells of
+#          this row still carry val. Symmetric for a column write.
+#
+#   NOTE : a row / column seen a 2nd time going backwards contributes 0, its
+#          write is fully overwritten.
+#
+# time = O(m), space = O(n)   (m = len(queries))
+class Solution(object):
+    def matrixSumQueries(self, n, queries):
+        row = set()
+        col = set()
+        res = 0
+        for i in range(len(queries) - 1, -1, -1):
+            t, idx, val = queries[i]
+            if t == 0:
+                if idx not in row:
+                    res += val * (n - len(col))
+                    row.add(idx)
+            else:
+                if idx not in col:
+                    res += val * (n - len(row))
+                    col.add(idx)
+        return res

--- a/leetcode_python/Heap/apply-operations-to-maximize-score.py
+++ b/leetcode_python/Heap/apply-operations-to-maximize-score.py
@@ -1,0 +1,124 @@
+"""
+
+2818. Apply Operations to Maximize Score
+Hard
+
+You are given an array nums of n positive integers and an integer k.
+
+Initially, you start with a score of 1. You have to maximize your score by applying the following operation at most k times:
+
+Choose any non-empty subarray nums[l, ..., r] that you haven't chosen previously.
+Choose an element x of nums[l, ..., r] with the highest prime score. If multiple such elements exist, choose the one with the smallest index.
+Multiply your score by x.
+
+Here, nums[l, ..., r] denotes the subarray of nums starting at index l and ending at the index r, both ends being inclusive.
+
+The prime score of an integer x is equal to the number of distinct prime factors of x. For example, the prime score of 300 is 3 since 300 = 2 * 2 * 3 * 5 * 5.
+
+Return the maximum possible score after applying at most k operations.
+
+Since the answer may be large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [8,3,9,3,8], k = 2
+Output: 81
+Explanation: To get a score of 81, we can apply the following operations:
+- Choose subarray nums[2, ..., 2]. nums[2] is the only element in this subarray. Hence, we multiply the score by nums[2]. The score becomes 1 * 9 = 9.
+- Choose subarray nums[2, ..., 3]. Both nums[2] and nums[3] have a prime score of 1, but nums[2] has the smaller index. Hence, we multiply the score by nums[2]. The score becomes 9 * 9 = 81.
+It can be proven that 81 is the highest score one can obtain.
+
+Example 2:
+
+Input: nums = [19,12,14,6,10,18], k = 3
+Output: 4788
+Explanation: To get a score of 4788, we can apply the following operations:
+- Choose subarray nums[0, ..., 0]. nums[0] is the only element in this subarray. Hence, we multiply the score by nums[0]. The score becomes 1 * 19 = 19.
+- Choose subarray nums[5, ..., 5]. nums[5] is the only element in this subarray. Hence, we multiply the score by nums[5]. The score becomes 19 * 18 = 342.
+- Choose subarray nums[2, ..., 3]. Both nums[2] and nums[3] have a prime score of 2, but nums[2] has the smaller index. Hence, we multipy the score by nums[2]. The score becomes 342 * 14 = 4788.
+It can be proven that 4788 is the highest score one can obtain.
+
+
+Constraints:
+
+1 <= nums.length == n <= 10^5
+1 <= nums[i] <= 10^5
+1 <= k <= min(n * (n + 1) / 2, 10^9)
+
+
+"""
+
+# V0
+# IDEA : PRIME SCORE (LINEAR SIEVE) + MONOTONIC STACK "DOMINANCE RANGE"
+#        + GREEDY (TAKE THE BIGGEST VALUES FIRST)
+#
+#   Step 1 - prime score : a sieve of smallest-prime-factor style pass over
+#            1..max(nums) lets us count DISTINCT prime factors of every value
+#            in O(V log log V) total, far cheaper than factoring each number.
+#
+#   Step 2 - how many subarrays does index i "win"? Index i is the chosen
+#            element of nums[l..r] exactly when it beats everything else in
+#            that window under the (prime score, then smallest index) rule:
+#              - every j in [l, i-1] must have score[j] <  score[i]
+#              - every j in [i+1, r] must have score[j] <= score[i]
+#            NOTE the asymmetry - that is precisely the "smallest index wins
+#            ties" tie-break, and getting it wrong double counts subarrays.
+#            Two monotonic-stack passes give
+#              left[i]  = last index on the left with score >= score[i]
+#              right[i] = first index on the right with score >  score[i]
+#            and the count is cnt[i] = (i - left[i]) * (right[i] - i).
+#            Every subarray has exactly one winner, so sum(cnt) = n(n+1)/2.
+#
+#   Step 3 - greedy : each operation costs one distinct subarray and multiplies
+#            the score by that subarray's winner. Since all values are >= 1,
+#            we simply spend our k operations on the LARGEST values first,
+#            taking min(cnt[i], k remaining) copies of value nums[i].
+#            Sorting by value descending is the whole "priority queue" here.
+#
+#   NOTE : use pow(v, take, MOD) - repeated multiplication would be O(k) with
+#          k up to 10^9. The exponent must NOT be taken mod anything.
+#
+# time = O(V log log V + n log n), space = O(V + n)   # V = max(nums) <= 10^5
+class Solution(object):
+    def maximumScore(self, nums, k):
+        MOD = 10 ** 9 + 7
+        n = len(nums)
+        top = max(nums)
+
+        # --- step 1 : distinct prime factor count for every value <= top ---
+        omega = [0] * (top + 1)
+        for p in range(2, top + 1):
+            if omega[p] == 0:            # p is prime (untouched so far)
+                for mult in range(p, top + 1, p):
+                    omega[mult] += 1
+        score = [omega[v] for v in nums]
+
+        # --- step 2 : dominance range of each index via monotonic stacks ---
+        left = [-1] * n                  # last j < i with score[j] >= score[i]
+        stack = []
+        for i in range(n):
+            while stack and score[stack[-1]] < score[i]:
+                stack.pop()
+            left[i] = stack[-1] if stack else -1
+            stack.append(i)
+
+        right = [n] * n                  # first j > i with score[j] > score[i]
+        stack = []
+        for i in range(n - 1, -1, -1):
+            while stack and score[stack[-1]] <= score[i]:
+                stack.pop()
+            right[i] = stack[-1] if stack else n
+            stack.append(i)
+
+        # --- step 3 : greedily spend k operations on the largest values ---
+        order = sorted(range(n), key=lambda i: -nums[i])
+        ans = 1
+        for i in order:
+            if k <= 0:
+                break
+            cnt = (i - left[i]) * (right[i] - i)
+            take = cnt if cnt < k else k
+            ans = ans * pow(nums[i], take, MOD) % MOD
+            k -= take
+        return ans

--- a/leetcode_python/Linked_list/double-a-number-represented-as-a-linked-list.py
+++ b/leetcode_python/Linked_list/double-a-number-represented-as-a-linked-list.py
@@ -1,0 +1,66 @@
+"""
+
+2816. Double a Number Represented as a Linked List
+Medium
+
+You are given the head of a non-empty linked list representing a non-negative integer without leading zeroes.
+
+Return the head of the linked list after doubling it.
+
+
+Example 1:
+
+Input: head = [1,8,9]
+Output: [3,7,8]
+Explanation: The figure above corresponds to the given linked list which represents the number 189. Hence, the returned linked list represents the number 189 * 2 = 378.
+
+Example 2:
+
+Input: head = [9,9,9]
+Output: [1,9,9,8]
+Explanation: The figure above corresponds to the given linked list which represents the number 999. Hence, the returned linked list represents the number 999 * 2 = 1998.
+
+
+Constraints:
+
+The number of nodes in the list is in the range [1, 10^4]
+0 <= Node.val <= 9
+The input is generated such that the list represents a number that does not have leading zeros, except the number 0 itself.
+
+"""
+
+# V0
+# IDEA : SINGLE FORWARD PASS - LOOK-AHEAD CARRY (NO REVERSING NEEDED)
+#
+#   Doubling is special: the carry out of any digit is at most 1, and it is
+#   fully decided by that digit alone (digit * 2 >= 10  <=>  digit >= 5).
+#   So we never have to walk the list backwards - while sitting on node `cur`
+#   we can PEEK at cur.next and know whether it will hand us a carry.
+#
+#     cur.val = (cur.val * 2) % 10  +  (1 if cur.next and cur.next.val >= 5 else 0)
+#
+#   NOTE : the only overflow into a NEW leading node happens when the first
+#          digit is >= 5; prepend a 0 node up front in that case and let the
+#          same rule fill it with the carry.
+#
+#   NOTE : this rewrites the nodes in place, so it is O(1) extra space - no
+#          reverse / reverse-back and no big-integer conversion (which would
+#          be O(n) digits of temporary storage).
+#
+# time = O(n), space = O(1)
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def doubleIt(self, head):
+        if head.val >= 5:
+            head = ListNode(0, head)
+        cur = head
+        while cur:
+            cur.val = (cur.val * 2) % 10
+            if cur.next and cur.next.val >= 5:
+                cur.val += 1
+            cur = cur.next
+        return head

--- a/leetcode_python/Math/account-balance-after-rounded-purchase.py
+++ b/leetcode_python/Math/account-balance-after-rounded-purchase.py
@@ -1,0 +1,67 @@
+"""
+
+2806. Account Balance After Rounded Purchase
+Easy
+
+Initially, you have a bank account balance of 100 dollars.
+
+You are given an integer purchaseAmount representing the amount you will spend on a purchase in dollars, in other words, its price.
+
+When making the purchase, first the purchaseAmount is rounded to the nearest multiple of 10. Let us call this value roundedAmount. Then, roundedAmount dollars are removed from your bank account.
+
+Return an integer denoting your final bank account balance after this purchase.
+
+Notes:
+
+0 is considered to be a multiple of 10 in this problem.
+When rounding, 5 is rounded upward (5 is rounded to 10, 15 is rounded to 20, 25 to 30, and so on).
+
+
+Example 1:
+
+Input: purchaseAmount = 9
+Output: 90
+Explanation:
+The nearest multiple of 10 to 9 is 10. So your account balance becomes 100 - 10 = 90.
+
+Example 2:
+
+Input: purchaseAmount = 15
+Output: 80
+Explanation:
+The nearest multiple of 10 to 15 is 20. So your account balance becomes 100 - 20 = 80.
+
+Example 3:
+
+Input: purchaseAmount = 10
+Output: 90
+Explanation:
+10 is a multiple of 10 itself. So your account balance becomes 100 - 10 = 90.
+
+
+Constraints:
+
+0 <= purchaseAmount <= 100
+
+"""
+
+# V0
+# IDEA : MATH (ROUND-HALF-UP TO THE NEAREST MULTIPLE OF 10)
+#
+#   rounding half UP to the nearest 10 is exactly
+#       rounded = ((x + 5) // 10) * 10
+#   adding 5 before the floor-division pushes any remainder of 5..9 into the
+#   next decade while leaving 0..4 in the current one.
+#
+#   NOTE : the problem's tie rule (5 goes UP) is what makes the +5 shift
+#          correct. python's built-in round() would NOT work here : it does
+#          banker's rounding, so round(0.5) == 0 and round(2.5) == 2.
+#
+#   NOTE : x <= 100, and (100 + 5) // 10 * 10 == 100, so the balance never
+#          goes below 0.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def accountBalanceAfterPurchase(self, purchaseAmount):
+        rounded = ((purchaseAmount + 5) // 10) * 10
+        return 100 - rounded

--- a/leetcode_python/Math/find-the-k-th-lucky-number.py
+++ b/leetcode_python/Math/find-the-k-th-lucky-number.py
@@ -1,0 +1,78 @@
+"""
+
+2802. Find The K-th Lucky Number
+Medium
+
+We know that 4 and 7 are lucky digits. Also, a number is called lucky if it contains only lucky digits.
+
+You are given an integer k, return the kth lucky number represented as a string.
+
+
+Example 1:
+
+Input: k = 4
+Output: "47"
+Explanation: The first lucky number is 4, the second one is 7, the third one is 44 and the fourth one is 47.
+
+Example 2:
+
+Input: k = 10
+Output: "477"
+Explanation: Here are lucky numbers sorted in increasing order:
+4, 7, 44, 47, 74, 77, 444, 447, 474, 477. So the 10th lucky number is 477.
+
+Example 3:
+
+Input: k = 1000
+Output: "777747447"
+Explanation: It can be shown that the 1000th lucky number is 777747447.
+
+
+Constraints:
+
+1 <= k <= 10^9
+
+"""
+
+# V0
+# IDEA : MATH / BINARY ENCODING (4 -> bit 0, 7 -> bit 1)
+#
+#   lucky numbers sorted increasingly group by digit length : all 1-digit
+#   ones first (2 of them), then all 2-digit ones (4), then 8, 16, ...
+#   there are exactly 2^n lucky numbers with n digits.
+#
+#   step 1 : peel off whole length-blocks to find the length n of the answer
+#            and the rank of k inside that block.
+#   step 2 : inside a block, the numbers are in increasing order, which is
+#            just lexicographic order of the digit string over {4 < 7}.
+#            that is plain binary counting : the (k-1)-th string of the
+#            block written in base 2 with 4=0 and 7=1.
+#
+#   NOTE : k is 1-indexed, so we compare with `k <= 2^(n-1)` to pick '4'
+#          (the lower half) and subtract the half-size before recursing when
+#          picking '7'. equivalently, encode k-1 in binary - both are done
+#          below via the halving loop.
+#
+#   NOTE : k <= 10^9 < 2^30, so the total number of lucky numbers of length
+#          <= 30 already exceeds k and the loop runs at most ~30 times.
+#          no big-integer or overflow concern in python.
+#
+# time = O(log k), space = O(log k)
+class Solution(object):
+    def kthLuckyNumber(self, k):
+        # find the digit length n : there are 2^n lucky numbers of length n
+        n = 1
+        while k > (1 << n):
+            k -= (1 << n)
+            n += 1
+
+        res = []
+        while n > 0:
+            n -= 1
+            half = 1 << n            # count of length-n suffixes per branch
+            if k <= half:
+                res.append('4')
+            else:
+                res.append('7')
+                k -= half
+        return ''.join(res)

--- a/leetcode_python/Math/furthest-point-from-origin.py
+++ b/leetcode_python/Math/furthest-point-from-origin.py
@@ -1,0 +1,65 @@
+"""
+
+2833. Furthest Point From Origin
+Easy
+
+You are given a string moves of length n consisting only of characters 'L', 'R', and '_'. The string represents your movement on a number line starting from the origin 0.
+
+In the i-th move, you can choose one of the following directions:
+
+move to the left if moves[i] = 'L' or moves[i] = '_'
+move to the right if moves[i] = 'R' or moves[i] = '_'
+
+Return the distance from the origin of the furthest point you can get to after n moves.
+
+
+Example 1:
+
+Input: moves = "L_RL__R"
+Output: 3
+Explanation: The furthest point we can reach from the origin 0 is point -3 through the following sequence of moves "LLRLLLR".
+
+Example 2:
+
+Input: moves = "_R__LL_"
+Output: 5
+Explanation: The furthest point we can reach from the origin 0 is point -5 through the following sequence of moves "LRLLLLL".
+
+Example 3:
+
+Input: moves = "_______"
+Output: 7
+Explanation: The furthest point we can reach from the origin 0 is point 7 through the following sequence of moves "RRRRRRR".
+
+
+Constraints:
+
+1 <= moves.length == n <= 50
+moves consists only of characters 'L', 'R' and '_'.
+
+"""
+
+# V0
+# IDEA : MATH / COUNTING (fixed displacement + free moves)
+#
+#   The 'L' and 'R' characters are forced, contributing a fixed displacement
+#   of (R - L). Each '_' is a free +/-1.
+#
+#   NOTE : to get as far from the ORIGIN as possible, every free move should
+#          point the same way as the forced displacement's sign — mixing
+#          directions would only cancel out. So the extreme point is at
+#          distance |R - L| + count('_').
+#
+#   NOTE : when R == L the forced part is 0 and either direction works, and
+#          the formula still gives count('_'), which is right (Example 3).
+#
+#   NOTE : the question asks for a DISTANCE, hence the absolute value — the
+#          furthest point itself may well be negative (Examples 1 and 2).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def furthestDistanceFromOrigin(self, moves):
+        left = moves.count('L')
+        right = moves.count('R')
+        free = len(moves) - left - right
+        return abs(right - left) + free

--- a/leetcode_python/Math/minimum-index-of-a-valid-split.py
+++ b/leetcode_python/Math/minimum-index-of-a-valid-split.py
@@ -1,0 +1,108 @@
+"""
+
+2780. Minimum Index of a Valid Split
+Medium
+
+An element x of an integer array arr of length m is dominant if more than half the elements of arr have a value of x.
+
+You are given a 0-indexed integer array nums of length n with one dominant element.
+
+You can split nums at an index i into two arrays nums[0, ..., i] and nums[i + 1, ..., n - 1], but the split is only valid if:
+
+0 <= i < n - 1
+nums[0, ..., i], and nums[i + 1, ..., n - 1] have the same dominant element.
+
+Here, nums[i, ..., j] denotes the subarray of nums starting at index i and ending at index j, both ends being inclusive. Particularly, if j < i then nums[i, ..., j] denotes an empty subarray.
+
+Return the minimum index of a valid split. If no valid split exists, return -1.
+
+
+Example 1:
+
+Input: nums = [1,2,2,2]
+Output: 2
+Explanation: We can split the array at index 2 to obtain arrays [1,2,2] and [2].
+In array [1,2,2], element 2 is dominant since it occurs twice in the array and 2 * 2 > 3.
+In array [2], element 2 is dominant since it occurs once in the array and 1 * 2 > 1.
+Both [1,2,2] and [2] have the same dominant element as nums, so this is a valid split.
+It can be shown that index 2 is the minimum index of a valid split.
+
+Example 2:
+
+Input: nums = [2,1,3,1,1,1,7,1,2,1]
+Output: 4
+Explanation: We can split the array at index 4 to obtain arrays [2,1,3,1,1] and [1,7,1,2,1].
+In array [2,1,3,1,1], element 1 is dominant since it occurs thrice in the array and 3 * 2 > 5.
+In array [1,7,1,2,1], element 1 is dominant since it occurs thrice in the array and 3 * 2 > 5.
+Both [2,1,3,1,1] and [1,7,1,2,1] have the same dominant element as nums, so this is a valid split.
+It can be shown that index 4 is the minimum index of a valid split.
+
+Example 3:
+
+Input: nums = [3,3,3,3,7,2,2]
+Output: -1
+Explanation: It can be shown that there is no valid split.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+nums has exactly one dominant element.
+
+"""
+
+# V0
+# IDEA : BOYER-MOORE MAJORITY VOTE + PREFIX COUNT SWEEP
+#
+#   key observation: a strict majority of the whole array is the ONLY value
+#   that can be the majority of both halves — if some other value y dominated a
+#   half, y would need > half of that half, and combining the two halves would
+#   give y > n/2 as well, contradicting uniqueness.
+#
+#   NOTE : so we never have to test candidates per split — find the single
+#          dominant value x once, then only count x.
+#
+#   step 1 : Boyer-Moore vote to get the candidate x, then one pass to get its
+#            total count `total` (the problem guarantees x exists, but counting
+#            it costs nothing and keeps the code honest).
+#   step 2 : sweep i from 0 to n - 2 keeping `left` = occurrences of x in
+#            nums[0..i]; the split is valid when x dominates BOTH sides:
+#
+#                left * 2 > i + 1
+#                (total - left) * 2 > n - i - 1
+#
+#            return the first such i.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumIndex(self, nums):
+        n = len(nums)
+
+        # step 1 : Boyer-Moore majority vote
+        cand, votes = nums[0], 0
+        for v in nums:
+            if votes == 0:
+                cand = v
+                votes = 1
+            elif v == cand:
+                votes += 1
+            else:
+                votes -= 1
+
+        total = 0
+        for v in nums:
+            if v == cand:
+                total += 1
+        if total * 2 <= n:
+            return -1
+
+        # step 2 : first index where the candidate dominates both sides
+        left = 0
+        for i in range(n - 1):
+            if nums[i] == cand:
+                left += 1
+            if left * 2 > i + 1 and (total - left) * 2 > n - i - 1:
+                return i
+
+        return -1

--- a/leetcode_python/Math/minimum-operations-to-make-the-integer-zero.py
+++ b/leetcode_python/Math/minimum-operations-to-make-the-integer-zero.py
@@ -1,0 +1,76 @@
+"""
+
+2749. Minimum Operations to Make the Integer Zero
+Medium
+
+You are given two integers num1 and num2.
+
+In one operation, you can choose integer i in the range [0, 60] and subtract 2^i + num2 from num1.
+
+Return the integer denoting the minimum number of operations needed to make num1 equal to 0.
+
+If it is impossible to make num1 equal to 0, return -1.
+
+
+Example 1:
+
+Input: num1 = 3, num2 = -2
+Output: 3
+Explanation: We can make 3 equal to 0 with the following operations:
+- We choose i = 2 and subtract 2^2 + (-2) from 3, 3 - (4 + (-2)) = 1.
+- We choose i = 2 and subtract 2^2 + (-2) from 1, 1 - (4 + (-2)) = -1.
+- We choose i = 0 and subtract 2^0 + (-2) from -1, (-1) - (1 + (-2)) = 0.
+It can be proven, that 3 is the minimum number of operations that we need to perform.
+
+Example 2:
+
+Input: num1 = 5, num2 = 7
+Output: -1
+Explanation: It can be proven, that it is impossible to make 5 equal to 0 with the given operation.
+
+
+Constraints:
+
+1 <= num1 <= 10^9
+-10^9 <= num2 <= 10^9
+
+"""
+
+# V0
+# IDEA : ENUMERATE THE OPERATION COUNT k (bit manipulation / brainteaser)
+#
+#  the ORDER of the operations does not matter, only HOW MANY we do.
+#  If we do exactly k operations picking exponents i1..ik, then
+#
+#       num1 - (2^i1 + ... + 2^ik) - k * num2 == 0
+#   =>  2^i1 + ... + 2^ik == num1 - k * num2  =:  x
+#
+#  so the whole question becomes: can x be written as a sum of EXACTLY k
+#  powers of two? That is possible iff
+#
+#       popcount(x) <= k <= x
+#
+#   - popcount(x) <= k : you need at least popcount(x) terms; and any set bit
+#                        2^i can always be split into 2^(i-1) + 2^(i-1), which
+#                        raises the term count by 1 -> every count in between
+#                        is reachable.
+#   - k <= x           : each term is >= 2^0 = 1, so k terms sum to >= k.
+#
+#   NOTE : we want the SMALLEST k, so scan k = 1, 2, 3, ... and return the
+#          first hit.
+#   NOTE : termination. If num2 > 0 then x shrinks and we stop as soon as
+#          x < 0. If num2 <= 0 then x grows, but x stays below 2^36 for any
+#          k <= 60 (num1, |num2| <= 10^9), so popcount(x) <= 36 <= k is
+#          guaranteed to fire well before k = 60 -> the loop always ends.
+#
+# time = O(log(max(num1, num2))), space = O(1)
+class Solution(object):
+    def makeTheIntegerZero(self, num1, num2):
+        k = 1
+        while True:
+            x = num1 - k * num2
+            if x < 0:
+                return -1
+            if bin(x).count('1') <= k <= x:
+                return k
+            k += 1

--- a/leetcode_python/Math/movement-of-robots.py
+++ b/leetcode_python/Math/movement-of-robots.py
@@ -1,0 +1,91 @@
+"""
+
+2731. Movement of Robots
+Medium
+
+Some robots are standing on an infinite number line with their initial coordinates given by a 0-indexed integer array nums and will start moving once given the command to move. The robots will move a unit distance each second.
+
+You are given a string s denoting the direction in which robots will move on command. 'L' means the robot will move towards the left side or negative side of the number line, whereas 'R' means the robot will move towards the right side or positive side of the number line.
+
+If two robots collide, they will start moving in opposite directions.
+
+Return the sum of distances between all the pairs of robots d seconds after the command. Since the sum can be very large, return it modulo 10^9 + 7.
+
+Note:
+
+For two robots at the index i and j, pair (i,j) and pair (j,i) are considered the same pair.
+When robots collide, they instantly change their directions without wasting any time.
+Collision happens when two robots share the same place in a moment.
+    For example, if a robot is positioned in 0 going to the right and another is positioned in 2 going to the left, the next second they'll be both in 1 and they will change direction and the next second the first one will be in 0, heading left, and another will be in 2, heading right.
+    For example, if a robot is positioned in 0 going to the right and another is positioned in 1 going to the left, the next second the first one will be in 0, heading left, and another will be in 1, heading right.
+
+
+Example 1:
+
+Input: nums = [-2,0,2], s = "RLL", d = 3
+Output: 8
+Explanation:
+After 1 second, the positions are [-1,-1,1]. Now, the robot at index 0 will move left, and the robot at index 1 will move right.
+After 2 seconds, the positions are [-2,0,0]. Now, the robot at index 1 will move left, and the robot at index 2 will move right.
+After 3 seconds, the positions are [-3,-1,1].
+The distance between the robot at index 0 and 1 is abs(-3 - (-1)) = 2.
+The distance between the robot at index 0 and 2 is abs(-3 - 1) = 4.
+The distance between the robot at index 1 and 2 is abs(-1 - 1) = 2.
+The sum of the pairs of all distances = 2 + 4 + 2 = 8.
+
+Example 2:
+
+Input: nums = [1,0], s = "RL", d = 2
+Output: 5
+Explanation:
+After 1 second, the positions are [2,-1].
+After 2 seconds, the positions are [3,-2].
+The distance between the two robots is abs(-2 - 3) = 5.
+
+
+Constraints:
+
+2 <= nums.length <= 10^5
+-2 * 10^9 <= nums[i] <= 2 * 10^9
+0 <= d <= 10^9
+nums.length == s.length
+s consists of 'L' and 'R' only
+nums[i] will be unique.
+
+"""
+
+# V0
+# IDEA : COLLISIONS ARE A RELABELLING (pass-through) + SORT + PREFIX SUM
+#
+#   key observation: two colliding robots bouncing off each other is
+#   indistinguishable, as a MULTISET of positions, from the two robots simply
+#   passing through each other. We only need the multiset (the answer sums
+#   over unordered pairs), so we can pretend nobody ever collides:
+#       pos[i] = nums[i] + d   if s[i] == 'R'
+#       pos[i] = nums[i] - d   if s[i] == 'L'
+#
+#   then sum over pairs of |pos[i] - pos[j]| — sort pos, and for each index i
+#   the i smaller elements each contribute (pos[i] - that element), i.e.
+#       i * pos[i] - (prefix sum of the first i elements)
+#   which removes the abs() entirely.
+#
+#   NOTE : mod only at the END. Taking the modulo of intermediate positions
+#          would break the ordering / the abs()-removal argument. Python ints
+#          are unbounded so the running sum (~10^5 * 3*10^9 * 10^5) is exact;
+#          in Java/C++ this needs 128-bit or incremental modding of the
+#          already-non-negative per-index term.
+#   NOTE : positions reach 3 * 10^9, past 32-bit — the reference C++/Java
+#          solutions cast to long long for exactly this reason.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def sumDistance(self, nums, s, d):
+        MOD = 10 ** 9 + 7
+        pos = [nums[i] + (d if s[i] == 'R' else -d) for i in range(len(nums))]
+        pos.sort()
+        res = 0
+        pre = 0
+        for i, x in enumerate(pos):
+            res += i * x - pre
+            pre += x
+        return res % MOD

--- a/leetcode_python/Math/prime-pairs-with-target-sum.py
+++ b/leetcode_python/Math/prime-pairs-with-target-sum.py
@@ -1,0 +1,72 @@
+"""
+
+2761. Prime Pairs With Target Sum
+Medium
+
+You are given an integer n. We say that two integers x and y form a prime number pair if:
+
+1 <= x <= y <= n
+x + y == n
+x and y are prime numbers
+
+Return the 2D sorted list of prime number pairs [xi, yi]. The list should be sorted in increasing order of xi. If there are no prime number pairs at all, return an empty array.
+
+Note: A prime number is a natural number greater than 1 with only two factors, itself and 1.
+
+
+Example 1:
+
+Input: n = 10
+Output: [[3,7],[5,5]]
+Explanation: In this example, there are two prime pairs that satisfy the criteria.
+These pairs are [3,7] and [5,5], and we return them in the sorted order as described in the problem statement.
+
+Example 2:
+
+Input: n = 2
+Output: []
+Explanation: We can show that there is no prime number pair that gives a sum of 2, so we return an empty array.
+
+
+Constraints:
+
+1 <= n <= 10^6
+
+"""
+
+# V0
+# IDEA : SIEVE OF ERATOSTHENES + ENUMERATE THE SMALLER PRIME
+#
+#  x <= y and x + y == n means x ranges over [2, n // 2] only, and y = n - x
+#  is then fully determined -> one pass once we can test primality in O(1).
+#
+#  so: sieve every prime up to n first, then walk x upward. Because x only
+#  increases, the pairs come out already sorted -> no final sort needed.
+#
+#   NOTE : n goes up to 10^6, so the sieve must be the real thing; marking the
+#          multiples with a SLICE assignment (`sieve[i*i::i] = [False] * ...`)
+#          keeps the inner loop in C and is what makes 10^6 comfortable.
+#   NOTE : start crossing out at i * i -- smaller multiples of i already got
+#          removed by a smaller prime factor.
+#   NOTE : 0 and 1 are not prime; also guard n < 4 so the sieve list is never
+#          indexed out of range (n = 1, 2, 3 simply have no pair).
+#
+# time = O(n * log log n), space = O(n)
+class Solution(object):
+    def findPrimePairs(self, n):
+        if n < 4:
+            return []
+
+        sieve = [True] * (n + 1)
+        sieve[0] = sieve[1] = False
+        i = 2
+        while i * i <= n:
+            if sieve[i]:
+                sieve[i * i::i] = [False] * len(sieve[i * i::i])
+            i += 1
+
+        res = []
+        for x in range(2, n // 2 + 1):
+            if sieve[x] and sieve[n - x]:
+                res.append([x, n - x])
+        return res

--- a/leetcode_python/Math/sum-of-squares-of-special-elements.py
+++ b/leetcode_python/Math/sum-of-squares-of-special-elements.py
@@ -1,0 +1,56 @@
+"""
+
+2778. Sum of Squares of Special Elements
+Easy
+
+You are given a 1-indexed integer array nums of length n.
+
+An element nums[i] of nums is called special if i divides n, i.e. n % i == 0.
+
+Return the sum of the squares of all special elements of nums.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4]
+Output: 21
+Explanation: There are exactly 3 special elements in nums: nums[1] since 1 divides 4, nums[2] since 2 divides 4, and nums[4] since 4 divides 4.
+Hence, the sum of the squares of all special elements of nums is nums[1] * nums[1] + nums[2] * nums[2] + nums[4] * nums[4] = 1 * 1 + 2 * 2 + 4 * 4 = 21.
+
+Example 2:
+
+Input: nums = [2,7,1,19,18,3]
+Output: 63
+Explanation: There are exactly 4 special elements in nums: nums[1] since 1 divides 6, nums[2] since 2 divides 6, nums[3] since 3 divides 6, and nums[6] since 6 divides 6.
+Hence, the sum of the squares of all special elements of nums is nums[1] * nums[1] + nums[2] * nums[2] + nums[3] * nums[3] + nums[6] * nums[6] = 2 * 2 + 7 * 7 + 1 * 1 + 3 * 3 = 63.
+
+
+Constraints:
+
+1 <= nums.length == n <= 50
+1 <= nums[i] <= 50
+
+"""
+
+# V0
+# IDEA : DIRECT SCAN OVER THE DIVISORS OF n
+#
+#   "special" is a property of the POSITION, not the value: keep nums[i] when
+#   the 1-based index i divides n.
+#
+#   NOTE : the statement is 1-indexed while Python is 0-indexed, so the element
+#          at list offset j carries index i = j + 1.
+#
+#   n <= 50, so a plain O(n) pass is more than enough (walking only the actual
+#   divisors would be O(sqrt(n)) but buys nothing at this size).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def sumOfSquares(self, nums):
+        n = len(nums)
+        res = 0
+        for j in range(n):
+            i = j + 1                  # 1-based index
+            if n % i == 0:
+                res += nums[j] * nums[j]
+        return res

--- a/leetcode_python/Math/total-distance-traveled.py
+++ b/leetcode_python/Math/total-distance-traveled.py
@@ -1,0 +1,65 @@
+"""
+
+2739. Total Distance Traveled
+Easy
+
+A truck has two fuel tanks. You are given two integers, mainTank representing the fuel present in the main tank in liters and additionalTank representing the fuel present in the additional tank in liters.
+
+The truck has a mileage of 10 km per liter. Whenever 5 liters of fuel get used up in the main tank, if the additional tank has at least 1 liters of fuel, 1 liters of fuel will be transferred from the additional tank to the main tank.
+
+Return the maximum distance which can be traveled.
+
+Note: Injection from the additional tank is not continuous. It happens suddenly and immediately for every 5 liters consumed.
+
+
+Example 1:
+
+Input: mainTank = 5, additionalTank = 10
+Output: 60
+Explanation:
+After spending 5 litre of fuel, fuel remaining is (5 - 5 + 1) = 1 litre and distance traveled is 50km.
+After spending another 1 litre of fuel, no fuel gets injected in the main tank and the main tank becomes empty.
+Total distance traveled is 60km.
+
+Example 2:
+
+Input: mainTank = 1, additionalTank = 2
+Output: 10
+Explanation:
+After spending 1 litre of fuel, the main tank becomes empty.
+Total distance traveled is 10km.
+
+
+Constraints:
+
+1 <= mainTank, additionalTank <= 100
+
+"""
+
+# V0
+# IDEA : SIMULATION (BURN 5 LITERS AT A TIME)
+#
+#   Instead of burning fuel liter by liter, burn it in blocks of 5 : every
+#   full block of 5 liters consumed from the main tank triggers ONE transfer
+#   of 1 liter from the additional tank (if it still has any).
+#
+#   NOTE : the transferred liter goes back into the main tank and counts
+#          toward the NEXT block of 5 — that is why the loop keeps running
+#          while mainTank >= 5, rather than dividing once.
+#
+#   NOTE : the transfer only fires on a FULL 5 liters. Leftover fuel < 5 is
+#          simply burned at the end and triggers nothing.
+#
+# time = O(mainTank + additionalTank), space = O(1)
+class Solution(object):
+    def distanceTraveled(self, mainTank, additionalTank):
+        used = 0
+        while mainTank >= 5 and additionalTank > 0:
+            # burn one block of 5, get 1 liter back
+            transfer = min(mainTank // 5, additionalTank)
+            used += transfer * 5
+            mainTank -= transfer * 5
+            mainTank += transfer
+            additionalTank -= transfer
+        used += mainTank
+        return used * 10

--- a/leetcode_python/Math/ways-to-split-array-into-good-subarrays.py
+++ b/leetcode_python/Math/ways-to-split-array-into-good-subarrays.py
@@ -1,0 +1,69 @@
+"""
+
+2750. Ways to Split Array Into Good Subarrays
+Medium
+
+You are given a binary array nums.
+
+A subarray of an array is good if it contains exactly one element with the value 1.
+
+Return an integer denoting the number of ways to split the array nums into good subarrays. As the number may be too large, return it modulo 10^9 + 7.
+
+A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [0,1,0,0,1]
+Output: 3
+Explanation: There are 3 ways to split nums into good subarrays:
+- [0,1] [0,0,1]
+- [0,1,0] [0,1]
+- [0,1,0,0] [1]
+
+Example 2:
+
+Input: nums = [0,1,0]
+Output: 1
+Explanation: There is 1 way to split nums into good subarrays:
+- [0,1,0]
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+0 <= nums[i] <= 1
+
+"""
+
+# V0
+# IDEA : MULTIPLICATION PRINCIPLE (count the cut positions between consecutive 1s)
+#
+#  every part must hold EXACTLY one 1, so between two consecutive 1s sitting
+#  at indices j < i there has to be exactly ONE cut, and that cut can go in
+#  any of the gaps right after j, right after j+1, ..., right after i-1
+#  -> that is (i - j) independent choices.
+#
+#  the zeros BEFORE the first 1 and AFTER the last 1 have no freedom at all:
+#  they must join the neighbouring 1's part, contributing a factor of 1.
+#
+#  the choices for different gaps are independent, so the answer is simply
+#  the product of all (i - j).
+#
+#   NOTE : if the array contains NO 1 at all, no valid split exists -> 0.
+#          (an array with exactly one 1 gives the empty product -> 1.)
+#   NOTE : take the modulo inside the loop; the product otherwise blows up.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def numberOfGoodSubarraySplits(self, nums):
+        MOD = 10 ** 9 + 7
+        res = 1
+        prev = -1
+        for i, x in enumerate(nums):
+            if x == 0:
+                continue
+            if prev != -1:
+                res = res * (i - prev) % MOD
+            prev = i
+        return 0 if prev == -1 else res

--- a/leetcode_python/Sort/count-nodes-that-are-great-enough.py
+++ b/leetcode_python/Sort/count-nodes-that-are-great-enough.py
@@ -1,0 +1,129 @@
+"""
+
+2792. Count Nodes That Are Great Enough
+Hard
+
+You are given a root to a binary tree and an integer k. A node of this tree is called great enough if the followings hold:
+
+Its subtree has at least k nodes.
+Its value is greater than the value of at least k nodes in its subtree.
+
+Return the number of nodes in this tree that are great enough.
+
+The node u is in the subtree of the node v, if u == v or v is an ancestor of u.
+
+
+Example 1:
+
+Input: root = [7,6,5,4,3,2,1], k = 2
+Output: 3
+Explanation: Number the nodes from 1 to 7.
+The values in the subtree of node 1: {1,2,3,4,5,6,7}. Since node.val == 7, there are 6 nodes having a smaller value than its value. So it's great enough.
+The values in the subtree of node 2: {3,4,6}. Since node.val == 6, there are 2 nodes having a smaller value than its value. So it's great enough.
+The values in the subtree of node 3: {1,2,5}. Since node.val == 5, there are 2 nodes having a smaller value than its value. So it's great enough.
+It can be shown that other nodes are not great enough.
+
+Example 2:
+
+Input: root = [1,2,3], k = 1
+Output: 0
+Explanation: Number the nodes from 1 to 3.
+The values in the subtree of node 1: {1,2,3}. Since node.val == 1, there are no nodes having a smaller value than its value. So it's not great enough.
+The values in the subtree of node 2: {2}. Since node.val == 2, there are no nodes having a smaller value than its value. So it's not great enough.
+The values in the subtree of node 3: {3}. Since node.val == 3, there are no nodes having a smaller value than its value. So it's not great enough.
+
+Example 3:
+
+Input: root = [3,2,2], k = 2
+Output: 1
+Explanation: Number the nodes from 1 to 3.
+The values in the subtree of node 1: {2,2,3}. Since node.val == 3, there are 2 nodes having a smaller value than its value. So it's great enough.
+The values in the subtree of node 2: {2}. Since node.val == 2, there are no nodes having a smaller value than its value. So it's not great enough.
+The values in the subtree of node 3: {2}. Since node.val == 2, there are no nodes having a smaller value than its value. So it's not great enough.
+
+
+Constraints:
+
+The number of nodes in the tree is in the range [1, 10^4].
+1 <= Node.val <= 10^4
+1 <= k <= 10
+
+"""
+
+# V0
+# IDEA : POST-ORDER + BOUNDED MAX-HEAP OF THE k SMALLEST SUBTREE VALUES
+#
+#   a node is "great enough" iff at least k values in its subtree are
+#   STRICTLY smaller than its own value. its own value never counts, so we
+#   only ever need to look at its descendants.
+#
+#   to decide that, we do NOT need the whole subtree - only its k smallest
+#   descendant values. if the k-th smallest is < node.val, then all k of
+#   them are < node.val and the node qualifies.
+#
+#   so each subtree returns a bounded container of size <= k holding the k
+#   smallest values seen so far. we merge child containers, test the node,
+#   then insert the node's own value for the parent to use.
+#
+#   NOTE : the container must behave like a MAX-heap (we evict the biggest
+#          to keep only the k smallest). python's heapq is a min-heap, so
+#          we store NEGATED values : -h[0] is then the current k-th
+#          smallest, i.e. the largest value we are keeping.
+#
+#   NOTE : k <= 10, so every heap operation is O(log k) ~ O(1).
+#
+#   NOTE : the tree can hold 10^4 nodes and may degenerate into a chain, so
+#          a plain recursive dfs would blow python's recursion limit. we run
+#          an explicit-stack post-order instead.
+#
+# time = O(n * k * log k), space = O(n * k)
+# Definition for a binary tree node.
+# class TreeNode(object):
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+import heapq
+
+
+class Solution(object):
+    def countGreatEnoughNodes(self, root, k):
+        if not root:
+            return 0
+
+        def push(heap, neg_val):
+            # keep only the k smallest values (stored negated -> max-heap)
+            heapq.heappush(heap, neg_val)
+            if len(heap) > k:
+                heapq.heappop(heap)
+
+        res = 0
+        # iterative post-order : visit both children before the node itself
+        heaps = {}
+        stack = [(root, False)]
+        while stack:
+            node, processed = stack.pop()
+            if not processed:
+                stack.append((node, True))
+                if node.left:
+                    stack.append((node.left, False))
+                if node.right:
+                    stack.append((node.right, False))
+                continue
+
+            cur = heaps.pop(id(node.left), []) if node.left else []
+            right = heaps.pop(id(node.right), []) if node.right else []
+            # merge the smaller heap into the bigger one
+            if len(right) > len(cur):
+                cur, right = right, cur
+            for x in right:
+                push(cur, x)
+
+            # -cur[0] is the k-th smallest descendant value
+            if len(cur) == k and -cur[0] < node.val:
+                res += 1
+
+            push(cur, -node.val)
+            heaps[id(node)] = cur
+
+        return res

--- a/leetcode_python/Sort/find-the-value-of-the-partition.py
+++ b/leetcode_python/Sort/find-the-value-of-the-partition.py
@@ -1,0 +1,75 @@
+"""
+
+2740. Find the Value of the Partition
+Medium
+
+You are given a positive integer array nums.
+
+Partition nums into two arrays, nums1 and nums2, such that:
+
+Each element of the array nums belongs to either the array nums1 or the array nums2.
+Both arrays are non-empty.
+The value of the partition is minimized.
+
+The value of the partition is |max(nums1) - min(nums2)|.
+
+Here, max(nums1) denotes the maximum element of the array nums1, and min(nums2) denotes the minimum element of the array nums2.
+
+Return the integer denoting the value of such partition.
+
+
+Example 1:
+
+Input: nums = [1,3,2,4]
+Output: 1
+Explanation: We can partition the array nums into nums1 = [1,2] and nums2 = [3,4].
+- The maximum element of the array nums1 is equal to 2.
+- The minimum element of the array nums2 is equal to 3.
+The value of the partition is |2 - 3| = 1.
+It can be proven that 1 is the minimum value out of all partitions.
+
+Example 2:
+
+Input: nums = [100,1,10]
+Output: 9
+Explanation: We can partition the array nums into nums1 = [10] and nums2 = [100,1].
+- The maximum element of the array nums1 is equal to 10.
+- The minimum element of the array nums2 is equal to 1.
+The value of the partition is |10 - 1| = 9.
+It can be proven that 9 is the minimum value out of all partitions.
+
+
+Constraints:
+
+2 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : SORT + MIN ADJACENT DIFFERENCE
+#
+#   Let a = max(nums1) and b = min(nums2). The value is |a - b|, and a, b are
+#   two DISTINCT positions of the array. So the answer is at least the
+#   smallest |nums[i] - nums[j]| over any pair i != j, i.e. after sorting,
+#   the smallest gap between two ADJACENT elements.
+#
+#   That bound is always reachable : sort the array, pick the adjacent pair
+#   (nums[i], nums[i+1]) with the smallest gap, put nums[0..i] into nums1 and
+#   nums[i+1..] into nums2. Then max(nums1) = nums[i], min(nums2) = nums[i+1],
+#   and both halves are non-empty.
+#
+#   NOTE : no abs() is needed after sorting — nums[i+1] >= nums[i].
+#
+#   NOTE : duplicates give a gap of 0, which the same argument handles.
+#
+# time = O(n * log n), space = O(n) for the sort
+class Solution(object):
+    def findValueOfPartition(self, nums):
+        nums = sorted(nums)
+        res = nums[1] - nums[0]
+        for i in range(1, len(nums) - 1):
+            gap = nums[i + 1] - nums[i]
+            if gap < res:
+                res = gap
+        return res

--- a/leetcode_python/Sort/sort-vowels-in-a-string.py
+++ b/leetcode_python/Sort/sort-vowels-in-a-string.py
@@ -1,0 +1,62 @@
+"""
+
+2785. Sort Vowels in a String
+Medium
+
+Given a 0-indexed string s, permute s to get a new string t such that:
+
+All consonants remain in their original places. More formally, if there is an index i with 0 <= i < s.length such that s[i] is a consonant, then t[i] = s[i].
+The vowels must be sorted in the nondecreasing order of their ASCII values. More formally, for pairs of indices i, j with 0 <= i < j < s.length such that s[i] and s[j] are vowels, then t[i] must not have a higher ASCII value than t[j].
+
+Return the resulting string.
+
+The vowels are 'a', 'e', 'i', 'o', and 'u', and they can appear in lowercase or uppercase. Consonants comprise all letters that are not vowels.
+
+
+Example 1:
+
+Input: s = "lEetcOde"
+Output: "lEOtcede"
+Explanation: 'E', 'O', and 'e' are the vowels in s; 'l', 't', 'c', and 'd' are all consonants. The vowels are sorted according to their ASCII values, and the consonants remain in the same places.
+
+Example 2:
+
+Input: s = "lYmpH"
+Output: "lYmpH"
+Explanation: There are no vowels in s (all characters in s are consonants), so we return "lYmpH".
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s consists only of letters of the English alphabet in uppercase and lowercase.
+
+"""
+
+# V0
+# IDEA : EXTRACT -> SORT -> RE-INSERT
+#
+#   consonants are frozen in place, so the vowel POSITIONS are fixed too.
+#   pull every vowel out (keeping its original case), sort that small list,
+#   then walk the string again and drop the sorted vowels back into the
+#   vowel slots in order.
+#
+#   NOTE : sorting is by ASCII value, NOT case-insensitive. All uppercase
+#          vowels ('A'=65 .. 'U'=85) therefore sort BEFORE every lowercase
+#          one ('a'=97 ..), which is exactly what plain sort() gives us.
+#
+#   NOTE : the vowel TEST is case-insensitive ("aeiouAEIOU") even though the
+#          ordering is not - keeping those two ideas apart is the whole trick.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def sortVowels(self, s):
+        VOWELS = set("aeiouAEIOU")
+        picked = sorted(c for c in s if c in VOWELS)
+        out = list(s)
+        j = 0
+        for i, c in enumerate(out):
+            if c in VOWELS:
+                out[i] = picked[j]
+                j += 1
+        return "".join(out)

--- a/leetcode_python/Stack/collecting-chocolates.py
+++ b/leetcode_python/Stack/collecting-chocolates.py
@@ -1,0 +1,72 @@
+"""
+
+2735. Collecting Chocolates
+Medium
+
+You are given a 0-indexed integer array nums of size n representing the cost of collecting different chocolates. The cost of collecting the chocolate at the index i is nums[i]. Each chocolate is of a different type, and initially, the chocolate at the index i is of ith type.
+
+In one operation, you can do the following with an incurred cost of x:
+
+Simultaneously change the chocolate of ith type to ((i + 1) mod n)th type for all chocolates.
+
+Return the minimum cost to collect chocolates of all types, given that you can perform as many operations as you would like.
+
+
+Example 1:
+
+Input: nums = [20,1,15], x = 5
+Output: 13
+Explanation: Initially, the chocolate types are [0,1,2]. We will buy the 1st type of chocolate at a cost of 1.
+Now, we will perform the operation at a cost of 5, and the types of chocolates will become [1,2,0]. We will buy the 2nd type of chocolate at a cost of 1.
+Now, we will again perform the operation at a cost of 5, and the chocolate types will become [2,0,1]. We will buy the 0th type of chocolate at a cost of 1.
+Thus, the total cost will become (1 + 5 + 1 + 5 + 1) = 13. We can prove that this is optimal.
+
+Example 2:
+
+Input: nums = [1,2,3], x = 4
+Output: 6
+Explanation: We will collect all three types of chocolates at their own price without performing any operations. Therefore, the total cost is 1 + 2 + 3 = 6.
+
+
+Constraints:
+
+1 <= nums.length <= 1000
+1 <= nums[i] <= 10^9
+1 <= x <= 10^9
+
+"""
+
+# V0
+# IDEA : ENUMERATE THE TOTAL NUMBER OF ROTATIONS + RUNNING PREFIX MIN
+#
+#   the operations are global rotations, and buying is free to happen at any
+#   moment, so the ONLY real decision is k = how many rotations we ever do.
+#   Fix k: we pay x * k, and for each type t we may buy it at any of the k + 1
+#   snapshots, i.e. at price min(nums[t], nums[t-1], ..., nums[t-k]) (indices
+#   mod n) — after r rotations the chocolate sitting at position t-r carries
+#   type t.
+#
+#   so, letting best(t, k) = min over that window,
+#       answer = min over k in [0, n-1] of ( x * k + sum_t best(t, k) ).
+#
+#   NOTE : k >= n is never worth it — at k = n-1 the window already covers the
+#          whole array, so growing k only adds x per step with no price gain.
+#   NOTE : best(t, k) = min(best(t, k-1), nums[(t - k) % n]) — so sweeping k
+#          upward per starting index t with ONE running minimum gives O(n^2)
+#          time and only O(n) extra space (the full 2D table of the editorial
+#          is not needed).
+#
+# time = O(n^2), space = O(n)   (n <= 1000 -> ~10^6 steps)
+class Solution(object):
+    def minCost(self, nums, x):
+        n = len(nums)
+        # cost[k] = total cost if we perform exactly k rotations
+        cost = [x * k for k in range(n)]
+        for i in range(n):
+            cur = nums[i]
+            for k in range(n):
+                v = nums[(i - k) % n]
+                if v < cur:
+                    cur = v
+                cost[k] += cur
+        return min(cost)

--- a/leetcode_python/Stack/is-array-a-preorder-of-some-binary-tree.py
+++ b/leetcode_python/Stack/is-array-a-preorder-of-some-binary-tree.py
@@ -1,0 +1,75 @@
+"""
+
+2764. Is Array a Preorder of Some Binary Tree
+Medium
+
+Given a 0-indexed integer 2D array nodes, your task is to determine if the given array represents the preorder traversal of some binary tree.
+
+For each index i, nodes[i] = [id, parentId], where id is the id of the node at the index i and parentId is the id of its parent in the tree (if the node has no parent, then parentId == -1).
+
+Return true if the given array represents the preorder traversal of some tree, and false otherwise.
+
+Note: the preorder traversal of a tree is a recursive way to traverse a tree in which we first visit the current node, then we do the preorder traversal for the left child, and finally, we do it for the right child.
+
+
+Example 1:
+
+Input: nodes = [[0,-1],[1,0],[2,0],[3,2],[4,2]]
+Output: true
+Explanation: The given nodes make the tree in the picture below.
+We can show that this is the preorder traversal of the tree, first we visit node 0, then we do the preorder traversal of the right child which is [1], then we do the preorder traversal of the left child which is [2,3,4].
+
+Example 2:
+
+Input: nodes = [[0,-1],[1,0],[2,0],[3,1],[4,1]]
+Output: false
+Explanation: The given nodes make the tree in the picture below.
+For the preorder traversal, first we visit node 0, then we do the preorder traversal of the right child which is [1,3,4], but we can see that in the given order, 2 comes between 1 and 3, so, it's not the preorder traversal of the tree.
+
+
+Constraints:
+
+1 <= nodes.length <= 10^5
+nodes[i].length == 2
+0 <= nodes[i][0] <= 10^5
+-1 <= nodes[i][1] <= 10^5
+The input is generated such that nodes make a binary tree.
+
+"""
+
+# V0
+# IDEA : MONOTONIC "ANCESTOR PATH" STACK
+#
+#   Left/right is NOT fixed for us — we may hand a node's two children to the
+#   traversal in either order. So the question is only whether the array is
+#   SOME depth-first order of the tree, and that has a clean characterisation:
+#
+#       when a node is emitted, its parent must still be on the active
+#       root-to-current path.
+#
+#   Keep that path in a stack. For each (id, par) in array order:
+#     - pop until the stack top is `par` (every popped node's subtree is
+#       finished, which is exactly what a DFS would do on the way back up),
+#     - if the stack drains without exposing `par`, some node was emitted
+#       outside its parent's subtree window -> not a preorder,
+#     - otherwise push `id` and carry on.
+#
+#   NOTE : the root (par == -1) is unique, so the only node ever allowed to
+#          face an empty stack is nodes[0]; if the real root sits later in the
+#          array, nodes[0] already fails the empty-stack test.
+#   NOTE : n reaches 1e5 and the tree can be a chain, so this is written
+#          iteratively — a recursive DFS would blow Python's stack.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def isPreorder(self, nodes):
+        stack = []                     # current root -> node path
+
+        for nid, par in nodes:
+            while stack and stack[-1] != par:
+                stack.pop()
+            if not stack and par != -1:
+                return False
+            stack.append(nid)
+
+        return True

--- a/leetcode_python/Stack/maximal-range-that-each-element-is-maximum-in-it.py
+++ b/leetcode_python/Stack/maximal-range-that-each-element-is-maximum-in-it.py
@@ -1,0 +1,86 @@
+"""
+
+2832. Maximal Range That Each Element Is Maximum in It
+Medium
+
+You are given a 0-indexed array nums of distinct integers.
+
+Let us define a 0-indexed array ans of the same length as nums in the following way:
+
+ans[i] is the maximum length of a subarray nums[l..r], such that the maximum element in that subarray is equal to nums[i].
+
+Return the array ans.
+
+Note that a subarray is a contiguous part of the array.
+
+
+Example 1:
+
+Input: nums = [1,5,4,3,6]
+Output: [1,4,2,1,5]
+Explanation: For nums[0] the longest subarray in which 1 is the maximum is nums[0..0] so ans[0] = 1.
+For nums[1] the longest subarray in which 5 is the maximum is nums[0..3] so ans[1] = 4.
+For nums[2] the longest subarray in which 4 is the maximum is nums[2..3] so ans[2] = 2.
+For nums[3] the longest subarray in which 3 is the maximum is nums[3..3] so ans[3] = 1.
+For nums[4] the longest subarray in which 6 is the maximum is nums[0..4] so ans[4] = 5.
+
+Example 2:
+
+Input: nums = [1,2,3,4,5]
+Output: [1,2,3,4,5]
+Explanation: For nums[i] the longest subarray in which it's the maximum is nums[0..i] so ans[i] = i + 1.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^5
+All elements in nums are distinct.
+
+"""
+
+# V0
+# IDEA : MONOTONIC STACK (previous greater / next greater element)
+#
+#   The widest window in which nums[i] is the maximum stretches from just
+#   after the previous strictly-greater element to just before the next
+#   strictly-greater one. Call those boundaries left[i] and right[i]
+#   (-1 and n when none exists); then
+#
+#       ans[i] = right[i] - left[i] - 1
+#
+#   NOTE : nums[i] must be the max of the window, so the window may freely
+#          contain SMALLER elements — it is blocked only by greater ones.
+#          Since all values are distinct, "greater" and "greater or equal"
+#          coincide and there is no tie-breaking subtlety to worry about.
+#
+#   Both boundary arrays come from one decreasing monotonic stack each:
+#   scan left to right for the previous greater element, right to left for
+#   the next greater element. Every index is pushed and popped once.
+#
+#   NOTE : iterative and O(n) — n reaches 10^5, so no recursion.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def maximumLengthOfRanges(self, nums):
+        n = len(nums)
+        left = [-1] * n   # index of previous greater element
+        right = [n] * n   # index of next greater element
+
+        stack = []
+        for i in range(n):
+            while stack and nums[stack[-1]] < nums[i]:
+                stack.pop()
+            if stack:
+                left[i] = stack[-1]
+            stack.append(i)
+
+        stack = []
+        for i in range(n - 1, -1, -1):
+            while stack and nums[stack[-1]] < nums[i]:
+                stack.pop()
+            if stack:
+                right[i] = stack[-1]
+            stack.append(i)
+
+        return [right[i] - left[i] - 1 for i in range(n)]

--- a/leetcode_python/Stack/maximum-sum-queries.py
+++ b/leetcode_python/Stack/maximum-sum-queries.py
@@ -1,0 +1,125 @@
+"""
+
+2736. Maximum Sum Queries
+Hard
+
+You are given two 0-indexed integer arrays nums1 and nums2, each of length n, and a 1-indexed 2D array queries where queries[i] = [xi, yi].
+
+For the ith query, find the maximum value of nums1[j] + nums2[j] among all indices j (0 <= j < n), where nums1[j] >= xi and nums2[j] >= yi, or -1 if there is no j satisfying the constraints.
+
+Return an array answer where answer[i] is the answer to the ith query.
+
+
+Example 1:
+
+Input: nums1 = [4,3,1,2], nums2 = [2,4,9,5], queries = [[4,1],[1,3],[2,5]]
+Output: [6,10,7]
+Explanation:
+For the 1st query xi = 4 and yi = 1, we can select index j = 0 since nums1[j] >= 4 and nums2[j] >= 1. The sum nums1[j] + nums2[j] is 6, and we can show that 6 is the maximum we can obtain.
+
+For the 2nd query xi = 1 and yi = 3, we can select index j = 2 since nums1[j] >= 1 and nums2[j] >= 3. The sum nums1[j] + nums2[j] is 10, and we can show that 10 is the maximum we can obtain.
+
+For the 3rd query xi = 2 and yi = 5, we can select index j = 3 since nums1[j] >= 2 and nums2[j] >= 5. The sum nums1[j] + nums2[j] is 7, and we can show that 7 is the maximum we can obtain.
+
+Therefore, we return [6,10,7].
+
+Example 2:
+
+Input: nums1 = [3,2,5], nums2 = [2,3,4], queries = [[4,4],[3,2],[1,1]]
+Output: [9,9,9]
+Explanation: For this example, we can use index j = 2 for all the queries since it satisfies the constraints for each query.
+
+Example 3:
+
+Input: nums1 = [2,1], nums2 = [2,3], queries = [[3,3]]
+Output: [-1]
+Explanation: There is one query in this example with xi = 3 and yi = 3. For every index, j, either nums1[j] < xi or nums2[j] < yi. Hence, there is no solution.
+
+
+Constraints:
+
+nums1.length == nums2.length
+n == nums1.length
+1 <= n <= 10^5
+1 <= nums1[i], nums2[i] <= 10^9
+1 <= queries.length <= 10^5
+queries[i].length == 2
+xi == queries[i][1]
+yi == queries[i][2]
+1 <= xi, yi <= 10^9
+
+"""
+
+import bisect
+
+# V0
+# IDEA : OFFLINE QUERIES (SORT BY x) + BINARY INDEXED TREE (MAX) OVER nums2
+#
+#   This is a 2D dominance query: for each (x, y) we want
+#       max{ nums1[j] + nums2[j] : nums1[j] >= x and nums2[j] >= y }.
+#
+#   Classic trick : peel off ONE dimension by sorting, handle the other with
+#   a Fenwick / BIT.
+#
+#     1) sort the (nums1[j], nums2[j]) pairs by nums1 DESC
+#     2) sort the queries by x DESC, remembering their original index
+#     3) sweep the queries; before answering (x, y) push every pair whose
+#        nums1 >= x into the BIT. From then on the "nums1 >= x" half of the
+#        condition is automatic, and only "nums2 >= y" is left.
+#
+#   NOTE : a BIT natively answers PREFIX max, but we need a SUFFIX max over
+#          nums2. So we index by the REVERSED rank
+#               k(v) = n - bisect_left(sorted_nums2, v)
+#                    = how many nums2 values are >= v
+#          Bigger v  ->  smaller k, hence "nums2 >= y" becomes the prefix
+#          1..k(y) and a plain prefix-max query works.
+#
+#   NOTE : k(v) >= 1 for any v that actually occurs in nums2 (so update never
+#          loops forever on index 0), while a query y larger than every nums2
+#          gives k = 0 and the `while k > 0` loop returns the -1 default.
+#
+#   NOTE : the answers must be written back at the ORIGINAL query index,
+#          since we consumed the queries out of order.
+#
+# time = O((n + m) * log n + m * log m), space = O(n + m)
+class Solution(object):
+    def maximumSumQueries(self, nums1, nums2, queries):
+        n = len(nums1)
+        m = len(queries)
+
+        # value list used for the (reversed) rank compression
+        sorted_n2 = sorted(nums2)
+
+        # pairs by nums1 descending
+        pairs = sorted(zip(nums1, nums2), key=lambda p: -p[0])
+        # query indices by x descending
+        order = sorted(range(m), key=lambda i: -queries[i][0])
+
+        tree = [-1] * (n + 1)   # BIT holding max(nums1 + nums2), -1 = empty
+        res = [-1] * m
+        j = 0
+
+        for qi in order:
+            x, y = queries[qi]
+
+            # push every pair with nums1 >= x (pointer only moves forward)
+            while j < n and pairs[j][0] >= x:
+                a, b = pairs[j]
+                k = n - bisect.bisect_left(sorted_n2, b)
+                v = a + b
+                while k <= n:
+                    if tree[k] < v:
+                        tree[k] = v
+                    k += k & (-k)
+                j += 1
+
+            # prefix max over ranks 1..k  <=>  nums2 >= y
+            k = n - bisect.bisect_left(sorted_n2, y)
+            best = -1
+            while k > 0:
+                if tree[k] > best:
+                    best = tree[k]
+                k -= k & (-k)
+            res[qi] = best
+
+        return res

--- a/leetcode_python/String/check-if-a-string-is-an-acronym-of-words.py
+++ b/leetcode_python/String/check-if-a-string-is-an-acronym-of-words.py
@@ -1,0 +1,65 @@
+"""
+
+2828. Check if a String Is an Acronym of Words
+Easy
+
+Given an array of strings words and a string s, determine if s is an acronym of words.
+
+The string s is considered an acronym of words if it can be formed by concatenating the first character of each string in words in order. For example, "ab" can be formed from ["apple", "banana"], but it can't be formed from ["bear", "aardvark"].
+
+Return true if s is an acronym of words, and false otherwise.
+
+
+Example 1:
+
+Input: words = ["alice","bob","charlie"], s = "abc"
+Output: true
+Explanation: The first character in the words "alice", "bob", and "charlie" are 'a', 'b', and 'c', respectively. Hence, s = "abc" is the acronym.
+
+Example 2:
+
+Input: words = ["an","apple"], s = "a"
+Output: false
+Explanation: The first character in the words "an" and "apple" are 'a' and 'a', respectively.
+The acronym formed by concatenating these characters is "aa".
+Hence, s = "a" is not the acronym.
+
+Example 3:
+
+Input: words = ["never","gonna","give","up","on","you"], s = "ngguoy"
+Output: true
+Explanation: By concatenating the first character of the words in the array, we get the string "ngguoy".
+Hence, s = "ngguoy" is the acronym.
+
+
+Constraints:
+
+1 <= words.length <= 100
+1 <= words[i].length <= 10
+1 <= s.length <= 100
+words[i] and s consist of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : SIMULATION (length check + pairwise first-letter compare)
+#
+#   The acronym has exactly one character per word, so len(words) must equal
+#   len(s) before anything else is worth checking.
+#
+#   NOTE : the length guard is not just an optimisation — zip() stops at the
+#          shorter side, so ["an","apple"] vs "a" would wrongly pass without
+#          it (Example 2).
+#
+#   NOTE : every word is guaranteed non-empty by the constraints, so w[0] is
+#          always safe.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def isAcronym(self, words, s):
+        if len(words) != len(s):
+            return False
+        for w, c in zip(words, s):
+            if w[0] != c:
+                return False
+        return True

--- a/leetcode_python/String/check-if-the-number-is-fascinating.py
+++ b/leetcode_python/String/check-if-the-number-is-fascinating.py
@@ -1,0 +1,51 @@
+"""
+
+2729. Check if The Number is Fascinating
+Easy
+
+You are given an integer n that consists of exactly 3 digits.
+
+We call the number n fascinating if, after the following modification, the resulting number contains all the digits from 1 to 9 exactly once and does not contain any 0's:
+
+Concatenate n with the numbers 2 * n and 3 * n.
+
+Return true if n is fascinating, or false otherwise.
+
+Concatenating two numbers means joining them together. For example, the concatenation of 121 and 371 is 121371.
+
+
+Example 1:
+
+Input: n = 192
+Output: true
+Explanation: We concatenate the numbers n = 192 and 2 * n = 384 and 3 * n = 576. The resulting number is 192384576. This number contains all the digits from 1 to 9 exactly once.
+
+Example 2:
+
+Input: n = 100
+Output: false
+Explanation: We concatenate the numbers n = 100 and 2 * n = 200 and 3 * n = 300. The resulting number is 100200300. This number does not satisfy any of the conditions.
+
+
+Constraints:
+
+100 <= n <= 999
+
+"""
+
+# V0
+# IDEA : STRING CONCAT + SORT
+#
+#   build s = str(n) + str(2n) + str(3n) and ask whether s is a permutation
+#   of "123456789". Sorting s and comparing to "123456789" checks everything
+#   at once: the length (must be 9), the absence of '0', and each of 1..9
+#   appearing exactly once.
+#
+#   NOTE : no need to special case len(s) != 9 (e.g. n = 500 -> "50010001500"),
+#          the sorted string simply cannot equal "123456789" then.
+#
+# time = O(1), space = O(1)   (the string is at most ~12 chars)
+class Solution(object):
+    def isFascinating(self, n):
+        s = str(n) + str(2 * n) + str(3 * n)
+        return "".join(sorted(s)) == "123456789"

--- a/leetcode_python/String/count-symmetric-integers.py
+++ b/leetcode_python/String/count-symmetric-integers.py
@@ -1,0 +1,61 @@
+"""
+
+2843. Count Symmetric Integers
+Easy
+
+You are given two positive integers low and high.
+
+An integer x consisting of 2 * n digits is symmetric if the sum of the first n digits of x is equal to the sum of the last n digits of x. Numbers with an odd number of digits are never symmetric.
+
+Return the number of symmetric integers in the range [low, high].
+
+
+Example 1:
+
+Input: low = 1, high = 100
+Output: 9
+Explanation: There are 9 symmetric integers between 1 and 100: 11, 22, 33, 44, 55, 66, 77, 88, and 99.
+
+Example 2:
+
+Input: low = 1200, high = 1230
+Output: 4
+Explanation: There are 4 symmetric integers between 1200 and 1230: 1203, 1212, 1221, and 1230.
+
+
+Constraints:
+
+1 <= low <= high <= 10^4
+
+"""
+
+# V0
+# IDEA : BRUTE FORCE ENUMERATION over [low, high]
+#
+#   high <= 10^4, so at most ~10000 candidates - just test each one.
+#
+#   for a number x: render it as a string; an odd digit count can never be
+#   symmetric, otherwise compare the digit sum of the first half against the
+#   digit sum of the second half.
+#
+#   NOTE : "symmetric" is about DIGIT SUMS of the two halves, not about the
+#          number being a palindrome - 1203 is symmetric (1+2 == 0+3) yet it
+#          is not a palindrome.
+#   NOTE : with high <= 10^4 only 2-digit and 4-digit numbers can qualify
+#          (10000 itself has 5 digits).
+#
+# time = O((high - low) * log(high)), space = O(log(high))
+class Solution(object):
+    def countSymmetricIntegers(self, low, high):
+        ans = 0
+        for x in range(low, high + 1):
+            d = str(x)
+            n = len(d)
+            if n & 1:
+                continue
+            half = n // 2
+            left = sum(int(c) for c in d[:half])
+            right = sum(int(c) for c in d[half:])
+            if left == right:
+                ans += 1
+        return ans

--- a/leetcode_python/String/faulty-keyboard.py
+++ b/leetcode_python/String/faulty-keyboard.py
@@ -1,0 +1,86 @@
+"""
+
+2810. Faulty Keyboard
+Easy
+
+Your laptop keyboard is faulty, and whenever you type a character 'i' on it, it reverses the string that you have written. Typing other characters works as expected.
+
+You are given a 0-indexed string s, and you type each character of s using your faulty keyboard.
+
+Return the final string that will be present on your laptop screen.
+
+
+Example 1:
+
+Input: s = "string"
+Output: "rtsng"
+Explanation:
+After typing first character, the text on the screen is "s".
+After the second character, the text is "st".
+After the third character, the text is "str".
+Since the fourth character is an 'i', the text gets reversed and becomes "rts".
+After the fifth character, the text is "rtsn".
+After the sixth character, the text is "rtsng".
+Therefore, we return "rtsng".
+
+Example 2:
+
+Input: s = "poiinter"
+Output: "ponter"
+Explanation:
+After the first character, the text on the screen is "p".
+After the second character, the text is "po".
+Since the third character you type is an 'i', the text gets reversed and becomes "op".
+Since the fourth character you type is an 'i', the text gets reversed and becomes "po".
+After the fifth character, the text is "pon".
+After the sixth character, the text is "pont".
+After the seventh character, the text is "ponte".
+After the eighth character, the text is "ponter".
+Therefore, we return "ponter".
+
+
+Constraints:
+
+1 <= s.length <= 100
+s consists of lowercase English letters.
+s[0] != 'i'
+
+"""
+
+# V0
+# IDEA : DEQUE + ORIENTATION FLAG (LAZY REVERSAL)
+#
+#   the naive simulation reverses the buffer on every 'i', costing O(n) per
+#   reversal. instead we never physically reverse : we keep a flag telling
+#   which END of the deque is currently the "tail", and flip it on each 'i'.
+#
+#   - normal orientation : a new char is appended on the right
+#   - flipped orientation : a new char is appended on the left
+#
+#   at the end, read the deque left-to-right if not flipped, right-to-left
+#   if flipped.
+#
+#   NOTE : 'i' itself is never written to the screen - it only triggers the
+#          reversal.
+#
+#   NOTE : the constraint s[0] != 'i' means we never reverse an empty
+#          buffer, but the code handles that case anyway.
+#
+# time = O(n), space = O(n)
+from collections import deque
+
+
+class Solution(object):
+    def finalString(self, s):
+        buf = deque()
+        flipped = False
+        for c in s:
+            if c == 'i':
+                flipped = not flipped
+            elif flipped:
+                buf.appendleft(c)
+            else:
+                buf.append(c)
+        if flipped:
+            buf.reverse()
+        return ''.join(buf)

--- a/leetcode_python/String/remove-trailing-zeros-from-a-string.py
+++ b/leetcode_python/String/remove-trailing-zeros-from-a-string.py
@@ -1,0 +1,45 @@
+"""
+
+2710. Remove Trailing Zeros From a String
+Easy
+
+Given a positive integer num represented as a string, return the integer num without trailing zeros as a string.
+
+
+Example 1:
+
+Input: num = "51230100"
+Output: "512301"
+Explanation: Integer "51230100" has 2 trailing zeros, we remove them and return integer "512301".
+
+Example 2:
+
+Input: num = "123"
+Output: "123"
+Explanation: Integer "123" has no trailing zeros, we return integer "123".
+
+
+Constraints:
+
+1 <= num.length <= 1000
+num consists of only digits.
+num doesn't have any leading zeros.
+
+"""
+
+# V0
+# IDEA : SCAN FROM THE RIGHT
+#
+#   walk backwards while the current char is '0', then cut the string there.
+#
+#   NOTE : num is a POSITIVE integer with no leading zeros, so it can never be
+#          all zeros -> the scan always stops at a non-'0' char and the result
+#          is never the empty string. (str.rstrip("0") does exactly this.)
+#
+# time = O(n), space = O(1) beyond the output
+class Solution(object):
+    def removeTrailingZeros(self, num):
+        i = len(num) - 1
+        while i >= 0 and num[i] == '0':
+            i -= 1
+        return num[:i + 1]

--- a/leetcode_python/String/shortest-string-that-contains-three-strings.py
+++ b/leetcode_python/String/shortest-string-that-contains-three-strings.py
@@ -1,0 +1,87 @@
+"""
+
+2800. Shortest String That Contains Three Strings
+Medium
+
+Given three strings a, b, and c, your task is to find a string that has the minimum length and contains all three strings as substrings.
+
+If there are multiple such strings, return the lexicographically smallest one.
+
+Return a string denoting the answer to the problem.
+
+Notes
+
+A string a is lexicographically smaller than a string b (of the same length) if in the first position where a and b differ, string a has a letter that appears earlier in the alphabet than the corresponding letter in b.
+A substring is a contiguous sequence of characters within a string.
+
+
+Example 1:
+
+Input: a = "abc", b = "bca", c = "aaa"
+Output: "aaabca"
+Explanation: We show that "aaabca" contains all the given strings: a = ans[2...4], b = ans[3..5], c = ans[0..2]. It can be shown that the length of the resulting string would be at least 6 and "aaabca" is the lexicographically smallest one.
+
+Example 2:
+
+Input: a = "ab", b = "ba", c = "aba"
+Output: "aba"
+Explanation: We show that the string "aba" contains all the given strings: a = ans[0..1], b = ans[1..2], c = ans[0..2]. Since the length of c is 3, the length of the resulting string would be at least 3. It can be shown that "aba" is the lexicographically smallest one.
+
+
+Constraints:
+
+1 <= a.length, b.length, c.length <= 100
+a, b, c consist only of lowercase English letters.
+
+
+"""
+
+# V0
+# IDEA : ENUMERATE THE 6 PERMUTATIONS + GREEDY PAIRWISE MERGE
+#
+#   with only 3 strings, an optimal superstring must lay them out in SOME
+#   order, and merging them left to right with maximum overlap each time is
+#   optimal for that order. so we just try all 3! = 6 orders.
+#
+#   merge(s, t) :
+#     - if one already contains the other, keep the container
+#     - otherwise find the longest suffix of s equal to a prefix of t, and
+#       glue t's remaining tail onto s
+#
+#   NOTE : the containment checks must come FIRST. if t sits INSIDE s (not
+#          at the border), the suffix/prefix scan would miss it and we would
+#          emit a longer string than necessary.
+#
+#   NOTE : merging is not associative, which is exactly why all 6 orders are
+#          tried rather than a single fixed one.
+#
+#   NOTE : the tie-break is (length, then lexicographic) - a shorter string
+#          always wins even if it is lexicographically larger.
+#
+# time = O(n^2), space = O(n)   n = max length of the three strings
+class Solution(object):
+    def minimumString(self, a, b, c):
+
+        def merge(s, t):
+            if t in s:
+                return s
+            if s in t:
+                return t
+            # longest suffix of s that is a prefix of t
+            for i in range(min(len(s), len(t)), 0, -1):
+                if s[-i:] == t[:i]:
+                    return s + t[i:]
+            return s + t
+
+        orders = [
+            (a, b, c), (a, c, b),
+            (b, a, c), (b, c, a),
+            (c, a, b), (c, b, a),
+        ]
+
+        res = None
+        for x, y, z in orders:
+            cand = merge(merge(x, y), z)
+            if res is None or len(cand) < len(res) or (len(cand) == len(res) and cand < res):
+                res = cand
+        return res

--- a/leetcode_python/String/split-strings-by-separator.py
+++ b/leetcode_python/String/split-strings-by-separator.py
@@ -1,0 +1,78 @@
+"""
+
+2788. Split Strings by Separator
+Easy
+
+Given an array of strings words and a character separator, split each string in words by separator.
+
+Return an array of strings containing the new strings formed after the splits, excluding empty strings.
+
+Notes
+
+separator is used to determine where the split should occur, but it is not included as part of the resulting strings.
+A split may result in more than two strings.
+The resulting strings must maintain the same order as they were initially given.
+
+
+Example 1:
+
+Input: words = ["one.two.three","four.five","six"], separator = "."
+Output: ["one","two","three","four","five","six"]
+Explanation: In this example we split as follows:
+
+"one.two.three" splits into "one", "two", "three"
+"four.five" splits into "four", "five"
+"six" splits into "six"
+
+Hence, the resulting array is ["one","two","three","four","five","six"].
+
+Example 2:
+
+Input: words = ["$easy$","$problem$"], separator = "$"
+Output: ["easy","problem"]
+Explanation: In this example we split as follows:
+
+"$easy$" splits into "easy" (excluding empty strings)
+"$problem$" splits into "problem" (excluding empty strings)
+
+Hence, the resulting array is ["easy","problem"].
+
+Example 3:
+
+Input: words = ["|||"], separator = "|"
+Output: []
+Explanation: In this example the resulting split of "|||" will contain only empty strings, so we return an empty array [].
+
+
+Constraints:
+
+1 <= words.length <= 100
+1 <= words[i].length <= 20
+characters in words[i] are either lowercase English letters or characters from the string ".,|$#@" (excluding the quotes)
+separator is a character from the string ".,|$#@" (excluding the quotes)
+
+"""
+
+# V0
+# IDEA : SPLIT + FILTER EMPTIES
+#
+#   str.split(sep) already does the whole job per word, and it preserves the
+#   left-to-right order, which is what the problem asks for.
+#
+#   NOTE : the separator is a PLAIN character, not a regex - Python's
+#          str.split is literal, so no escaping is needed (unlike Java's
+#          String.split, which needs Pattern.quote for '.', '|', '$').
+#
+#   NOTE : leading / trailing / consecutive separators produce "" pieces
+#          (e.g. "|||".split("|") -> ['', '', '', '']); those must be dropped,
+#          which is what the `if piece` filter does.
+#
+# time = O(n * m), space = O(n * m) for the output
+class Solution(object):
+    def splitWordsBySeparator(self, words, separator):
+        res = []
+        for w in words:
+            for piece in w.split(separator):
+                if piece:
+                    res.append(piece)
+        return res

--- a/leetcode_python/Two_Pointers/continuous-subarrays.py
+++ b/leetcode_python/Two_Pointers/continuous-subarrays.py
@@ -1,0 +1,96 @@
+"""
+
+2762. Continuous Subarrays
+Medium
+
+You are given a 0-indexed integer array nums. A subarray of nums is called continuous if:
+
+Let i, i + 1, ..., j be the indices in the subarray. Then, for each pair of indices i <= i1, i2 <= j, 0 <= |nums[i1] - nums[i2]| <= 2.
+
+Return the total number of continuous subarrays.
+
+A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [5,4,2,4]
+Output: 8
+Explanation:
+Continuous subarray of size 1: [5], [4], [2], [4].
+Continuous subarray of size 2: [5,4], [4,2], [2,4].
+Continuous subarray of size 3: [4,2,4].
+There are no subarrys of size 4.
+Total continuous subarrays = 4 + 3 + 1 = 8.
+It can be shown that there are no more continuous subarrays.
+
+Example 2:
+
+Input: nums = [1,2,3]
+Output: 6
+Explanation:
+Continuous subarray of size 1: [1], [2], [3].
+Continuous subarray of size 2: [1,2], [2,3].
+Continuous subarray of size 3: [1,2,3].
+Total continuous subarrays = 3 + 2 + 1 = 6.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : SLIDING WINDOW + TWO MONOTONIC DEQUES (window max & window min)
+#
+#  "|nums[i1] - nums[i2]| <= 2 for every pair" is just
+#       max(window) - min(window) <= 2
+#
+#  and that property is MONOTONE: shrinking a valid window keeps it valid.
+#  So for every right end r there is a smallest left end l(r), and l(r) never
+#  decreases as r grows -> classic sliding window, and every window ending at
+#  r contributes r - l + 1 subarrays.
+#
+#  to read max/min of the window in O(1) we keep two deques of INDICES:
+#     maxq : values decreasing -> maxq[0] is the window maximum
+#     minq : values increasing -> minq[0] is the window minimum
+#
+#  while the spread exceeds 2 we must drop whichever extreme is FURTHEST LEFT
+#  (it is the one blocking us), and move l just past it.
+#
+#   NOTE : store indices, not values -- we need to know WHERE the extreme is
+#          to decide how far l jumps.
+#   NOTE : the answer can reach ~n^2/2 = 5*10^9, i.e. beyond 32 bits; Python
+#          ints are unbounded so nothing to do here, but the Java/C++ versions
+#          of this problem require a long long.
+#   NOTE : an ordered multiset (SortedList / TreeMap) also works but costs an
+#          extra log n; the deques give a clean O(n).
+#
+# time = O(n), space = O(n)
+from collections import deque
+class Solution(object):
+    def continuousSubarrays(self, nums):
+        maxq = deque()      # indices, nums values decreasing
+        minq = deque()      # indices, nums values increasing
+        res = 0
+        l = 0
+        for r, x in enumerate(nums):
+            while maxq and nums[maxq[-1]] <= x:
+                maxq.pop()
+            maxq.append(r)
+            while minq and nums[minq[-1]] >= x:
+                minq.pop()
+            minq.append(r)
+
+            while nums[maxq[0]] - nums[minq[0]] > 2:
+                if maxq[0] < minq[0]:
+                    l = maxq[0] + 1
+                    maxq.popleft()
+                else:
+                    l = minq[0] + 1
+                    minq.popleft()
+
+            res += r - l + 1
+        return res

--- a/leetcode_python/Two_Pointers/count-complete-subarrays-in-an-array.py
+++ b/leetcode_python/Two_Pointers/count-complete-subarrays-in-an-array.py
@@ -1,0 +1,77 @@
+"""
+
+2799. Count Complete Subarrays in an Array
+Medium
+
+You are given an array nums consisting of positive integers.
+
+We call a subarray of an array complete if the following condition is satisfied:
+
+The number of distinct elements in the subarray is equal to the number of distinct elements in the whole array.
+
+Return the number of complete subarrays.
+
+A subarray is a contiguous non-empty part of an array.
+
+
+Example 1:
+
+Input: nums = [1,3,1,2,2]
+Output: 4
+Explanation: The complete subarrays are the following: [1,3,1,2], [1,3,1,2,2], [3,1,2] and [3,1,2,2].
+
+Example 2:
+
+Input: nums = [5,5,5,5]
+Output: 10
+Explanation: The array consists only of the integer 5, so any subarray is complete. The number of subarrays that we can choose is 10.
+
+
+Constraints:
+
+1 <= nums.length <= 1000
+1 <= nums[i] <= 2000
+
+"""
+
+# V0
+# IDEA : SLIDING WINDOW (TWO POINTERS) + COUNTER
+#
+#   let `total` be the number of distinct values in the whole array. a
+#   subarray is complete iff it contains all `total` distinct values.
+#
+#   key monotonicity : if nums[i..j] is complete, then nums[i..j'] is also
+#   complete for every j' >= j (extending right can only add values). so for
+#   each left endpoint i there is a smallest right endpoint j making the
+#   window complete, and that contributes (n - j) complete subarrays.
+#
+#   we sweep j to the right and, whenever the window [i..j] holds all
+#   distinct values, we add (n - j) and shrink from the left. every index is
+#   pushed and popped once -> linear.
+#
+#   NOTE : delete a key from the counter the moment its count hits 0,
+#          otherwise len(cnt) keeps counting values no longer in the window
+#          and the window never looks incomplete.
+#
+#   NOTE : we add (n - j) BEFORE moving i, because at that moment [i..j] is
+#          the shortest complete window starting at i.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def countCompleteSubarrays(self, nums):
+        n = len(nums)
+        total = len(set(nums))
+
+        res = 0
+        cnt = {}
+        i = 0
+        for j in range(n):
+            cnt[nums[j]] = cnt.get(nums[j], 0) + 1
+            while len(cnt) == total:
+                # [i..j], [i..j+1], ... [i..n-1] are all complete
+                res += n - j
+                cnt[nums[i]] -= 1
+                if cnt[nums[i]] == 0:
+                    del cnt[nums[i]]
+                i += 1
+        return res

--- a/leetcode_python/Two_Pointers/count-pairs-whose-sum-is-less-than-target.py
+++ b/leetcode_python/Two_Pointers/count-pairs-whose-sum-is-less-than-target.py
@@ -1,0 +1,72 @@
+"""
+
+2824. Count Pairs Whose Sum is Less than Target
+Easy
+
+Given a 0-indexed integer array nums of length n and an integer target, return the number of pairs (i, j) where 0 <= i < j < n and nums[i] + nums[j] < target.
+
+
+Example 1:
+
+Input: nums = [-1,1,2,3,1], target = 2
+Output: 3
+Explanation: There are 3 pairs of indices that satisfy the conditions in the statement:
+- (0, 1) since 0 < 1 and nums[0] + nums[1] = 0 < target
+- (0, 2) since 0 < 2 and nums[0] + nums[2] = 1 < target
+- (0, 4) since 0 < 4 and nums[0] + nums[4] = 0 < target
+Note that (0, 3) is not counted since nums[0] + nums[3] is not strictly less than the target.
+
+Example 2:
+
+Input: nums = [-6,2,5,-2,-7,-1,3], target = -2
+Output: 10
+Explanation: There are 10 pairs of indices that satisfy the conditions in the statement:
+- (0, 1) since 0 < 1 and nums[0] + nums[1] = -4 < target
+- (0, 3) since 0 < 3 and nums[0] + nums[3] = -8 < target
+- (0, 4) since 0 < 4 and nums[0] + nums[4] = -13 < target
+- (0, 5) since 0 < 5 and nums[0] + nums[5] = -7 < target
+- (0, 6) since 0 < 6 and nums[0] + nums[6] = -3 < target
+- (1, 4) since 1 < 4 and nums[1] + nums[4] = -5 < target
+- (3, 4) since 3 < 4 and nums[3] + nums[4] = -9 < target
+- (3, 5) since 3 < 5 and nums[3] + nums[5] = -3 < target
+- (4, 5) since 4 < 5 and nums[4] + nums[5] = -8 < target
+- (4, 6) since 4 < 6 and nums[4] + nums[6] = -4 < target
+
+
+Constraints:
+
+1 <= nums.length == n <= 50
+-50 <= nums[i], target <= 50
+
+"""
+
+# V0
+# IDEA : SORT + TWO POINTERS
+#
+#   The condition only involves the pair of VALUES (i < j is just "an
+#   unordered pair"), so sorting is free - it changes which index pairs we
+#   report but not how many pairs there are.
+#
+#   After sorting, walk l from the left and r from the right:
+#     - if nums[l] + nums[r] < target, then pairing nums[l] with ANY of the
+#       r - l elements strictly between l and r (plus r itself) also works,
+#       since those values are all <= nums[r]. Add (r - l) at once and l += 1.
+#     - otherwise nums[r] is too big for every remaining left partner, so
+#       r -= 1.
+#
+#   NOTE : the counted block is (r - l), not (r - l + 1) - the pair (l, l) is
+#          not a valid pair, only indices strictly greater than l count.
+#
+# time = O(n * log n), space = O(n)   # O(1) extra if sorting in place
+class Solution(object):
+    def countPairs(self, nums, target):
+        arr = sorted(nums)
+        l, r = 0, len(arr) - 1
+        ans = 0
+        while l < r:
+            if arr[l] + arr[r] < target:
+                ans += r - l
+                l += 1
+            else:
+                r -= 1
+        return ans

--- a/leetcode_python/Two_Pointers/count-substrings-without-repeating-character.py
+++ b/leetcode_python/Two_Pointers/count-substrings-without-repeating-character.py
@@ -1,0 +1,76 @@
+"""
+
+2743. Count Substrings Without Repeating Character
+Medium
+
+You are given a string s consisting only of lowercase English letters. We call a substring special if it contains no character which has occurred at least twice (in other words, it does not contain a repeating character). Your task is to count the number of special substrings. For example, in the string "pop", the substring "po" is a special substring, however, "pop" is not special (since 'p' has occurred twice).
+
+Return the number of special substrings.
+
+A substring is a contiguous sequence of characters within a string. For example, "abc" is a substring of "abcd", but "acd" is not.
+
+
+Example 1:
+
+Input: s = "abcd"
+Output: 10
+Explanation: Since each character occurs once, every substring is a special substring. We have 4 substrings of length one, 3 of length two, 2 of length three, and 1 substring of length four. So overall there are 4 + 3 + 2 + 1 = 10 special substrings.
+
+Example 2:
+
+Input: s = "ooo"
+Output: 3
+Explanation: Any substring with a length of at least two contains a repeating character. So we have to count the number of substrings of length one, which is 3.
+
+Example 3:
+
+Input: s = "abab"
+Output: 7
+Explanation: Special substrings are as follows (sorted by their start positions):
+Special substrings of length 1: "a", "b", "a", "b"
+Special substrings of length 2: "ab", "ba", "ab"
+And it can be shown that there are no special substrings with a length of at least three. So the answer would be 4 + 3 = 7.
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s consists of lowercase English letters
+
+"""
+
+# V0
+# IDEA : SLIDING WINDOW (TWO POINTERS) + "COUNT SUBSTRINGS ENDING AT i"
+#
+#   Maintain the longest window [left, i] that has no repeated character.
+#   When s[i] enters the window, jump `left` past the PREVIOUS occurrence of
+#   s[i] (if that occurrence is still inside the window).
+#
+#   Key counting idea : every special substring is counted exactly once by
+#   its RIGHT end. A substring [j, i] is special iff j >= left, so there are
+#   i - left + 1 special substrings ending at i. Summing over i gives the
+#   answer.
+#
+#   NOTE : monotonicity is what makes this valid — dropping characters from
+#          the left can never CREATE a duplicate, so the maximal valid left
+#          boundary never moves backwards.
+#
+#   NOTE : `last[c]` may point BEFORE the current left (an older occurrence
+#          already evicted), hence the max() — left must never rewind.
+#
+#   NOTE : the answer can be ~n^2/2 = 5 * 10^9 for n = 10^5, which overflows
+#          32-bit ints in other languages. Python ints are unbounded, so no
+#          special handling is needed here.
+#
+# time = O(n), space = O(C) with C = 26
+class Solution(object):
+    def numberOfSpecialSubstrings(self, s):
+        last = {}
+        res = 0
+        left = 0
+        for i, c in enumerate(s):
+            if c in last and last[c] >= left:
+                left = last[c] + 1
+            last[c] = i
+            res += i - left + 1
+        return res

--- a/leetcode_python/Two_Pointers/count-zero-request-servers.py
+++ b/leetcode_python/Two_Pointers/count-zero-request-servers.py
@@ -1,0 +1,90 @@
+"""
+
+2747. Count Zero Request Servers
+Medium
+
+You are given an integer n denoting the total number of servers and a 2D 0-indexed integer array logs, where logs[i] = [server_id, time] denotes that the server with id server_id received a request at time time.
+
+You are also given an integer x and a 0-indexed integer array queries.
+
+Return a 0-indexed integer array arr of length queries.length where arr[i] represents the number of servers that did not receive any requests during the time interval [queries[i] - x, queries[i]].
+
+Note that the time intervals are inclusive.
+
+
+Example 1:
+
+Input: n = 3, logs = [[1,3],[2,6],[1,5]], x = 5, queries = [10,11]
+Output: [1,2]
+Explanation:
+For queries[0]: The servers with ids 1 and 2 get requests in the duration of [5, 10]. Hence, only server 3 gets zero requests.
+For queries[1]: Only the server with id 2 gets a request in duration of [6,11]. Hence, the servers with ids 1 and 3 are the only servers that do not receive any requests during that time period.
+
+Example 2:
+
+Input: n = 3, logs = [[2,4],[2,1],[1,2],[3,1]], x = 2, queries = [3,4]
+Output: [0,1]
+Explanation:
+For queries[0]: All servers get at least one request in the duration of [1, 3].
+For queries[1]: Only server with id 3 gets no request in the duration [2,4].
+
+
+Constraints:
+
+1 <= n <= 10^5
+1 <= logs.length <= 10^5
+1 <= queries.length <= 10^5
+logs[i].length == 2
+1 <= logs[i][0] <= n
+1 <= logs[i][1] <= 10^6
+1 <= x <= 10^5
+x < queries[i] <= 10^6
+
+"""
+
+# V0
+# IDEA : OFFLINE QUERIES + SORTING + SLIDING WINDOW (two pointers)
+#
+#  every query asks about the window [q - x, q]. All windows have the SAME
+#  width, so if we answer the queries in INCREASING order of q, both window
+#  ends only ever move to the RIGHT -> one single sweep over the sorted logs.
+#
+#  -> sort logs by time, sort the queries but REMEMBER their original index
+#     (we must write the answer back at that index)
+#  -> keep a counter of "how many logs of server s are currently inside the
+#     window". `len(cnt)` is then the number of DISTINCT active servers, so
+#     the answer is n - len(cnt).
+#
+#   NOTE : the right pointer `k` admits logs with time <= q (inclusive),
+#          while the left pointer `j` evicts logs with time < q - x
+#          (so time == q - x STAYS in the window). Getting either boundary
+#          wrong is the classic off-by-one here.
+#   NOTE : a server must be DELETED from the dict once its count hits 0,
+#          otherwise len(cnt) keeps counting servers that already left.
+#
+# time = O(L*logL + M*logM + n), space = O(L + M)  (L = len(logs), M = len(queries))
+class Solution(object):
+    def countServers(self, n, logs, x, queries):
+        logs = sorted(logs, key=lambda log: log[1])
+        order = sorted(range(len(queries)), key=lambda i: queries[i])
+
+        res = [0] * len(queries)
+        cnt = {}
+        j = k = 0
+        for i in order:
+            r = queries[i]
+            l = r - x
+            # grow the window on the right
+            while k < len(logs) and logs[k][1] <= r:
+                sid = logs[k][0]
+                cnt[sid] = cnt.get(sid, 0) + 1
+                k += 1
+            # shrink the window on the left
+            while j < len(logs) and logs[j][1] < l:
+                sid = logs[j][0]
+                cnt[sid] -= 1
+                if cnt[sid] == 0:
+                    del cnt[sid]
+                j += 1
+            res[i] = n - len(cnt)
+        return res

--- a/leetcode_python/Two_Pointers/find-the-longest-equal-subarray.py
+++ b/leetcode_python/Two_Pointers/find-the-longest-equal-subarray.py
@@ -1,0 +1,82 @@
+"""
+
+2831. Find the Longest Equal Subarray
+Medium
+
+You are given a 0-indexed integer array nums and an integer k.
+
+A subarray is called equal if all of its elements are equal. Note that the empty subarray is an equal subarray.
+
+Return the length of the longest possible equal subarray after deleting at most k elements from nums.
+
+A subarray is a contiguous, possibly empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [1,3,2,3,1,3], k = 3
+Output: 3
+Explanation: It's optimal to delete the elements at index 2 and index 4.
+After deleting them, nums becomes equal to [1, 3, 3, 3].
+The longest equal subarray starts at i = 1 and ends at j = 3 with length equal to 3.
+It can be proven that no longer equal subarrays can be created.
+
+Example 2:
+
+Input: nums = [1,1,2,2,1,1], k = 2
+Output: 4
+Explanation: It's optimal to delete the elements at index 2 and index 3.
+After deleting them, nums becomes equal to [1, 1, 1, 1].
+The array itself is an equal subarray, so the answer is 4.
+It can be proven that no longer equal subarrays can be created.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= nums.length
+0 <= k <= nums.length
+
+"""
+
+# V0
+# IDEA : TWO POINTERS OVER THE INDEX LIST OF EACH VALUE
+#
+#   Fix the surviving value v. Group the positions where v occurs into a list
+#   ids. Keeping ids[l..r] means every non-v element strictly between
+#   ids[l] and ids[r] has to be deleted, and that count is
+#
+#       (ids[r] - ids[l] + 1) - (r - l + 1) = ids[r] - ids[l] - (r - l)
+#
+#   NOTE : deletions outside [ids[l], ids[r]] are never needed — removing an
+#          element outside the window cannot make the window's elements any
+#          more contiguous, so only the gaps inside it matter.
+#
+#   The gap count grows with r and shrinks with l, so a sliding window over
+#   ids works: advance r, then advance l while the gap exceeds k.
+#
+#   NOTE : the pointers only move forward, so the total work over ALL values
+#          is O(n), not O(n) per value — the index lists partition nums.
+#
+#   NOTE : the answer is a count of kept elements (r - l + 1), NOT a span in
+#          the original array.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def longestEqualSubarray(self, nums, k):
+        groups = {}
+        for i, x in enumerate(nums):
+            if x not in groups:
+                groups[x] = []
+            groups[x].append(i)
+
+        ans = 0
+        for ids in groups.values():
+            l = 0
+            for r in range(len(ids)):
+                # number of foreign elements sitting inside ids[l] .. ids[r]
+                while ids[r] - ids[l] - (r - l) > k:
+                    l += 1
+                if r - l + 1 > ans:
+                    ans = r - l + 1
+        return ans

--- a/leetcode_python/Two_Pointers/find-the-longest-semi-repetitive-substring.py
+++ b/leetcode_python/Two_Pointers/find-the-longest-semi-repetitive-substring.py
@@ -1,0 +1,72 @@
+"""
+
+2730. Find the Longest Semi-Repetitive Substring
+Medium
+
+You are given a digit string s that consists of digits from 0 to 9.
+
+A string is called semi-repetitive if there is at most one adjacent pair of the same digit. For example, "0010", "002020", "0123", "2002", and "54944" are semi-repetitive while the following are not: "00101022" (adjacent same digit pairs are 00 and 22), and "1101234883" (adjacent same digit pairs are 11 and 88).
+
+Return the length of the longest semi-repetitive substring of s.
+
+
+Example 1:
+
+Input: s = "52233"
+Output: 4
+Explanation:
+The longest semi-repetitive substring is "5223". Picking the whole string "52233" has two adjacent same digit pairs 22 and 33, but at most one is allowed.
+
+Example 2:
+
+Input: s = "5494"
+Output: 4
+Explanation:
+s is a semi-repetitive string.
+
+Example 3:
+
+Input: s = "1111111"
+Output: 2
+Explanation:
+The longest semi-repetitive substring is "11". Picking the substring "111" has two adjacent same digit pairs, but at most one is allowed.
+
+
+Constraints:
+
+1 <= s.length <= 50
+'0' <= s[i] <= '9'
+
+"""
+
+# V0
+# IDEA : TWO POINTERS / SLIDING WINDOW ON ADJACENT-EQUAL PAIRS
+#
+#   the property "at most one adjacent equal pair" is monotone: shrinking a
+#   window can only remove pairs. So a plain sliding window works.
+#
+#   count `cnt` = number of indices p in [l+1, r] with s[p] == s[p-1], i.e.
+#   the pairs that live entirely inside the window s[l..r].
+#
+#   NOTE : entering r adds the pair (r-1, r); advancing l from l to l+1 drops
+#          the pair (l, l+1) — the pair is indexed by its RIGHT end, so the
+#          add/remove tests are s[r]==s[r-1] and s[l]==s[l+1] respectively.
+#   NOTE : answer starts at 1 — a single char is always semi-repetitive, and
+#          for n == 1 the loop body never runs.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def longestSemiRepetitiveSubstring(self, s):
+        n = len(s)
+        res = 1
+        l = 0
+        cnt = 0
+        for r in range(1, n):
+            if s[r] == s[r - 1]:
+                cnt += 1
+            while cnt > 1:
+                if s[l] == s[l + 1]:
+                    cnt -= 1
+                l += 1
+            res = max(res, r - l + 1)
+        return res

--- a/leetcode_python/Two_Pointers/length-of-the-longest-valid-substring.py
+++ b/leetcode_python/Two_Pointers/length-of-the-longest-valid-substring.py
@@ -1,0 +1,76 @@
+"""
+
+2781. Length of the Longest Valid Substring
+Hard
+
+You are given a string word and an array of strings forbidden.
+
+A string is called valid if none of its substrings are present in forbidden.
+
+Return the length of the longest valid substring of the string word.
+
+A substring is a contiguous sequence of characters in a string, possibly empty.
+
+
+Example 1:
+
+Input: word = "cbaaaabc", forbidden = ["aaa","cb"]
+Output: 4
+Explanation: There are 11 valid substrings in word: "c", "b", "a", "ba", "aa", "bc", "baa", "aab", "ab", "abc" and "aabc". The length of the longest valid substring is 4.
+It can be shown that all other substrings contain either "aaa" or "cb" as a substring.
+
+Example 2:
+
+Input: word = "leetcode", forbidden = ["de","le","e"]
+Output: 4
+Explanation: There are 11 valid substrings in word: "l", "t", "c", "o", "d", "tc", "co", "od", "tco", "cod", and "tcod". The length of the longest valid substring is 4.
+It can be shown that all other substrings contain either "de", "le", or "e" as a substring.
+
+
+Constraints:
+
+1 <= word.length <= 10^5
+word consists only of lowercase English letters.
+1 <= forbidden.length <= 10^5
+1 <= forbidden[i].length <= 10
+forbidden[i] consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : SLIDING WINDOW + BOUNDED SUFFIX LOOKUP
+#
+#   keep a window [left, right] that contains no forbidden substring.
+#   when the window grows by word[right], the ONLY new substrings are the
+#   suffixes ending at `right`, so we just have to test those.
+#
+#   NOTE : forbidden[i] has length <= 10, so a bad suffix can be at most 10
+#          chars long -> checking 10 suffixes per right index is enough,
+#          which keeps the whole scan linear.
+#
+#   NOTE : if suffix word[k..right] is forbidden, every window starting at
+#          index <= k is dead, so left must jump to k + 1. We probe the
+#          suffixes from the longest end toward `right`; the FIRST hit found
+#          while walking k downward from right gives the largest k, i.e. the
+#          smallest legal left, so we can break right there.
+#
+#   NOTE : left never moves backwards, hence the `k > left - 1` guard.
+#
+# time = O(n * L^2) with L = 10 (substring slicing), space = O(total forbidden chars)
+class Solution(object):
+    def longestValidSubstring(self, word, forbidden):
+        bad = set(forbidden)
+        max_len = max(len(w) for w in bad)
+        res = 0
+        left = 0
+        for right in range(len(word)):
+            # only suffixes of length 1 .. max_len can be forbidden
+            low = max(left, right - max_len + 1)
+            k = right
+            while k >= low:
+                if word[k:right + 1] in bad:
+                    left = k + 1
+                    break
+                k -= 1
+            res = max(res, right - left + 1)
+        return res

--- a/leetcode_python/Two_Pointers/maximum-beauty-of-an-array-after-applying-operation.py
+++ b/leetcode_python/Two_Pointers/maximum-beauty-of-an-array-after-applying-operation.py
@@ -1,0 +1,79 @@
+"""
+
+2779. Maximum Beauty of an Array After Applying Operation
+Medium
+
+You are given a 0-indexed array nums and a non-negative integer k.
+
+In one operation, you can do the following:
+
+Choose an index i that hasn't been chosen before from the range [0, nums.length - 1].
+Replace nums[i] with any integer from the range [nums[i] - k, nums[i] + k].
+
+The beauty of the array is the length of the longest subsequence consisting of equal elements.
+
+Return the maximum possible beauty of the array nums after applying the operation any number of times.
+
+Note that you can apply the operation to each index only once.
+
+A subsequence of an array is a new array generated from the original array by deleting some elements (possibly none) without changing the order of the remaining elements.
+
+
+Example 1:
+
+Input: nums = [4,6,1,2], k = 2
+Output: 3
+Explanation: In this example, we apply the following operations:
+- Choose index 1, replace it with 4 (from range [4,8]), nums = [4,4,1,2].
+- Choose index 3, replace it with 4 (from range [0,4]), nums = [4,4,1,4].
+After the applied operations, the beauty of the array nums is 3 (subsequence consisting of indices 0, 1, and 3).
+It can be proven that 3 is the maximum possible length we can achieve.
+
+Example 2:
+
+Input: nums = [1,1,1,1], k = 10
+Output: 4
+Explanation: In this example we don't have to apply any operations.
+The beauty of the array nums is 4 (whole array).
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+0 <= nums[i], k <= 10^5
+
+"""
+
+# V0
+# IDEA : SORT + SLIDING WINDOW OF WIDTH 2k
+#
+#   each nums[i] can become anything in [nums[i] - k, nums[i] + k]. A set of
+#   elements can all be made equal to the same target exactly when their
+#   intervals share a point, i.e. when
+#
+#       max(nums) - min(nums) <= 2 * k
+#
+#   NOTE : we want a SUBSEQUENCE, so order is irrelevant — sorting is free, and
+#          after sorting the best group is always a contiguous run.
+#
+#   So sort and slide a window keeping nums[right] - nums[left] <= 2k; the
+#   answer is the widest such window.
+#
+#   NOTE : k may be 0 (no real freedom), and the window condition degenerates
+#          to "equal values", which is still handled correctly.
+#
+# time = O(n log n), space = O(n) for the sort
+class Solution(object):
+    def maximumBeauty(self, nums, k):
+        nums = sorted(nums)
+        span = 2 * k
+        res = 0
+        left = 0
+
+        for right in range(len(nums)):
+            while nums[right] - nums[left] > span:
+                left += 1
+            if right - left + 1 > res:
+                res = right - left + 1
+
+        return res

--- a/leetcode_python/Two_Pointers/maximum-coins-heroes-can-collect.py
+++ b/leetcode_python/Two_Pointers/maximum-coins-heroes-can-collect.py
@@ -1,0 +1,87 @@
+"""
+
+2838. Maximum Coins Heroes Can Collect
+Medium
+
+There is a battle and n heroes are trying to defeat m monsters. You are given two 1-indexed arrays of positive integers heroes and monsters of length n and m, respectively. heroes[i] is the power of ith hero, and monsters[i] is the power of ith monster.
+
+The ith hero can defeat the jth monster if monsters[j] <= heroes[i].
+
+You are also given a 1-indexed array coins of length m consisting of positive integers. coins[i] is the number of coins that each hero earns after defeating the ith monster.
+
+Return an array ans of length n where ans[i] is the maximum number of coins that the ith hero can collect from this battle.
+
+Notes
+
+- The health of a hero doesn't get reduced after defeating a monster.
+- Multiple heroes can defeat a monster, but each monster can be defeated by a given hero only once.
+
+
+Example 1:
+
+Input: heroes = [1,4,2], monsters = [1,1,5,2,3], coins = [2,3,4,5,6]
+Output: [5,16,10]
+Explanation: For each hero, we list the index of all the monsters he can defeat:
+1st hero: [1,2] since the power of this hero is 1 and monsters[1], monsters[2] <= 1. So this hero collects coins[1] + coins[2] = 5 coins.
+2nd hero: [1,2,4,5] since the power of this hero is 4 and monsters[1], monsters[2], monsters[4], monsters[5] <= 4. So this hero collects coins[1] + coins[2] + coins[4] + coins[5] = 16 coins.
+3rd hero: [1,2,4] since the power of this hero is 2 and monsters[1], monsters[2], monsters[4] <= 2. So this hero collects coins[1] + coins[2] + coins[4] = 10 coins.
+So the answer would be [5,16,10].
+
+Example 2:
+
+Input: heroes = [5], monsters = [2,3,1,2], coins = [10,6,5,2]
+Output: [23]
+Explanation: This hero can defeat all the monsters since monsters[i] <= 5. So he collects all of the coins: coins[1] + coins[2] + coins[3] + coins[4] = 23, and the answer would be [23].
+
+Example 3:
+
+Input: heroes = [4,4], monsters = [5,7,8], coins = [1,1,1]
+Output: [0,0]
+Explanation: In this example, no hero can defeat a monster. So the answer would be [0,0],
+
+
+Constraints:
+
+1 <= n == heroes.length <= 10^5
+1 <= m == monsters.length <= 10^5
+coins.length == m
+1 <= heroes[i], monsters[i], coins[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : SORT + PREFIX SUM + TWO POINTERS
+#
+#   a hero of power h collects EVERY monster with power <= h (no health cost,
+#   no competition between heroes), so the answer only depends on h.
+#
+#   sort the (monster power, coin) pairs by power and build a prefix sum over
+#   the coins. then ans[i] = prefix[ #monsters with power <= heroes[i] ].
+#
+#   to keep it O((n + m) log(n + m)) without repeated binary searches, sort the
+#   HEROES by power too and sweep both sorted lists with two pointers: since
+#   hero powers are non-decreasing, the monster pointer only moves forward.
+#
+#   NOTE : the output must follow the ORIGINAL hero order, so sort hero indices
+#          (not the values) and scatter the results back.
+#   NOTE : sums reach 10^5 * 10^9 = 10^14 - needs 64-bit in a Java/C++ port.
+#
+# time = O(n log n + m log m), space = O(n + m)
+class Solution(object):
+    def maximumCoins(self, heroes, monsters, coins):
+        m = len(monsters)
+        pairs = sorted(zip(monsters, coins))
+
+        pre = [0] * (m + 1)
+        for i in range(m):
+            pre[i + 1] = pre[i] + pairs[i][1]
+
+        n = len(heroes)
+        ans = [0] * n
+        j = 0
+        for i in sorted(range(n), key=lambda t: heroes[t]):
+            h = heroes[i]
+            while j < m and pairs[j][0] <= h:
+                j += 1
+            ans[i] = pre[j]
+        return ans

--- a/leetcode_python/Two_Pointers/maximum-sum-of-almost-unique-subarray.py
+++ b/leetcode_python/Two_Pointers/maximum-sum-of-almost-unique-subarray.py
@@ -1,0 +1,81 @@
+"""
+
+2841. Maximum Sum of Almost Unique Subarray
+Medium
+
+You are given an integer array nums and two positive integers m and k.
+
+Return the maximum sum out of all almost unique subarrays of length k of nums. If no such subarray exists, return 0.
+
+A subarray of nums is almost unique if it contains at least m distinct elements.
+
+A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [2,6,7,3,1,7], m = 3, k = 4
+Output: 18
+Explanation: There are 3 almost unique subarrays of size k = 4. These subarrays are [2, 6, 7, 3], [6, 7, 3, 1], and [7, 3, 1, 7]. Among these subarrays, the one with the maximum sum is [2, 6, 7, 3] which has a sum of 18.
+
+Example 2:
+
+Input: nums = [5,9,9,2,4,5,4], m = 1, k = 3
+Output: 23
+Explanation: There are 5 almost unique subarrays of size k. These subarrays are [5, 9, 9], [9, 9, 2], [9, 2, 4], [2, 4, 5], and [4, 5, 4]. Among these subarrays, the one with the maximum sum is [5, 9, 9] which has a sum of 23.
+
+Example 3:
+
+Input: nums = [1,2,1,2,1,2,1], m = 3, k = 3
+Output: 0
+Explanation: There are no subarrays of size k = 3 that contain at least m = 3 distinct elements in the given array [1,2,1,2,1,2,1]. Therefore, no almost unique subarrays exist, and the maximum sum is 0.
+
+
+Constraints:
+
+1 <= nums.length <= 2 * 10^4
+1 <= m <= k <= nums.length
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : FIXED-SIZE SLIDING WINDOW + HASH TABLE (running sum & distinct count)
+#
+#   the window length is pinned at k, so slide it one step at a time and keep
+#   two things incrementally:
+#     - `s`   : the running sum (add the entering value, drop the leaving one)
+#     - `cnt` : value -> occurrences inside the window; len(cnt) is the number
+#               of distinct values
+#
+#   whenever len(cnt) >= m the window is "almost unique" and we take its sum
+#   as an answer candidate.
+#
+#   NOTE : delete the key once its count hits 0, otherwise len(cnt) counts
+#          stale values that already left the window and m is over-satisfied.
+#   NOTE : return 0 when no window qualifies - the default answer, not -inf.
+#
+# time = O(n), space = O(k)
+class Solution(object):
+    def maxSum(self, nums, m, k):
+        n = len(nums)
+        if n < k:
+            return 0
+
+        cnt = {}
+        s = 0
+        for i in range(k):
+            s += nums[i]
+            cnt[nums[i]] = cnt.get(nums[i], 0) + 1
+
+        ans = s if len(cnt) >= m else 0
+        for i in range(k, n):
+            inv, outv = nums[i], nums[i - k]
+            s += inv - outv
+            cnt[inv] = cnt.get(inv, 0) + 1
+            cnt[outv] -= 1
+            if cnt[outv] == 0:
+                del cnt[outv]
+            if len(cnt) >= m and s > ans:
+                ans = s
+        return ans

--- a/leetcode_python/Two_Pointers/sum-of-imbalance-numbers-of-all-subarrays.py
+++ b/leetcode_python/Two_Pointers/sum-of-imbalance-numbers-of-all-subarrays.py
@@ -1,0 +1,98 @@
+"""
+
+2763. Sum of Imbalance Numbers of All Subarrays
+Hard
+
+The imbalance number of a 0-indexed integer array arr of length n is defined as the number of indices in sarr = sorted(arr) such that:
+
+0 <= i < n - 1, and
+sarr[i+1] - sarr[i] > 1
+
+Here, sorted(arr) is the function that returns the sorted version of arr.
+
+Given a 0-indexed integer array nums, return the sum of imbalance numbers of all its subarrays.
+
+A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [2,3,1,4]
+Output: 3
+Explanation: There are 3 subarrays with non-zero imbalance numbers:
+- Subarray [3, 1] with an imbalance number of 1.
+- Subarray [3, 1, 4] with an imbalance number of 1.
+- Subarray [1, 4] with an imbalance number of 1.
+The imbalance number of all other subarrays is 0. Hence, the sum of imbalance numbers of all the subarrays of nums is 3.
+
+Example 2:
+
+Input: nums = [1,3,3,3,5]
+Output: 8
+Explanation: There are 7 subarrays with non-zero imbalance numbers:
+- Subarray [1, 3] with an imbalance number of 1.
+- Subarray [1, 3, 3] with an imbalance number of 1.
+- Subarray [1, 3, 3, 3] with an imbalance number of 1.
+- Subarray [1, 3, 3, 3, 5] with an imbalance number of 2.
+- Subarray [3, 3, 3, 5] with an imbalance number of 1.
+- Subarray [3, 3, 5] with an imbalance number of 1.
+- Subarray [3, 5] with an imbalance number of 1.
+The imbalance number of all other subarrays is 0. Hence, the sum of imbalance numbers of all the subarrays of nums is 8.
+
+
+Constraints:
+
+1 <= nums.length <= 1000
+1 <= nums[i] <= nums.length
+
+"""
+
+# V0
+# IDEA : GROW THE RIGHT END + REWRITE IMBALANCE AS A COUNT OVER THE VALUE SET
+#
+#   duplicates contribute a gap of 0, so only the DISTINCT values of a subarray
+#   matter. Let S be that set of distinct values, d = |S|. Sorting S gives
+#   d - 1 adjacent pairs, and a pair fails the "> 1" test exactly when the two
+#   values are consecutive integers. Hence
+#
+#       imbalance(S) = (d - 1) - #{ v in S : v + 1 in S }
+#
+#   NOTE : this turns the sorted-array definition into something maintainable
+#          incrementally — no SortedList / re-sorting needed.
+#
+#   So fix the left end i and push the right end j forward, keeping a boolean
+#   `seen` table (values are bounded by n, so a plain array works):
+#
+#       new value v -> d += 1
+#                      c += (v + 1 in S) + (v - 1 in S)   # 1 or 2 new joins
+#       repeated v  -> S unchanged, imbalance unchanged
+#
+#   NOTE : `seen` is reset per left end by re-walking only the values that were
+#          actually inserted, so the reset is O(subarray length), not O(n).
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def sumImbalanceNumbers(self, nums):
+        n = len(nums)
+        seen = [False] * (n + 2)      # values are in [1, n]
+        res = 0
+
+        for i in range(n):
+            distinct = 0              # d
+            joins = 0                 # c = #{v in S : v+1 in S}
+            for j in range(i, n):
+                v = nums[j]
+                if not seen[v]:
+                    seen[v] = True
+                    distinct += 1
+                    if seen[v + 1]:
+                        joins += 1
+                    if v - 1 >= 1 and seen[v - 1]:
+                        joins += 1
+                res += distinct - 1 - joins
+
+            # undo this left end's insertions
+            for j in range(i, n):
+                seen[nums[j]] = False
+
+        return res


### PR DESCRIPTION
Fifth tranche of the LC 2001-3000 coverage gap vs
kamyu104/LeetCode-Solutions. 23 Easy / 51 Medium / 24 Hard, including 15 premium/locked problems.

Same convention as the rest of the directory: problem docstring, then a V0 solution with an IDEA block explaining the approach and a time/space complexity comment.

Written by ten agents working in parallel over disjoint slices of the range, then swept as a whole before committing.

Verified:
- all 98 files parse cleanly and match the directory's format conventions
- all 98 run correctly against every example in their problem statement
- the non-obvious ones additionally cross-checked against brute-force reference implementations on randomized inputs, and the ones with large stated constraints sanity-checked for runtime at those limits
- 2708, 2712, 2770, 2789, 2790, 2811 and 2824 independently re-checked against a second, separately written set of brute-force references
- no duplicate coverage: none of the 98 is already solved elsewhere in the repo, by LC number or by slug
- declared difficulty matches LeetCode for all 98

Repairs the audit files so the to-add list can no longer generate duplicates:

- coverage is now detected by LC number, not just by filename. LC 2086 was renamed by LeetCode (minimum-number-of-buckets-required-to-collect- rainwater-from-houses -> minimum-number-of-food-buckets-to-feed-the- hamsters); the repo has it under the old name, so the record now points at the existing file instead of being re-solved under the new slug.
- slugs and difficulty come from the canonical leetcode.com URL and front matter of each problem statement. 3 slugs and 19 difficulty labels corrected; the LC 2522 record that collided with LC 2499 is repaired in place rather than dropped.
- JavaScript-track problems are removed from the work list rather than only recorded next to it. Detection is by the JavaScript tag, not by which reference files happen to exist -- LC 2691 and 2756 have no solution files at all in the source and slipped past a has-.ts-but-no-.py test. 35 more skipped, 139 total.

work_2001-3000.json: 852 -> 783 records. Remaining to add: 130.