### PR TITLE
feat(leetcode_python): add 50 solutions for LC 2095-2151

### DIFF
--- a/leetcode_python/Array/check-if-every-row-and-column-contains-all-numbers.py
+++ b/leetcode_python/Array/check-if-every-row-and-column-contains-all-numbers.py
@@ -1,0 +1,53 @@
+"""
+
+2133. Check if Every Row and Column Contains All Numbers
+Easy
+
+An n x n matrix is valid if every row and every column contains all the integers from 1 to n (inclusive).
+
+Given an n x n integer matrix matrix, return true if the matrix is valid. Otherwise, return false.
+
+
+Example 1:
+
+Input: matrix = [[1,2,3],[3,1,2],[2,3,1]]
+Output: true
+Explanation: In this case, n = 3, and every row and column contains the numbers 1, 2, and 3.
+Hence, we return true.
+
+Example 2:
+
+Input: matrix = [[1,1,1],[1,2,3],[1,2,3]]
+Output: false
+Explanation: In this case, n = 3, but the first row and the first column do not contain the numbers 2 or 3.
+Hence, we return false.
+
+
+Constraints:
+
+n == matrix.length == matrix[i].length
+1 <= n <= 100
+1 <= matrix[i][j] <= n
+
+"""
+
+# V0
+# IDEA : EVERY ROW AND EVERY COLUMN MUST BE A SET OF SIZE n
+#
+#   values are already guaranteed to lie in 1..n, so "contains all of 1..n"
+#   collapses to "has no duplicates", i.e. the set of the line has n
+#   distinct members.
+#
+#   zip(*matrix) hands back the columns, so both checks are the same loop.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def checkValid(self, matrix):
+        n = len(matrix)
+        for row in matrix:
+            if len(set(row)) != n:
+                return False
+        for col in zip(*matrix):
+            if len(set(col)) != n:
+                return False
+        return True

--- a/leetcode_python/Array/count-elements-with-strictly-smaller-and-greater-elements.py
+++ b/leetcode_python/Array/count-elements-with-strictly-smaller-and-greater-elements.py
@@ -1,0 +1,46 @@
+"""
+
+2148. Count Elements With Strictly Smaller and Greater Elements
+Easy
+
+Given an integer array nums, return the number of elements that have both a strictly smaller and a strictly greater element appear in nums.
+
+
+Example 1:
+
+Input: nums = [11,7,2,15]
+Output: 2
+Explanation: The element 7 has the element 2 strictly smaller than it and the element 11 strictly greater than it.
+Element 11 has element 7 strictly smaller than it and element 15 strictly greater than it.
+In total there are 2 elements having both a strictly smaller and a strictly greater element appear in nums.
+
+Example 2:
+
+Input: nums = [-3,3,3,90]
+Output: 2
+Explanation: The element 3 has the element -3 strictly smaller than it and the element 90 strictly greater than it.
+Since there are two elements with the value 3, in total there are 2 elements having both a strictly smaller and a strictly greater element appear in nums.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+-10^5 <= nums[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : "HAS BOTH" MEANS STRICTLY BETWEEN THE MIN AND THE MAX
+#
+#   something strictly smaller exists iff the value is above the array
+#   minimum; something strictly greater exists iff it is below the maximum.
+#   so the answer counts the values in the open interval (min, max).
+#
+#   duplicates count individually, which the straight per-element loop
+#   already does.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def countElements(self, nums):
+        lo, hi = min(nums), max(nums)
+        return sum(1 for x in nums if lo < x < hi)

--- a/leetcode_python/Array/count-the-hidden-sequences.py
+++ b/leetcode_python/Array/count-the-hidden-sequences.py
@@ -1,0 +1,81 @@
+"""
+
+2145. Count the Hidden Sequences
+Medium
+
+You are given a 0-indexed array of n integers differences, which describes the differences between each pair of consecutive integers of a hidden sequence of length (n + 1). More formally, call the hidden sequence hidden, then we have that differences[i] = hidden[i + 1] - hidden[i].
+
+You are further given two integers lower and upper that describe the inclusive range of values [lower, upper] that the hidden sequence can contain.
+
+For example, given differences = [1, -3, 4], lower = 1, upper = 6, the hidden sequence is a sequence of length 4 whose elements are in between 1 and 6 (inclusive).
+[3, 4, 1, 5] and [4, 5, 2, 6] are possible hidden sequences.
+[5, 6, 3, 7] is not possible since it contains an element greater than 6.
+[1, 2, 3, 4] is not possible since the differences are not correct.
+
+Return the number of possible hidden sequences there are. If there are no possible sequences, return 0.
+
+
+Example 1:
+
+Input: differences = [1,-3,4], lower = 1, upper = 6
+Output: 2
+Explanation: The possible hidden sequences are:
+- [3, 4, 1, 5]
+- [4, 5, 2, 6]
+Thus, we return 2.
+
+Example 2:
+
+Input: differences = [3,-4,5,1,-2], lower = -4, upper = 5
+Output: 4
+Explanation: The possible hidden sequences are:
+- [-3, 0, -4, 1, 2, 0]
+- [-2, 1, -3, 2, 3, 1]
+- [-1, 2, -2, 3, 4, 2]
+- [0, 3, -1, 4, 5, 3]
+Thus, we return 4.
+
+Example 3:
+
+Input: differences = [4,-7,2], lower = 3, upper = 6
+Output: 0
+Explanation: There are no possible hidden sequences. Thus, we return 0.
+
+
+Constraints:
+
+n == differences.length
+1 <= n <= 10^5
+-10^5 <= differences[i] <= 10^5
+-10^5 <= lower <= upper <= 10^5
+
+"""
+
+# V0
+# IDEA : THE SHAPE IS FIXED — ONLY THE STARTING VALUE IS FREE
+#
+#   the differences pin every element relative to the first one :
+#       hidden[i] = hidden[0] + prefix[i]
+#   so the whole sequence is one rigid shape that slides up and down with
+#   hidden[0].
+#
+#   the shape fits inside [lower, upper] exactly when
+#       lower <= hidden[0] + min(prefix)  and  hidden[0] + max(prefix) <= upper
+#   which leaves a contiguous window of starting values whose size is
+#
+#       (upper - lower) - (max(prefix) - min(prefix)) + 1
+#
+#   clamped at 0 when the shape is already taller than the allowed range.
+#
+#   NOTE : prefix must include the leading 0 (hidden[0] itself).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def numberOfArrays(self, differences, lower, upper):
+        cur = 0
+        lo = hi = 0                     # min / max of the running prefix
+        for d in differences:
+            cur += d
+            lo = min(lo, cur)
+            hi = max(hi, cur)
+        return max(0, (upper - lower) - (hi - lo) + 1)

--- a/leetcode_python/Array/execution-of-all-suffix-instructions-staying-in-a-grid.py
+++ b/leetcode_python/Array/execution-of-all-suffix-instructions-staying-in-a-grid.py
@@ -1,0 +1,82 @@
+"""
+
+2120. Execution of All Suffix Instructions Staying in a Grid
+Medium
+
+There is an n x n grid, with the top-left cell at (0, 0) and the bottom-right cell at (n - 1, n - 1). You are given the integer n and an integer array startPos where startPos = [startrow, startcol] indicates that a robot is initially at cell (startrow, startcol).
+
+You are also given a 0-indexed string s of length m and where s[i] is the ith instruction for the robot: 'L' (move left), 'R' (move right), 'U' (move up), and 'D' (move down).
+
+The robot can begin executing from any ith instruction in s. It executes the instructions one by one towards the end of s but it stops if either of these conditions is met:
+
+The next instruction will move the robot off the grid.
+There are no more instructions left to execute.
+
+Return an array answer of length m where answer[i] is the number of instructions the robot can execute if the robot begins executing from the ith instruction in s.
+
+
+Example 1:
+
+Input: n = 3, startPos = [0,1], s = "RRDDLU"
+Output: [1,5,4,3,1,0]
+Explanation: Starting from startPos and beginning execution from the ith instruction:
+- 0th: "RRDDLU". Only one instruction "R" can be executed before it moves off the grid.
+- 1st:  "RDDLU". All five instructions can be executed while it stays in the grid and ends at (1, 1).
+- 2nd:   "DDLU". All four instructions can be executed while it stays in the grid and ends at (1, 0).
+- 3rd:    "DLU". All three instructions can be executed while it stays in the grid and ends at (0, 0).
+- 4th:     "LU". Only one instruction "L" can be executed before it moves off the grid.
+- 5th:      "U". No instruction can be executed as it moves off the grid.
+
+Example 2:
+
+Input: n = 2, startPos = [1,1], s = "LURD"
+Output: [4,1,0,0]
+Explanation:
+- 0th: "LURD".
+- 1st:  "URD".
+- 2nd:   "RD".
+- 3rd:    "D".
+
+Example 3:
+
+Input: n = 1, startPos = [0,0], s = "LRUD"
+Output: [0,0,0,0]
+Explanation: No instruction can be executed because the grid is of size 1x1.
+
+
+Constraints:
+
+m == s.length
+1 <= n, m <= 500
+startPos.length == 2
+0 <= startrow, startcol < n
+s consists of 'L', 'R', 'U', and 'D'.
+
+"""
+
+# V0
+# IDEA : DIRECT SIMULATION OF EVERY SUFFIX
+#
+#   m <= 500, so the m suffixes cost at most 500 * 500 = 250k steps — small
+#   enough to just replay each one from startPos and stop at the first move
+#   that leaves the grid.
+#
+#   NOTE : the count is the number of instructions ACTUALLY executed, so the
+#          offending instruction itself is not counted.
+#
+# time = O(m^2), space = O(m)
+class Solution(object):
+    def executeInstructions(self, n, startPos, s):
+        moves = {'L': (0, -1), 'R': (0, 1), 'U': (-1, 0), 'D': (1, 0)}
+        res = []
+        for i in range(len(s)):
+            r, c = startPos
+            cnt = 0
+            for j in range(i, len(s)):
+                dr, dc = moves[s[j]]
+                r, c = r + dr, c + dc
+                if not (0 <= r < n and 0 <= c < n):
+                    break
+                cnt += 1
+            res.append(cnt)
+        return res

--- a/leetcode_python/Array/remove-all-ones-with-row-and-column-flips.py
+++ b/leetcode_python/Array/remove-all-ones-with-row-and-column-flips.py
@@ -1,0 +1,64 @@
+"""
+
+2128. Remove All Ones With Row and Column Flips
+Medium
+🔒 (premium)
+
+You are given an m x n binary matrix grid.
+
+In one operation, you can choose any row or column and flip each value in that row or column (i.e., changing all 0's to 1's, and all 1's to 0's).
+
+Return true if it is possible to remove all 1's from grid using any number of operations or false otherwise.
+
+
+Example 1:
+
+Input: grid = [[0,1,0],[1,0,1],[0,1,0]]
+Output: true
+Explanation: One possible way to remove all 1's from grid is to:
+- Flip the middle row
+- Flip the middle column
+
+Example 2:
+
+Input: grid = [[1,1,0],[0,0,0],[0,0,0]]
+Output: false
+Explanation: It is impossible to remove all 1's from grid.
+
+Example 3:
+
+Input: grid = [[0]]
+Output: true
+Explanation: There are no 1's in grid and it is already all zero.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m, n <= 300
+grid[i][j] is either 0 or 1.
+
+"""
+
+# V0
+# IDEA : EVERY ROW MUST EQUAL ROW 0, OR BE ITS EXACT COMPLEMENT
+#
+#   column flips act on every row identically, so they can never change the
+#   RELATIONSHIP between two rows — two rows that agree in a column keep
+#   agreeing, two that differ keep differing. a row flip only inverts one
+#   whole row.
+#
+#   so the grid is clearable iff, after the column flips that zero out row 0,
+#   every other row is already all-0 or all-1 — which is exactly the
+#   condition "row i equals row 0, or is its bitwise complement".
+#
+# time = O(m * n), space = O(n)
+class Solution(object):
+    def removeOnes(self, grid):
+        first = grid[0]
+        flipped = [1 - x for x in first]
+        for row in grid[1:]:
+            if row != first and row != flipped:
+                return False
+        return True

--- a/leetcode_python/Array/stamping-the-grid.py
+++ b/leetcode_python/Array/stamping-the-grid.py
@@ -1,0 +1,97 @@
+"""
+
+2132. Stamping the Grid
+Hard
+
+You are given an m x n binary matrix grid where each cell is either 0 (empty) or 1 (occupied).
+
+You are then given stamps of size stampHeight x stampWidth. We want to fit the stamps such that they follow the given restrictions and requirements:
+
+Cover all the empty cells.
+Do not cover any of the occupied cells.
+We can put as many stamps as we want.
+Stamps can overlap with each other.
+Stamps are not allowed to be rotated.
+Stamps must stay completely inside the grid.
+
+Return true if it is possible to fit the stamps while following the given restrictions and requirements. Otherwise, return false.
+
+
+Example 1:
+
+Input: grid = [[1,0,0,0],[1,0,0,0],[1,0,0,0],[1,0,0,0],[1,0,0,0]], stampHeight = 4, stampWidth = 3
+Output: true
+Explanation: We have two overlapping stamps (labeled 1 and 2 in the image) that are able to cover all the empty cells.
+
+Example 2:
+
+Input: grid = [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]], stampHeight = 2, stampWidth = 2
+Output: false
+Explanation: There is no way to fit the stamps onto all the empty cells without the stamps going outside the grid.
+
+
+Constraints:
+
+m == grid.length
+n == grid[r].length
+1 <= m, n <= 10^5
+1 <= m * n <= 2 * 10^5
+grid[r][c] is either 0 or 1.
+1 <= stampHeight, stampWidth <= 10^5
+
+"""
+
+# V0
+# IDEA : 2D PREFIX SUM TO TEST A PLACEMENT, 2D DIFFERENCE ARRAY TO PAINT IT
+#
+#   stamps may overlap freely, so the greedy answer is "place a stamp
+#   wherever it legally fits" — nothing is lost by placing one more. two
+#   O(m*n) sweeps do the whole job :
+#
+#   1) prefix sums of grid -> a stamp anchored at (i, j) is legal iff the
+#      rectangle it covers sums to 0 (contains no occupied cell).
+#
+#   2) for every legal anchor, stamp a +1 / -1 pattern into a DIFFERENCE
+#      array instead of writing h*w cells. its 2D prefix sum then gives, per
+#      cell, how many stamps cover it.
+#
+#   finally every empty cell must be covered at least once.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def possibleToStamp(self, grid, stampHeight, stampWidth):
+        m, n = len(grid), len(grid[0])
+
+        # 1) prefix[i][j] = sum of grid[0..i-1][0..j-1]
+        prefix = [[0] * (n + 1) for _ in range(m + 1)]
+        for i in range(m):
+            row = grid[i]
+            pre_up, pre_cur = prefix[i], prefix[i + 1]
+            for j in range(n):
+                pre_cur[j + 1] = row[j] + pre_cur[j] + pre_up[j + 1] - pre_up[j]
+
+        # 2) mark every legal stamp into a difference array
+        diff = [[0] * (n + 1) for _ in range(m + 1)]
+        for i in range(m - stampHeight + 1):
+            for j in range(n - stampWidth + 1):
+                bi, bj = i + stampHeight, j + stampWidth
+                occupied = (prefix[bi][bj] - prefix[i][bj]
+                            - prefix[bi][j] + prefix[i][j])
+                if occupied == 0:
+                    diff[i][j] += 1
+                    diff[i][bj] -= 1
+                    diff[bi][j] -= 1
+                    diff[bi][bj] += 1
+
+        # 3) prefix-sum the difference array back into coverage counts
+        for i in range(m):
+            for j in range(n):
+                if i:
+                    diff[i][j] += diff[i - 1][j]
+                if j:
+                    diff[i][j] += diff[i][j - 1]
+                if i and j:
+                    diff[i][j] -= diff[i - 1][j - 1]
+                if grid[i][j] == 0 and diff[i][j] == 0:
+                    return False
+        return True

--- a/leetcode_python/Binary_Search/maximum-running-time-of-n-computers.py
+++ b/leetcode_python/Binary_Search/maximum-running-time-of-n-computers.py
@@ -1,0 +1,71 @@
+"""
+
+2141. Maximum Running Time of N Computers
+Hard
+
+You have n computers. You are given the integer n and a 0-indexed integer array batteries where the ith battery can run a computer for batteries[i] minutes. You are interested in running all n computers simultaneously using the given batteries.
+
+Initially, you can insert at most one battery into each computer. After that and at any integer time moment, you can remove a battery from a computer and insert another battery any number of times. The inserted battery can be a totally new battery or a battery from another computer. You may assume that the removing and inserting processes take no time.
+
+Note that the batteries cannot be recharged.
+
+Return the maximum number of minutes you can run all the n computers simultaneously.
+
+
+Example 1:
+
+Input: n = 2, batteries = [3,3,3]
+Output: 4
+Explanation:
+Initially, insert battery 0 into the first computer and battery 1 into the second computer.
+After two minutes, remove battery 1 from the second computer and insert battery 2 instead. Note that battery 1 can still run for one minute.
+At the end of the third minute, battery 0 is drained, and you need to remove it from the first computer and insert battery 1 instead.
+By the end of the fourth minute, battery 1 is also drained, and the first computer is no longer running.
+We can run the two computers simultaneously for at most 4 minutes, so we return 4.
+
+Example 2:
+
+Input: n = 2, batteries = [1,1,1,1]
+Output: 2
+Explanation:
+Initially, insert battery 0 into the first computer and battery 2 into the second computer.
+After one minute, battery 0 and battery 2 are drained so you need to remove them and insert battery 1 into the first computer and battery 3 into the second computer.
+After another minute, battery 1 and battery 3 are also drained so the first and second computers are no longer running.
+We can run the two computers simultaneously for at most 2 minutes, so we return 2.
+
+
+Constraints:
+
+1 <= n <= batteries.length <= 10^5
+1 <= batteries[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH ON THE RUNNING TIME
+#
+#   can we run all n computers for t minutes ? swapping is free and
+#   instantaneous, so the batteries form one shared pool with a single
+#   catch : ONE battery can never power two computers at once, so a battery
+#   larger than t only ever contributes t minutes.
+#
+#       feasible(t)  <=>  sum(min(b, t) for b in batteries) >= n * t
+#
+#   feasibility is monotone in t, so binary search over
+#   [0, sum(batteries) // n] — the total energy is an obvious upper bound.
+#
+# time = O(len(batteries) * log(sum/n)), space = O(1)
+class Solution(object):
+    def maxRunTime(self, n, batteries):
+
+        def feasible(t):
+            return sum(min(b, t) for b in batteries) >= n * t
+
+        lo, hi = 0, sum(batteries) // n
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if feasible(mid):
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo

--- a/leetcode_python/Binary_Search/minimum-operations-to-make-the-array-k-increasing.py
+++ b/leetcode_python/Binary_Search/minimum-operations-to-make-the-array-k-increasing.py
@@ -1,0 +1,94 @@
+"""
+
+2111. Minimum Operations to Make the Array K-Increasing
+Hard
+
+You are given a 0-indexed array arr consisting of n positive integers, and a positive integer k.
+
+The array arr is called K-increasing if arr[i-k] <= arr[i] holds for every index i, where k <= i <= n-1.
+
+For example, arr = [4, 1, 5, 2, 6, 2] is K-increasing for k = 2 because:
+arr[0] <= arr[2] (4 <= 5)
+arr[1] <= arr[3] (1 <= 2)
+arr[2] <= arr[4] (5 <= 6)
+arr[3] <= arr[5] (2 <= 2)
+However, the same arr is not K-increasing for k = 1 (because arr[0] > arr[1]) or k = 3 (because arr[0] > arr[3]).
+
+In one operation, you can choose an index i and change arr[i] into any positive integer.
+
+Return the minimum number of operations required to make the array K-increasing for the given k.
+
+
+Example 1:
+
+Input: arr = [5,4,3,2,1], k = 1
+Output: 4
+Explanation:
+For k = 1, the resultant array has to be non-decreasing.
+Some of the K-increasing arrays that can be formed are [5,6,7,8,9], [1,1,1,1,1], [2,2,3,4,4]. All of them require 4 operations.
+It is suboptimal to change the array to, for example, [6,7,8,9,10] because it would take 5 operations.
+It can be shown that we cannot make the array K-increasing in less than 4 operations.
+
+Example 2:
+
+Input: arr = [4,1,5,2,6,2], k = 2
+Output: 0
+Explanation:
+This is the same example as the one in the problem description.
+Here, for every index i where 2 <= i <= 5, arr[i-2] <= arr[i].
+Since the given array is already K-increasing, we do not need to perform any operations.
+
+Example 3:
+
+Input: arr = [4,1,5,2,6,2], k = 3
+Output: 2
+Explanation:
+Indices 3 and 5 are the only ones not satisfying arr[i-3] <= arr[i] for 3 <= i <= 5.
+One of the ways we can make the array K-increasing is by changing arr[3] to 4 and arr[5] to 5.
+The array will now be [4,1,5,4,6,5].
+Note that there can be other ways to make the array K-increasing, but none of them require less than 2 operations.
+
+
+Constraints:
+
+1 <= arr.length <= 10^5
+1 <= arr[i], k <= arr.length
+
+"""
+
+# V0
+# IDEA : k INDEPENDENT SUBSEQUENCES, EACH NEEDS ITS LONGEST NON-DECREASING RUN KEPT
+#
+#   the constraint only ever links indices k apart, so the array splits into
+#   k independent chains :
+#       chain r = arr[r], arr[r+k], arr[r+2k], ...
+#   each chain must end up NON-DECREASING, and values may be any positive
+#   integer, so any element can be rewritten to fit between its neighbours.
+#
+#   for one chain, the cheapest fix is to KEEP a longest non-decreasing
+#   subsequence and rewrite everything else :
+#       ops(chain) = len(chain) - LNDS(chain)
+#
+#   LNDS is the classic patience-sorting tails array, but with bisect_RIGHT
+#   (not left) because equal values are allowed to stay.
+#
+#   answer = n - sum of all the LNDS lengths.
+#
+# time = O(n log n), space = O(n)
+import bisect
+
+
+class Solution(object):
+    def kIncreasing(self, arr, k):
+        n = len(arr)
+        keep = 0
+        for r in range(k):
+            tails = []
+            for i in range(r, n, k):
+                pos = bisect.bisect_right(tails, arr[i])
+                if pos == len(tails):
+                    tails.append(arr[i])
+                else:
+                    tails[pos] = arr[i]
+            keep += len(tails)
+        return n - keep

--- a/leetcode_python/Binary_Search/pour-water-between-buckets-to-make-water-levels-equal.py
+++ b/leetcode_python/Binary_Search/pour-water-between-buckets-to-make-water-levels-equal.py
@@ -1,0 +1,85 @@
+"""
+
+2137. Pour Water Between Buckets to Make Water Levels Equal
+Medium
+🔒 (premium)
+
+You have n buckets each containing some gallons of water in it, represented by a 0-indexed integer array buckets, where the ith bucket contains buckets[i] gallons of water. You are also given an integer loss.
+
+You want to make the amount of water in each bucket equal. You can pour any amount of water from one bucket to another bucket (not necessarily an integer). However, every time you pour k gallons of water, you spill loss percent of k.
+
+Return the maximum amount of water in each bucket after making the amount of water equal. Answers within 10^-5 of the actual answer will be accepted.
+
+
+Example 1:
+
+Input: buckets = [1,2,7], loss = 80
+Output: 2.00000
+Explanation: Pour 5 gallons of water from buckets[2] to buckets[0].
+5 * 80% = 4 gallons are spilled and buckets[0] only receives 5 - 4 = 1 gallon of water.
+All buckets have 2 gallons of water in them so return 2.
+
+Example 2:
+
+Input: buckets = [2,4,6], loss = 50
+Output: 3.50000
+Explanation: Pour 0.5 gallons of water from buckets[1] to buckets[0].
+0.5 * 50% = 0.25 gallons are spilled and buckets[0] only receives 0.5 - 0.25 = 0.25 gallons of water.
+Now, buckets = [2.25, 3.5, 6].
+Pour 2.5 gallons of water from buckets[2] to buckets[0].
+2.5 * 50% = 1.25 gallons are spilled and buckets[0] only receives 2.5 - 1.25 = 1.25 gallons of water.
+All buckets have 3.5 gallons of water in them so return 3.5.
+
+Example 3:
+
+Input: buckets = [3,3,3,3], loss = 40
+Output: 3.00000
+Explanation: All buckets already have the same amount of water in them.
+
+
+Constraints:
+
+1 <= buckets.length <= 10^5
+0 <= buckets[i] <= 10^5
+0 <= loss <= 99
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH ON THE FINAL LEVEL (MONOTONE FEASIBILITY)
+#
+#   a target level x is reachable iff the water the over-full buckets can
+#   DELIVER covers what the under-full ones NEED :
+#
+#       supply = sum(b - x for b > x) * (1 - loss/100)     # after spillage
+#       demand = sum(x - b for b < x)
+#       feasible(x)  <=>  supply >= demand
+#
+#   raising x makes supply shrink and demand grow, so feasibility is
+#   monotone — binary search on the real interval [0, max(buckets)].
+#
+#   100 iterations of bisection shrink the interval by 2^-100, far inside
+#   the 10^-5 tolerance.
+#
+# time = O(n * 100), space = O(1)
+class Solution(object):
+    def equalizeWater(self, buckets, loss):
+        keep = 1.0 - loss / 100.0
+
+        def feasible(x):
+            supply = demand = 0.0
+            for b in buckets:
+                if b > x:
+                    supply += (b - x) * keep
+                else:
+                    demand += (x - b)
+            return supply >= demand
+
+        lo, hi = 0.0, float(max(buckets))
+        for _ in range(100):
+            mid = (lo + hi) / 2
+            if feasible(mid):
+                lo = mid
+            else:
+                hi = mid
+        return lo

--- a/leetcode_python/Bit_Manipulation/count-words-obtained-after-adding-a-letter.py
+++ b/leetcode_python/Bit_Manipulation/count-words-obtained-after-adding-a-letter.py
@@ -1,0 +1,82 @@
+"""
+
+2135. Count Words Obtained After Adding a Letter
+Medium
+
+You are given two 0-indexed arrays of strings startWords and targetWords. Each string consists of lowercase English letters only.
+
+For each string in targetWords, check if it is possible to choose a string from startWords and perform a conversion operation on it to be equal to that from targetWords.
+
+The conversion operation is described in the following two steps:
+
+1. Append any lowercase letter that is not present in the string to its end.
+For example, if the string is "abc", the letters 'd', 'e', or 'y' can be added to it, but not 'a'. If 'd' is added, the resulting string will be "abcd".
+2. Rearrange the letters of the new string in any arbitrary order.
+For example, "abcd" can be rearranged to "acbd", "bacd", "cbda", and so on. Note that it can also be rearranged to "abcd" itself.
+
+Return the number of strings in targetWords that can be obtained by performing the operations on any string of startWords.
+
+Note that you will only be verifying if the string in targetWords can be obtained from a string in startWords by performing the operations. The strings in startWords do not actually change during this process.
+
+
+Example 1:
+
+Input: startWords = ["ant","act","tack"], targetWords = ["tack","act","acti"]
+Output: 2
+Explanation:
+- In order to form targetWords[0] = "tack", we use startWords[1] = "act", append 'k' to it, and rearrange "actk" to "tack".
+- There is no string in startWords that can be used to obtain targetWords[1] = "act".
+  Note that "act" does exist in startWords, but we must append one letter to the string before rearranging it.
+- In order to form targetWords[2] = "acti", we use startWords[1] = "act", append 'i' to it, and rearrange "acti" to "acti" itself.
+
+Example 2:
+
+Input: startWords = ["ab","a"], targetWords = ["abc","abcd"]
+Output: 1
+Explanation:
+- In order to form targetWords[0] = "abc", we use startWords[0] = "ab", add 'c' to it, and rearrange it to "abc".
+- There is no string in startWords that can be used to obtain targetWords[1] = "abcd".
+
+
+Constraints:
+
+1 <= startWords.length, targetWords.length <= 5 * 10^4
+1 <= startWords[i].length, targetWords[j].length <= 26
+Each string of startWords and targetWords consists of lowercase English letters only.
+No letter occurs more than once in any string of startWords or targetWords.
+
+"""
+
+# V0
+# IDEA : LETTERS ARE UNIQUE PER WORD -> A WORD *IS* A 26-BIT MASK
+#
+#   rearranging is free and no letter repeats, so a word carries no more
+#   information than its SET of letters — encode it as a bitmask.
+#
+#   the conversion adds exactly one new letter, so target t is reachable iff
+#   removing ONE of t's own letters leaves a mask that exists in startWords :
+#
+#       any c in t  with  mask(t) ^ bit(c)  in the start set
+#
+#   26 checks per target, each an O(1) set lookup.
+#
+# time = O(sum of word lengths + 26 * len(targetWords)), space = O(len(startWords))
+class Solution(object):
+    def wordCount(self, startWords, targetWords):
+
+        def mask(w):
+            m = 0
+            for c in w:
+                m |= 1 << (ord(c) - ord('a'))
+            return m
+
+        starts = set(mask(w) for w in startWords)
+
+        res = 0
+        for t in targetWords:
+            m = mask(t)
+            for c in t:
+                if m ^ (1 << (ord(c) - ord('a'))) in starts:
+                    res += 1
+                    break
+        return res

--- a/leetcode_python/Bit_Manipulation/maximum-good-people-based-on-statements.py
+++ b/leetcode_python/Bit_Manipulation/maximum-good-people-based-on-statements.py
@@ -1,0 +1,113 @@
+"""
+
+2151. Maximum Good People Based on Statements
+Hard
+
+There are two types of persons:
+
+The good person: The person who always tells the truth.
+The bad person: The person who might tell the truth and might lie.
+
+You are given a 0-indexed 2D integer array statements of size n x n that represents the statements made by n people about each other. More specifically, statements[i][j] could be one of the following:
+
+0 which represents a statement made by person i that person j is a bad person.
+1 which represents a statement made by person i that person j is a good person.
+2 represents that no statement is made by person i about person j.
+
+Additionally, no person ever makes a statement about themselves. Formally, we have that statements[i][i] = 2 for all 0 <= i < n.
+
+Return the maximum number of people who can be good based on the statements made by the n people.
+
+
+Example 1:
+
+Input: statements = [[2,1,2],[1,2,2],[2,0,2]]
+Output: 2
+Explanation: Each person makes a single statement.
+- Person 0 states that person 1 is good.
+- Person 1 states that person 0 is good.
+- Person 2 states that person 1 is bad.
+Let's take person 2 as the key.
+- Assuming that person 2 is a good person:
+    - Based on the statement made by person 2, person 1 is a bad person.
+    - Now we know for sure that person 1 is bad and person 2 is good.
+    - Based on the statement made by person 1, and since person 1 is bad, they could be:
+        - telling the truth. There will be a contradiction in this case and this assumption is invalid.
+        - lying. In this case, person 0 is also a bad person and lied in their statement.
+    - Following that person 2 is a good person, there will be only one good person in the group.
+- Assuming that person 2 is a bad person:
+    - Based on the statement made by person 2, and since person 2 is bad, they could be:
+        - telling the truth. Following this scenario, person 0 and 1 are both bad as explained before.
+            - Following that person 2 is bad but told the truth, there will be no good persons in the group.
+        - lying. In this case person 1 is a good person.
+            - Since person 1 is a good person, person 0 is also a good person.
+            - Following that person 2 is bad and lied, there will be two good persons in the group.
+We can see that at most 2 persons are good in the best case, so we return 2.
+Note that there is more than one way to arrive at this conclusion.
+
+Example 2:
+
+Input: statements = [[2,0],[0,2]]
+Output: 1
+Explanation: Each person makes a single statement.
+- Person 0 states that person 1 is bad.
+- Person 1 states that person 0 is bad.
+Let's take person 0 as the key.
+- Assuming that person 0 is a good person:
+    - Based on the statement made by person 0, person 1 is a bad person and lied.
+    - Following that person 0 is a good person, there will be only one good person in the group.
+- Assuming that person 0 is a bad person:
+    - Based on the statement made by person 0, and since person 0 is bad, they could be:
+        - telling the truth. Following this scenario, person 0 and 1 are both bad.
+            - Following that person 0 is bad but told the truth, there will be no good persons in the group.
+        - lying. In this case person 1 is a good person.
+            - Following that person 0 is bad and lied, there will be only one good person in the group.
+We can see that at most, one person is good in the best case, so we return 1.
+Note that there is more than one way to arrive at this conclusion.
+
+
+Constraints:
+
+n == statements.length == statements[i].length
+2 <= n <= 15
+statements[i][j] is either 0, 1, or 2.
+statements[i][i] == 2
+
+"""
+
+# V0
+# IDEA : ENUMERATE EVERY GOOD/BAD ASSIGNMENT AS A BITMASK, KEEP THE CONSISTENT ONES
+#
+#   n <= 15, so all 2^15 assignments can be tested directly. bit i of the
+#   mask says "person i is good".
+#
+#   only GOOD people constrain anything — they always tell the truth, so
+#   every statement they made must agree with the mask :
+#       statements[i][j] == 1  ->  j must be good
+#       statements[i][j] == 0  ->  j must be bad
+#   bad people may say anything, so their rows are simply ignored.
+#
+#   among the masks that survive, the answer is the largest popcount.
+#
+# time = O(2^n * n^2), space = O(1)
+class Solution(object):
+    def maximumGood(self, statements):
+        n = len(statements)
+        res = 0
+        for mask in range(1 << n):
+            ok = True
+            for i in range(n):
+                if not (mask >> i) & 1:          # bad people may lie -> no constraint
+                    continue
+                for j in range(n):
+                    s = statements[i][j]
+                    if s == 2:
+                        continue
+                    if s != ((mask >> j) & 1):
+                        ok = False
+                        break
+                if not ok:
+                    break
+            if ok:
+                res = max(res, bin(mask).count('1'))
+        return res

--- a/leetcode_python/Breadth-First-Search/k-highest-ranked-items-within-a-price-range.py
+++ b/leetcode_python/Breadth-First-Search/k-highest-ranked-items-within-a-price-range.py
@@ -1,0 +1,127 @@
+"""
+
+2146. K Highest Ranked Items Within a Price Range
+Medium
+
+You are given a 0-indexed 2D integer array grid of size m x n that represents a map of the items in a shop. The integers in the grid represent the following:
+
+0 represents a wall that you cannot pass through.
+1 represents an empty cell that you can freely move to and from.
+All other positive integers represent the price of an item in that cell. You may also freely move to and from these item cells.
+
+It takes 1 step to travel between adjacent grid cells.
+
+You are also given integer arrays pricing and start where pricing = [low, high] and start = [row, col] indicates that you start at the position (row, col) and are interested only in items with a price in the range of [low, high] (inclusive). You are further given an integer k.
+
+You are interested in the positions of the k highest-ranked items whose prices are within the given price range. The rank is determined by the first of these criteria that is different:
+
+1. Distance, defined as the length of the shortest path from the start (shorter distance has a higher rank).
+2. Price (lower price has a higher rank, but it must be in the price range).
+3. The row number (smaller row number has a higher rank).
+4. The column number (smaller column number has a higher rank).
+
+Return the k highest-ranked items within the price range sorted by their rank (highest to lowest). If there are fewer than k reachable items within the price range, return all of them.
+
+
+Example 1:
+
+Input: grid = [[1,2,0,1],[1,3,0,1],[0,2,5,1]], pricing = [2,5], start = [0,0], k = 3
+Output: [[0,1],[1,1],[2,1]]
+Explanation: You start at (0,0).
+With a price range of [2,5], we can take items from (0,1), (1,1), (2,1) and (2,2).
+The ranks of these items are:
+- (0,1) with distance 1
+- (1,1) with distance 2
+- (2,1) with distance 3
+- (2,2) with distance 4
+Thus, the 3 highest ranked items in the price range are (0,1), (1,1), and (2,1).
+
+Example 2:
+
+Input: grid = [[1,2,0,1],[1,3,3,1],[0,2,5,1]], pricing = [2,3], start = [2,3], k = 2
+Output: [[2,1],[1,2]]
+Explanation: You start at (2,3).
+With a price range of [2,3], we can take items from (0,1), (1,1), (1,2) and (2,1).
+The ranks of these items are:
+- (2,1) with distance 2, price 2
+- (1,2) with distance 3, price 3
+- (1,1) with distance 4, price 3
+- (0,1) with distance 5, price 2
+Thus, the 2 highest ranked items in the price range are (2,1) and (1,2).
+
+Example 3:
+
+Input: grid = [[1,1,1],[0,0,1],[2,3,4]], pricing = [2,3], start = [0,0], k = 3
+Output: [[2,1],[2,0]]
+Explanation: You start at (0,0).
+With a price range of [2,3], we can take items from (2,0) and (2,1).
+The ranks of these items are:
+- (2,1) with distance 5
+- (2,0) with distance 6
+Thus, the 2 highest ranked items in the price range are (2,1) and (2,0).
+Note that k = 3 but there are only 2 reachable items within the price range.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m, n <= 10^5
+1 <= m * n <= 10^5
+0 <= grid[i][j] <= 10^5
+pricing.length == 2
+2 <= low <= high <= 10^5
+start.length == 2
+0 <= row <= m - 1
+0 <= col <= n - 1
+grid[row][col] > 0
+1 <= k <= m * n
+
+"""
+
+# V0
+# IDEA : BFS *LEVEL BY LEVEL*, SORT ONLY WITHIN A LEVEL
+#
+#   distance is the first tie-break key, and BFS on an unweighted grid hands
+#   the cells to us in exactly that order — one whole level at a time.
+#
+#   so the only sorting needed is INSIDE a level, by the remaining keys
+#   (price, row, col). collect the in-range items of the level, sort them,
+#   append, and stop as soon as k items are gathered.
+#
+#   NOTE : the starting cell itself counts (distance 0) if its price is in
+#          range, and walls (0) are never enqueued.
+#
+# time = O(m*n log(m*n)) worst case, space = O(m*n)
+from collections import deque
+
+
+class Solution(object):
+    def highestRankedKItems(self, grid, pricing, start, k):
+        m, n = len(grid), len(grid[0])
+        low, high = pricing
+        sr, sc = start
+
+        res = []
+        seen = [[False] * n for _ in range(m)]
+        seen[sr][sc] = True
+        q = deque([(sr, sc)])
+
+        while q and len(res) < k:
+            level = []
+            for _ in range(len(q)):
+                r, c = q.popleft()
+                price = grid[r][c]
+                if low <= price <= high:
+                    level.append((price, r, c))
+                for dr, dc in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                    nr, nc = r + dr, c + dc
+                    if 0 <= nr < m and 0 <= nc < n and not seen[nr][nc] and grid[nr][nc] != 0:
+                        seen[nr][nc] = True
+                        q.append((nr, nc))
+            level.sort()
+            for _, r, c in level:
+                res.append([r, c])
+                if len(res) == k:
+                    break
+        return res

--- a/leetcode_python/Design/sequentially-ordinal-rank-tracker.py
+++ b/leetcode_python/Design/sequentially-ordinal-rank-tracker.py
@@ -1,0 +1,126 @@
+"""
+
+2102. Sequentially Ordinal Rank Tracker
+Hard
+
+A scenic location is represented by its name and attractiveness score, where name is a unique string among all locations and score is an integer. Locations can be ranked from the best to the worst. The higher the score, the better the location. If the scores of two locations are equal, then the location with the lexicographically smaller name is better.
+
+You are building a system that tracks the ranking of locations with the system initially starting with no locations. It supports:
+
+Adding scenic locations, one at a time.
+Querying the ith best location of all locations already added, where i is the number of times the system has been queried (including the current query).
+For example, when the system is queried for the 4th time, it returns the 4th best location of all locations already added.
+
+Note that the test data are generated so that at any time, the number of queries does not exceed the number of locations added to the system.
+
+Implement the SORTracker class:
+
+SORTracker() Initializes the tracker system.
+void add(string name, int score) Adds a scenic location with name and score to the system.
+string get() Queries and returns the ith best location, where i is the number of times this method has been invoked (including this invocation).
+
+
+Example 1:
+
+Input
+["SORTracker", "add", "add", "get", "add", "get", "add", "get", "add", "get", "get"]
+[[], ["bradford", 2], ["branford", 3], [], ["alps", 2], [], ["orland", 2], [], ["orlando", 3], [], []]
+Output
+[null, null, null, "branford", null, "alps", null, "bradford", null, "bradford", "orland"]
+
+Explanation
+SORTracker tracker = new SORTracker(); // Initialize the tracker system.
+tracker.add("bradford", 2); // Add location with name="bradford" and score=2 to the system.
+tracker.add("branford", 3); // Add location with name="branford" and score=3 to the system.
+tracker.get();              // The sorted locations, from best to worst, are: branford, bradford.
+                            // Note that branford precedes bradford due to its higher score (3 > 2).
+                            // This is the 1st time get() is called, so return the best location: "branford".
+tracker.add("alps", 2);     // Add location with name="alps" and score=2 to the system.
+tracker.get();              // Sorted locations: branford, alps, bradford.
+                            // Note that alps precedes bradford even though they have the same score (2).
+                            // This is because "alps" is lexicographically smaller than "bradford".
+                            // Return the 2nd best location "alps", as it is the 2nd time get() is called.
+tracker.add("orland", 2);   // Add location with name="orland" and score=2 to the system.
+tracker.get();              // Sorted locations: branford, alps, bradford, orland.
+                            // Return "bradford", as it is the 3rd time get() is called.
+tracker.add("orlando", 3);  // Add location with name="orlando" and score=3 to the system.
+tracker.get();              // Sorted locations: branford, orlando, alps, bradford, orland.
+                            // Return "bradford", as it is the 4th time get() is called.
+tracker.get();              // Sorted locations: branford, orlando, alps, bradford, orland.
+                            // Return "orland", as it is the 5th time get() is called.
+
+
+Constraints:
+
+name consists of lowercase English letters, and is unique among all locations.
+1 <= name.length <= 10
+1 <= score <= 10^5
+At any time, the number of calls to get does not exceed the number of calls to add.
+At most 4 * 10^4 calls in total will be made to add and get.
+
+"""
+
+# V0
+# IDEA : TWO HEAPS STRADDLING THE ANSWER POSITION
+#
+#   the k-th get() must return the k-th best location, and k only ever grows
+#   by one. so keep the locations split in two :
+#
+#       best  : the k best so far, as a MAX-heap on "goodness"
+#               -> its top is the WORST of the good ones = the k-th best
+#       rest  : everything else, as a MIN-heap on "goodness"
+#               -> its top is the best one not yet promoted
+#
+#   get()  : promote rest's top into best, then read best's top.
+#   add()  : drop the new location into rest; if it is better than best's
+#            current worst, swap the two so `best` still holds the true top-k.
+#
+#   ordering — better means higher score, ties broken by SMALLER name. so as
+#   a min-heap key,  (-score, name)  puts the best first. for the max-heap
+#   the name must compare backwards, hence the tiny _RevStr wrapper.
+#
+# time = O(log n) per add / get, space = O(n)
+import heapq
+
+
+class _RevStr(object):
+    """String that compares in reverse order, so heapq can act as a max-heap."""
+
+    def __init__(self, s):
+        self.s = s
+
+    def __lt__(self, other):
+        return self.s > other.s
+
+    def __eq__(self, other):
+        return self.s == other.s
+
+
+class SORTracker(object):
+
+    def __init__(self):
+        self.best = []   # max-heap of (score, _RevStr(name)) -> worst-of-best on top
+        self.rest = []   # min-heap of (-score, name)         -> best-of-rest on top
+
+    def add(self, name, score):
+        heapq.heappush(self.rest, (-score, name))
+        if self.best:
+            b_score, b_name = self.best[0][0], self.best[0][1].s
+            r_score, r_name = -self.rest[0][0], self.rest[0][1]
+            # is rest's best strictly better than best's worst ?
+            if (-r_score, r_name) < (-b_score, b_name):
+                heapq.heappop(self.rest)
+                heapq.heappop(self.best)
+                heapq.heappush(self.best, (r_score, _RevStr(r_name)))
+                heapq.heappush(self.rest, (-b_score, b_name))
+
+    def get(self):
+        score, name = heapq.heappop(self.rest)
+        heapq.heappush(self.best, (-score, _RevStr(name)))
+        return self.best[0][1].s
+
+
+# Your SORTracker object will be instantiated and called as such:
+# obj = SORTracker()
+# obj.add(name,score)
+# param_2 = obj.get()

--- a/leetcode_python/Dynamic_Programming/choose-numbers-from-two-arrays-in-range.py
+++ b/leetcode_python/Dynamic_Programming/choose-numbers-from-two-arrays-in-range.py
@@ -1,0 +1,97 @@
+"""
+
+2143. Choose Numbers From Two Arrays in Range
+Hard
+🔒 (premium)
+
+You are given two 0-indexed integer arrays nums1 and nums2 of length n.
+
+A range [l, r] (inclusive) where 0 <= l <= r < n is balanced if:
+
+For every i in the range [l, r], you pick either nums1[i] or nums2[i].
+The sum of the numbers you pick from nums1 equals to the sum of the numbers you pick from nums2 (the sum is considered to be 0 if you pick no numbers from an array).
+
+Two balanced ranges from [l1, r1] and [l2, r2] are considered to be different if at least one of the following is true:
+
+l1 != l2
+r1 != r2
+nums1[i] is picked in the first range, and nums2[i] is picked in the second range.
+
+Return the number of different ranges that are balanced. Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums1 = [1,2,5], nums2 = [2,6,3]
+Output: 3
+Explanation: The balanced ranges are:
+- [0, 1] where we choose nums2[0], and nums1[1].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 2 = 2.
+- [0, 2] where we choose nums1[0], nums2[1], and nums1[2].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 1 + 5 = 6.
+- [0, 2] where we choose nums1[0], nums1[1], and nums2[2].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 1 + 2 = 3.
+Note that the second and third balanced ranges are different.
+In the second balanced range, we choose nums2[1] and in the third balanced range, we choose nums1[1].
+
+Example 2:
+
+Input: nums1 = [0,1], nums2 = [1,0]
+Output: 4
+Explanation: The balanced ranges are:
+- [0, 0] where we choose nums1[0].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 0 = 0.
+- [1, 1] where we choose nums2[1].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 0 = 0.
+- [0, 1] where we choose nums1[0] and nums2[1].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 0 = 0.
+- [0, 1] where we choose nums2[0] and nums1[1].
+  The sum of the numbers chosen from nums1 equals the sum of the numbers chosen from nums2: 1 = 1.
+
+
+Constraints:
+
+n == nums1.length == nums2.length
+1 <= n <= 100
+0 <= nums1[i], nums2[i] <= 100
+
+"""
+
+# V0
+# IDEA : DP ON THE RUNNING *DIFFERENCE*, ONE STATE PER RANGE END
+#
+#   only the gap between the two running sums matters, so track
+#       d = (sum taken from nums1) - (sum taken from nums2)
+#   and count, for every left endpoint still "open", how many pick-patterns
+#   reach each d.
+#
+#   dp is a dict  d -> number of (start, pick-pattern) combinations for
+#   ranges ENDING at the current index. moving to index i :
+#
+#       every open pattern extends, either by +nums1[i] or by -nums2[i]
+#       plus a brand new range starting at i, again two ways
+#
+#   a balanced range ending at i is exactly a state with d == 0, so add
+#   dp[0] into the answer at every index.
+#
+#   n <= 100 and values <= 100 keep |d| <= 10^4, so the dict stays small.
+#
+# time = O(n^2 * max_value), space = O(n * max_value)
+from collections import defaultdict
+
+
+class Solution(object):
+    def countSubranges(self, nums1, nums2):
+        MOD = 10 ** 9 + 7
+        res = 0
+        dp = defaultdict(int)              # difference -> ways
+        for a, b in zip(nums1, nums2):
+            nxt = defaultdict(int)
+            nxt[a] += 1                    # new range starting here, take nums1
+            nxt[-b] += 1                   # new range starting here, take nums2
+            for d, c in dp.items():
+                nxt[d + a] = (nxt[d + a] + c) % MOD
+                nxt[d - b] = (nxt[d - b] + c) % MOD
+            dp = nxt
+            res = (res + dp[0]) % MOD
+        return res

--- a/leetcode_python/Dynamic_Programming/find-good-days-to-rob-the-bank.py
+++ b/leetcode_python/Dynamic_Programming/find-good-days-to-rob-the-bank.py
@@ -1,0 +1,80 @@
+"""
+
+2100. Find Good Days to Rob the Bank
+Medium
+
+You and a gang of thieves are planning on robbing a bank. You are given a 0-indexed integer array security, where security[i] is the number of guards on duty on the ith day. The days are numbered starting from 0. You are also given an integer time.
+
+The ith day is a good day to rob the bank if:
+
+There are at least time days before and after the ith day,
+The number of guards at the bank for the time days before i are non-increasing, and
+The number of guards at the bank for the time days after i are non-decreasing.
+
+More formally, this means day i is a good day to rob the bank if and only if security[i - time] >= security[i - time + 1] >= ... >= security[i] <= ... <= security[i + time - 1] <= security[i + time].
+
+Return a list of all days (0-indexed) that are good days to rob the bank. The order that the days are returned in does not matter.
+
+
+Example 1:
+
+Input: security = [5,3,3,3,5,6,2], time = 2
+Output: [2,3]
+Explanation:
+On day 2, we have security[0] >= security[1] >= security[2] <= security[3] <= security[4].
+On day 3, we have security[1] >= security[2] >= security[3] <= security[4] <= security[5].
+No other days satisfy this condition, so days 2 and 3 are the only good days to rob the bank.
+
+Example 2:
+
+Input: security = [1,1,1,1,1], time = 0
+Output: [0,1,2,3,4]
+Explanation:
+Since time equals 0, every day is a good day to rob the bank, so return every day.
+
+Example 3:
+
+Input: security = [1,2,3,4,5,6], time = 2
+Output: []
+Explanation:
+No day has 2 days before it that have a non-increasing number of guards.
+Thus, no day is a good day to rob the bank, so return an empty list.
+
+
+Constraints:
+
+1 <= security.length <= 10^5
+0 <= security[i], time <= 10^5
+
+"""
+
+# V0
+# IDEA : TWO PREFIX RUNS — HOW FAR THE NON-INCREASING / NON-DECREASING STREAK REACHES
+#
+#   non_inc[i] = length of the non-increasing run ENDING at i
+#   non_dec[i] = length of the non-decreasing run STARTING at i
+#
+#   both are one-liners on a single pass :
+#       non_inc[i] = non_inc[i-1] + 1  when security[i-1] >= security[i]
+#       non_dec[i] = non_dec[i+1] + 1  when security[i] <= security[i+1]
+#
+#   day i is good iff both runs are long enough — non_inc[i] >= time and
+#   non_dec[i] >= time. that also covers the "at least time days on each
+#   side" requirement, since a run of length time cannot leave the array.
+#
+#   NOTE : time == 0 makes every day good, and the runs (>= 1 everywhere)
+#          already say so.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def goodDaysToRobBank(self, security, time):
+        n = len(security)
+        non_inc = [0] * n
+        non_dec = [0] * n
+        for i in range(1, n):
+            if security[i - 1] >= security[i]:
+                non_inc[i] = non_inc[i - 1] + 1
+        for i in range(n - 2, -1, -1):
+            if security[i] <= security[i + 1]:
+                non_dec[i] = non_dec[i + 1] + 1
+        return [i for i in range(n) if non_inc[i] >= time and non_dec[i] >= time]

--- a/leetcode_python/Dynamic_Programming/number-of-smooth-descent-periods-of-a-stock.py
+++ b/leetcode_python/Dynamic_Programming/number-of-smooth-descent-periods-of-a-stock.py
@@ -1,0 +1,62 @@
+"""
+
+2110. Number of Smooth Descent Periods of a Stock
+Medium
+
+You are given an integer array prices representing the daily price history of a stock, where prices[i] is the stock price on the ith day.
+
+A smooth descent period of a stock consists of one or more contiguous days such that the price on each day is lower than the price on the preceding day by exactly 1. The first day of the period is exempted from this rule.
+
+Return the number of smooth descent periods.
+
+
+Example 1:
+
+Input: prices = [3,2,1,4]
+Output: 7
+Explanation: There are 7 smooth descent periods:
+[3], [2], [1], [4], [3,2], [2,1], and [3,2,1]
+Note that a period with one day is a smooth descent period by the definition.
+
+Example 2:
+
+Input: prices = [8,6,7,7]
+Output: 4
+Explanation: There are 4 smooth descent periods: [8], [6], [7], and [7]
+Note that [8,6] is not a smooth descent period as 8 - 6 ≠ 1.
+
+Example 3:
+
+Input: prices = [1]
+Output: 1
+Explanation: There is 1 smooth descent period: [1]
+
+
+Constraints:
+
+1 <= prices.length <= 10^5
+1 <= prices[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : DP — COUNT THE PERIODS *ENDING* AT EACH DAY
+#
+#   let dp[i] = number of smooth descent periods that end on day i.
+#   if prices[i] == prices[i-1] - 1 the streak continues, so every period
+#   ending at i-1 can be extended, plus the single day itself :
+#       dp[i] = dp[i-1] + 1
+#   otherwise the streak restarts :  dp[i] = 1.
+#
+#   summing dp over all days counts every period exactly once (by its last
+#   day). only the previous dp value is ever needed, so keep one variable.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def getDescentPeriods(self, prices):
+        res = 1
+        cur = 1
+        for i in range(1, len(prices)):
+            cur = cur + 1 if prices[i] == prices[i - 1] - 1 else 1
+            res += cur
+        return res

--- a/leetcode_python/Dynamic_Programming/number-of-ways-to-divide-a-long-corridor.py
+++ b/leetcode_python/Dynamic_Programming/number-of-ways-to-divide-a-long-corridor.py
@@ -1,0 +1,70 @@
+"""
+
+2147. Number of Ways to Divide a Long Corridor
+Hard
+
+Along a long library corridor, there is a line of seats and decorative plants. You are given a 0-indexed string corridor of length n consisting of letters 'S' and 'P' where each character describes a seat or plant in the ith position.
+
+One room divider has already been installed to the left of index 0, and another to the right of index n - 1. Additional room dividers can be installed. For each position between indices i - 1 and i (1 <= i <= n - 1), at most one divider can be installed.
+
+Divide the corridor into non-overlapping sections, where each section has exactly two seats with any number of plants. There may be multiple ways to perform the division. Two ways are different if there is a position with a room divider installed in the first way but not in the second way.
+
+Return the number of ways to divide the corridor. Since the answer may be very large, return it modulo 10^9 + 7. If there is no way, return 0.
+
+
+Example 1:
+
+Input: corridor = "SSPPSPS"
+Output: 3
+Explanation: There are 3 different ways to divide the corridor.
+The black bars in the above image indicate the two room dividers already installed.
+Note that in each of the ways, each section has exactly two seats.
+
+Example 2:
+
+Input: corridor = "PPSPSP"
+Output: 1
+Explanation: There is only 1 way to divide the corridor, by not installing any additional dividers.
+Installing any would create some section that does not have exactly two seats.
+
+Example 3:
+
+Input: corridor = "S"
+Output: 0
+Explanation: There is no way to divide the corridor because there will always be a section that does not have exactly two seats.
+
+
+Constraints:
+
+n == corridor.length
+1 <= n <= 10^5
+corridor[i] is either 'S' or 'P'.
+
+"""
+
+# V0
+# IDEA : PAIR UP THE SEATS, MULTIPLY THE GAPS BETWEEN CONSECUTIVE PAIRS
+#
+#   the seats must split as (1st,2nd), (3rd,4th), (5th,6th), ... — no other
+#   pairing keeps two seats per section. so an odd seat count, or none at
+#   all, means 0 ways.
+#
+#   between the 2nd seat of one pair and the 1st seat of the next there is a
+#   stretch of plants; the divider may go in ANY of the slots along that
+#   stretch. if those two seats sit at indices a < b, there are (b - a)
+#   choices, and the pairs are independent — so multiply.
+#
+#   NOTE : the plants before the first seat and after the last one never
+#          create a choice; they belong to the outer sections.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def numberOfWays(self, corridor):
+        MOD = 10 ** 9 + 7
+        seats = [i for i, ch in enumerate(corridor) if ch == 'S']
+        if not seats or len(seats) % 2:
+            return 0
+        res = 1
+        for i in range(2, len(seats), 2):
+            res = res * (seats[i] - seats[i - 1]) % MOD
+        return res

--- a/leetcode_python/Dynamic_Programming/solving-questions-with-brainpower.py
+++ b/leetcode_python/Dynamic_Programming/solving-questions-with-brainpower.py
@@ -1,0 +1,72 @@
+"""
+
+2140. Solving Questions With Brainpower
+Medium
+
+You are given a 0-indexed 2D integer array questions where questions[i] = [pointsi, brainpoweri].
+
+The array describes the questions of an exam, where you have to process the questions in order (i.e., starting from question 0) and make a decision whether to solve or skip each question. Solving question i will earn you pointsi points but you will be unable to solve each of the next brainpoweri questions. If you skip question i, you get to make the decision on the next question.
+
+For example, given questions = [[3, 2], [4, 3], [4, 4], [2, 5]]:
+If question 0 is solved, you will earn 3 points but you will be unable to solve questions 1 and 2.
+If instead, question 0 is skipped and question 1 is solved, you will earn 4 points but you will be unable to solve questions 2 and 3.
+
+Return the maximum points you can earn for the exam.
+
+
+Example 1:
+
+Input: questions = [[3,2],[4,3],[4,4],[2,5]]
+Output: 5
+Explanation: The maximum points can be earned by solving questions 0 and 3.
+- Solve question 0: Earn 3 points, will be unable to solve the next 2 questions
+- Unable to solve questions 1 and 2
+- Solve question 3: Earn 2 points
+Total points earned: 3 + 2 = 5. There is no other way to earn 5 or more points.
+
+Example 2:
+
+Input: questions = [[1,1],[2,2],[3,3],[4,4],[5,5]]
+Output: 7
+Explanation: The maximum points can be earned by solving questions 1 and 4.
+- Skip question 0
+- Solve question 1: Earn 2 points, will be unable to solve the next 2 questions
+- Unable to solve questions 2 and 3
+- Solve question 4: Earn 5 points
+Total points earned: 2 + 5 = 7. There is no other way to earn 7 or more points.
+
+
+Constraints:
+
+1 <= questions.length <= 10^5
+questions[i].length == 2
+1 <= pointsi, brainpoweri <= 10^5
+
+"""
+
+# V0
+# IDEA : DP FROM THE BACK — "SOLVE AND JUMP" vs "SKIP"
+#
+#   let dp[i] = best score obtainable from question i onwards. two choices :
+#
+#       skip  ->  dp[i+1]
+#       solve ->  points[i] + dp[i + brainpower[i] + 1]
+#
+#   so  dp[i] = max(dp[i+1], points[i] + dp[min(n, i + brainpower[i] + 1)]).
+#
+#   filling backwards makes both terms already known, and indices past the
+#   end clamp to n where dp is 0.
+#
+#   NOTE : going FORWARD would need a "blocked until" marker; backwards the
+#          jump is a plain array read.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def mostPoints(self, questions):
+        n = len(questions)
+        dp = [0] * (n + 1)
+        for i in range(n - 1, -1, -1):
+            points, brain = questions[i]
+            nxt = min(n, i + brain + 1)
+            dp[i] = max(dp[i + 1], points + dp[nxt])
+        return dp[0]

--- a/leetcode_python/Graph/detonate-the-maximum-bombs.py
+++ b/leetcode_python/Graph/detonate-the-maximum-bombs.py
@@ -1,0 +1,91 @@
+"""
+
+2101. Detonate the Maximum Bombs
+Medium
+
+You are given a list of bombs. The range of a bomb is defined as the area where its effect can be felt. This area is in the shape of a circle with the center as the location of the bomb.
+
+The bombs are represented by a 0-indexed 2D integer array bombs where bombs[i] = [xi, yi, ri]. xi and yi denote the X-coordinate and Y-coordinate of the location of the ith bomb, whereas ri denotes the radius of its range.
+
+You may choose to detonate a single bomb. When a bomb is detonated, it will detonate all bombs that lie in its range. These bombs will further detonate the bombs that lie in their ranges.
+
+Given the list of bombs, return the maximum number of bombs that can be detonated if you are allowed to detonate only one bomb.
+
+
+Example 1:
+
+Input: bombs = [[2,1,3],[6,1,4]]
+Output: 2
+Explanation:
+The above figure shows the positions and ranges of the 2 bombs.
+If we detonate the left bomb, the right bomb will not be affected.
+But if we detonate the right bomb, both bombs will be detonated.
+So the maximum bombs that can be detonated is max(1, 2) = 2.
+
+Example 2:
+
+Input: bombs = [[1,1,5],[10,10,5]]
+Output: 1
+Explanation:
+Detonating either bomb will not detonate the other bomb, so the maximum number of bombs that can be detonated is 1.
+
+Example 3:
+
+Input: bombs = [[1,2,3],[2,3,1],[3,4,2],[4,5,3],[5,6,4]]
+Output: 5
+Explanation:
+The best bomb to detonate is bomb 0 because:
+- Bomb 0 detonates bombs 1 and 2. The red circle denotes the range of bomb 0.
+- Bomb 2 detonates bomb 3. The blue circle denotes the range of bomb 2.
+- Bomb 3 detonates bomb 4. The green circle denotes the range of bomb 3.
+Thus all 5 bombs are detonated.
+
+
+Constraints:
+
+1 <= bombs.length <= 100
+bombs[i].length == 3
+1 <= xi, yi, ri <= 10^5
+
+"""
+
+# V0
+# IDEA : DIRECTED REACHABILITY GRAPH + DFS FROM EVERY BOMB
+#
+#   bomb i triggers bomb j when j's CENTRE falls inside i's circle :
+#       (xi-xj)^2 + (yi-yj)^2 <= ri^2
+#   note this is one-way — a big bomb reaching a small one says nothing
+#   about the reverse — so the graph is DIRECTED, not a union-find.
+#
+#   compare SQUARED distances so the check stays in integers (no sqrt, no
+#   float rounding at the boundary).
+#
+#   with n <= 100 we can afford to build all n^2 edges and run a DFS from
+#   each start, taking the largest reachable set.
+#
+# time = O(n^2) to build + O(n * (n + E)) = O(n^3) worst case, space = O(n^2)
+class Solution(object):
+    def maximumDetonation(self, bombs):
+        n = len(bombs)
+        adj = [[] for _ in range(n)]
+        for i in range(n):
+            xi, yi, ri = bombs[i]
+            for j in range(n):
+                if i == j:
+                    continue
+                xj, yj, _ = bombs[j]
+                if (xi - xj) ** 2 + (yi - yj) ** 2 <= ri * ri:
+                    adj[i].append(j)
+
+        res = 0
+        for start in range(n):
+            seen = set([start])
+            stack = [start]
+            while stack:
+                cur = stack.pop()
+                for nxt in adj[cur]:
+                    if nxt not in seen:
+                        seen.add(nxt)
+                        stack.append(nxt)
+            res = max(res, len(seen))
+        return res

--- a/leetcode_python/Graph/maximum-employees-to-be-invited-to-a-meeting.py
+++ b/leetcode_python/Graph/maximum-employees-to-be-invited-to-a-meeting.py
@@ -1,0 +1,115 @@
+"""
+
+2127. Maximum Employees to Be Invited to a Meeting
+Hard
+
+A company is organizing a meeting and has a list of n employees, waiting to be invited. They have arranged for a large circular table, capable of seating any number of employees.
+
+The employees are numbered from 0 to n - 1. Each employee has a favorite person and they will attend the meeting only if they can sit next to their favorite person at the table. The favorite person of an employee is not themself.
+
+Given a 0-indexed integer array favorite, where favorite[i] denotes the favorite person of the ith employee, return the maximum number of employees that can be invited to the meeting.
+
+
+Example 1:
+
+Input: favorite = [2,2,1,2]
+Output: 3
+Explanation:
+The above figure shows how the company can invite employees 0, 1, and 2, and seat them at the round table.
+All employees cannot be invited because employee 2 cannot sit beside employees 0, 1, and 3, simultaneously.
+Note that the company can also invite employees 1, 2, and 3, and give them their desired seats.
+The maximum number of employees that can be invited to the meeting is 3.
+
+Example 2:
+
+Input: favorite = [1,2,0]
+Output: 3
+Explanation:
+Each employee is the favorite person of at least one other employee, and the only way the company can invite them is if they invite every employee.
+The seating arrangement will be the same as that in the figure given in example 1:
+- Employee 0 will sit between employees 2 and 1.
+- Employee 1 will sit between employees 0 and 2.
+- Employee 2 will sit between employees 1 and 0.
+The maximum number of employees that can be invited to the meeting is 3.
+
+Example 3:
+
+Input: favorite = [3,0,1,4,1]
+Output: 4
+Explanation:
+The above figure shows how the company will invite employees 0, 1, 3, and 4, and seat them at the round table.
+Employee 2 cannot be invited because the two spots next to their favorite employee 1 are taken.
+So the company leaves them out of the meeting.
+The maximum number of employees that can be invited to the meeting is 4.
+
+
+Constraints:
+
+n == favorite.length
+2 <= n <= 10^5
+0 <= favorite[i] <= n - 1
+favorite[i] != i
+
+"""
+
+# V0
+# IDEA : FUNCTIONAL GRAPH — ONE BIG CYCLE, OR MANY 2-CYCLES WITH TAILS
+#
+#   every employee points at exactly one favorite, so the graph i -> fav[i]
+#   is a functional graph : each component is one cycle with trees hanging
+#   off it. only two seating shapes are possible :
+#
+#   (a) ONE cycle of length >= 3 fills the whole table by itself — nothing
+#       else fits, because every seated person needs their favorite adjacent.
+#
+#   (b) any number of MUTUAL pairs (cycles of length 2) can share the table,
+#       each pair extended outwards by the longest chain of admirers feeding
+#       into each of its two members.
+#
+#   so : answer = max(longest cycle >= 3, sum over 2-cycles of the two chains)
+#
+#   the chains come from a Kahn peel : repeatedly drop indegree-0 nodes,
+#   carrying depth[v] = longest chain ending at v. whatever survives with
+#   indegree > 0 is exactly the cycles.
+#
+# time = O(n), space = O(n)
+from collections import deque
+
+
+class Solution(object):
+    def maximumInvitations(self, favorite):
+        n = len(favorite)
+        indeg = [0] * n
+        for f in favorite:
+            indeg[f] += 1
+
+        depth = [1] * n                       # longest chain ending at node
+        q = deque(i for i in range(n) if indeg[i] == 0)
+        removed = [False] * n
+        while q:
+            u = q.popleft()
+            removed[u] = True
+            v = favorite[u]
+            depth[v] = max(depth[v], depth[u] + 1)
+            indeg[v] -= 1
+            if indeg[v] == 0:
+                q.append(v)
+
+        longest_cycle = 0
+        pairs_total = 0
+        for i in range(n):
+            if removed[i]:
+                continue
+            # walk this cycle once, marking as we go
+            length = 0
+            cur = i
+            while not removed[cur]:
+                removed[cur] = True
+                length += 1
+                cur = favorite[cur]
+            if length == 2:
+                pairs_total += depth[i] + depth[favorite[i]]
+            else:
+                longest_cycle = max(longest_cycle, length)
+
+        return max(longest_cycle, pairs_total)

--- a/leetcode_python/Graph/minimum-operations-to-remove-adjacent-ones-in-matrix.py
+++ b/leetcode_python/Graph/minimum-operations-to-remove-adjacent-ones-in-matrix.py
@@ -1,0 +1,133 @@
+"""
+
+2123. Minimum Operations to Remove Adjacent Ones in Matrix
+Hard
+🔒 (premium)
+
+You are given a 0-indexed binary matrix grid. In one operation, you can flip any 1 in grid to be 0.
+
+A binary matrix is well-isolated if there is no 1 in the matrix that is 4-directionally connected (i.e., horizontal and vertical) to another 1.
+
+Return the minimum number of operations to make grid well-isolated.
+
+
+Example 1:
+
+Input: grid = [[1,1,0],[0,1,1],[1,1,1]]
+Output: 3
+Explanation:
+Use 3 operations to change grid[0][1], grid[1][2], and grid[2][1] to 0.
+After, no more 1's are 4-directionally connected and grid is well-isolated.
+
+Example 2:
+
+Input: grid = [[0,0,0],[0,0,0],[0,0,0]]
+Output: 0
+Explanation:
+There are no 1's in grid and it is well-isolated.
+No operations were done so return 0.
+
+Example 3:
+
+Input: grid = [[0,1],[1,0]]
+Output: 0
+Explanation:
+None of the 1's are 4-directionally connected and grid is well-isolated.
+No operations were done so return 0.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m, n <= 300
+grid[i][j] is either 0 or 1.
+
+"""
+
+# V0
+# IDEA : MINIMUM VERTEX COVER ON A BIPARTITE GRID = MAXIMUM MATCHING (KÖNIG)
+#
+#   build a graph whose vertices are the 1-cells and whose edges join
+#   4-adjacent 1s. "no two 1s adjacent" means every edge must lose at least
+#   one endpoint, i.e. the flipped cells form a VERTEX COVER — and we want
+#   the smallest one.
+#
+#   the grid is bipartite by the checkerboard colouring : (i+j) even on one
+#   side, odd on the other, and every edge crosses sides. König's theorem
+#   then says
+#           minimum vertex cover = maximum matching
+#   so the answer is just the size of a maximum bipartite matching.
+#
+#   Hopcroft-Karp finds it in O(E * sqrt(V)) — the plain augmenting-path
+#   loop would be O(V*E), too slow for a full 300x300 grid.
+#
+# time = O(E * sqrt(V)) with V <= m*n and E <= 2*m*n, space = O(m*n)
+from collections import deque
+
+
+class Solution(object):
+    def minimumOperations(self, grid):
+        m, n = len(grid), len(grid[0])
+        INF = float('inf')
+
+        # left  = 1-cells on the even squares of the checkerboard
+        # right = 1-cells on the odd squares
+        left_id = {}
+        right_id = {}
+        for i in range(m):
+            for j in range(n):
+                if grid[i][j] == 1:
+                    if (i + j) % 2 == 0:
+                        left_id[(i, j)] = len(left_id)
+                    else:
+                        right_id[(i, j)] = len(right_id)
+
+        adj = [[] for _ in range(len(left_id))]
+        for (i, j), u in left_id.items():
+            for di, dj in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                v = right_id.get((i + di, j + dj))
+                if v is not None:
+                    adj[u].append(v)
+
+        nl, nr = len(left_id), len(right_id)
+        match_l = [-1] * nl          # left  -> right
+        match_r = [-1] * nr          # right -> left
+        dist = [0] * nl
+
+        def bfs():
+            q = deque()
+            found = False
+            for u in range(nl):
+                if match_l[u] == -1:
+                    dist[u] = 0
+                    q.append(u)
+                else:
+                    dist[u] = INF
+            while q:
+                u = q.popleft()
+                for v in adj[u]:
+                    w = match_r[v]
+                    if w == -1:
+                        found = True
+                    elif dist[w] == INF:
+                        dist[w] = dist[u] + 1
+                        q.append(w)
+            return found
+
+        def dfs(u):
+            for v in adj[u]:
+                w = match_r[v]
+                if w == -1 or (dist[w] == dist[u] + 1 and dfs(w)):
+                    match_l[u] = v
+                    match_r[v] = u
+                    return True
+            dist[u] = INF
+            return False
+
+        res = 0
+        while bfs():
+            for u in range(nl):
+                if match_l[u] == -1 and dfs(u):
+                    res += 1
+        return res

--- a/leetcode_python/Graph/valid-arrangement-of-pairs.py
+++ b/leetcode_python/Graph/valid-arrangement-of-pairs.py
@@ -1,0 +1,100 @@
+"""
+
+2097. Valid Arrangement of Pairs
+Hard
+
+You are given a 0-indexed 2D integer array pairs where pairs[i] = [starti, endi]. An arrangement of pairs is valid if for every index i where 1 <= i < pairs.length, we have endi-1 == starti.
+
+Return any valid arrangement of pairs.
+
+Note: The inputs will be generated such that there exists a valid arrangement of pairs.
+
+
+Example 1:
+
+Input: pairs = [[5,1],[4,5],[11,9],[9,4]]
+Output: [[11,9],[9,4],[4,5],[5,1]]
+Explanation:
+This is a valid arrangement since endi-1 always equals starti.
+end0 = 9 == 9 = start1
+end1 = 4 == 4 = start2
+end2 = 5 == 5 = start3
+
+Example 2:
+
+Input: pairs = [[1,3],[3,2],[2,1]]
+Output: [[1,3],[3,2],[2,1]]
+Explanation:
+This is a valid arrangement since endi-1 always equals starti.
+end0 = 3 == 3 = start1
+end1 = 2 == 2 = start2
+The arrangements [[2,1],[1,3],[3,2]] and [[3,2],[2,1],[1,3]] are also valid.
+
+Example 3:
+
+Input: pairs = [[1,2],[1,3],[2,1]]
+Output: [[1,2],[2,1],[1,3]]
+Explanation:
+This is a valid arrangement since endi-1 always equals starti.
+end0 = 2 == 2 = start1
+end1 = 1 == 1 = start2
+
+
+Constraints:
+
+1 <= pairs.length <= 10^5
+pairs[i].length == 2
+0 <= starti, endi <= 10^9
+starti != endi
+No two pairs are exactly the same.
+There exists a valid arrangement of pairs.
+
+"""
+
+# V0
+# IDEA : EULERIAN PATH (HIERHOLZER)
+#
+#   read each pair [a, b] as a DIRECTED EDGE a -> b. an arrangement that
+#   chains end == next start is exactly a walk using every edge once, i.e.
+#   an Eulerian path.
+#
+#   start vertex :
+#       the one with  outdegree - indegree == 1  if it exists (path),
+#       otherwise any vertex with an outgoing edge (the walk is a circuit).
+#
+#   Hierholzer, iteratively so 10^5 edges cannot blow the stack :
+#       push start on a stack; while the top still has unused edges, walk
+#       one and push the neighbour; when it runs dry, pop it into `route`.
+#       `route` reversed is the Eulerian path of VERTICES, and consecutive
+#       vertices are the pairs to output.
+#
+# time = O(V + E), space = O(V + E)
+from collections import defaultdict
+
+
+class Solution(object):
+    def validArrangement(self, pairs):
+        adj = defaultdict(list)
+        degree = defaultdict(int)          # outdegree - indegree
+        for a, b in pairs:
+            adj[a].append(b)
+            degree[a] += 1
+            degree[b] -= 1
+
+        start = pairs[0][0]
+        for node, d in degree.items():
+            if d == 1:
+                start = node
+                break
+
+        route = []
+        stack = [start]
+        while stack:
+            node = stack[-1]
+            if adj[node]:
+                stack.append(adj[node].pop())
+            else:
+                route.append(stack.pop())
+        route.reverse()
+
+        return [[route[i], route[i + 1]] for i in range(len(route) - 1)]

--- a/leetcode_python/Greedy/check-if-a-parentheses-string-can-be-valid.py
+++ b/leetcode_python/Greedy/check-if-a-parentheses-string-can-be-valid.py
@@ -1,0 +1,86 @@
+"""
+
+2116. Check if a Parentheses String Can Be Valid
+Medium
+
+A parentheses string is a non-empty string consisting only of '(' and ')'. It is valid if any of the following conditions is true:
+
+It is ().
+It can be written as AB (A concatenated with B), where A and B are valid parentheses strings.
+It can be written as (A), where A is a valid parentheses string.
+
+You are given a parentheses string s and a string locked, both of length n. locked is a binary string consisting only of '0's and '1's. For each index i of locked,
+
+If locked[i] is '1', you cannot change s[i].
+But if locked[i] is '0', you can change s[i] to either '(' or ')'.
+
+Return true if you can make s a valid parentheses string. Otherwise, return false.
+
+
+Example 1:
+
+Input: s = "))()))", locked = "010100"
+Output: true
+Explanation: locked[1] == '1' and locked[3] == '1', so we cannot change s[1] or s[3].
+We change s[0] and s[4] to '(' while leaving s[2] and s[5] unchanged to make s valid.
+
+Example 2:
+
+Input: s = "()()", locked = "0000"
+Output: true
+Explanation: We do not need to make any changes because s is already valid.
+
+Example 3:
+
+Input: s = ")", locked = "0"
+Output: false
+Explanation: locked permits us to change s[0].
+Changing s[0] to either '(' or ')' will not make s valid.
+
+
+Constraints:
+
+n == s.length == locked.length
+1 <= n <= 10^5
+s[i] is either '(' or ')'.
+locked[i] is either '0' or '1'.
+
+"""
+
+# V0
+# IDEA : TWO GREEDY SWEEPS — BEST CASE FROM THE LEFT, BEST CASE FROM THE RIGHT
+#
+#   an odd length can never balance, so reject it immediately.
+#
+#   left-to-right : count every unlocked slot as '(' (the most generous
+#   choice for keeping the running balance non-negative). if the balance
+#   still goes negative at some point, there is a ')' too early that no
+#   assignment can rescue -> false.
+#
+#   right-to-left : symmetrically count every unlocked slot as ')'. a
+#   negative balance here means a '(' too late.
+#
+#   passing BOTH sweeps is enough : the first says every prefix can be made
+#   non-negative, the second says every suffix can, and with an even length
+#   that is exactly validity.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def canBeValid(self, s, locked):
+        n = len(s)
+        if n % 2:
+            return False
+
+        bal = 0
+        for i in range(n):
+            bal += 1 if (locked[i] == '0' or s[i] == '(') else -1
+            if bal < 0:
+                return False
+
+        bal = 0
+        for i in range(n - 1, -1, -1):
+            bal += 1 if (locked[i] == '0' or s[i] == ')') else -1
+            if bal < 0:
+                return False
+
+        return True

--- a/leetcode_python/Greedy/earliest-possible-day-of-full-bloom.py
+++ b/leetcode_python/Greedy/earliest-possible-day-of-full-bloom.py
@@ -1,0 +1,79 @@
+"""
+
+2136. Earliest Possible Day of Full Bloom
+Hard
+
+You have n flower seeds. Every seed must be planted first before it can begin to grow, then bloom. Planting a seed takes time and so does the growth of a seed. You are given two 0-indexed integer arrays plantTime and growTime, of length n each:
+
+plantTime[i] is the number of full days it takes you to plant the ith seed. Every day, you can work on planting exactly one seed. You do not have to work on planting the same seed on consecutive days, but the planting of a seed is not complete until you have worked plantTime[i] days on planting it in total.
+growTime[i] is the number of full days it takes the ith seed to grow after being completely planted. After the last day of its growth, the flower blooms and stays bloomed forever.
+
+From the beginning of day 0, you can plant the seeds in any order.
+
+Return the earliest possible day where all seeds are blooming.
+
+
+Example 1:
+
+Input: plantTime = [1,4,3], growTime = [2,3,1]
+Output: 9
+Explanation: The grayed out pots represent planting days, colored pots represent growing days, and the flower represents the day it blooms.
+One optimal way is:
+On day 0, plant the 0th seed. The seed grows for 2 full days and blooms on day 3.
+On days 1, 2, 3, and 4, plant the 1st seed. The seed grows for 3 full days and blooms on day 8.
+On days 5, 6, and 7, plant the 2nd seed. The seed grows for 1 full day and blooms on day 9.
+Thus, on day 9, all the seeds are blooming.
+
+Example 2:
+
+Input: plantTime = [1,2,3,2], growTime = [2,1,2,1]
+Output: 9
+Explanation: The grayed out pots represent planting days, colored pots represent growing days, and the flower represents the day it blooms.
+One optimal way is:
+On day 1, plant the 0th seed. The seed grows for 2 full days and blooms on day 4.
+On days 0 and 3, plant the 1st seed. The seed grows for 1 full day and blooms on day 5.
+On days 2, 4, and 5, plant the 2nd seed. The seed grows for 2 full days and blooms on day 8.
+On days 6 and 7, plant the 3rd seed. The seed grows for 1 full day and blooms on day 9.
+Thus, on day 9, all the seeds are blooming.
+
+Example 3:
+
+Input: plantTime = [1], growTime = [1]
+Output: 2
+Explanation: On day 0, plant the 0th seed. The seed grows for 1 full day and blooms on day 2.
+Thus, on day 1, all the seeds are blooming.
+
+
+Constraints:
+
+n == plantTime.length == growTime.length
+1 <= n <= 10^5
+1 <= plantTime[i], growTime[i] <= 10^4
+
+"""
+
+# V0
+# IDEA : GREEDY — PLANT THE SLOWEST-GROWING SEED FIRST
+#
+#   the total planting work is fixed (sum of plantTime) no matter what order
+#   is chosen, and only one seed can be planted per day, so the schedule is
+#   really just a PERMUTATION. a seed finishes planting at the running total
+#   of plant times up to it, and blooms growTime later.
+#
+#   exchange argument : swapping two adjacent seeds so that the one with the
+#   LARGER growTime is planted first never makes the answer worse — its long
+#   growth then overlaps the other's planting. so sort by growTime desc.
+#
+#   walk that order, keep the cumulative planting day, and take the max of
+#   (day planting finished + growTime).
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def earliestFullBloom(self, plantTime, growTime):
+        order = sorted(zip(growTime, plantTime), reverse=True)
+        res = 0
+        planted = 0
+        for grow, plant in order:
+            planted += plant
+            res = max(res, planted + grow)
+        return res

--- a/leetcode_python/Greedy/minimum-cost-of-buying-candies-with-discount.py
+++ b/leetcode_python/Greedy/minimum-cost-of-buying-candies-with-discount.py
@@ -1,0 +1,63 @@
+"""
+
+2144. Minimum Cost of Buying Candies With Discount
+Easy
+
+A shop is selling candies at a discount. For every two candies sold, the shop gives a third candy for free.
+
+The customer can choose any candy to take away for free as long as the cost of the chosen candy is less than or equal to the minimum cost of the two candies bought.
+
+For example, if there are 4 candies with costs 1, 2, 3, and 4, and the customer buys candies with costs 2 and 3, they can take the candy with cost 1 for free, but not the candy with cost 4.
+
+Given a 0-indexed integer array cost, where cost[i] denotes the cost of the ith candy, return the minimum cost of buying all the candies.
+
+
+Example 1:
+
+Input: cost = [1,2,3]
+Output: 5
+Explanation: We buy the candies with costs 2 and 3, and take the candy with cost 1 for free.
+The total cost of buying all candies is 2 + 3 = 5. This is the only way we can buy the candies.
+Note that we cannot buy candies with costs 1 and 3, and then take the candy with cost 2 for free.
+The cost of the free candy has to be less than or equal to the minimum cost of the purchased candies.
+
+Example 2:
+
+Input: cost = [6,5,7,9,2,2]
+Output: 23
+Explanation: The way in which we can get the minimum cost is described below:
+- Buy candies with costs 9 and 7
+- Take the candy with cost 6 for free
+- We buy candies with costs 5 and 2
+- Take the last remaining candy with cost 2 for free
+Hence, the minimum cost to buy all candies is 9 + 7 + 5 + 2 = 23.
+
+Example 3:
+
+Input: cost = [5,5]
+Output: 10
+Explanation: Since there are only 2 candies, we buy both candies. There is not a third candy we can take for free.
+Hence, the minimum cost to buy all candies is 5 + 5 = 10.
+
+
+Constraints:
+
+1 <= cost.length <= 100
+1 <= cost[i] <= 100
+
+"""
+
+# V0
+# IDEA : SORT DESCENDING, EVERY THIRD CANDY IS THE FREE ONE
+#
+#   the free candy must not exceed the cheaper of the two bought, so the
+#   best possible freebie in any group of three is its SMALLEST member.
+#   sorting descending and grouping consecutively makes each group
+#   (expensive, expensive, cheap) — so skipping indices 2, 5, 8, ... gives
+#   away the most money possible.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def minimumCost(self, cost):
+        cost = sorted(cost, reverse=True)
+        return sum(c for i, c in enumerate(cost) if i % 3 != 2)

--- a/leetcode_python/Greedy/minimum-moves-to-reach-target-score.py
+++ b/leetcode_python/Greedy/minimum-moves-to-reach-target-score.py
@@ -1,0 +1,75 @@
+"""
+
+2139. Minimum Moves to Reach Target Score
+Medium
+
+You are playing a game with integers. You start with the integer 1 and you want to reach the integer target.
+
+In one move, you can either:
+
+Increment the current integer by one (i.e., x = x + 1).
+Double the current integer (i.e., x = 2 * x).
+
+You can use the increment operation any number of times, however, you can only use the double operation at most maxDoubles times.
+
+Given the two integers target and maxDoubles, return the minimum number of moves needed to reach target.
+
+
+Example 1:
+
+Input: target = 5, maxDoubles = 0
+Output: 4
+Explanation: Keep incrementing by 1 until you reach target.
+
+Example 2:
+
+Input: target = 19, maxDoubles = 2
+Output: 7
+Explanation: Initially, x = 1
+Increment 3 times so x = 4
+Double once so x = 8
+Increment once so x = 9
+Double again so x = 18
+Increment once so x = 19
+
+Example 3:
+
+Input: target = 10, maxDoubles = 4
+Output: 4
+Explanation: Initially, x = 1
+Increment once so x = 2
+Double once so x = 4
+Increment once so x = 5
+Double again so x = 10
+
+
+Constraints:
+
+1 <= target <= 10^9
+0 <= maxDoubles <= 100
+
+"""
+
+# V0
+# IDEA : WALK BACKWARDS FROM target — HALVE WHENEVER POSSIBLE
+#
+#   run the game in reverse : from target down to 1, an increment becomes
+#   "-1" and a double becomes "/2". halving is worth far more than
+#   decrementing, so take it whenever the number is even and doubles remain;
+#   when it is odd, one "-1" makes it even again.
+#
+#   once the doubling budget is spent, only decrements are left, so the rest
+#   costs exactly (x - 1) moves.
+#
+# time = O(log target), space = O(1)
+class Solution(object):
+    def minMoves(self, target, maxDoubles):
+        moves = 0
+        while target > 1 and maxDoubles > 0:
+            if target % 2:
+                target -= 1
+            else:
+                target //= 2
+                maxDoubles -= 1
+            moves += 1
+        return moves + (target - 1)

--- a/leetcode_python/Greedy/subsequence-of-size-k-with-the-largest-even-sum.py
+++ b/leetcode_python/Greedy/subsequence-of-size-k-with-the-largest-even-sum.py
@@ -1,0 +1,86 @@
+"""
+
+2098. Subsequence of Size K With the Largest Even Sum
+Medium
+🔒 (premium)
+
+You are given an integer array nums and an integer k. Find the largest even sum of any subsequence of nums that has a length of k.
+
+Return this sum, or -1 if such a sum does not exist.
+
+A subsequence is an array that can be derived from another array by deleting some or no elements without changing the order of the remaining elements.
+
+
+Example 1:
+
+Input: nums = [4,1,5,3,1], k = 3
+Output: 12
+Explanation:
+The subsequence with the largest possible even sum is [4,5,3]. It has a sum of 4 + 5 + 3 = 12.
+
+Example 2:
+
+Input: nums = [4,6,2], k = 3
+Output: 12
+Explanation:
+The subsequence with the largest possible even sum is [4,6,2]. It has a sum of 4 + 6 + 2 = 12.
+
+Example 3:
+
+Input: nums = [1,3,5], k = 1
+Output: -1
+Explanation:
+No subsequence of nums with length 1 has an even sum.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+0 <= nums[i] <= 10^9
+1 <= k <= nums.length
+
+"""
+
+# V0
+# IDEA : TAKE THE K LARGEST, THEN FIX THE PARITY WITH ONE SWAP
+#
+#   the k largest values give the biggest sum of any length-k subsequence.
+#   if that sum is already even we are done.
+#
+#   if it is odd, the parity must flip, and flipping costs exactly one swap :
+#   drop one taken value and pick up one untaken value OF THE OPPOSITE
+#   PARITY. two candidate swaps, and each should lose as little as possible :
+#
+#       (a) drop the smallest ODD  taken, add the largest EVEN untaken
+#       (b) drop the smallest EVEN taken, add the largest ODD  untaken
+#
+#   take whichever swap exists and loses less; if neither exists, -1.
+#
+#   NOTE : order inside a subsequence never matters here, so sorting is free.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def largestEvenSum(self, nums, k):
+        nums = sorted(nums)
+        taken = nums[len(nums) - k:]
+        rest = nums[:len(nums) - k]
+        total = sum(taken)
+        if total % 2 == 0:
+            return total
+
+        # smallest taken of each parity (taken is ascending)
+        min_taken = {0: None, 1: None}
+        for x in taken:
+            if min_taken[x % 2] is None:
+                min_taken[x % 2] = x
+        # largest untaken of each parity (rest is ascending -> scan backwards)
+        max_rest = {0: None, 1: None}
+        for x in reversed(rest):
+            if max_rest[x % 2] is None:
+                max_rest[x % 2] = x
+
+        best = -1
+        for p in (0, 1):
+            if min_taken[p] is not None and max_rest[1 - p] is not None:
+                best = max(best, total - min_taken[p] + max_rest[1 - p])
+        return best

--- a/leetcode_python/Hash_table/find-all-lonely-numbers-in-the-array.py
+++ b/leetcode_python/Hash_table/find-all-lonely-numbers-in-the-array.py
@@ -1,0 +1,58 @@
+"""
+
+2150. Find All Lonely Numbers in the Array
+Medium
+
+You are given an integer array nums. A number x is lonely when it appears only once, and no adjacent numbers (i.e. x + 1 and x - 1) appear in the array.
+
+Return all lonely numbers in nums. You may return the answer in any order.
+
+
+Example 1:
+
+Input: nums = [10,6,5,8]
+Output: [10,8]
+Explanation:
+- 10 is a lonely number since it appears exactly once and 9 and 11 does not appear in nums.
+- 8 is a lonely number since it appears exactly once and 7 and 9 does not appear in nums.
+- 5 is not a lonely number since 6 appears in nums and vice versa.
+Hence, the lonely numbers in nums are [10, 8].
+Note that [8, 10] may also be returned.
+
+Example 2:
+
+Input: nums = [1,3,5,3]
+Output: [1,5]
+Explanation:
+- 1 is a lonely number since it appears exactly once and 0 and 2 does not appear in nums.
+- 5 is a lonely number since it appears exactly once and 4 and 6 does not appear in nums.
+- 3 is not a lonely number since it appears twice.
+Hence, the lonely numbers in nums are [1, 5].
+Note that [5, 1] may also be returned.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+0 <= nums[i] <= 10^6
+
+"""
+
+# V0
+# IDEA : COUNTER, THEN CHECK THE TWO NEIGHBOURS
+#
+#   the definition is a direct lookup once occurrences are counted :
+#       cnt[x] == 1  and  x-1 not in cnt  and  x+1 not in cnt
+#
+#   iterating the Counter (not the array) visits each distinct value once,
+#   and duplicates are already excluded by the cnt[x] == 1 test.
+#
+# time = O(n), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def findLonely(self, nums):
+        cnt = Counter(nums)
+        return [x for x, c in cnt.items()
+                if c == 1 and (x - 1) not in cnt and (x + 1) not in cnt]

--- a/leetcode_python/Hash_table/intervals-between-identical-elements.py
+++ b/leetcode_python/Hash_table/intervals-between-identical-elements.py
@@ -1,0 +1,80 @@
+"""
+
+2121. Intervals Between Identical Elements
+Medium
+
+You are given a 0-indexed array of n integers arr.
+
+The interval between two elements in arr is defined as the absolute difference between their indices. More formally, the interval between arr[i] and arr[j] is |i - j|.
+
+Return an array intervals of length n where intervals[i] is the sum of intervals between arr[i] and each element in arr with the same value as arr[i].
+
+Note: |x| is the absolute value of x.
+
+
+Example 1:
+
+Input: arr = [2,1,3,1,2,3,3]
+Output: [4,2,7,2,4,4,5]
+Explanation:
+- Index 0: Another 2 is found at index 4. |0 - 4| = 4
+- Index 1: Another 1 is found at index 3. |1 - 3| = 2
+- Index 2: Two more 3s are found at indices 5 and 6. |2 - 5| + |2 - 6| = 7
+- Index 3: Another 1 is found at index 1. |3 - 1| = 2
+- Index 4: Another 2 is found at index 0. |4 - 0| = 4
+- Index 5: Two more 3s are found at indices 2 and 6. |5 - 2| + |5 - 6| = 4
+- Index 6: Two more 3s are found at indices 2 and 5. |6 - 2| + |6 - 5| = 5
+
+Example 2:
+
+Input: arr = [10,5,10,10]
+Output: [5,0,3,4]
+Explanation:
+- Index 0: Two more 10s are found at indices 2 and 3. |0 - 2| + |0 - 3| = 5
+- Index 1: There is only one 5 in the array, so its sum of intervals to identical elements is 0.
+- Index 2: Two more 10s are found at indices 0 and 3. |2 - 0| + |2 - 3| = 3
+- Index 3: Two more 10s are found at indices 0 and 2. |3 - 0| + |3 - 2| = 4
+
+
+Constraints:
+
+n == arr.length
+1 <= n <= 10^5
+1 <= arr[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : GROUP INDICES BY VALUE, THEN PREFIX SUMS INSIDE EACH GROUP
+#
+#   values never interact, so bucket the positions by value. inside one
+#   bucket the positions are already ascending, and for the k-th of m
+#   positions p :
+#
+#       left  part : k*p - (sum of the k positions before it)
+#       right part : (sum of the m-k-1 positions after it) - (m-k-1)*p
+#
+#   both drop the absolute value because the sign is known on each side.
+#   running `left_sum` forward and deriving `right_sum = total - left_sum - p`
+#   makes each bucket a single pass.
+#
+# time = O(n), space = O(n)
+from collections import defaultdict
+
+
+class Solution(object):
+    def getDistances(self, arr):
+        pos = defaultdict(list)
+        for i, x in enumerate(arr):
+            pos[x].append(i)
+
+        res = [0] * len(arr)
+        for idxs in pos.values():
+            m = len(idxs)
+            total = sum(idxs)
+            left_sum = 0
+            for k, p in enumerate(idxs):
+                right_sum = total - left_sum - p
+                res[p] = (k * p - left_sum) + (right_sum - (m - k - 1) * p)
+                left_sum += p
+        return res

--- a/leetcode_python/Hash_table/longest-palindrome-by-concatenating-two-letter-words.py
+++ b/leetcode_python/Hash_table/longest-palindrome-by-concatenating-two-letter-words.py
@@ -1,0 +1,75 @@
+"""
+
+2131. Longest Palindrome by Concatenating Two Letter Words
+Medium
+
+You are given an array of strings words. Each element of words consists of two lowercase English letters.
+
+Create the longest possible palindrome by selecting some elements from words and concatenating them in any order. Each element can be selected at most once.
+
+Return the length of the longest palindrome that you can create. If it is impossible to create any palindrome, return 0.
+
+A palindrome is a string that reads the same forward and backward.
+
+
+Example 1:
+
+Input: words = ["lc","cl","gg"]
+Output: 6
+Explanation: One longest palindrome is "lc" + "gg" + "cl" = "lcggcl", of length 6.
+Note that "clgglc" is another longest palindrome that can be created.
+
+Example 2:
+
+Input: words = ["ab","ty","yt","lc","cl","ab"]
+Output: 8
+Explanation: One longest palindrome is "ty" + "lc" + "cl" + "yt" = "tylcclyt", of length 8.
+Note that "lcyttycl" is another longest palindrome that can be created.
+
+Example 3:
+
+Input: words = ["cc","ll","xx"]
+Output: 2
+Explanation: One longest palindrome is "cc", of length 2.
+Note that "ll" is another longest palindrome that can be created, and so is "xx".
+
+
+Constraints:
+
+1 <= words.length <= 10^5
+words[i].length == 2
+words[i] consists of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : PAIR EACH WORD WITH ITS REVERSE; ONE DOUBLE LETTER MAY SIT IN THE MIDDLE
+#
+#   a palindrome built from 2-letter blocks mirrors block by block : a block
+#   "xy" on the left must be answered by "yx" on the right. so
+#
+#     - for x != y : the number of usable pairs is min(cnt["xy"], cnt["yx"]),
+#       and each pair contributes 4 characters. count each unordered pair
+#       once (guard with x < y).
+#
+#     - for x == y ("gg") : two copies mirror each other (4 chars each pair),
+#       and ONE leftover copy may sit in the exact middle — but only one such
+#       leftover in the whole answer, worth 2 more characters.
+#
+# time = O(n), space = O(1)  (at most 26*26 keys)
+from collections import Counter
+
+
+class Solution(object):
+    def longestPalindrome(self, words):
+        cnt = Counter(words)
+        res = 0
+        center = False
+        for w, c in cnt.items():
+            if w[0] == w[1]:
+                res += (c // 2) * 4
+                if c % 2:
+                    center = True
+            elif w[0] < w[1]:
+                res += min(c, cnt[w[::-1]]) * 4
+        return res + (2 if center else 0)

--- a/leetcode_python/Hash_table/recover-the-original-array.py
+++ b/leetcode_python/Hash_table/recover-the-original-array.py
@@ -1,0 +1,96 @@
+"""
+
+2122. Recover the Original Array
+Hard
+
+Alice had a 0-indexed array arr consisting of n positive integers. She chose an arbitrary positive integer k and created two new 0-indexed integer arrays lower and higher in the following manner:
+
+lower[i] = arr[i] - k, for every index i where 0 <= i < n
+higher[i] = arr[i] + k, for every index i where 0 <= i < n
+
+Unfortunately, Alice lost all three arrays. However, she remembers the integers that were present in the arrays lower and higher, but not the array each integer belonged to. Help Alice and recover the original array.
+
+Given an array nums consisting of 2n integers, where exactly n of the integers were present in lower and the remaining in higher, return the original array arr. In case the answer is not unique, return any valid array.
+
+Note: The test cases are generated such that there exists at least one valid array arr.
+
+
+Example 1:
+
+Input: nums = [2,10,6,4,8,12]
+Output: [3,7,11]
+Explanation:
+If arr = [3,7,11] and k = 1, we get lower = [2,6,10] and higher = [4,8,12].
+Combining lower and higher gives us [2,6,10,4,8,12], which is a permutation of nums.
+Another valid possibility is that arr = [5,7,9] and k = 3. In that case, lower = [2,4,6] and higher = [8,10,12].
+
+Example 2:
+
+Input: nums = [1,1,3,3]
+Output: [2,2]
+Explanation:
+If arr = [2,2] and k = 1, we get lower = [1,1] and higher = [3,3].
+Combining lower and higher gives us [1,1,3,3], which is equal to nums.
+Note that arr cannot be [1,3] and k = 0, as the values in arr must be positive.
+
+Example 3:
+
+Input: nums = [5,435]
+Output: [220]
+Explanation:
+The only possible combination is arr = [220] and k = 215. Using them, we get lower = [5] and higher = [435].
+
+
+Constraints:
+
+2 * n == nums.length
+1 <= n <= 1000
+1 <= nums[i] <= 10^9
+The test cases are generated such that there exists at least one valid array arr.
+
+"""
+
+# V0
+# IDEA : GUESS 2k FROM THE SMALLEST ELEMENT, THEN GREEDILY PAIR
+#
+#   sort nums. the smallest element must come from `lower` (nothing can be
+#   below it), so it pairs with SOME later element, and that pairing fixes
+#   2k = nums[j] - nums[0].  only n candidates for j, and 2k must be
+#   positive and even.
+#
+#   for a fixed k, the pairing is forced : walk the sorted array, and the
+#   first unused value x must be a `lower` value, so x + 2k has to be
+#   available to pair with it. a Counter of the remaining values makes each
+#   check O(1), and arr[i] = x + k.
+#
+#   the first k that consumes every element cleanly is an answer.
+#
+# time = O(n^2), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def recoverArray(self, nums):
+        nums = sorted(nums)
+        n = len(nums)
+
+        for j in range(1, n):
+            diff = nums[j] - nums[0]
+            if diff <= 0 or diff % 2:
+                continue
+            k2 = diff                       # = 2k
+            cnt = Counter(nums)
+            arr = []
+            ok = True
+            for x in nums:
+                if cnt[x] == 0:
+                    continue
+                if cnt[x + k2] == 0:
+                    ok = False
+                    break
+                cnt[x] -= 1
+                cnt[x + k2] -= 1
+                arr.append(x + k2 // 2)
+            if ok and len(arr) == n // 2:
+                return arr
+        return []

--- a/leetcode_python/Hash_table/rings-and-rods.py
+++ b/leetcode_python/Hash_table/rings-and-rods.py
@@ -1,0 +1,73 @@
+"""
+
+2103. Rings and Rods
+Easy
+
+There are n rings and each ring is either red, green, or blue. The rings are distributed across ten rods labeled from 0 to 9.
+
+You are given a string rings of length 2n that describes the n rings that are placed onto the rods. Every two characters in rings forms a color-position pair that is used to describe each ring where:
+
+The first character of the ith pair denotes the ith ring's color ('R', 'G', 'B').
+The second character of the ith pair denotes the rod that the ith ring is placed on ('0' to '9').
+
+For example, "R3G2B1" describes n == 3 rings: a red ring placed onto the rod labeled 3, a green ring placed onto the rod labeled 2, and a blue ring placed onto the rod labeled 1.
+
+Return the number of rods that have all three colors of rings on them.
+
+
+Example 1:
+
+Input: rings = "B0B6G0R6R0R6"
+Output: 1
+Explanation:
+- The rod labeled 0 holds 3 rings with all colors: red, green, and blue.
+- The rod labeled 6 holds 3 rings, but it only has red and blue.
+- The rod labeled 5 holds 0 rings.
+Thus, the number of rods with all three colors is 1.
+
+Example 2:
+
+Input: rings = "B0R0G0R9R0B0"
+Output: 1
+Explanation:
+- The rod labeled 0 holds 6 rings with all colors: red, green, and blue.
+- The rod labeled 9 holds 1 ring, but it only has red.
+Thus, the number of rods with all three colors is 1.
+
+Example 3:
+
+Input: rings = "G4"
+Output: 0
+Explanation:
+Only one ring is given. Thus, no rods have all three colors.
+
+
+Constraints:
+
+rings.length == 2 * n
+1 <= n <= 100
+rings[i] where i is even is either 'R', 'G', or 'B' (0-indexed).
+rings[i] where i is odd is a digit from '0' to '9' (0-indexed).
+
+"""
+
+# V0
+# IDEA : ONE COLOR SET PER ROD
+#
+#   walk the string two characters at a time — colour, then rod — and record
+#   the colour in that rod's set. a rod qualifies once its set has size 3,
+#   which (given only R/G/B exist) means all three colours are present.
+#
+#   NOTE : duplicates on a rod are absorbed by the set, so "R0R0R0" still
+#          counts as one colour.
+#
+# time = O(n), space = O(1)  (at most 10 rods x 3 colours)
+from collections import defaultdict
+
+
+class Solution(object):
+    def countPoints(self, rings):
+        rod = defaultdict(set)
+        for i in range(0, len(rings), 2):
+            rod[rings[i + 1]].add(rings[i])
+        return sum(1 for colors in rod.values() if len(colors) == 3)

--- a/leetcode_python/Heap/find-subsequence-of-length-k-with-the-largest-sum.py
+++ b/leetcode_python/Heap/find-subsequence-of-length-k-with-the-largest-sum.py
@@ -1,0 +1,59 @@
+"""
+
+2099. Find Subsequence of Length K With the Largest Sum
+Easy
+
+You are given an integer array nums and an integer k. You want to find a subsequence of nums of length k that has the largest sum.
+
+Return any such subsequence as an integer array of length k.
+
+A subsequence is an array that can be derived from another array by deleting some or no elements without changing the order of the remaining elements.
+
+
+Example 1:
+
+Input: nums = [2,1,3,3], k = 2
+Output: [3,3]
+Explanation:
+The subsequence has the largest sum of 3 + 3 = 6.
+
+Example 2:
+
+Input: nums = [-1,-2,3,4], k = 3
+Output: [-1,3,4]
+Explanation:
+The subsequence has the largest sum of -1 + 3 + 4 = 6.
+
+Example 3:
+
+Input: nums = [3,4,3,3], k = 2
+Output: [3,4]
+Explanation:
+The subsequence has the largest sum of 3 + 4 = 7.
+Another possible subsequence is [4, 3].
+
+
+Constraints:
+
+1 <= nums.length <= 1000
+-10^5 <= nums[i] <= 10^5
+1 <= k <= nums.length
+
+"""
+
+# V0
+# IDEA : PICK THE K LARGEST *INDICES*, THEN RESTORE THE ORIGINAL ORDER
+#
+#   the sum only depends on WHICH k values are taken, so take the k largest.
+#   but the answer must stay a subsequence, so keep the indices (not the
+#   values), sort those indices, and read the values back in that order.
+#
+#   NOTE : working with indices also handles duplicates for free — picking
+#          "one of the two 3s" is unambiguous once it is index 0 vs index 2.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def maxSubsequence(self, nums, k):
+        idx = sorted(range(len(nums)), key=lambda i: nums[i], reverse=True)[:k]
+        idx.sort()
+        return [nums[i] for i in idx]

--- a/leetcode_python/Linked_list/delete-the-middle-node-of-a-linked-list.py
+++ b/leetcode_python/Linked_list/delete-the-middle-node-of-a-linked-list.py
@@ -1,0 +1,74 @@
+"""
+
+2095. Delete the Middle Node of a Linked List
+Medium
+
+You are given the head of a linked list. Delete the middle node, and return the head of the modified linked list.
+
+The middle node of a linked list of size n is the ⌊n / 2⌋th node from the start using 0-based indexing, where ⌊x⌋ denotes the largest integer less than or equal to x.
+
+For n = 1, 2, 3, 4, and 5, the middle nodes are 0, 1, 1, 2, and 2, respectively.
+
+
+Example 1:
+
+Input: head = [1,3,4,7,1,2,6]
+Output: [1,3,4,1,2,6]
+Explanation:
+The above figure represents the given linked list. The indices of the nodes are written below.
+Since n = 7, node 3 with value 7 is the middle node, which is marked in red.
+We return the new list after removing this node.
+
+Example 2:
+
+Input: head = [1,2,3,4]
+Output: [1,2,4]
+Explanation:
+The above figure represents the given linked list.
+For n = 4, node 2 with value 3 is the middle node, which is marked in red.
+
+Example 3:
+
+Input: head = [2,1]
+Output: [2]
+Explanation:
+The above figure represents the given linked list.
+For n = 2, node 1 with value 1 is the middle node, which is marked in red.
+Node 0 with value 2 is the only node remaining after removing node 1.
+
+
+Constraints:
+
+The number of nodes in the list is in the range [1, 10^5].
+1 <= Node.val <= 10^5
+
+"""
+
+# V0
+# IDEA : SLOW / FAST POINTER, KEEPING THE NODE BEFORE SLOW
+#
+#   when fast walks 2 steps per 1 step of slow, slow lands exactly on the
+#   floor(n/2)-th node (0-based) — which is the node to delete. holding
+#   `prev` lets us unlink it in O(1) :  prev.next = slow.next.
+#
+#   NOTE : a 1-node list has nothing left after deleting index 0, so return
+#          None early.
+#
+# time = O(n), space = O(1)
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def deleteMiddle(self, head):
+        if not head or not head.next:
+            return None
+        prev = None
+        slow, fast = head, head
+        while fast and fast.next:
+            prev = slow
+            slow = slow.next
+            fast = fast.next.next
+        prev.next = slow.next
+        return head

--- a/leetcode_python/Linked_list/maximum-twin-sum-of-a-linked-list.py
+++ b/leetcode_python/Linked_list/maximum-twin-sum-of-a-linked-list.py
@@ -1,0 +1,89 @@
+"""
+
+2130. Maximum Twin Sum of a Linked List
+Medium
+
+In a linked list of size n, where n is even, the ith node (0-indexed) of the linked list is known as the twin of the (n-1-i)th node, if 0 <= i <= (n / 2) - 1.
+
+For example, if n = 4, then node 0 is the twin of node 3, and node 1 is the twin of node 2. These are the only nodes with twins for n = 4.
+
+The twin sum is defined as the sum of a node and its twin.
+
+Given the head of a linked list with even length, return the maximum twin sum of the linked list.
+
+
+Example 1:
+
+Input: head = [5,4,2,1]
+Output: 6
+Explanation:
+Nodes 0 and 1 are the twins of nodes 3 and 2, respectively. All have twin sum = 6.
+There are no other nodes with twins in the linked list.
+Thus, the maximum twin sum of the linked list is 6.
+
+Example 2:
+
+Input: head = [4,2,2,3]
+Output: 7
+Explanation:
+The nodes with twins present in this linked list are:
+- Node 0 is the twin of node 3 having a twin sum of 4 + 3 = 7.
+- Node 1 is the twin of node 2 having a twin sum of 2 + 2 = 4.
+Thus, the maximum twin sum of the linked list is max(7, 4) = 7.
+
+Example 3:
+
+Input: head = [1,100000]
+Output: 100001
+Explanation:
+There is only one node with a twin in the linked list having twin sum of 1 + 100000 = 100001.
+
+
+Constraints:
+
+The number of nodes in the list is an even integer in the range [2, 10^5].
+1 <= Node.val <= 10^5
+
+"""
+
+# V0
+# IDEA : SPLIT AT THE MIDDLE, REVERSE THE SECOND HALF, WALK BOTH TOGETHER
+#
+#   twins are "i-th from the front" and "i-th from the back". a singly
+#   linked list cannot walk backwards, so reverse the back half in place —
+#   then a single pair of pointers, one per half, meets twins at each step.
+#
+#   slow/fast finds the start of the second half (n is guaranteed even, so
+#   slow lands exactly on the boundary), and the reversal is O(1) extra
+#   space.
+#
+# time = O(n), space = O(1)
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def pairSum(self, head):
+        # 1) middle
+        slow, fast = head, head
+        while fast and fast.next:
+            slow = slow.next
+            fast = fast.next.next
+
+        # 2) reverse from the middle on
+        prev = None
+        while slow:
+            nxt = slow.next
+            slow.next = prev
+            prev = slow
+            slow = nxt
+
+        # 3) walk the two halves in lockstep
+        res = 0
+        front, back = head, prev
+        while back:
+            res = max(res, front.val + back.val)
+            front = front.next
+            back = back.next
+        return res

--- a/leetcode_python/Math/a-number-after-a-double-reversal.py
+++ b/leetcode_python/Math/a-number-after-a-double-reversal.py
@@ -1,0 +1,51 @@
+"""
+
+2119. A Number After a Double Reversal
+Easy
+
+Reversing an integer means to reverse all its digits.
+
+For example, reversing 2021 gives 1202. Reversing 12300 gives 321 as the leading zeros are not retained.
+
+Given an integer num, reverse num to get reversed1, then reverse reversed1 to get reversed2. Return true if reversed2 equals num. Otherwise return false.
+
+
+Example 1:
+
+Input: num = 526
+Output: true
+Explanation: Reverse num to get 625, then reverse 625 to get 526, which equals num.
+
+Example 2:
+
+Input: num = 1800
+Output: false
+Explanation: Reverse num to get 81, then reverse 81 to get 18, which does not equal num.
+
+Example 3:
+
+Input: num = 0
+Output: true
+Explanation: Reverse num to get 0, then reverse 0 to get 0, which equals num.
+
+
+Constraints:
+
+0 <= num <= 10^6
+
+"""
+
+# V0
+# IDEA : ONLY TRAILING ZEROS SURVIVE THE ROUND TRIP BADLY
+#
+#   the first reversal turns trailing zeros into LEADING zeros, which are
+#   then dropped — that information is gone for good. every other digit
+#   comes back in place.
+#
+#   so the double reversal is lossless exactly when num has no trailing
+#   zero, with 0 itself as the one exception (it reverses to 0).
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def isSameAfterReversals(self, num):
+        return num == 0 or num % 10 != 0

--- a/leetcode_python/Math/abbreviating-the-product-of-a-range.py
+++ b/leetcode_python/Math/abbreviating-the-product-of-a-range.py
@@ -1,0 +1,110 @@
+"""
+
+2117. Abbreviating the Product of a Range
+Hard
+
+You are given two positive integers left and right with left <= right. Calculate the product of all integers in the inclusive range [left, right].
+
+Since the product may be very large, you will abbreviate it following these steps:
+
+Count all trailing zeros in the product and remove them. Let us denote this count as C.
+For example, there are 3 trailing zeros in 1000, and there are 0 trailing zeros in 546.
+Denote the remaining number of digits in the product as d. If d > 10, then express the product as <pre>...<suf> where <pre> denotes the first 5 digits of the product, and <suf> denotes the last 5 digits of the product after removing all trailing zeros. If d <= 10, we keep it unchanged.
+For example, we express 1234567654321 as 12345...54321, but 1234567 is represented as 1234567.
+Finally, represent the product as a string "<pre>...<suf>eC".
+For example, 12345678987600000 will be represented as "12345...89876e5".
+
+Return a string denoting the abbreviated product of all integers in the inclusive range [left, right].
+
+
+Example 1:
+
+Input: left = 1, right = 4
+Output: "24e0"
+Explanation: The product is 1 × 2 × 3 × 4 = 24.
+There are no trailing zeros, so 24 remains the same. The abbreviation will end with "e0".
+Since the number of digits is 2, which is less than 10, we do not have to abbreviate it further.
+Thus, the final representation is "24e0".
+
+Example 2:
+
+Input: left = 2, right = 11
+Output: "399168e2"
+Explanation: The product is 39916800.
+There are 2 trailing zeros, which we remove to get 399168. The abbreviation will end with "e2".
+The number of digits after removing the trailing zeros is 6, so we do not abbreviate it further.
+Hence, the abbreviated product is "399168e2".
+
+Example 3:
+
+Input: left = 371, right = 375
+Output: "7219856259e3"
+Explanation: The product is 7219856259000.
+The abbreviated product is "7219856259e3".
+
+
+Constraints:
+
+1 <= left <= right <= 10^4
+
+"""
+
+# V0
+# IDEA : TRACK THE HEAD AND THE TAIL SEPARATELY — NEVER MATERIALISE THE PRODUCT
+#
+#   the product of 1..10^4 runs to ~36k digits, so building it and calling
+#   str() is both slow and blocked outright by CPython's 4300-digit int ->
+#   str limit. all three pieces of the answer can be had without it :
+#
+#   C (trailing zeros) : a trailing zero is a factor 10 = 2 * 5, so
+#       C = min(total exponent of 2, total exponent of 5) over the range.
+#
+#   TAIL : strip every 2 and 5 out of each factor while multiplying modulo
+#       10^15, then multiply back the LEFTOVER powers, 2^(c2-C) * 5^(c5-C).
+#       that is exactly prod / 10^C modulo 10^15 — one of the two leftover
+#       exponents is 0, so no trailing zero can survive.
+#
+#   HEAD : keep a running `head` truncated to 20 digits, counting the digits
+#       dropped in `exp`. the product is then head * 10^exp up to a relative
+#       error below 10^-15, which is plenty for 5 leading digits, and the
+#       total digit count len(str(head)) + exp is exact.
+#
+#   d = total digits - C. when d <= 10 the whole number fits in the 10^15
+#   window, so the tail alone IS the answer; otherwise glue head[:5], "...",
+#   and the tail's last 5 digits.
+#
+# time = O(right - left), space = O(1)
+class Solution(object):
+    def abbreviateProduct(self, left, right):
+        MOD = 10 ** 15
+
+        c2 = c5 = 0
+        core = 1
+        head = 1
+        exp = 0
+        for x in range(left, right + 1):
+            y = x
+            while y % 2 == 0:
+                y //= 2
+                c2 += 1
+            while y % 5 == 0:
+                y //= 5
+                c5 += 1
+            core = core * y % MOD
+
+            head *= x
+            while head >= 10 ** 20:
+                head //= 10
+                exp += 1
+
+        C = min(c2, c5)
+        core = core * pow(2, c2 - C, MOD) % MOD
+        core = core * pow(5, c5 - C, MOD) % MOD
+
+        head_str = str(head)
+        d = len(head_str) + exp - C          # digits left after stripping zeros
+
+        if d <= 10:
+            return str(core) + "e" + str(C)
+        return (head_str[:5] + "..." + str(core % 10 ** 5).zfill(5)
+                + "e" + str(C))

--- a/leetcode_python/Math/elements-in-array-after-removing-and-replacing-elements.py
+++ b/leetcode_python/Math/elements-in-array-after-removing-and-replacing-elements.py
@@ -1,0 +1,85 @@
+"""
+
+2113. Elements in Array After Removing and Replacing Elements
+Medium
+🔒 (premium)
+
+You are given a 0-indexed integer array nums. Initially on minute 0, the array is unchanged. Every minute, the leftmost element in nums is removed until no elements remain. Then, every minute, one element is appended to the end of nums, in the order they were removed in, until the original array is restored. This process repeats indefinitely.
+
+For example, the array [0,1,2] would change as follows: [0,1,2] -> [1,2] -> [2] -> [] -> [0] -> [0,1] -> [0,1,2] -> [1,2] -> [2] -> [] -> [0] -> [0,1] -> [0,1,2] -> ...
+
+You are also given a 2D integer array queries of size n where queries[j] = [timej, indexj]. The answer to the jth query is:
+
+nums[indexj] if indexj < nums.length at minute timej
+-1 if indexj >= nums.length at minute timej
+
+Return an integer array ans of size n where ans[j] is the answer to the jth query.
+
+
+Example 1:
+
+Input: nums = [0,1,2], queries = [[0,2],[2,0],[3,2],[5,0]]
+Output: [2,2,-1,0]
+Explanation:
+Minute 0: [0,1,2] - All elements are in the nums.
+Minute 1: [1,2]   - The leftmost element, 0, is removed.
+Minute 2: [2]     - The leftmost element, 1, is removed.
+Minute 3: []      - The leftmost element, 2, is removed.
+Minute 4: [0]     - 0 is added to the end of nums.
+Minute 5: [0,1]   - 1 is added to the end of nums.
+
+At minute 0, nums[2] is 2.
+At minute 2, nums[0] is 2.
+At minute 3, nums[2] does not exist.
+At minute 5, nums[0] is 0.
+
+Example 2:
+
+Input: nums = [2], queries = [[0,0],[1,0],[2,0]]
+Output: [2,-1,2]
+Explanation:
+Minute 0: [2] - All elements are in the nums.
+Minute 1: []  - The leftmost element, 2, is removed.
+Minute 2: [2] - 2 is added to the end of nums.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+0 <= nums[i] <= 100
+n == queries.length
+1 <= n <= 10^5
+queries[j].length == 2
+0 <= timej <= 10^5
+0 <= indexj < nums.length
+
+"""
+
+# V0
+# IDEA : THE STATE IS PERIODIC WITH PERIOD 2n — ANSWER EACH QUERY IN O(1)
+#
+#   n minutes to empty the array, n more to refill it, so minute t behaves
+#   exactly like minute  t % (2n).  let  m = t % (2n) :
+#
+#       m <  n  ->  SHRINKING phase, the array is nums[m:]
+#                   so length = n - m and position i holds nums[m + i]
+#       m >= n  ->  GROWING phase with r = m - n elements back,
+#                   the array is nums[:r]
+#                   so length = r and position i holds nums[i]
+#
+#   in both phases an index at or past the current length answers -1.
+#
+#   NOTE : no simulation is needed — 10^5 queries each cost O(1).
+#
+# time = O(n + q), space = O(q)
+class Solution(object):
+    def elementInNums(self, nums, queries):
+        n = len(nums)
+        res = []
+        for t, i in queries:
+            m = t % (2 * n)
+            if m < n:                       # shrinking : nums[m:]
+                res.append(nums[m + i] if i < n - m else -1)
+            else:                           # growing : nums[:m-n]
+                res.append(nums[i] if i < m - n else -1)
+        return res

--- a/leetcode_python/String/adding-spaces-to-a-string.py
+++ b/leetcode_python/String/adding-spaces-to-a-string.py
@@ -1,0 +1,67 @@
+"""
+
+2109. Adding Spaces to a String
+Medium
+
+You are given a 0-indexed string s and a 0-indexed integer array spaces that describes the indices in the original string where spaces will be added. Each space should be inserted before the character at the given index.
+
+For example, given s = "EnjoyYourCoffee" and spaces = [5, 9], we place spaces before 'Y' and 'C', which are at indices 5 and 9 respectively. Thus, we obtain "Enjoy Your Coffee".
+
+Return the modified string after the spaces have been added.
+
+
+Example 1:
+
+Input: s = "LeetcodeHelpsMeLearn", spaces = [8,13,15]
+Output: "Leetcode Helps Me Learn"
+Explanation:
+The indices 8, 13, and 15 correspond to the underlined characters in "LeetcodeHelpsMeLearn".
+We then place spaces before those characters.
+
+Example 2:
+
+Input: s = "icodeinpython", spaces = [1,5,7,9]
+Output: "i code in py thon"
+Explanation:
+The indices 1, 5, 7, and 9 correspond to the underlined characters in "icodeinpython".
+We then place spaces before those characters.
+
+Example 3:
+
+Input: s = "spacing", spaces = [0,1,2,3,4,5,6]
+Output: " s p a c i n g"
+Explanation:
+We are also able to place spaces before the first character of the string.
+
+
+Constraints:
+
+1 <= s.length <= 3 * 10^5
+s consists only of lowercase and uppercase English letters.
+1 <= spaces.length <= 3 * 10^5
+0 <= spaces[i] <= s.length - 1
+All the values of spaces are strictly increasing.
+
+"""
+
+# V0
+# IDEA : CUT THE STRING AT THE GIVEN INDICES AND JOIN WITH ' '
+#
+#   because `spaces` is strictly increasing, the indices already are the cut
+#   points in order — slice s between consecutive cuts and ' '.join the
+#   pieces. building one list and joining once avoids the O(n^2) trap of
+#   repeated string concatenation on a 3*10^5-char input.
+#
+#   NOTE : a cut at index 0 produces an empty first piece, which is exactly
+#          the leading space example 3 asks for.
+#
+# time = O(n + m), space = O(n + m)
+class Solution(object):
+    def addSpaces(self, s, spaces):
+        parts = []
+        prev = 0
+        for i in spaces:
+            parts.append(s[prev:i])
+            prev = i
+        parts.append(s[prev:])
+        return ' '.join(parts)

--- a/leetcode_python/String/capitalize-the-title.py
+++ b/leetcode_python/String/capitalize-the-title.py
@@ -1,0 +1,59 @@
+"""
+
+2129. Capitalize the Title
+Easy
+
+You are given a string title consisting of one or more words separated by a single space, where each word consists of English letters. Capitalize the string by changing the capitalization of each word such that:
+
+If the length of the word is 1 or 2 letters, change all letters to lowercase.
+Otherwise, change the first letter to uppercase and the remaining letters to lowercase.
+
+Return the capitalized title.
+
+
+Example 1:
+
+Input: title = "capiTalIze tHe titLe"
+Output: "Capitalize The Title"
+Explanation:
+Since all the words have a length of at least 3, the first letter of each word is uppercase, and the remaining letters are lowercase.
+
+Example 2:
+
+Input: title = "First leTTeR of EACH Word"
+Output: "First Letter of Each Word"
+Explanation:
+The word "of" has length 2, so it is all lowercase.
+The remaining words have a length of at least 3, so the first letter of each remaining word is uppercase, and the remaining letters are lowercase.
+
+Example 3:
+
+Input: title = "i lOve leetcode"
+Output: "i Love Leetcode"
+Explanation:
+The word "i" has length 1, so it is lowercase.
+The remaining words have a length of at least 3, so the first letter of each remaining word is uppercase, and the remaining letters are lowercase.
+
+
+Constraints:
+
+1 <= title.length <= 100
+title consists of words separated by a single space without any leading or trailing spaces.
+Each word consists of uppercase and lowercase English letters and is non-empty.
+
+"""
+
+# V0
+# IDEA : PER-WORD RULE ON LENGTH
+#
+#   split on the single space, then apply the rule word by word :
+#       len <= 2 -> lower()
+#       else     -> capitalize()   (upper first letter, lower the rest —
+#                                   exactly what the spec asks for)
+#   and re-join with a space.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def capitalizeTitle(self, title):
+        return ' '.join(w.lower() if len(w) <= 2 else w.capitalize()
+                        for w in title.split(' '))

--- a/leetcode_python/String/check-if-all-as-appears-before-all-bs.py
+++ b/leetcode_python/String/check-if-all-as-appears-before-all-bs.py
@@ -1,0 +1,51 @@
+"""
+
+2124. Check if All A's Appears Before All B's
+Easy
+
+Given a string s consisting of only the characters 'a' and 'b', return true if every 'a' appears before every 'b' in the string. Otherwise, return false.
+
+
+Example 1:
+
+Input: s = "aaabbb"
+Output: true
+Explanation:
+The 'a's are at indices 0, 1, and 2, while the 'b's are at indices 3, 4, and 5.
+Hence, every 'a' appears before every 'b' and we return true.
+
+Example 2:
+
+Input: s = "abab"
+Output: false
+Explanation:
+There is an 'a' at index 2 and a 'b' at index 1.
+Hence, not every 'a' appears before every 'b' and we return false.
+
+Example 3:
+
+Input: s = "bbb"
+Output: true
+Explanation:
+There are no 'a's, hence, every 'a' appears before every 'b' and we return true.
+
+
+Constraints:
+
+1 <= s.length <= 100
+s[i] is either 'a' or 'b'.
+
+"""
+
+# V0
+# IDEA : THE ONLY WAY TO FAIL IS A 'b' IMMEDIATELY FOLLOWED BY AN 'a'
+#
+#   with just two letters, "some a after some b" is equivalent to the
+#   substring "ba" existing somewhere : if any 'a' sits after any 'b', then
+#   somewhere along the way the string flips from b back to a, and that flip
+#   point is a literal "ba".
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def checkString(self, s):
+        return 'ba' not in s

--- a/leetcode_python/String/divide-a-string-into-groups-of-size-k.py
+++ b/leetcode_python/String/divide-a-string-into-groups-of-size-k.py
@@ -1,0 +1,55 @@
+"""
+
+2138. Divide a String Into Groups of Size k
+Easy
+
+A string s can be partitioned into groups of size k using the following procedure:
+
+The first group consists of the first k characters of the string, the second group consists of the next k characters of the string, and so on. Each character can be a part of exactly one group.
+For the last group, if the string does not have k characters remaining, a character fill is used to complete the group.
+
+Note that the partition is done so that after removing the fill character from the last group (if it exists) and concatenating all the groups in order, the resultant string should be s.
+
+Given the string s, the size of each group k and the character fill, return a string array denoting the composition of every group s has been divided into, using the above procedure.
+
+
+Example 1:
+
+Input: s = "abcdefghi", k = 3, fill = "x"
+Output: ["abc","def","ghi"]
+Explanation:
+The first 3 characters "abc" form the first group.
+The next 3 characters "def" form the second group.
+The last 3 characters "ghi" form the third group.
+Since all groups can be completely filled by characters from the string, we do not need to use fill.
+Thus, the groups formed are "abc", "def", and "ghi".
+
+Example 2:
+
+Input: s = "abcdefghij", k = 3, fill = "x"
+Output: ["abc","def","ghi","jxx"]
+Explanation:
+Similar to the previous example, we are forming the first three groups "abc", "def", and "ghi".
+For the last group, we can only use the character 'j' from the string. To complete this group, we add 'x' twice.
+Thus, the 4 groups formed are "abc", "def", "ghi", and "jxx".
+
+
+Constraints:
+
+1 <= s.length <= 100
+s consists of lowercase English letters only.
+1 <= k <= 100
+fill is a lowercase English letter.
+
+"""
+
+# V0
+# IDEA : SLICE EVERY k CHARACTERS, PAD ONLY THE LAST PIECE
+#
+#   range(0, len(s), k) walks the group starts; s[i:i+k] is short only for
+#   the final group, and ljust(k, fill) tops that one up.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def divideString(self, s, k, fill):
+        return [s[i:i + k].ljust(k, fill) for i in range(0, len(s), k)]

--- a/leetcode_python/String/find-first-palindromic-string-in-the-array.py
+++ b/leetcode_python/String/find-first-palindromic-string-in-the-array.py
@@ -1,0 +1,51 @@
+"""
+
+2108. Find First Palindromic String in the Array
+Easy
+
+Given an array of strings words, return the first palindromic string in the array. If there is no such string, return an empty string "".
+
+A string is palindromic if it reads the same forward and backward.
+
+
+Example 1:
+
+Input: words = ["abc","car","ada","racecar","cool"]
+Output: "ada"
+Explanation: The first string that is palindromic is "ada".
+Note that "racecar" is also palindromic, but it is not the first.
+
+Example 2:
+
+Input: words = ["notapalindrome","racecar"]
+Output: "racecar"
+Explanation: The first and only string that is palindromic is "racecar".
+
+Example 3:
+
+Input: words = ["def","ghi"]
+Output: ""
+Explanation: There are no palindromic strings, so the empty string is returned.
+
+
+Constraints:
+
+1 <= words.length <= 100
+1 <= words[i].length <= 100
+words[i] consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : SCAN IN ORDER, RETURN THE FIRST WORD EQUAL TO ITS REVERSE
+#
+#   "first" is the whole point — the loop must return on the earliest match,
+#   not collect all palindromes and pick one.
+#
+# time = O(n * L), space = O(L)
+class Solution(object):
+    def firstPalindrome(self, words):
+        for w in words:
+            if w == w[::-1]:
+                return w
+        return ""

--- a/leetcode_python/String/maximum-number-of-words-found-in-sentences.py
+++ b/leetcode_python/String/maximum-number-of-words-found-in-sentences.py
@@ -1,0 +1,50 @@
+"""
+
+2114. Maximum Number of Words Found in Sentences
+Easy
+
+A sentence is a list of words that are separated by a single space with no leading or trailing spaces.
+
+You are given an array of strings sentences, where each sentences[i] represents a single sentence.
+
+Return the maximum number of words that appear in a single sentence.
+
+
+Example 1:
+
+Input: sentences = ["alice and bob love leetcode", "i think so too", "this is great thanks very much"]
+Output: 6
+Explanation:
+- The first sentence, "alice and bob love leetcode", has 5 words in total.
+- The second sentence, "i think so too", has 4 words in total.
+- The third sentence, "this is great thanks very much", has 6 words in total.
+Thus, the maximum number of words in a single sentence comes from the third sentence, which has 6 words.
+
+Example 2:
+
+Input: sentences = ["please wait", "continue to fight", "continue to win"]
+Output: 3
+Explanation: It is possible that multiple sentences contain the same number of words.
+In this example, the second and third sentences (underlined) have the same number of words.
+
+
+Constraints:
+
+1 <= sentences.length <= 100
+1 <= sentences[i].length <= 100
+sentences[i] consists only of lowercase English letters and ' ' only.
+sentences[i] does not have leading or trailing spaces.
+All the words in sentences[i] are separated by a single space.
+
+"""
+
+# V0
+# IDEA : WORDS = SPACES + 1
+#
+#   the guarantees (single spaces, no leading/trailing space) mean the word
+#   count is just  s.count(' ') + 1  — no splitting or allocation needed.
+#
+# time = O(total characters), space = O(1)
+class Solution(object):
+    def mostWordsFound(self, sentences):
+        return max(s.count(' ') + 1 for s in sentences)

--- a/leetcode_python/Tree/step-by-step-directions-from-a-binary-tree-node-to-another.py
+++ b/leetcode_python/Tree/step-by-step-directions-from-a-binary-tree-node-to-another.py
@@ -1,0 +1,85 @@
+"""
+
+2096. Step-By-Step Directions From a Binary Tree Node to Another
+Medium
+
+You are given the root of a binary tree with n nodes. Each node is uniquely assigned a value from 1 to n. You are also given an integer startValue representing the value of the start node s, and a different integer destValue representing the value of the destination node t.
+
+Find the shortest path starting from node s and ending at node t. Generate step-by-step directions of such path as a string consisting of only the uppercase letters 'L', 'R', and 'U'. Each letter indicates a specific direction:
+
+'L' means to go from a node to its left child node.
+'R' means to go from a node to its right child node.
+'U' means to go from a node to its parent node.
+
+Return the step-by-step directions of the shortest path from node s to node t.
+
+
+Example 1:
+
+Input: root = [5,1,2,3,null,6,4], startValue = 3, destValue = 6
+Output: "UURL"
+Explanation: The shortest path is: 3 -> 1 -> 5 -> 2 -> 6.
+
+Example 2:
+
+Input: root = [2,1], startValue = 2, destValue = 1
+Output: "L"
+Explanation: The shortest path is: 2 -> 1.
+
+
+Constraints:
+
+The number of nodes in the tree is n.
+2 <= n <= 10^5
+1 <= Node.val <= n
+All the values in the tree are unique.
+1 <= startValue, destValue <= n
+startValue != destValue
+
+"""
+
+# V0
+# IDEA : ROOT -> NODE PATHS, THEN DROP THE SHARED PREFIX (LCA)
+#
+#   record the L/R turns taken from the root down to s, and the same down to
+#   t. the two strings share a prefix — that prefix is the path to their
+#   lowest common ancestor.
+#
+#   after stripping the common prefix :
+#       every remaining step of the s-path is walked BACKWARDS  -> 'U'
+#       every remaining step of the t-path is walked FORWARDS   -> kept as is
+#
+#   so the answer is  'U' * len(rest_of_s)  +  rest_of_t.
+#
+# time = O(n), space = O(n)
+# Definition for a binary tree node.
+# class TreeNode(object):
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution(object):
+    def getDirections(self, root, startValue, destValue):
+
+        def find(node, target, path):
+            if not node:
+                return False
+            if node.val == target:
+                return True
+            path.append('L')
+            if find(node.left, target, path):
+                return True
+            path[-1] = 'R'
+            if find(node.right, target, path):
+                return True
+            path.pop()
+            return False
+
+        src, dst = [], []
+        find(root, startValue, src)
+        find(root, destValue, dst)
+
+        i = 0
+        while i < len(src) and i < len(dst) and src[i] == dst[i]:
+            i += 1
+        return 'U' * (len(src) - i) + ''.join(dst[i:])

--- a/leetcode_python/Two_Pointers/rearrange-array-elements-by-sign.py
+++ b/leetcode_python/Two_Pointers/rearrange-array-elements-by-sign.py
@@ -1,0 +1,67 @@
+"""
+
+2149. Rearrange Array Elements by Sign
+Medium
+
+You are given a 0-indexed integer array nums of even length consisting of an equal number of positive and negative integers.
+
+You should rearrange the elements of nums such that the modified array follows the given conditions:
+
+1. Every consecutive pair of integers have opposite signs.
+2. For all integers with the same sign, the order in which they were present in nums is preserved.
+3. The rearranged array begins with a positive integer.
+
+Return the modified array after rearranging the elements to satisfy the aforementioned conditions.
+
+
+Example 1:
+
+Input: nums = [3,1,-2,-5,2,-4]
+Output: [3,-2,1,-5,2,-4]
+Explanation:
+The positive integers in nums are [3,1,2]. The negative integers are [-2,-5,-4].
+The only possible way to rearrange them such that they satisfy all conditions is [3,-2,1,-5,2,-4].
+Other ways such as [1,-2,2,-5,3,-4], [3,1,2,-2,-5,-4], [-2,3,-5,1,-4,2] are incorrect because they do not satisfy one or more conditions.
+
+Example 2:
+
+Input: nums = [-1,1]
+Output: [1,-1]
+Explanation:
+1 is the only positive integer and -1 the only negative integer in nums.
+So nums is rearranged to [1,-1].
+
+
+Constraints:
+
+2 <= nums.length <= 2 * 10^5
+nums.length is even
+1 <= |nums[i]| <= 10^5
+nums consists of equal number of positive and negative integers.
+
+"""
+
+# V0
+# IDEA : TWO WRITE CURSORS — EVEN SLOTS FOR POSITIVES, ODD SLOTS FOR NEGATIVES
+#
+#   the layout is forced : positives land at indices 0, 2, 4, ... and
+#   negatives at 1, 3, 5, ..., each group keeping its original relative
+#   order.
+#
+#   so one pass over nums, appending each value at the next free slot of its
+#   own parity, builds the answer directly — no partitioning into two lists
+#   and no sorting.
+#
+# time = O(n), space = O(n) for the output
+class Solution(object):
+    def rearrangeArray(self, nums):
+        res = [0] * len(nums)
+        pos, neg = 0, 1
+        for x in nums:
+            if x > 0:
+                res[pos] = x
+                pos += 2
+            else:
+                res[neg] = x
+                neg += 2
+        return res

--- a/leetcode_python/Two_Pointers/watering-plants-ii.py
+++ b/leetcode_python/Two_Pointers/watering-plants-ii.py
@@ -1,0 +1,92 @@
+"""
+
+2105. Watering Plants II
+Medium
+
+Alice and Bob want to water n plants in their garden. The plants are arranged in a row and are labeled from 0 to n - 1 from left to right where the ith plant is located at x = i.
+
+Each plant needs a specific amount of water. Alice and Bob have a watering can each, initially full. They water the plants in the following way:
+
+Alice waters the plants in order from left to right, starting from the 0th plant. Bob waters the plants in order from right to left, starting from the (n - 1)th plant. They begin watering the plants simultaneously.
+It takes the same amount of time to water each plant regardless of how much water it needs.
+Alice/Bob must water the plant if they have enough in their can to fully water it. Otherwise, they first refill their can (instantaneously) then water the plant.
+In case both Alice and Bob reach the same plant, the one with more water currently in his/her watering can should water this plant. If they have the same amount of water, then Alice should water this plant.
+
+Given a 0-indexed integer array plants of n integers, where plants[i] is the amount of water the ith plant needs, and two integers capacityA and capacityB representing the capacities of Alice's and Bob's watering cans respectively, return the number of times they have to refill to water all the plants.
+
+
+Example 1:
+
+Input: plants = [2,2,3,3], capacityA = 5, capacityB = 5
+Output: 1
+Explanation:
+- Initially, Alice and Bob have 5 units of water each in their watering cans.
+- Alice waters plant 0, Bob waters plant 3.
+- Alice and Bob now have 3 units and 2 units of water respectively.
+- Alice has enough water for plant 1, so she waters it. Bob does not have enough water for plant 2, so he refills his can then waters it.
+So, the total number of times they have to refill to water all the plants is 0 + 0 + 1 + 0 = 1.
+
+Example 2:
+
+Input: plants = [2,2,3,3], capacityA = 3, capacityB = 4
+Output: 2
+Explanation:
+- Initially, Alice and Bob have 3 units and 4 units of water in their watering cans respectively.
+- Alice waters plant 0, Bob waters plant 3.
+- Alice and Bob now have 1 unit of water each, and need to water plants 1 and 2 respectively.
+- Since neither of them have enough water for their current plants, they refill their cans and then water the plants.
+So, the total number of times they have to refill to water all the plants is 0 + 1 + 1 + 0 = 2.
+
+Example 3:
+
+Input: plants = [5], capacityA = 10, capacityB = 8
+Output: 0
+Explanation:
+- There is only one plant.
+- Alice's watering can has 10 units of water, whereas Bob's can has 8 units. Since Alice has more water in her can, she waters this plant.
+So, the total number of times they have to refill is 0.
+
+
+Constraints:
+
+n == plants.length
+1 <= n <= 10^5
+1 <= plants[i] <= 10^6
+max(plants[i]) <= capacityA, capacityB <= 10^9
+
+"""
+
+# V0
+# IDEA : TWO POINTERS WALKING TOWARDS EACH OTHER
+#
+#   Alice from the left, Bob from the right, one plant each per tick, so
+#   simulating with two pointers reproduces the timeline exactly.
+#
+#   each of them refills only when the can cannot cover the current plant,
+#   and a refill costs 1 and resets the can to full capacity.
+#
+#   NOTE : the middle plant of an odd-length row is reached by BOTH at the
+#          same tick — whoever holds more water takes it (Alice on a tie),
+#          and one refill may still be needed there.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumRefill(self, plants, capacityA, capacityB):
+        i, j = 0, len(plants) - 1
+        a, b = capacityA, capacityB
+        res = 0
+        while i < j:
+            if a < plants[i]:
+                res += 1
+                a = capacityA
+            a -= plants[i]
+            if b < plants[j]:
+                res += 1
+                b = capacityB
+            b -= plants[j]
+            i += 1
+            j -= 1
+        if i == j:
+            if max(a, b) < plants[i]:
+                res += 1
+        return res

--- a/leetcode_python/slide_window/maximum-fruits-harvested-after-at-most-k-steps.py
+++ b/leetcode_python/slide_window/maximum-fruits-harvested-after-at-most-k-steps.py
@@ -1,0 +1,91 @@
+"""
+
+2106. Maximum Fruits Harvested After at Most K Steps
+Hard
+
+Fruits are positioned along an infinite x-axis. You are given a 2D integer array fruits where fruits[i] = [positioni, amounti] depicts amounti fruits at the position positioni. fruits is already sorted by positioni in ascending order, and each positioni is unique.
+
+You are also given an integer startPos and an integer k. You start at the position startPos and you can walk at most k steps. In each step, you can walk one unit to the right or one unit to the left. Optionally, you may also pick fruits at the position you are at. Once you harvest fruits at a position, the fruits will disappear at that position.
+
+Return the maximum total number of fruits you can harvest.
+
+
+Example 1:
+
+Input: fruits = [[2,8],[6,3],[8,6]], startPos = 5, k = 4
+Output: 9
+Explanation:
+The optimal way is to:
+- Move right to position 6 and harvest 3 fruits
+- Move right to position 8 and harvest 6 fruits
+You moved 3 steps and harvested 3 + 6 = 9 fruits in total.
+
+Example 2:
+
+Input: fruits = [[0,9],[4,1],[5,7],[6,2],[7,4],[10,9]], startPos = 5, k = 4
+Output: 14
+Explanation:
+You can move at most k = 4 steps, so you cannot reach position 0 nor 10.
+The optimal way is to:
+- Harvest the 7 fruits at the starting position 5
+- Move left to position 4 and harvest 1 fruit
+- Move right to position 6 and harvest 2 fruits
+- Move right to position 7 and harvest 4 fruits
+You moved 1 + 3 = 4 steps and harvested 7 + 1 + 2 + 4 = 14 fruits in total.
+
+Example 3:
+
+Input: fruits = [[0,3],[6,4],[8,5]], startPos = 3, k = 2
+Output: 0
+Explanation:
+You can move at most k = 2 steps and cannot reach any position with fruits.
+
+
+Constraints:
+
+1 <= fruits.length <= 10^5
+fruits[i].length == 2
+0 <= startPos, positioni <= 2 * 10^5
+positioni-1 < positioni for any i > 0 (0-indexed)
+1 <= amounti <= 10^4
+0 <= k <= 2 * 10^5
+
+"""
+
+# V0
+# IDEA : SLIDING WINDOW OVER THE FRUIT POSITIONS, COST = "GO ONE WAY, THEN TURN"
+#
+#   an optimal walk visits exactly one CONTIGUOUS range of positions — you
+#   never gain by skipping a position you walk past. so the answer is the
+#   best window [l, r] of the fruit array whose cost fits in k steps.
+#
+#   for a window from L = pos[l] to R = pos[r], the cheapest route is to
+#   cover the shorter side first and then sweep across :
+#
+#       cost = (R - L) + min(|start - L|, |start - R|)
+#
+#   this stays correct when the whole window sits on one side of start (the
+#   min term simply collapses to the near end).
+#
+#   cost is non-increasing as l grows, so a plain two-pointer works : extend
+#   r, shrink l while the cost exceeds k, and track the running sum.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maxTotalFruits(self, fruits, startPos, k):
+
+        def cost(l, r):
+            left, right = fruits[l][0], fruits[r][0]
+            return (right - left) + min(abs(startPos - left), abs(startPos - right))
+
+        res = 0
+        cur = 0
+        l = 0
+        for r in range(len(fruits)):
+            cur += fruits[r][1]
+            while l <= r and cost(l, r) > k:
+                cur -= fruits[l][1]
+                l += 1
+            if l <= r:
+                res = max(res, cur)
+        return res

--- a/leetcode_python/slide_window/minimum-swaps-to-group-all-1s-together-ii.py
+++ b/leetcode_python/slide_window/minimum-swaps-to-group-all-1s-together-ii.py
@@ -1,0 +1,77 @@
+"""
+
+2134. Minimum Swaps to Group All 1's Together II
+Medium
+
+A swap is defined as taking two distinct positions in an array and swapping the values in them.
+
+A circular array is defined as an array where we consider the first element and the last element to be adjacent.
+
+Given a binary circular array nums, return the minimum number of swaps required to group all 1's present in the array together at any location.
+
+
+Example 1:
+
+Input: nums = [0,1,0,1,1,0,0]
+Output: 1
+Explanation: Here are a few of the ways to group all the 1's together:
+[0,0,1,1,1,0,0] using 1 swap.
+[0,1,1,1,0,0,0] using 1 swap.
+[1,1,0,0,0,0,1] using 2 swaps (using the circular property of the array).
+There is no way to group all 1's together with 0 swaps.
+Thus, the minimum number of swaps required is 1.
+
+Example 2:
+
+Input: nums = [0,1,1,1,0,0,1,1,0]
+Output: 2
+Explanation: Here are a few of the ways to group all the 1's together:
+[1,1,1,0,0,0,0,1,1] using 2 swaps (using the circular property of the array).
+[1,1,1,1,1,0,0,0,0] using 2 swaps.
+There is no way to group all 1's together with 0 or 1 swaps.
+Thus, the minimum number of swaps required is 2.
+
+Example 3:
+
+Input: nums = [1,1,0,0,1]
+Output: 0
+Explanation: All the 1's are already grouped together due to the circular property of the array.
+Thus, we do not need any swaps.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+nums[i] is either 0 or 1.
+
+"""
+
+# V0
+# IDEA : FIXED WINDOW OF SIZE (TOTAL ONES), MINIMISE THE ZEROS INSIDE IT
+#
+#   after the swaps all the 1s occupy one contiguous circular block, and
+#   that block has exactly k = (number of 1s) cells. every 0 sitting inside
+#   the chosen block costs one swap (trade it with a 1 from outside), so
+#
+#       answer = min over all windows of length k of (zeros in the window)
+#
+#   the circular wrap is handled by letting the window index run over
+#   0 .. n-1 with modular reads, keeping the sliding update O(1).
+#
+#   NOTE : k == 0 (no 1s at all) needs no swap.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minSwaps(self, nums):
+        n = len(nums)
+        k = sum(nums)
+        if k == 0 or k == n:
+            return 0
+
+        ones = sum(nums[:k])
+        best = ones
+        for i in range(1, n):
+            ones -= nums[i - 1]
+            ones += nums[(i + k - 1) % n]
+            best = max(best, ones)
+        return k - best

--- a/leetcode_python/slide_window/number-of-unique-flavors-after-sharing-k-candies.py
+++ b/leetcode_python/slide_window/number-of-unique-flavors-after-sharing-k-candies.py
@@ -1,0 +1,81 @@
+"""
+
+2107. Number of Unique Flavors After Sharing K Candies
+Medium
+🔒 (premium)
+
+You are given a 0-indexed integer array candies, where candies[i] represents the flavor of the ith candy. Your mom wants you to share these candies with your little sister by giving her k consecutive candies, but you want to keep as many flavors of candies as possible.
+
+Return the maximum number of unique flavors of candy you can keep after sharing with your sister.
+
+
+Example 1:
+
+Input: candies = [1,2,2,3,4,3], k = 3
+Output: 3
+Explanation:
+Give the candies in the range [1, 3] (inclusive) with flavors [2,2,3].
+You can eat candies with flavors [1,4,3].
+There are 3 unique flavors, so return 3.
+
+Example 2:
+
+Input: candies = [2,2,2,2,3,3], k = 2
+Output: 2
+Explanation:
+Give the candies in the range [3, 4] (inclusive) with flavors [2,3].
+You can eat candies with flavors [2,2,2,3].
+There are 2 unique flavors, so return 2.
+Note that you can also share the candies with flavors [2,2] and eat the candies with flavors [2,2,3,3], which also return 2.
+
+Example 3:
+
+Input: candies = [2,4,5], k = 0
+Output: 3
+Explanation:
+You do not have to give any candies.
+You can eat the candies with flavors [2,4,5], and there are 3 unique flavors.
+
+
+Constraints:
+
+1 <= candies.length <= 10^5
+1 <= candies[i] <= 10^5
+0 <= k <= candies.length
+
+"""
+
+# V0
+# IDEA : FIXED-SIZE WINDOW = THE GIVEN-AWAY CANDIES, COUNT WHAT IS LEFT
+#
+#   the sister's share is a window of exactly k consecutive candies, so
+#   slide that window and ask how many distinct flavors survive OUTSIDE it.
+#
+#   keep a Counter of the whole array, then for the current window decrement
+#   its flavors; a flavor disappears from the answer only when its count
+#   drops to 0. the number of live keys in the Counter is the answer for
+#   that window.
+#
+#   NOTE : k == 0 means giving nothing, so the answer is just the total
+#          number of distinct flavors — the loop below handles it since the
+#          window is empty.
+#
+# time = O(n), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def shareCandies(self, candies, k):
+        cnt = Counter(candies)
+        for x in candies[:k]:
+            cnt[x] -= 1
+            if cnt[x] == 0:
+                del cnt[x]
+        res = len(cnt)
+        for i in range(k, len(candies)):
+            cnt[candies[i]] -= 1                 # candy i joins the sister's share
+            if cnt[candies[i]] == 0:
+                del cnt[candies[i]]
+            cnt[candies[i - k]] += 1             # candy i-k leaves it, back to us
+            res = max(res, len(cnt))
+        return res


### PR DESCRIPTION
Third tranche of the LC 2001-3000 coverage gap vs
kamyu104/LeetCode-Solutions. Includes 7 premium/locked problems (2098, 2107, 2113, 2123, 2128, 2137, 2143). The three database problems in this range (2112, 2118, 2142) are skipped — they belong in leetcode_SQL, not here.

Same convention as the rest of the directory: problem docstring, then a V0 solution with an IDEA block explaining the approach and a time/space complexity comment.

Verified:
- all 50 files parse cleanly
- all 50 run correctly against every example in their problem statement (134 assertions)
- 29 of them additionally cross-checked against independent brute-force references on randomized inputs: 2096, 2097, 2098, 2100, 2102, 2105, 2106, 2111, 2116, 2117, 2121, 2122, 2123, 2127, 2131, 2132, 2134, 2135, 2136, 2137, 2140, 2141, 2143, 2144, 2145, 2146, 2147, 2151
- the heavy ones timed at full constraints: 2117 over 1..10^4, 2123 on a 300x300 grid, 2132 on a 400x500 grid

2117 deliberately avoids materialising the ~36k-digit product: CPython caps int -> str at 4300 digits, so it tracks a truncated 20-digit head for the leading digits and a modular tail with the factors of 2 and 5 divided out for the trailing ones.