### PR TITLE
feat(leetcode_python): add 50 solutions for LC 3062-3129

### DIFF
--- a/leetcode_python/Array/count-submatrices-with-top-left-element-and-sum-less-than-k.py
+++ b/leetcode_python/Array/count-submatrices-with-top-left-element-and-sum-less-than-k.py
@@ -1,0 +1,57 @@
+"""
+
+3070. Count Submatrices with Top-Left Element and Sum Less Than k
+Medium
+
+You are given a 0-indexed integer matrix grid and an integer k.
+
+Return the number of submatrices that contain the top-left element of the grid, and have a sum less than or equal to k.
+
+
+Example 1:
+
+Input: grid = [[7,6,3],[6,6,1]], k = 18
+Output: 4
+Explanation: There are only 4 submatrices, shown in the image above, that contain the top-left element of grid, and have a sum less than or equal to 18.
+
+Example 2:
+
+Input: grid = [[7,2,9],[1,5,0],[2,6,6]], k = 20
+Output: 6
+Explanation: There are only 6 submatrices, shown in the image above, that contain the top-left element of grid, and have a sum less than or equal to 20.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= n, m <= 1000
+0 <= grid[i][j] <= 1000
+1 <= k <= 10^9
+
+"""
+
+# V0
+# IDEA : A SUBMATRIX CONTAINING (0,0) *IS* A PREFIX RECTANGLE
+#
+#   "contains the top-left element" forces the submatrix to start at (0, 0),
+#   so it is fully described by its bottom-right corner (i, j) — one
+#   candidate per cell.
+#
+#   its sum is the 2D prefix sum at that corner, built with the usual
+#       pre[i+1][j+1] = grid[i][j] + pre[i][j+1] + pre[i+1][j] - pre[i][j]
+#   so the answer is simply how many corners have prefix sum <= k.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def countSubmatrices(self, grid, k):
+        m, n = len(grid), len(grid[0])
+        pre = [[0] * (n + 1) for _ in range(m + 1)]
+        res = 0
+        for i in range(m):
+            for j in range(n):
+                pre[i + 1][j + 1] = (grid[i][j] + pre[i][j + 1]
+                                     + pre[i + 1][j] - pre[i][j])
+                if pre[i + 1][j + 1] <= k:
+                    res += 1
+        return res

--- a/leetcode_python/Array/distribute-elements-into-two-arrays-i.py
+++ b/leetcode_python/Array/distribute-elements-into-two-arrays-i.py
@@ -1,0 +1,64 @@
+"""
+
+3069. Distribute Elements Into Two Arrays I
+Easy
+
+You are given a 1-indexed array of distinct integers nums of length n.
+
+You need to distribute all the elements of nums between two arrays arr1 and arr2 using n operations. In the first operation, append nums[1] to arr1. In the second operation, append nums[2] to arr2. Afterwards, in the ith operation:
+
+If the last element of arr1 is greater than the last element of arr2, append nums[i] to arr1. Otherwise, append nums[i] to arr2.
+
+The array result is formed by concatenating the arrays arr1 and arr2. For example, if arr1 == [1,2,3] and arr2 == [4,5,6], then result = [1,2,3,4,5,6].
+
+Return the array result.
+
+
+Example 1:
+
+Input: nums = [2,1,3]
+Output: [2,3,1]
+Explanation: After the first 2 operations, arr1 = [2] and arr2 = [1].
+In the 3rd operation, as the last element of arr1 is greater than the last element of arr2 (2 > 1), append nums[3] to arr1.
+After 3 operations, arr1 = [2,3] and arr2 = [1].
+Hence, the array result formed by concatenation is [2,3,1].
+
+Example 2:
+
+Input: nums = [5,4,3,8]
+Output: [5,3,4,8]
+Explanation: After the first 2 operations, arr1 = [5] and arr2 = [4].
+In the 3rd operation, as the last element of arr1 is greater than the last element of arr2 (5 > 4), append nums[3] to arr1, hence arr1 becomes [5,3].
+In the 4th operation, as the last element of arr2 is greater than the last element of arr1 (4 > 3), append nums[4] to arr2, hence arr2 becomes [4,8].
+After 4 operations, arr1 = [5,3] and arr2 = [4,8].
+Hence, the array result formed by concatenation is [5,3,4,8].
+
+
+Constraints:
+
+3 <= n <= 50
+1 <= nums[i] <= 100
+All elements in nums are distinct.
+
+"""
+
+# V0
+# IDEA : DIRECT SIMULATION — ONLY THE TWO TAIL VALUES DECIDE EACH STEP
+#
+#   the rule looks only at the last element of each array, and since both
+#   arrays are non-empty from the third operation on, there is nothing to
+#   guard against.
+#
+#   elements are distinct, so the comparison never ties.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def resultArray(self, nums):
+        arr1 = [nums[0]]
+        arr2 = [nums[1]]
+        for x in nums[2:]:
+            if arr1[-1] > arr2[-1]:
+                arr1.append(x)
+            else:
+                arr2.append(x)
+        return arr1 + arr2

--- a/leetcode_python/Array/longest-strictly-increasing-or-strictly-decreasing-subarray.py
+++ b/leetcode_python/Array/longest-strictly-increasing-or-strictly-decreasing-subarray.py
@@ -1,0 +1,61 @@
+"""
+
+3105. Longest Strictly Increasing or Strictly Decreasing Subarray
+Easy
+
+You are given an array of integers nums. Return the length of the longest subarray of nums which is either strictly increasing or strictly decreasing.
+
+
+Example 1:
+
+Input: nums = [1,4,3,3,2]
+Output: 2
+Explanation:
+The strictly increasing subarrays of nums are [1], [2], [3], [3], [4], and [1,4].
+The strictly decreasing subarrays of nums are [1], [2], [3], [3], [4], [3,2], and [4,3].
+Hence, we return 2.
+
+Example 2:
+
+Input: nums = [3,3,3,3]
+Output: 1
+Explanation:
+The strictly increasing subarrays of nums are [3], [3], [3], and [3].
+The strictly decreasing subarrays of nums are [3], [3], [3], and [3].
+Hence, we return 1.
+
+Example 3:
+
+Input: nums = [3,2,1]
+Output: 3
+Explanation:
+The strictly increasing subarrays of nums are [3], [2], and [1].
+The strictly decreasing subarrays of nums are [3], [2], [1], [3,2], [2,1], and [3,2,1].
+Hence, we return 3.
+
+
+Constraints:
+
+1 <= nums.length <= 50
+1 <= nums[i] <= 50
+
+"""
+
+# V0
+# IDEA : TWO RUNNING STREAK COUNTERS, ONE PER DIRECTION
+#
+#   `inc` is the length of the strictly increasing run ending here and `dec`
+#   the strictly decreasing one. each extends when the comparison holds and
+#   resets to 1 otherwise — equal neighbours reset BOTH, which is why
+#   [3,3,3,3] answers 1.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def longestMonotonicSubarray(self, nums):
+        inc = dec = 1
+        res = 1
+        for i in range(1, len(nums)):
+            inc = inc + 1 if nums[i] > nums[i - 1] else 1
+            dec = dec + 1 if nums[i] < nums[i - 1] else 1
+            res = max(res, inc, dec)
+        return res

--- a/leetcode_python/Array/make-a-square-with-the-same-color.py
+++ b/leetcode_python/Array/make-a-square-with-the-same-color.py
@@ -1,0 +1,63 @@
+"""
+
+3127. Make a Square with the Same Color
+Easy
+
+You are given a 2D matrix grid of size 3 x 3 consisting only of characters 'B' and 'W'. Character 'W' represents the white color, and character 'B' represents the black color.
+
+Your task is to change the color of at most one cell so that the matrix has a 2 x 2 square where all cells are of the same color.
+
+Return true if it is possible to create a 2 x 2 square of the same color, otherwise, return false.
+
+
+Example 1:
+
+Input: grid = [["B","W","B"],["B","W","W"],["B","W","B"]]
+Output: true
+Explanation:
+It can be done by changing the color of the grid[0][2].
+
+Example 2:
+
+Input: grid = [["B","W","B"],["W","B","W"],["B","W","B"]]
+Output: false
+Explanation:
+It cannot be done by changing at most one cell.
+
+Example 3:
+
+Input: grid = [["B","W","B"],["B","W","W"],["B","W","W"]]
+Output: true
+Explanation:
+The grid already contains a 2 x 2 square of the same color.
+
+
+Constraints:
+
+grid.length == 3
+grid[i].length == 3
+grid[i][j] is either 'W' or 'B'.
+
+"""
+
+# V0
+# IDEA : A 2x2 BLOCK IS FIXABLE IFF IT IS NOT ALREADY 2-2 SPLIT
+#
+#   with one change allowed, a block of four cells can be made uniform
+#   whenever at least three of them already agree — i.e. its count of 'B'
+#   is 0, 1, 3 or 4. only an even 2-2 split needs two changes.
+#
+#   there are just four 2x2 blocks in a 3x3 grid, so check them all.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def canMakeSquare(self, grid):
+        for r in range(2):
+            for c in range(2):
+                blacks = sum(1
+                             for dr in range(2)
+                             for dc in range(2)
+                             if grid[r + dr][c + dc] == 'B')
+                if blacks != 2:
+                    return True
+        return False

--- a/leetcode_python/Array/match-alphanumerical-pattern-in-matrix-i.py
+++ b/leetcode_python/Array/match-alphanumerical-pattern-in-matrix-i.py
@@ -1,0 +1,101 @@
+"""
+
+3078. Match Alphanumerical Pattern in Matrix I
+Medium
+🔒 (premium)
+
+You are given a 2D integer matrix board and a 2D character matrix pattern. Where 0 <= board[r][c] <= 9 and each element of pattern is either a digit or a lowercase English letter.
+
+Your task is to find a submatrix of board that matches pattern.
+
+An integer matrix part matches pattern if we can replace cells containing letters in pattern with some digits (each distinct letter with a unique digit) in such a way that the resulting matrix equals part. In other words,
+
+The matrices have identical dimensions.
+If pattern[r][c] is a digit, then part[r][c] must be the same digit.
+If pattern[r][c] is a letter x:
+    If there is another cell (r', c') in pattern with pattern[r'][c'] == x, then part[r][c] must equal part[r'][c'].
+    Distinct letters must map to distinct digits, i.e. if pattern[r][c] != pattern[r'][c'] and both are letters, then part[r][c] != part[r'][c'].
+
+Return an array of length 2 containing the row number and column number of the upper-left corner of the submatrix of board that matches pattern, or [-1, -1] if there is no such submatrix.
+
+If there are multiple such submatrices, return the coordinates of the upper-left corner of the topmost one, and if there are multiple such rows, return the leftmost one.
+
+
+Example 1:
+
+Input: board = [[1,2,2],[2,2,3],[2,3,3]], pattern = ["ab","bb"]
+Output: [0,0]
+Explanation: If we consider this mapping: "a" -> 1 and "b" -> 2; the submatrix with the upper-left corner (0,0) is a match as outlined in the matrix above.
+Note that the submatrix with the upper-left corner (1,1) is also a match but since it comes after the other one, we return [0,0].
+
+Example 2:
+
+Input: board = [[1,1,2],[3,3,4],[6,6,6]], pattern = ["ab","66"]
+Output: [1,1]
+Explanation: If we consider this mapping: "a" -> 3 and "b" -> 4; the submatrix with the upper-left corner (1,1) is a match as outlined in the matrix above.
+Note that the submatrix with the upper-left corner (0,1) is not a match because the mapping is not one-to-one.
+
+Example 3:
+
+Input: board = [[1,2],[2,1]], pattern = ["22"]
+Output: [-1,-1]
+Explanation: The pattern requires two adjacent equal cells with the value 2, which board does not have.
+
+
+Constraints:
+
+1 <= board.length <= 50
+1 <= board[i].length <= 50
+0 <= board[i][j] <= 9
+1 <= pattern.length <= 50
+1 <= pattern[i].length <= 50
+pattern[i][j] is either a digit represented as a character or a lowercase English letter.
+
+"""
+
+# V0
+# IDEA : TRY EVERY ANCHOR, VERIFY WITH A *BIJECTIVE* LETTER -> DIGIT MAP
+#
+#   50x50 against 50x50 is at most 6.25 * 10^6 cell comparisons, so the
+#   direct anchor sweep is affordable — and scanning rows then columns
+#   naturally yields the topmost-then-leftmost answer first.
+#
+#   the verification is where the care goes. digits in the pattern must match
+#   literally; letters need a consistent assignment that is ONE-TO-ONE in
+#   both directions, so keep two maps :
+#       letter -> digit   (the same letter always means the same digit)
+#       digit -> letter   (two different letters may not claim one digit)
+#   both are rebuilt per anchor, which is what makes the check local.
+#
+# time = O(m * n * pm * pn), space = O(1)  (at most 10 letters can map)
+class Solution(object):
+    def findPattern(self, board, pattern):
+        m, n = len(board), len(board[0])
+        pm, pn = len(pattern), len(pattern[0])
+
+        def matches(r0, c0):
+            letter_to_digit = {}
+            digit_to_letter = {}
+            for r in range(pm):
+                for c in range(pn):
+                    p = pattern[r][c]
+                    v = board[r0 + r][c0 + c]
+                    if p.isdigit():
+                        if v != int(p):
+                            return False
+                        continue
+                    if p in letter_to_digit:
+                        if letter_to_digit[p] != v:
+                            return False
+                    elif v in digit_to_letter:
+                        return False            # digit already taken by another letter
+                    else:
+                        letter_to_digit[p] = v
+                        digit_to_letter[v] = p
+            return True
+
+        for r0 in range(m - pm + 1):
+            for c0 in range(n - pn + 1):
+                if matches(r0, c0):
+                    return [r0, c0]
+        return [-1, -1]

--- a/leetcode_python/Array/minimum-levels-to-gain-more-points.py
+++ b/leetcode_python/Array/minimum-levels-to-gain-more-points.py
@@ -1,0 +1,82 @@
+"""
+
+3096. Minimum Levels to Gain More Points
+Medium
+
+You are given a binary array possible of length n.
+
+Alice and Bob are playing a game that consists of n levels. Some of the levels in the game are impossible to clear while others can always be cleared. In particular, if possible[i] == 0, then the ith level is impossible to clear for both the players. A player gains 1 point on clearing a level and loses 1 point if the player fails to clear it.
+
+At the start of the game, Alice will play some levels in the given order starting from the 0th level, after which Bob will play for the rest of the levels.
+
+Alice wants to know the minimum number of levels she should play to gain more points than Bob, if both players play optimally to maximize their points.
+
+Return the minimum number of levels Alice should play to gain more points. If this is not possible, return -1.
+
+Note that each player must play at least 1 level.
+
+
+Example 1:
+
+Input: possible = [1,0,1,0]
+Output: 1
+Explanation:
+Let's look at all the levels that Alice can play up to:
+If Alice plays only level 0 and Bob plays the rest of the levels, Alice has 1 point, while Bob has -1 + 1 - 1 = -1 point.
+If Alice plays till level 1 and Bob plays the rest of the levels, Alice has 1 - 1 = 0 points, while Bob has 1 - 1 = 0 points.
+If Alice plays till level 2 and Bob plays the rest of the levels, Alice has 1 - 1 + 1 = 1 point, while Bob has -1 point.
+Alice must play a minimum of 1 level to gain more points.
+
+Example 2:
+
+Input: possible = [1,1,1,1,1]
+Output: 3
+Explanation:
+Let's look at all the levels that Alice can play up to:
+If Alice plays only level 0 and Bob plays the rest of the levels, Alice has 1 point, while Bob has 4 points.
+If Alice plays till level 1 and Bob plays the rest of the levels, Alice has 2 points, while Bob has 3 points.
+If Alice plays till level 2 and Bob plays the rest of the levels, Alice has 3 points, while Bob has 2 points.
+If Alice plays till level 3 and Bob plays the rest of the levels, Alice has 4 points, while Bob has 1 point.
+Alice must play a minimum of 3 levels to gain more points.
+
+Example 3:
+
+Input: possible = [0,0]
+Output: -1
+Explanation:
+The only possible way is for both players to play 1 level each. Alice plays level 0 and loses 1 point. Bob plays level 1 and loses 1 point. As both players have equal points, Alice can't gain more points than Bob.
+
+
+Constraints:
+
+2 <= n == possible.length <= 10^5
+possible[i] is either 0 or 1.
+
+"""
+
+# V0
+# IDEA : SCORES ARE PREFIX SUMS OF +1 / -1 — SCAN FOR THE FIRST SPLIT THAT WINS
+#
+#   "playing optimally" is a red herring : a clearable level always scores
+#   +1 and an impossible one always -1, with no choice involved. so map the
+#   array to +-1 and let `total` be its whole sum.
+#
+#   if Alice stops after i levels her score is prefix[i] and Bob's is
+#   total - prefix[i], so she wins exactly when
+#
+#       prefix[i] > total - prefix[i]     <=>     2 * prefix[i] > total
+#
+#   scan i = 1 .. n-1 (both players must play at least one level) and return
+#   the first i that satisfies it.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumLevels(self, possible):
+        n = len(possible)
+        total = sum(1 if v == 1 else -1 for v in possible)
+        prefix = 0
+        for i in range(n - 1):                 # Alice plays levels 0..i
+            prefix += 1 if possible[i] == 1 else -1
+            if 2 * prefix > total:
+                return i + 1
+        return -1

--- a/leetcode_python/Array/minimum-operations-to-exceed-threshold-value-i.py
+++ b/leetcode_python/Array/minimum-operations-to-exceed-threshold-value-i.py
@@ -1,0 +1,56 @@
+"""
+
+3065. Minimum Operations to Exceed Threshold Value I
+Easy
+
+You are given a 0-indexed integer array nums, and an integer k.
+
+In one operation, you can remove one occurrence of the smallest element of nums.
+
+Return the minimum number of operations needed so that all elements of the array are greater than or equal to k.
+
+
+Example 1:
+
+Input: nums = [2,11,10,1,3], k = 10
+Output: 3
+Explanation: After one operation, nums becomes equal to [2, 11, 10, 3].
+After two operations, nums becomes equal to [11, 10, 3].
+After three operations, nums becomes equal to [11, 10].
+At this stage, all the elements of nums are greater than or equal to 10 so we can stop.
+It can be shown that 3 is the minimum number of operations needed so that all elements of the array are greater than or equal to 10.
+
+Example 2:
+
+Input: nums = [1,1,2,4,9], k = 1
+Output: 0
+Explanation: All elements of the array are greater than or equal to 1 so we do not need to apply any operations on nums.
+
+Example 3:
+
+Input: nums = [1,1,2,4,9], k = 9
+Output: 4
+Explanation: only a single element of nums is greater than or equal to 9 so we need to apply the operations 4 times on nums.
+
+
+Constraints:
+
+1 <= nums.length <= 50
+1 <= nums[i] <= 10^9
+1 <= k <= 10^9
+The input is generated such that there is at least one index i such that nums[i] >= k.
+
+"""
+
+# V0
+# IDEA : THE OPERATION ALWAYS TAKES THE SMALLEST — SO IT JUST DELETES EVERY VALUE BELOW k
+#
+#   repeatedly removing the minimum removes the sub-k values first and in
+#   ascending order, and it can never touch a value >= k while any smaller
+#   one remains. so the number of operations is exactly how many elements
+#   fall below k — no sorting or simulation needed.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minOperations(self, nums, k):
+        return sum(1 for x in nums if x < k)

--- a/leetcode_python/Array/minimum-operations-to-write-the-letter-y-on-a-grid.py
+++ b/leetcode_python/Array/minimum-operations-to-write-the-letter-y-on-a-grid.py
@@ -1,0 +1,87 @@
+"""
+
+3071. Minimum Operations to Write the Letter Y on a Grid
+Medium
+
+You are given a 0-indexed n x n grid where n is odd, and grid[r][c] is 0, 1, or 2.
+
+We say that a cell belongs to the Letter Y if it belongs to one of the following:
+
+The diagonal starting at the top-left cell and ending at the center cell of the grid.
+The diagonal starting at the top-right cell and ending at the center cell of the grid.
+The vertical line starting at the center cell and ending at the bottom border of the grid.
+
+The Letter Y is written on the grid if and only if:
+
+All values at cells belonging to the Y are equal.
+All values at cells not belonging to the Y are equal.
+The values at cells belonging to the Y are different from the values at cells not belonging to the Y.
+
+Return the minimum number of operations needed to write the letter Y on the grid given that in one operation you can change the value at any cell to 0, 1, or 2.
+
+
+Example 1:
+
+Input: grid = [[1,2,2],[1,1,0],[0,1,0]]
+Output: 3
+Explanation: We can write Y on the grid by applying the changes highlighted in blue in the image above. After the operations, all cells that belong to Y, denoted in bold, have the same value of 1 while those that do not belong to Y are equal to 0.
+It can be shown that 3 is the minimum number of operations needed to write Y on the grid.
+
+Example 2:
+
+Input: grid = [[0,1,0,1,0],[2,1,0,1,2],[2,2,2,0,1],[2,2,2,2,2],[2,1,2,2,2]]
+Output: 12
+Explanation: We can write Y on the grid by applying the changes highlighted in blue in the image above. After the operations, all cells that belong to Y, denoted in bold, have the same value of 0 while those that do not belong to Y are equal to 2.
+It can be shown that 12 is the minimum number of operations needed to write Y on the grid.
+
+
+Constraints:
+
+3 <= n <= 49
+n == grid.length == grid[i].length
+0 <= grid[i][j] <= 2
+n is odd.
+
+"""
+
+# V0
+# IDEA : ONLY 6 TARGET COLOURINGS EXIST — COUNT ONCE, THEN SCORE EACH
+#
+#   the final grid is fully described by two values : `a` on the Y and `b`
+#   off it, with a != b. that is only 3 * 2 = 6 possibilities.
+#
+#   so tally, once, how many Y cells already hold each value and how many
+#   non-Y cells hold each value. the cost of a choice (a, b) is
+#
+#       (Y cells not already a) + (non-Y cells not already b)
+#
+#   and the answer is the cheapest of the six.
+#
+#   membership in the Y is a coordinate test around the centre m = n // 2 :
+#       above the centre  -> the two diagonals,  r == c or r + c == n - 1
+#       at or below it    -> the stem,           c == m
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def minimumOperationsToWriteY(self, grid):
+        n = len(grid)
+        m = n // 2
+        in_y = [0, 0, 0]
+        out_y = [0, 0, 0]
+
+        for r in range(n):
+            for c in range(n):
+                if (r < m and (r == c or r + c == n - 1)) or (r >= m and c == m):
+                    in_y[grid[r][c]] += 1
+                else:
+                    out_y[grid[r][c]] += 1
+
+        total_in = sum(in_y)
+        total_out = sum(out_y)
+        best = float('inf')
+        for a in range(3):
+            for b in range(3):
+                if a == b:
+                    continue
+                best = min(best, (total_in - in_y[a]) + (total_out - out_y[b]))
+        return best

--- a/leetcode_python/Binary_Search/distribute-elements-into-two-arrays-ii.py
+++ b/leetcode_python/Binary_Search/distribute-elements-into-two-arrays-ii.py
@@ -1,0 +1,112 @@
+"""
+
+3072. Distribute Elements Into Two Arrays II
+Hard
+
+You are given a 1-indexed array of integers nums of length n.
+
+We define a function greaterCount such that greaterCount(arr, val) returns the number of elements in arr that are strictly greater than val.
+
+You need to distribute all the elements of nums between two arrays arr1 and arr2 using n operations. In the first operation, append nums[1] to arr1. In the second operation, append nums[2] to arr2. Afterwards, in the ith operation:
+
+If greaterCount(arr1, nums[i]) > greaterCount(arr2, nums[i]), append nums[i] to arr1.
+If greaterCount(arr1, nums[i]) < greaterCount(arr2, nums[i]), append nums[i] to arr2.
+If greaterCount(arr1, nums[i]) == greaterCount(arr2, nums[i]), append nums[i] to the array with a lesser number of elements.
+If there is still a tie, append nums[i] to arr1.
+
+The array result is formed by concatenating the arrays arr1 and arr2. For example, if arr1 == [1,2,3] and arr2 == [4,5,6], then result = [1,2,3,4,5,6].
+
+Return the integer array result.
+
+
+Example 1:
+
+Input: nums = [2,1,3,3]
+Output: [2,3,1,3]
+Explanation: After the first 2 operations, arr1 = [2] and arr2 = [1].
+In the 3rd operation, the number of elements greater than 3 is zero in both arrays. Also, the lengths are equal, hence, append nums[3] to arr1.
+In the 4th operation, the number of elements greater than 3 is zero in both arrays. As the length of arr2 is lesser, hence, append nums[4] to arr2.
+After 4 operations, arr1 = [2,3] and arr2 = [1,3].
+Hence, the array result formed by concatenation is [2,3,1,3].
+
+Example 2:
+
+Input: nums = [5,14,3,1,2]
+Output: [5,3,1,2,14]
+Explanation: After the first 2 operations, arr1 = [5] and arr2 = [14].
+In the 3rd operation, the number of elements greater than 3 is one in both arrays. Also, the lengths are equal, hence, append nums[3] to arr1.
+In the 4th operation, the number of elements greater than 1 is greater in arr1 than arr2 (2 > 1). Hence, append nums[4] to arr1.
+In the 5th operation, the number of elements greater than 2 is greater in arr1 than arr2 (2 > 1). Hence, append nums[5] to arr1.
+After 5 operations, arr1 = [5,3,1,2] and arr2 = [14].
+Hence, the array result formed by concatenation is [5,3,1,2,14].
+
+Example 3:
+
+Input: nums = [3,3,3,3]
+Output: [3,3,3,3]
+Explanation: At the end of 4 operations, arr1 = [3,3] and arr2 = [3,3].
+Hence, the array result formed by concatenation is [3,3,3,3].
+
+
+Constraints:
+
+3 <= n <= 10^5
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : TWO FENWICK TREES OVER THE COMPRESSED VALUES
+#
+#   the rule needs greaterCount(arr, v) after every append, which a linear
+#   scan would answer in O(n) per step — 10^10 in total. a Fenwick tree per
+#   array answers it in O(log n) instead :
+#
+#       greaterCount(arr, v) = size(arr) - (how many entries are <= v)
+#
+#   values reach 10^9 but there are only n of them, so compress them to
+#   ranks 1..n first and index the trees by rank.
+#
+#   the tie-breaks are then just the sizes, and finally arr1 + arr2.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def resultArray(self, nums):
+        order = sorted(set(nums))
+        rank = {v: i + 1 for i, v in enumerate(order)}
+        size = len(order)
+
+        class BIT(object):
+            def __init__(self, n):
+                self.n = n
+                self.t = [0] * (n + 1)
+
+            def add(self, i):
+                while i <= self.n:
+                    self.t[i] += 1
+                    i += i & -i
+
+            def query(self, i):          # count of entries with rank <= i
+                s = 0
+                while i > 0:
+                    s += self.t[i]
+                    i -= i & -i
+                return s
+
+        bit1, bit2 = BIT(size), BIT(size)
+        arr1, arr2 = [nums[0]], [nums[1]]
+        bit1.add(rank[nums[0]])
+        bit2.add(rank[nums[1]])
+
+        for x in nums[2:]:
+            r = rank[x]
+            g1 = len(arr1) - bit1.query(r)
+            g2 = len(arr2) - bit2.query(r)
+            if g1 > g2 or (g1 == g2 and len(arr1) <= len(arr2)):
+                arr1.append(x)
+                bit1.add(r)
+            else:
+                arr2.append(x)
+                bit2.add(r)
+
+        return arr1 + arr2

--- a/leetcode_python/Binary_Search/kth-smallest-amount-with-single-denomination-combination.py
+++ b/leetcode_python/Binary_Search/kth-smallest-amount-with-single-denomination-combination.py
@@ -1,0 +1,92 @@
+"""
+
+3116. Kth Smallest Amount With Single Denomination Combination
+Hard
+
+You are given an integer array coins representing coins of different denominations and an integer k.
+
+You have an infinite number of coins of each denomination. However, you are not allowed to combine coins of different denominations.
+
+Return the kth smallest amount that can be made using these coins.
+
+
+Example 1:
+
+Input: coins = [3,6,9], k = 3
+Output: 9
+Explanation: The given coins can make the following amounts:
+Coin 3 produces multiples of 3: 3, 6, 9, 12, 15, etc.
+Coin 6 produces multiples of 6: 6, 12, 18, 24, etc.
+Coin 9 produces multiples of 9: 9, 18, 27, 36, etc.
+All of the coins combined produce: 3, 6, 9, 12, 15, etc.
+
+Example 2:
+
+Input: coins = [5,2], k = 7
+Output: 12
+Explanation: The given coins can make the following amounts:
+Coin 5 produces multiples of 5: 5, 10, 15, 20, etc.
+Coin 2 produces multiples of 2: 2, 4, 6, 8, 10, 12, etc.
+All of the coins combined produce: 2, 4, 5, 6, 8, 10, 12, 14, 15, etc.
+
+
+Constraints:
+
+1 <= coins.length <= 15
+1 <= coins[i] <= 25
+1 <= k <= 2 * 10^9
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH THE AMOUNT, COUNT WITH INCLUSION-EXCLUSION
+#
+#   "no mixing denominations" means the reachable amounts are exactly the
+#   union of the multiple-sets of each coin. how many of them are <= x is
+#   therefore a union cardinality, which inclusion-exclusion gives :
+#
+#       |union| = sum over non-empty subsets S of
+#                     (-1)^(|S|+1) * floor(x / lcm(S))
+#
+#   with at most 15 coins that is 32767 subsets, each an O(1) division once
+#   the subset's lcm is known.
+#
+#   the count is non-decreasing in x, so binary search for the smallest x
+#   whose count reaches k — and that x is itself reachable, because the count
+#   only increases at reachable amounts.
+#
+#   the upper bound min(coins) * k is safe : that coin alone already produces
+#   k amounts by then.
+#
+# time = O(2^n * log(min(coins) * k)), space = O(2^n)
+class Solution(object):
+    def findKthSmallest(self, coins, k):
+
+        def gcd(a, b):
+            while b:
+                a, b = b, a % b
+            return a
+
+        n = len(coins)
+        # precompute (lcm, sign) for every non-empty subset
+        subsets = []
+        for mask in range(1, 1 << n):
+            lcm = 1
+            bits = 0
+            for i in range(n):
+                if (mask >> i) & 1:
+                    bits += 1
+                    lcm = lcm // gcd(lcm, coins[i]) * coins[i]
+            subsets.append((lcm, 1 if bits % 2 else -1))
+
+        def count(x):
+            return sum(sign * (x // lcm) for lcm, sign in subsets)
+
+        lo, hi = 1, min(coins) * k
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if count(mid) >= k:
+                hi = mid
+            else:
+                lo = mid + 1
+        return lo

--- a/leetcode_python/Binary_Search/maximum-increasing-triplet-value.py
+++ b/leetcode_python/Binary_Search/maximum-increasing-triplet-value.py
@@ -1,0 +1,86 @@
+"""
+
+3073. Maximum Increasing Triplet Value
+Medium
+🔒 (premium)
+
+Given an array nums, return the maximum value of a triplet (i, j, k) such that i < j < k and nums[i] < nums[j] < nums[k].
+
+The value of a triplet (i, j, k) is nums[i] - nums[j] + nums[k].
+
+
+Example 1:
+
+Input: nums = [5,6,9]
+Output: 8
+Explanation: We only have one choice for an increasing triplet and that is choosing all three elements. The value of this triplet would be 5 - 6 + 9 = 8.
+
+Example 2:
+
+Input: nums = [1,5,3,6]
+Output: 4
+Explanation: There are only two increasing triplets:
+(0, 1, 3): The value of this triplet is nums[0] - nums[1] + nums[3] = 1 - 5 + 6 = 2.
+(0, 2, 3): The value of this triplet is nums[0] - nums[2] + nums[3] = 1 - 3 + 6 = 4.
+Thus the answer would be 4.
+
+
+Constraints:
+
+3 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+The input is generated such that at least one triplet meets the given condition.
+
+"""
+
+# V0
+# IDEA : FIX THE MIDDLE, THEN WANT THE BIGGEST VALID LEFT AND RIGHT
+#
+#   for a fixed j the value splits cleanly :
+#       nums[i] - nums[j] + nums[k]
+#   so take the LARGEST nums[i] < nums[j] with i < j, and the LARGEST
+#   nums[k] > nums[j] with k > j — the two choices are independent.
+#
+#   right side : a suffix maximum array. it is a valid k exactly when that
+#   maximum exceeds nums[j] (nothing bigger can hide behind a bigger value).
+#
+#   left side : "max value strictly below nums[j] among what came before" is
+#   a prefix-max query over the VALUE axis, so compress the values and keep a
+#   Fenwick tree of maxima indexed by rank.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def maximumTripletValue(self, nums):
+        n = len(nums)
+        order = sorted(set(nums))
+        rank = {v: i + 1 for i, v in enumerate(order)}
+        size = len(order)
+
+        tree = [0] * (size + 1)          # Fenwick tree of prefix maxima
+
+        def update(i, val):
+            while i <= size:
+                if tree[i] < val:
+                    tree[i] = val
+                i += i & -i
+
+        def query(i):                    # max over ranks 1..i, 0 when empty
+            best = 0
+            while i > 0:
+                if tree[i] > best:
+                    best = tree[i]
+                i -= i & -i
+            return best
+
+        suffix_max = [0] * (n + 1)
+        for t in range(n - 1, -1, -1):
+            suffix_max[t] = max(suffix_max[t + 1], nums[t])
+
+        res = float('-inf')
+        for j in range(n):
+            left = query(rank[nums[j]] - 1)      # biggest value < nums[j], so far
+            right = suffix_max[j + 1]
+            if left > 0 and right > nums[j]:
+                res = max(res, left - nums[j] + right)
+            update(rank[nums[j]], nums[j])
+        return res

--- a/leetcode_python/Bit_Manipulation/maximum-number-that-makes-result-of-bitwise-and-zero.py
+++ b/leetcode_python/Bit_Manipulation/maximum-number-that-makes-result-of-bitwise-and-zero.py
@@ -1,0 +1,55 @@
+"""
+
+3125. Maximum Number That Makes Result of Bitwise AND Zero
+Medium
+🔒 (premium)
+
+Given an integer n, return the maximum integer x such that x <= n, and the bitwise AND of all the numbers in the range [x, n] is equal to 0.
+
+
+Example 1:
+
+Input: n = 7
+Output: 3
+Explanation:
+The bitwise AND of [3, 4, 5, 6, 7] is 0.
+
+Example 2:
+
+Input: n = 9
+Output: 7
+Explanation:
+The bitwise AND of [7, 8, 9] is 0.
+
+Example 3:
+
+Input: n = 17
+Output: 15
+Explanation:
+The bitwise AND of [15, 16, 17] is 0.
+
+
+Constraints:
+
+1 <= n <= 10^9
+
+"""
+
+# V0
+# IDEA : THE ANSWER IS ALWAYS 2^h - 1, WHERE h IS n'S HIGHEST SET BIT
+#
+#   n has bit h set, so every number from 2^h up to n also has it. an AND
+#   over a range that stays inside [2^h, n] therefore keeps bit h and cannot
+#   be 0 — which means x must dip below 2^h, i.e. x <= 2^h - 1.
+#
+#   and x = 2^h - 1 already achieves it : that number has bit h clear and all
+#   lower bits set, while 2^h (which is <= n, so it is in the range) has
+#   exactly the opposite. their AND alone is 0.
+#
+#   so the largest valid x is 2^h - 1, and h = n.bit_length() - 1.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def maxNumber(self, n):
+        h = n.bit_length() - 1
+        return (1 << h) - 1

--- a/leetcode_python/Bit_Manipulation/shortest-subarray-with-or-at-least-k-i.py
+++ b/leetcode_python/Bit_Manipulation/shortest-subarray-with-or-at-least-k-i.py
@@ -1,0 +1,62 @@
+"""
+
+3095. Shortest Subarray With OR at Least K I
+Easy
+
+You are given an array nums of non-negative integers and an integer k.
+
+An array is called special if the bitwise OR of all of its elements is at least k.
+
+Return the length of the shortest special non-empty subarray of nums, or return -1 if no special subarray exists.
+
+
+Example 1:
+
+Input: nums = [1,2,3], k = 2
+Output: 1
+Explanation: The subarray [3] has OR value of 3. Hence, we return 1.
+
+Example 2:
+
+Input: nums = [2,1,8], k = 10
+Output: 3
+Explanation: The subarray [2,1,8] has OR value of 11. Hence, we return 3.
+
+Example 3:
+
+Input: nums = [1,2], k = 0
+Output: 1
+Explanation: The subarray [1] has OR value of 1. Hence, we return 1.
+
+
+Constraints:
+
+1 <= nums.length <= 50
+0 <= nums[i] <= 50
+0 <= k < 64
+
+"""
+
+# V0
+# IDEA : n <= 50 — GROW EVERY SUBARRAY AND STOP AS SOON AS THE OR CLEARS k
+#
+#   the OR only ever gains bits as a subarray grows, so for each start index
+#   extend rightwards and break at the first index whose running OR reaches
+#   k — nothing longer from that start can be shorter.
+#
+#   the sequel (LC 3097) has the same statement at 2*10^5 elements and needs
+#   a sliding window with per-bit counters instead.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def minimumSubarrayLength(self, nums, k):
+        n = len(nums)
+        best = float('inf')
+        for i in range(n):
+            cur = 0
+            for j in range(i, n):
+                cur |= nums[j]
+                if cur >= k:
+                    best = min(best, j - i + 1)
+                    break
+        return -1 if best == float('inf') else best

--- a/leetcode_python/Depth-First-Search/count-pairs-of-connectable-servers-in-a-weighted-tree-network.py
+++ b/leetcode_python/Depth-First-Search/count-pairs-of-connectable-servers-in-a-weighted-tree-network.py
@@ -1,0 +1,89 @@
+"""
+
+3067. Count Pairs of Connectable Servers in a Weighted Tree Network
+Medium
+
+You are given an unrooted weighted tree with n vertices representing servers numbered from 0 to n - 1, an array edges where edges[i] = [ai, bi, weighti] represents a bidirectional edge between vertices ai and bi of weight weighti. You are also given an integer signalSpeed.
+
+Two servers a and b are connectable through a server c if:
+
+a < b, a != c and b != c.
+The distance from c to a is divisible by signalSpeed.
+The distance from c to b is divisible by signalSpeed.
+The path from c to a and the path from c to b do not share any edges.
+
+Return an integer array count of length n where count[i] is the number of server pairs that are connectable through the server i.
+
+
+Example 1:
+
+Input: edges = [[0,1,1],[1,2,5],[2,3,13],[3,4,9],[4,5,2]], signalSpeed = 1
+Output: [0,4,6,6,4,0]
+Explanation: Since signalSpeed is 1, count[c] is equal to the number of pairs of paths that start at c and do not share any edges.
+In the case of the given path graph, count[c] is equal to the number of servers to the left of c multiplied by the servers to the right of c.
+
+Example 2:
+
+Input: edges = [[0,6,3],[6,5,3],[0,3,1],[3,2,7],[3,1,6],[3,4,2]], signalSpeed = 3
+Output: [2,0,0,0,0,0,2]
+Explanation: Through server 0 that can be connected through the two paths (3, 6), (3, 5).
+Through server 6 that can be connected through the two paths (0, 3), (0, 4).
+It can be shown that no two servers are connectable through servers other than 0 and 6.
+
+
+Constraints:
+
+2 <= n <= 1000
+edges.length == n - 1
+edges[i].length == 3
+0 <= ai, bi < n
+edges[i] = [ai, bi, weighti]
+1 <= weighti <= 10^6
+1 <= signalSpeed <= 10^6
+The input is generated such that edges represents a valid tree.
+
+"""
+
+# V0
+# IDEA : ROOT AT EACH SERVER, COUNT PER BRANCH, MULTIPLY ACROSS BRANCHES
+#
+#   "the two paths share no edge" means a and b must leave c through
+#   DIFFERENT neighbours — every subtree hanging off c is one branch.
+#
+#   so for a fixed c, walk each branch and count how many vertices sit at a
+#   distance divisible by signalSpeed. if the branches yield c1, c2, ..., cm
+#   such vertices, the connectable pairs through c number
+#
+#       sum over i < j of ci * cj
+#
+#   which a running total computes in one pass :  add prev_total * ci, then
+#   prev_total += ci.
+#
+#   n <= 1000, so repeating the whole DFS from every c is O(n^2) — fine.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def countPairsOfConnectableServers(self, edges, signalSpeed):
+        n = len(edges) + 1
+        adj = [[] for _ in range(n)]
+        for a, b, w in edges:
+            adj[a].append((b, w))
+            adj[b].append((a, w))
+
+        res = [0] * n
+        for c in range(n):
+            seen_total = 0
+            for nxt, w in adj[c]:
+                # count vertices in this branch whose distance from c divides evenly
+                cnt = 0
+                stack = [(nxt, w, c)]
+                while stack:
+                    node, dist, parent = stack.pop()
+                    if dist % signalSpeed == 0:
+                        cnt += 1
+                    for nb, nw in adj[node]:
+                        if nb != parent:
+                            stack.append((nb, dist + nw, node))
+                res[c] += seen_total * cnt
+                seen_total += cnt
+        return res

--- a/leetcode_python/Dynamic_Programming/count-alternating-subarrays.py
+++ b/leetcode_python/Dynamic_Programming/count-alternating-subarrays.py
@@ -1,0 +1,54 @@
+"""
+
+3101. Count Alternating Subarrays
+Medium
+
+You are given a binary array nums.
+
+We call a subarray alternating if no two adjacent elements in the subarray have the same value.
+
+Return the number of alternating subarrays in nums.
+
+
+Example 1:
+
+Input: nums = [0,1,1,1]
+Output: 5
+Explanation:
+The following subarrays are alternating: [0], [1], [1], [1], and [0,1].
+
+Example 2:
+
+Input: nums = [1,0,1,0]
+Output: 10
+Explanation:
+Every subarray of the array is alternating. There are 10 possible subarrays that we can choose.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+nums[i] is either 0 or 1.
+
+"""
+
+# V0
+# IDEA : COUNT THE ALTERNATING SUBARRAYS *ENDING* AT EACH INDEX
+#
+#   let run be the length of the longest alternating stretch ending at i.
+#   every suffix of that stretch is itself alternating and ends at i, so
+#   index i contributes exactly `run` subarrays.
+#
+#   run extends when nums[i] != nums[i-1] and restarts at 1 otherwise, so a
+#   single counter suffices and each subarray is counted once — by its right
+#   end.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def countAlternatingSubarrays(self, nums):
+        res = 0
+        run = 0
+        for i, v in enumerate(nums):
+            run = run + 1 if i and nums[i - 1] != v else 1
+            res += run
+        return res

--- a/leetcode_python/Dynamic_Programming/find-all-possible-stable-binary-arrays-i.py
+++ b/leetcode_python/Dynamic_Programming/find-all-possible-stable-binary-arrays-i.py
@@ -1,0 +1,90 @@
+"""
+
+3129. Find All Possible Stable Binary Arrays I
+Medium
+
+You are given 3 positive integers zero, one, and limit.
+
+A binary array arr is called stable if:
+
+The number of occurrences of 0 in arr is exactly zero.
+The number of occurrences of 1 in arr is exactly one.
+Each subarray of arr with a size greater than limit must contain both 0 and 1.
+
+Return the total number of stable binary arrays.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: zero = 1, one = 1, limit = 2
+Output: 2
+Explanation:
+The two possible stable binary arrays are [1,0] and [0,1], as both arrays have a single 0 and a single 1, and no subarray has a length greater than 2.
+
+Example 2:
+
+Input: zero = 1, one = 2, limit = 1
+Output: 1
+Explanation:
+The only possible stable binary array is [1,0,1].
+Note that the binary arrays [1,1,0] and [0,1,1] have subarrays of length 2 with identical elements, hence, they are not stable.
+
+Example 3:
+
+Input: zero = 3, one = 3, limit = 2
+Output: 14
+Explanation:
+All the possible stable binary arrays are [0,0,1,0,1,1], [0,0,1,1,0,1], [0,1,0,0,1,1], [0,1,0,1,0,1], [0,1,0,1,1,0], [0,1,1,0,0,1], [0,1,1,0,1,0], [1,0,0,1,0,1], [1,0,0,1,1,0], [1,0,1,0,0,1], [1,0,1,0,1,0], [1,0,1,1,0,0], [1,1,0,0,1,0], and [1,1,0,1,0,0].
+
+Constraints:
+
+1 <= zero, one, limit <= 200
+
+"""
+
+# V0
+# IDEA : "NO SUBARRAY LONGER THAN limit IS UNIFORM" == "NO RUN EXCEEDS limit"
+#
+#   a subarray missing one of the two values is exactly a stretch of equal
+#   elements, so the condition is simply : every maximal run has length
+#   <= limit.
+#
+#   dp[i][j][b] = arrays using i zeros and j ones that END with the value b.
+#   appending a 0 to anything that ends in 0 or 1 gives
+#
+#       dp[i][j][0] = dp[i-1][j][0] + dp[i-1][j][1] - dp[i-limit-1][j][1]
+#
+#   the subtracted term removes the arrays whose trailing 0-run was already
+#   exactly `limit` : those are precisely the ones formed by a 1-ending array
+#   followed by limit zeros, i.e. dp[i-limit-1][j][1]. the 1-side is the
+#   mirror image.
+#
+#   bases : all-zero and all-one arrays exist only while they fit in `limit`.
+#
+# time = O(zero * one), space = O(zero * one)
+class Solution(object):
+    def numberOfStableArrays(self, zero, one, limit):
+        MOD = 10 ** 9 + 7
+        dp0 = [[0] * (one + 1) for _ in range(zero + 1)]     # ends with 0
+        dp1 = [[0] * (one + 1) for _ in range(zero + 1)]     # ends with 1
+
+        for i in range(1, zero + 1):
+            dp0[i][0] = 1 if i <= limit else 0
+        for j in range(1, one + 1):
+            dp1[0][j] = 1 if j <= limit else 0
+
+        for i in range(1, zero + 1):
+            for j in range(1, one + 1):
+                v = dp0[i - 1][j] + dp1[i - 1][j]
+                if i - limit - 1 >= 0:
+                    v -= dp1[i - limit - 1][j]
+                dp0[i][j] = v % MOD
+
+                v = dp1[i][j - 1] + dp0[i][j - 1]
+                if j - limit - 1 >= 0:
+                    v -= dp0[i][j - limit - 1]
+                dp1[i][j] = v % MOD
+
+        return (dp0[zero][one] + dp1[zero][one]) % MOD

--- a/leetcode_python/Dynamic_Programming/find-the-maximum-sum-of-node-values.py
+++ b/leetcode_python/Dynamic_Programming/find-the-maximum-sum-of-node-values.py
@@ -1,0 +1,81 @@
+"""
+
+3068. Find the Maximum Sum of Node Values
+Hard
+
+There exists an undirected tree with n nodes numbered 0 to n - 1. You are given a 0-indexed 2D integer array edges of length n - 1, where edges[i] = [ui, vi] indicates that there is an edge between nodes ui and vi in the tree. You are also given a positive integer k, and a 0-indexed array of non-negative integers nums of length n, where nums[i] represents the value of the node numbered i.
+
+Alice wants the sum of values of tree nodes to be maximum, for which Alice can perform the following operation any number of times (including zero) on the tree:
+
+Choose any edge [u, v] connecting the nodes u and v, and update their values as follows:
+    nums[u] = nums[u] XOR k
+    nums[v] = nums[v] XOR k
+
+Return the maximum possible sum of the values Alice can achieve by performing the operation any number of times.
+
+
+Example 1:
+
+Input: nums = [1,2,1], k = 3, edges = [[0,1],[0,2]]
+Output: 6
+Explanation: Alice can achieve the maximum sum of 6 using a single operation:
+- Choose the edge [0,2]. nums becomes [1 XOR 3, 2, 1 XOR 3] = [2, 2, 2].
+The total sum of values is 2 + 2 + 2 = 6.
+It can be shown that 6 is the maximum achievable sum of values.
+
+Example 2:
+
+Input: nums = [2,3], k = 7, edges = [[0,1]]
+Output: 9
+Explanation: Alice can achieve the maximum sum of 9 using a single operation:
+- Choose the edge [0,1]. nums becomes [2 XOR 7, 3 XOR 7] = [5, 4].
+The total sum of values is 5 + 4 = 9.
+It can be shown that 9 is the maximum achievable sum of values.
+
+Example 3:
+
+Input: nums = [7,7,7,7,7,7], k = 3, edges = [[0,1],[0,2],[0,3],[0,4],[0,5]]
+Output: 42
+Explanation: The maximum achievable sum is 42 which can be achieved by Alice performing no operations.
+
+
+Constraints:
+
+2 <= n == nums.length <= 2 * 10^4
+1 <= k <= 10^9
+0 <= nums[i] <= 10^9
+edges.length == n - 1
+edges[i].length == 2
+0 <= edges[i][0], edges[i][1] <= n - 1
+The input is generated such that edges represent a valid tree.
+
+"""
+
+# V0
+# IDEA : THE TREE IS A RED HERRING — ANY *EVEN-SIZED* SUBSET CAN BE FLIPPED
+#
+#   one operation flips two endpoints of an edge. chaining operations along a
+#   path u -> ... -> v flips every interior node TWICE (back to its original
+#   value) and the two ends once. since a tree connects every pair, any two
+#   nodes can be flipped together — and therefore any subset of EVEN size,
+#   and nothing of odd size (each operation changes the flipped count by 0
+#   or 2, so its parity is invariant).
+#
+#   so the problem reduces to : pick an even number of nodes to XOR with k,
+#   maximising the total. a two-state DP over the nodes does it :
+#
+#       even = best total so far having flipped an even count
+#       odd  = best total so far having flipped an odd count
+#
+#   each node is either left alone (+x) or flipped (+ x^k, parity switches).
+#   the answer is `even` at the end.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maximumValueSum(self, nums, k, edges):
+        even, odd = 0, float('-inf')
+        for x in nums:
+            flipped = x ^ k
+            even, odd = (max(even + x, odd + flipped),
+                         max(odd + x, even + flipped))
+        return even

--- a/leetcode_python/Dynamic_Programming/find-the-sum-of-subsequence-powers.py
+++ b/leetcode_python/Dynamic_Programming/find-the-sum-of-subsequence-powers.py
@@ -1,0 +1,101 @@
+"""
+
+3098. Find the Sum of Subsequence Powers
+Hard
+
+You are given an integer array nums of length n, and a positive integer k.
+
+The power of a subsequence is defined as the minimum absolute difference between any two elements in the subsequence.
+
+Return the sum of powers of all subsequences of nums which have length equal to k.
+
+Since the answer may be large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4], k = 3
+Output: 4
+Explanation:
+There are 4 subsequences in nums which have length 3: [1,2,3], [1,3,4], [1,2,4], and [2,3,4]. The sum of powers is |2 - 3| + |3 - 4| + |2 - 1| + |3 - 4| = 4.
+
+Example 2:
+
+Input: nums = [2,2], k = 2
+Output: 0
+Explanation:
+The only subsequence in nums which has length 2 is [2,2]. The sum of powers is |2 - 2| = 0.
+
+Example 3:
+
+Input: nums = [4,3,-1], k = 2
+Output: 10
+Explanation:
+There are 3 subsequences in nums which have length 2: [4,3], [4,-1], and [3,-1]. The sum of powers is |4 - 3| + |4 - (-1)| + |3 - (-1)| = 10.
+
+
+Constraints:
+
+2 <= n == nums.length <= 50
+-10^8 <= nums[i] <= 10^8
+2 <= k <= n
+
+"""
+
+# V0
+# IDEA : SUM THE MINIMUM BY *LAYERS* — count(power >= d) SUMMED OVER d
+#
+#   for a non-negative quantity,  value = sum over d >= 1 of [value >= d],
+#   so the answer equals
+#
+#       sum over d >= 1 of  #{ length-k subsequences with min gap >= d }
+#
+#   the count only changes at the distinct pairwise differences, so let those
+#   be D_1 < D_2 < ... and collapse the sum to
+#
+#       sum over t of (D_t - D_{t-1}) * count(min gap >= D_t)
+#
+#   with only 50 values there are at most 1225 distinct differences.
+#
+#   counting for a fixed d : sort nums; then "min gap >= d" means every pair
+#   of CONSECUTIVE chosen elements is at least d apart. so
+#       f[i][j] = ways to choose j elements ending at index i
+#               = sum of f[t][j-1] over t with nums[i] - nums[t] >= d
+#   and since nums is sorted the eligible t form a prefix — a moving pointer
+#   plus prefix sums makes each d cost O(n * k).
+#
+# time = O(n^2 * n * k) = O(n^3 * k) worst case, space = O(n * k)
+class Solution(object):
+    def sumOfPowers(self, nums, k):
+        MOD = 10 ** 9 + 7
+        nums = sorted(nums)
+        n = len(nums)
+
+        diffs = set([0])
+        for i in range(n):
+            for j in range(i + 1, n):
+                diffs.add(nums[j] - nums[i])
+        diffs = sorted(diffs)
+
+        def count_at_least(d):
+            """length-k subsequences whose consecutive gaps are all >= d."""
+            # f[j][i] = ways of length j ending exactly at index i
+            f = [[0] * n for _ in range(k + 1)]
+            for i in range(n):
+                f[1][i] = 1
+            for j in range(2, k + 1):
+                pre = [0] * (n + 1)             # prefix sums of f[j-1]
+                for i in range(n):
+                    pre[i + 1] = (pre[i] + f[j - 1][i]) % MOD
+                t = 0                           # first index with nums[i]-nums[t] < d
+                for i in range(n):
+                    while t < i and nums[i] - nums[t] >= d:
+                        t += 1
+                    f[j][i] = pre[t] % MOD      # indices 0..t-1 are far enough
+            return sum(f[k]) % MOD
+
+        res = 0
+        for t in range(1, len(diffs)):
+            gap = (diffs[t] - diffs[t - 1]) % MOD
+            res = (res + gap * count_at_least(diffs[t])) % MOD
+        return res

--- a/leetcode_python/Dynamic_Programming/find-the-sum-of-the-power-of-all-subsequences.py
+++ b/leetcode_python/Dynamic_Programming/find-the-sum-of-the-power-of-all-subsequences.py
@@ -1,0 +1,88 @@
+"""
+
+3082. Find the Sum of the Power of All Subsequences
+Hard
+
+You are given an integer array nums of length n and a positive integer k.
+
+The power of an array of integers is defined as the number of subsequences with their sum equal to k.
+
+Return the sum of power of all subsequences of nums.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [1,2,3], k = 3
+Output: 6
+Explanation:
+There are 5 subsequences of nums with non-zero power:
+The subsequence [1,2,3] has 2 subsequences with sum == 3: [1,2,3] and [1,2,3].
+The subsequence [1,2,3] has 1 subsequence with sum == 3: [1,2,3].
+The subsequence [1,2,3] has 1 subsequence with sum == 3: [1,2,3].
+The subsequence [1,2,3] has 1 subsequence with sum == 3: [1,2,3].
+The subsequence [1,2,3] has 1 subsequence with sum == 3: [1,2,3].
+Hence the answer is 2 + 1 + 1 + 1 + 1 = 6.
+
+Example 2:
+
+Input: nums = [2,3,3], k = 5
+Output: 4
+Explanation:
+There are 3 subsequences of nums with non-zero power:
+The subsequence [2,3,3] has 2 subsequences with sum == 5: [2,3,3] and [2,3,3].
+The subsequence [2,3,3] has 1 subsequence with sum == 5: [2,3,3].
+The subsequence [2,3,3] has 1 subsequence with sum == 5: [2,3,3].
+Hence the answer is 2 + 1 + 1 = 4.
+
+Example 3:
+
+Input: nums = [1,2,3], k = 7
+Output: 0
+Explanation: There exists no subsequence with sum 7. Hence all subsequences of nums have power = 0.
+
+
+Constraints:
+
+1 <= n <= 100
+1 <= nums[i] <= 10^4
+1 <= k <= 100
+
+"""
+
+# V0
+# IDEA : COUNT *PAIRS* (SUBSEQUENCE S, SUB-SUBSEQUENCE T OF S WITH SUM k)
+#
+#   the quantity asked for is a double sum — over subsequences S, of the
+#   number of subsequences of S summing to k. rather than enumerate S, count
+#   the PAIRS (S, T) directly, since each pair is worth exactly 1.
+#
+#   for each element there are three mutually exclusive roles :
+#       not in S            -> the running sum is unchanged
+#       in S but not in T   -> the running sum is unchanged
+#       in S and in T       -> the running sum grows by nums[i]
+#
+#   so with dp[j] = number of partial pairs whose T-sum is j,
+#
+#       dp_new[j] = 2 * dp[j] + dp[j - nums[i]]
+#
+#   the factor 2 is the two ways to leave the running sum alone. sweeping j
+#   downwards makes the update in-place safe, and dp[k] at the end is the
+#   answer.
+#
+#   NOTE : elements above k can never join T, but they still double the
+#          count — the recurrence handles that on its own.
+#
+# time = O(n * k), space = O(k)
+class Solution(object):
+    def sumOfPower(self, nums, k):
+        MOD = 10 ** 9 + 7
+        dp = [0] * (k + 1)
+        dp[0] = 1
+        for x in nums:
+            for j in range(k, -1, -1):
+                dp[j] = dp[j] * 2 % MOD
+                if j >= x:
+                    dp[j] = (dp[j] + dp[j - x]) % MOD
+        return dp[k]

--- a/leetcode_python/Dynamic_Programming/maximum-strength-of-k-disjoint-subarrays.py
+++ b/leetcode_python/Dynamic_Programming/maximum-strength-of-k-disjoint-subarrays.py
@@ -1,0 +1,88 @@
+"""
+
+3077. Maximum Strength of K Disjoint Subarrays
+Hard
+
+You are given a 0-indexed array of integers nums of length n, and a positive odd integer k.
+
+The strength of x subarrays is defined as strength = sum[1] * x - sum[2] * (x - 1) + sum[3] * (x - 2) - sum[4] * (x - 3) + ... + sum[x] * 1 where sum[i] is the sum of the elements in the ith subarray. Formally, strength is sum of (-1)^(i+1) * sum[i] * (x - i + 1) over all i's such that 1 <= i <= x.
+
+You need to select k disjoint subarrays from nums, such that their strength is maximum.
+
+Return the maximum possible strength that can be obtained.
+
+Note that the selected subarrays don't need to cover the entire array.
+
+
+Example 1:
+
+Input: nums = [1,2,3,-1,2], k = 3
+Output: 22
+Explanation: The best possible way to select 3 subarrays is: nums[0..2], nums[3..3], and nums[4..4]. The strength is (1 + 2 + 3) * 3 - (-1) * 2 + 2 * 1 = 22.
+
+Example 2:
+
+Input: nums = [12,-2,-2,-2,-2], k = 5
+Output: 64
+Explanation: The only possible way to select 5 disjoint subarrays is: nums[0..0], nums[1..1], nums[2..2], nums[3..3], and nums[4..4]. The strength is 12 * 5 - (-2) * 4 + (-2) * 3 - (-2) * 2 + (-2) * 1 = 64.
+
+Example 3:
+
+Input: nums = [-1,-2,-3], k = 1
+Output: -1
+Explanation: The best possible way to select 1 subarray is: nums[0..0]. The strength is -1.
+
+
+Constraints:
+
+1 <= n <= 10^4
+-10^9 <= nums[i] <= 10^9
+1 <= k <= n
+1 <= n * k <= 10^6
+k is odd.
+
+"""
+
+# V0
+# IDEA : DP OVER (SUBARRAYS USED, PREFIX LENGTH), WITH A "STILL OPEN" STATE
+#
+#   the coefficient of the j-th chosen subarray is fixed in advance :
+#       coef[j] = (k - j + 1) with a + sign for odd j and - for even j
+#   so once we know a subarray is the j-th, every element inside it is worth
+#   coef[j] and nothing else about it matters.
+#
+#   two rolling arrays over the prefix length i :
+#       open[i] = best total where the j-th subarray is still OPEN at i
+#                 (it must include nums[i-1])
+#       done[i] = best total where at most j subarrays are finished by i
+#
+#   open[i] = max(open[i-1], done_prev[i-1]) + coef * nums[i-1]
+#             (extend the current one, or start it right here)
+#   done[i] = max(done[i-1], open[i])
+#
+#   `done_prev` is the previous j's table, so the new subarray always starts
+#   after the previous one ended — disjointness for free.
+#
+#   states before j elements have been seen are impossible, hence the -inf
+#   padding.
+#
+# time = O(n * k), space = O(n)
+class Solution(object):
+    def maximumStrength(self, nums, k):
+        n = len(nums)
+        NEG = float('-inf')
+
+        done_prev = [0] * (n + 1)              # j = 0 : nothing chosen yet
+        for j in range(1, k + 1):
+            coef = (k - j + 1) * (1 if j % 2 else -1)
+            open_cur = [NEG] * (n + 1)
+            done_cur = [NEG] * (n + 1)
+            for i in range(1, n + 1):
+                best_start = done_prev[i - 1]
+                extend = open_cur[i - 1]
+                base = max(best_start, extend)
+                open_cur[i] = NEG if base == NEG else base + coef * nums[i - 1]
+                done_cur[i] = max(done_cur[i - 1], open_cur[i])
+            done_prev = done_cur
+
+        return done_prev[n]

--- a/leetcode_python/Dynamic_Programming/minimum-sum-of-values-by-dividing-array.py
+++ b/leetcode_python/Dynamic_Programming/minimum-sum-of-values-by-dividing-array.py
@@ -1,0 +1,103 @@
+"""
+
+3117. Minimum Sum of Values by Dividing Array
+Hard
+
+You are given two arrays nums and andValues of length n and m respectively.
+
+The value of an array is equal to the last element of that array.
+
+You have to divide nums into m disjoint contiguous subarrays such that for the ith subarray [li, ri], the bitwise AND of the subarray elements is equal to andValues[i], in other words, nums[li] & nums[li + 1] & ... & nums[ri] == andValues[i] for all 1 <= i <= m, where & represents the bitwise AND operator.
+
+Return the minimum possible sum of the values of the m subarrays nums is divided into. If it is not possible to divide nums into m subarrays satisfying these conditions, return -1.
+
+
+Example 1:
+
+Input: nums = [1,4,3,3,2], andValues = [0,3,3,2]
+Output: 12
+Explanation:
+The only possible way to divide nums is:
+[1,4] as 1 & 4 == 0.
+[3] as the bitwise AND of a single element subarray is that element itself.
+[3] as the bitwise AND of a single element subarray is that element itself.
+[2] as the bitwise AND of a single element subarray is that element itself.
+The sum of the values for these subarrays is 4 + 3 + 3 + 2 = 12.
+
+Example 2:
+
+Input: nums = [2,3,5,7,7,7,5], andValues = [0,7,5]
+Output: 17
+Explanation:
+There are three ways to divide nums:
+[[2,3,5],[7,7,7],[5]] with the sum of the values 5 + 7 + 5 == 17.
+[[2,3,5,7],[7,7],[5]] with the sum of the values 7 + 7 + 5 == 19.
+[[2,3,5,7,7],[7],[5]] with the sum of the values 7 + 7 + 5 == 19.
+The minimum possible sum of the values is 17.
+
+Example 3:
+
+Input: nums = [1,2,3,4], andValues = [2]
+Output: -1
+Explanation:
+The bitwise AND of the entire array nums is 0. As there is no possible way to divide nums into a single subarray to have the bitwise AND of elements 2, return -1.
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^4
+1 <= m == andValues.length <= 10
+1 <= nums[i] < 10^5
+0 <= andValues[j] < 10^5
+
+"""
+
+# V0
+# IDEA : DP BY SEGMENT INDEX, CARRYING THE FEW DISTINCT SUFFIX-AND VALUES
+#
+#   dp[j][i] = min total value after splitting the first i elements into j
+#   subarrays. the naive transition tries every start of the j-th subarray,
+#   which is O(n^2 * m).
+#
+#   the saving trick : as the start of a subarray ending at i moves left, the
+#   running AND only loses bits, so it takes at most ~17 DISTINCT values.
+#   keep them as a dict
+#
+#       cur[a] = best dp[j-1][start] over all starts whose AND from start to
+#                i equals a
+#
+#   extending i to i+1 maps every key a to a & nums[i], merging collisions by
+#   the smaller dp value, plus the fresh single-element start.
+#
+#   whenever the wanted andValues[j-1] is a key, the segment may close here
+#   at a cost of nums[i] (the value of a subarray is its LAST element).
+#
+# time = O(n * m * 17), space = O(n)
+class Solution(object):
+    def minimumValueSum(self, nums, andValues):
+        n, m = len(nums), len(andValues)
+        INF = float('inf')
+
+        prev = [INF] * (n + 1)          # dp[0][i] : 0 elements used
+        prev[0] = 0
+
+        for j in range(1, m + 1):
+            target = andValues[j - 1]
+            cur_dp = [INF] * (n + 1)
+            states = {}                 # running AND -> best dp[j-1][start]
+            for i in range(n):
+                nxt = {}
+                for a, best in states.items():
+                    v = a & nums[i]
+                    if v not in nxt or best < nxt[v]:
+                        nxt[v] = best
+                if prev[i] < INF:       # a new subarray may start at i
+                    v = nums[i]
+                    if v not in nxt or prev[i] < nxt[v]:
+                        nxt[v] = prev[i]
+                states = nxt
+                if target in states and states[target] < INF:
+                    cur_dp[i + 1] = states[target] + nums[i]
+            prev = cur_dp
+
+        return -1 if prev[n] == INF else prev[n]

--- a/leetcode_python/Geometry/minimize-manhattan-distances.py
+++ b/leetcode_python/Geometry/minimize-manhattan-distances.py
@@ -1,0 +1,69 @@
+"""
+
+3102. Minimize Manhattan Distances
+Hard
+
+You are given an array points representing integer coordinates of some points on a 2D plane, where points[i] = [xi, yi].
+
+The distance between two points is defined as their Manhattan distance.
+
+Return the minimum possible value for maximum distance between any two points by removing exactly one point.
+
+
+Example 1:
+
+Input: points = [[3,10],[5,15],[10,2],[4,4]]
+Output: 12
+Explanation:
+The maximum distance after removing each point is the following:
+After removing the 0th point the maximum distance is between points (5, 15) and (10, 2), which is |5 - 10| + |15 - 2| = 18.
+After removing the 1st point the maximum distance is between points (3, 10) and (10, 2), which is |3 - 10| + |10 - 2| = 15.
+After removing the 2nd point the maximum distance is between points (5, 15) and (4, 4), which is |5 - 4| + |15 - 4| = 12.
+After removing the 3rd point the maximum distance is between points (5, 15) and (10, 2), which is |5 - 10| + |15 - 2| = 18.
+12 is the minimum possible maximum distance between any two points after removing exactly one point.
+
+Example 2:
+
+Input: points = [[1,1],[1,1],[1,1]]
+Output: 0
+Explanation:
+Removing any of the points results in the maximum distance between any two points of 0.
+
+
+Constraints:
+
+3 <= points.length <= 10^5
+points[i].length == 2
+1 <= points[i][0], points[i][1] <= 10^8
+
+"""
+
+# V0
+# IDEA : ROTATE TO CHEBYSHEV — MANHATTAN MAX BECOMES TWO INDEPENDENT SPREADS
+#
+#   with u = x + y and v = x - y,
+#       |x1-x2| + |y1-y2| = max(|u1-u2|, |v1-v2|)
+#   so the largest pairwise Manhattan distance in a set is simply
+#       max(spread of u, spread of v)
+#   where spread = max - min. no pair enumeration needed.
+#
+#   removing one point can only change a spread if that point is the current
+#   extreme, so keeping the TWO largest and TWO smallest of u and of v is
+#   enough : dropping point i falls back to the runner-up exactly when i held
+#   the record.
+#
+#   try all n removals with those precomputed extremes and take the minimum.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def minimumDistance(self, points):
+        us = sorted((x + y, i) for i, (x, y) in enumerate(points))
+        vs = sorted((x - y, i) for i, (x, y) in enumerate(points))
+
+        def spread_without(arr, i):
+            lo = arr[0][0] if arr[0][1] != i else arr[1][0]
+            hi = arr[-1][0] if arr[-1][1] != i else arr[-2][0]
+            return hi - lo
+
+        return min(max(spread_without(us, i), spread_without(vs, i))
+                   for i in range(len(points)))

--- a/leetcode_python/Graph/minimum-cost-walk-in-weighted-graph.py
+++ b/leetcode_python/Graph/minimum-cost-walk-in-weighted-graph.py
@@ -1,0 +1,95 @@
+"""
+
+3108. Minimum Cost Walk in Weighted Graph
+Hard
+
+There is an undirected weighted graph with n vertices labeled from 0 to n - 1.
+
+You are given the integer n and an array edges, where edges[i] = [ui, vi, wi] indicates that there is an edge between vertices ui and vi with a weight of wi.
+
+A walk on a graph is a sequence of vertices and edges. The walk starts and ends with a vertex, and each edge connects the vertex that comes before it and the vertex that comes after it. It's important to note that a walk may visit the same edge or vertex more than once.
+
+The cost of a walk starting at node u and ending at node v is defined as the bitwise AND of the weights of the edges traversed during the walk. In other words, if the sequence of edge weights encountered during the walk is w0, w1, w2, ..., wk, then the cost is calculated as w0 & w1 & w2 & ... & wk, where & denotes the bitwise AND operator.
+
+You are also given a 2D array query, where query[i] = [si, ti]. For each query, you need to find the minimum cost of the walk starting at vertex si and ending at vertex ti. If there exists no such walk, the answer is -1.
+
+Return the array answer, where answer[i] denotes the minimum cost of a walk for query i.
+
+
+Example 1:
+
+Input: n = 5, edges = [[0,1,7],[1,3,7],[1,2,1]], query = [[0,3],[3,4]]
+Output: [1,-1]
+Explanation:
+To achieve the cost of 1 in the first query, we need to move on the following edges: 0->1 (weight 7), 1->2 (weight 1), 2->1 (weight 1), 1->3 (weight 7).
+In the second query, there is no walk between nodes 3 and 4, so the answer is -1.
+
+Example 2:
+
+Input: n = 3, edges = [[0,2,7],[0,1,15],[1,2,6],[1,2,1]], query = [[1,2]]
+Output: [0]
+Explanation:
+To achieve the cost of 0 in the first query, we need to move on the following edges: 1->2 (weight 1), 2->1 (weight 6).
+
+
+Constraints:
+
+2 <= n <= 10^5
+0 <= edges.length <= 10^5
+edges[i].length == 3
+0 <= ui, vi <= n - 1
+ui != vi
+0 <= wi <= 10^5
+1 <= query.length <= 10^5
+query[i].length == 2
+0 <= si, ti <= n - 1
+
+"""
+
+# V0
+# IDEA : A WALK MAY REUSE EDGES — SO IT CAN AND *EVERY* EDGE OF ITS COMPONENT
+#
+#   ANDing more weights can only clear bits, never set them, so the cheapest
+#   walk wants to traverse as many distinct edges as possible. and since a
+#   walk is free to repeat edges, it can detour down any edge of the
+#   connected component and come straight back.
+#
+#   therefore the answer for a reachable pair is exactly the AND of ALL edge
+#   weights in their component — no path finding required :
+#       union-find the components, then fold each edge's weight into its
+#       component's accumulator.
+#
+#   s == t answers 0 (an empty walk needs no edges), and different components
+#   answer -1.
+#
+# time = O((n + E + Q) * alpha), space = O(n)
+class Solution(object):
+    def minimumCost(self, n, edges, query):
+        parent = list(range(n))
+
+        def find(x):
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        for u, v, _ in edges:
+            ru, rv = find(u), find(v)
+            if ru != rv:
+                parent[ru] = rv
+
+        ALL = -1                                # identity for AND (all bits set)
+        acc = [ALL] * n
+        for u, _, w in edges:
+            r = find(u)
+            acc[r] &= w
+
+        res = []
+        for s, t in query:
+            if s == t:
+                res.append(0)
+            elif find(s) != find(t):
+                res.append(-1)
+            else:
+                res.append(acc[find(s)])
+        return res

--- a/leetcode_python/Greedy/apple-redistribution-into-boxes.py
+++ b/leetcode_python/Greedy/apple-redistribution-into-boxes.py
@@ -1,0 +1,58 @@
+"""
+
+3074. Apple Redistribution into Boxes
+Easy
+
+You are given an array apple of size n and an array capacity of size m.
+
+There are n packs where the ith pack contains apple[i] apples. There are m boxes as well, and the ith box has a capacity of capacity[i] apples.
+
+Return the minimum number of boxes you need to select to redistribute these n packs of apples into boxes.
+
+Note that, apples from the same pack can be distributed into different boxes.
+
+
+Example 1:
+
+Input: apple = [1,3,2], capacity = [4,3,1,5,2]
+Output: 2
+Explanation: We will use boxes with capacities 4 and 5.
+It is possible to distribute the apples as the total capacity is greater than or equal to the total number of apples.
+
+Example 2:
+
+Input: apple = [5,5,5], capacity = [2,4,2,7]
+Output: 4
+Explanation: We will need to use all the boxes.
+
+
+Constraints:
+
+1 <= n == apple.length <= 50
+1 <= m == capacity.length <= 50
+1 <= apple[i], capacity[i] <= 50
+The input is generated such that it's possible to redistribute packs of apples into boxes.
+
+"""
+
+# V0
+# IDEA : PACKS CAN BE SPLIT, SO ONLY THE TOTALS MATTER — TAKE THE BIGGEST BOXES
+#
+#   because apples from one pack may be spread across boxes, there is no
+#   packing constraint at all : any set of boxes whose capacities sum to at
+#   least the total number of apples works.
+#
+#   so sort the capacities descending and keep taking until the running total
+#   covers the apples — the fewest boxes possible.
+#
+# time = O(m log m), space = O(m)
+class Solution(object):
+    def minimumBoxes(self, apple, capacity):
+        need = sum(apple)
+        res = 0
+        for c in sorted(capacity, reverse=True):
+            if need <= 0:
+                break
+            need -= c
+            res += 1
+        return res

--- a/leetcode_python/Greedy/latest-time-you-can-obtain-after-replacing-characters.py
+++ b/leetcode_python/Greedy/latest-time-you-can-obtain-after-replacing-characters.py
@@ -1,0 +1,56 @@
+"""
+
+3114. Latest Time You Can Obtain After Replacing Characters
+Easy
+
+You are given a string s representing a 12-hour format time where some of the digits (possibly none) are replaced with a "?".
+
+12-hour times are formatted as "HH:MM", where HH is between 00 and 11, and MM is between 00 and 59. The earliest 12-hour time is 00:00, and the latest is 11:59.
+
+You have to replace all the "?" characters in s with digits such that the time we obtain by the resulting string is a valid 12-hour format time and is the latest possible.
+
+Return the resulting string.
+
+
+Example 1:
+
+Input: s = "1?:?4"
+Output: "11:54"
+Explanation: The latest 12-hour format time we can achieve by replacing "?" characters is "11:54".
+
+Example 2:
+
+Input: s = "0?:5?"
+Output: "09:59"
+Explanation: The latest 12-hour format time we can achieve by replacing "?" characters is "09:59".
+
+
+Constraints:
+
+s.length == 5
+s[2] is equal to the character ":".
+All characters except s[2] are digits or "?" characters.
+The input is generated such that there is at least one time between "00:00" and "11:59" that you can obtain after replacing the "?" characters.
+
+"""
+
+# V0
+# IDEA : ONLY 720 VALID TIMES EXIST — TRY THEM FROM THE LATEST DOWN
+#
+#   hours run 00..11 and minutes 00..59, so the whole search space is 720
+#   strings. walking them from "11:59" backwards and returning the first one
+#   compatible with the mask is trivially correct, with no per-digit case
+#   analysis to get wrong (the tens and units digits of the hour interact,
+#   which is where hand-rolled greedy versions usually slip).
+#
+#   compatible means : every non-'?' character of s matches.
+#
+# time = O(1)  (720 candidates x 5 characters), space = O(1)
+class Solution(object):
+    def findLatestTime(self, s):
+        for h in range(11, -1, -1):
+            for m in range(59, -1, -1):
+                cand = "%02d:%02d" % (h, m)
+                if all(a == '?' or a == b for a, b in zip(s, cand)):
+                    return cand
+        return ""

--- a/leetcode_python/Greedy/lexicographically-smallest-string-after-operations-with-constraint.py
+++ b/leetcode_python/Greedy/lexicographically-smallest-string-after-operations-with-constraint.py
@@ -1,0 +1,81 @@
+"""
+
+3106. Lexicographically Smallest String After Operations With Constraint
+Medium
+
+You are given a string s and an integer k.
+
+Define a function distance(s1, s2) between two strings s1 and s2 of the same length n as:
+
+The sum of the minimum distance between s1[i] and s2[i] when the characters from 'a' to 'z' are placed in a cyclic order, for all i in the range [0, n - 1].
+
+For example, distance("ab", "cd") == 4, and distance("a", "z") == 1.
+
+You can change any letter of s to any other lowercase English letter, any number of times.
+
+Return a string denoting the lexicographically smallest string t you can get after some changes, such that distance(s, t) <= k.
+
+
+Example 1:
+
+Input: s = "zbbz", k = 3
+Output: "aaaz"
+Explanation:
+Change s to "aaaz". The distance between "zbbz" and "aaaz" is equal to k = 3.
+
+Example 2:
+
+Input: s = "xaxcd", k = 4
+Output: "aawcd"
+Explanation:
+The distance between "xaxcd" and "aawcd" is equal to k = 4.
+
+Example 3:
+
+Input: s = "lol", k = 0
+Output: "lol"
+Explanation:
+It's impossible to change any character as k = 0.
+
+
+Constraints:
+
+1 <= s.length <= 100
+0 <= k <= 2000
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : GREEDY LEFT TO RIGHT — SPEND THE BUDGET ON THE EARLIEST POSITIONS
+#
+#   an earlier position outranks every later one lexicographically, so at
+#   each index push the letter as low as the remaining budget allows, then
+#   move on with what is left. no lookahead can beat that.
+#
+#   the cyclic distance between two letters is
+#       d = |a - b|,  then  min(d, 26 - d)
+#   so reaching 'a' from c costs min(c, 26 - c).
+#
+#   if 'a' is affordable, take it; otherwise walk up from 'a' and take the
+#   first letter within budget — and if even the original letter's own cost
+#   (0) is all we can afford, the letter simply stays.
+#
+# time = O(26 * n), space = O(n)
+class Solution(object):
+    def getSmallestString(self, s, k):
+
+        def dist(a, b):
+            d = abs(a - b)
+            return min(d, 26 - d)
+
+        out = []
+        for ch in s:
+            c = ord(ch) - 97
+            for target in range(26):
+                cost = dist(c, target)
+                if cost <= k:
+                    out.append(chr(97 + target))
+                    k -= cost
+                    break
+        return ''.join(out)

--- a/leetcode_python/Greedy/make-string-anti-palindrome.py
+++ b/leetcode_python/Greedy/make-string-anti-palindrome.py
@@ -1,0 +1,90 @@
+"""
+
+3088. Make String Anti-palindrome
+Hard
+🔒 (premium)
+
+We call a string s of even length n an anti-palindrome if for each index 0 <= i < n, s[i] != s[n - i - 1].
+
+Given a string s, your task is to make s an anti-palindrome by doing any number of operations (including zero).
+
+In one operation, you can select two characters from s and swap them.
+
+Return the resulting string. If multiple strings meet the conditions, return the lexicographically smallest one. If it can't be made into an anti-palindrome, return "-1".
+
+
+Example 1:
+
+Input: s = "abca"
+Output: "aabc"
+Explanation: "aabc" is an anti-palindrome string since s[0] != s[3] and s[1] != s[2]. Also, it is a rearrangement of "abca". It can be proven that it's the lexicographically smallest.
+
+Example 2:
+
+Input: s = "abba"
+Output: "aabb"
+Explanation: "aabb" is an anti-palindrome string since s[0] != s[3] and s[1] != s[2]. Also, it is a rearrangement of "abba". It can be proven that it's the lexicographically smallest.
+
+Example 3:
+
+Input: s = "cccd"
+Output: "-1"
+Explanation: It can be proven that there is no way to make "cccd" an anti-palindrome string.
+
+
+Constraints:
+
+2 <= s.length <= 10^5
+s.length % 2 == 0
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : SORT, THEN REPAIR THE MIRROR CLASHES BY TOUCHING THE *RIGHT* HALF ONLY
+#
+#   sorting gives the lexicographically smallest arrangement outright, so the
+#   only work is fixing positions where the sorted string mirrors itself.
+#
+#   feasibility first : a letter appearing more than n/2 times must collide
+#   with itself under any pairing, so that case is "-1".
+#
+#   in a sorted string, t[i] == t[n-1-i] forces everything between them to be
+#   that same letter — so all the clashes sit in one contiguous block of some
+#   letter c straddling the centre. to repair a clash at mirror position
+#   p = n-1-i, swap t[p] with the nearest position AFTER the c-block; that
+#   position holds the smallest letter greater than c still available.
+#
+#   repairing only the right half keeps the (more significant) left half
+#   untouched, and taking the nearest larger letter keeps the replacement as
+#   small as possible — both are what lexicographic minimality wants.
+#
+# time = O(n log n), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def makeAntiPalindrome(self, s):
+        n = len(s)
+        cnt = Counter(s)
+        if max(cnt.values()) > n // 2:
+            return "-1"
+
+        t = sorted(s)
+        # every clash involves the letter sitting just left of the centre
+        c = t[n // 2 - 1]
+        # the block of c, and the first index past it
+        j = n // 2
+        while j < n and t[j] == c:
+            j += 1
+
+        for p in range(n // 2, n):
+            if t[p] != t[n - 1 - p]:
+                continue
+            while j < n and t[j] == c:
+                j += 1
+            if j == n:
+                return "-1"
+            t[p], t[j] = t[j], t[p]
+            j += 1
+        return ''.join(t)

--- a/leetcode_python/Greedy/maximize-happiness-of-selected-children.py
+++ b/leetcode_python/Greedy/maximize-happiness-of-selected-children.py
@@ -1,0 +1,75 @@
+"""
+
+3075. Maximize Happiness of Selected Children
+Medium
+
+You are given an array happiness of length n, and a positive integer k.
+
+There are n children standing in a queue, where the ith child has happiness value happiness[i]. You want to select k children from these n children in k turns.
+
+In each turn, when you select a child, the happiness value of all the children that have not been selected till now decreases by 1. Note that the happiness value cannot become negative and gets decremented only if it is positive.
+
+Return the maximum sum of the happiness values of the selected children you can achieve by selecting k children.
+
+
+Example 1:
+
+Input: happiness = [1,2,3], k = 2
+Output: 4
+Explanation: We can pick 2 children in the following way:
+- Pick the child with the happiness value == 3. The happiness value of the remaining children becomes [0,1].
+- Pick the child with the happiness value == 1. The happiness value of the remaining child becomes [0]. Note that the happiness value cannot become less than 0.
+The sum of the happiness values of the selected children is 3 + 1 = 4.
+
+Example 2:
+
+Input: happiness = [1,1,1,1], k = 2
+Output: 1
+Explanation: We can pick 2 children in the following way:
+- Pick any child with the happiness value == 1. The happiness value of the remaining children becomes [0,0,0].
+- Pick the child with the happiness value == 0. The happiness value of the remaining child becomes [0,0].
+The sum of the happiness values of the selected children is 1 + 0 = 1.
+
+Example 3:
+
+Input: happiness = [2,3,4,5], k = 1
+Output: 5
+Explanation: We can pick 1 child in the following way:
+- Pick the child with the happiness value == 5. The happiness value of the remaining children becomes [1,2,3].
+The sum of the happiness values of the selected children is 5.
+
+
+Constraints:
+
+1 <= n == happiness.length <= 2 * 10^5
+1 <= happiness[i] <= 10^8
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : PICK THE HAPPIEST FIRST — THE i-TH PICK HAS ALREADY LOST i POINTS
+#
+#   the decay does not depend on WHICH children are picked, only on how many
+#   picks came before : a child selected on turn i (0-based) has been
+#   decremented exactly i times.
+#
+#   so the order is forced to be descending — giving the largest values the
+#   smallest penalties — and the total is
+#
+#       sum over i < k of max(0, sorted_desc[i] - i)
+#
+#   the max(0, ...) is the "happiness never goes negative" clause, and once
+#   one term hits 0 every later one does too.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def maximumHappinessSum(self, happiness, k):
+        vals = sorted(happiness, reverse=True)
+        res = 0
+        for i in range(k):
+            gain = vals[i] - i
+            if gain <= 0:
+                break
+            res += gain
+        return res

--- a/leetcode_python/Greedy/maximum-number-of-potholes-that-can-be-fixed.py
+++ b/leetcode_python/Greedy/maximum-number-of-potholes-that-can-be-fixed.py
@@ -1,0 +1,79 @@
+"""
+
+3119. Maximum Number of Potholes That Can Be Fixed
+Medium
+🔒 (premium)
+
+You are given a string road, consisting only of characters "x" and ".", where each "x" denotes a pothole and each "." denotes a smooth road, and an integer budget.
+
+In one repair operation, you can repair n consecutive potholes for a price of n + 1.
+
+Return the maximum number of potholes that can be fixed such that the sum of the price of all of the fixes doesn't go over the given budget.
+
+
+Example 1:
+
+Input: road = "..", budget = 5
+Output: 0
+Explanation: There are no potholes to be fixed.
+
+Example 2:
+
+Input: road = "..xxxxx", budget = 4
+Output: 3
+Explanation: We fix the first three potholes (they are consecutive). The cost of this fix is 3 + 1 = 4.
+
+Example 3:
+
+Input: road = "x.....x", budget = 14
+Output: 2
+Explanation: We can fix both potholes. The cost of fixing the two potholes is 1 + 1 + 1 + 1 = 4.
+
+
+Constraints:
+
+1 <= road.length <= 10^5
+1 <= budget <= 10^5 + 1
+road consists only of characters '.' and 'x'.
+
+"""
+
+# V0
+# IDEA : EACH REPAIR PAYS A FLAT +1 OVERHEAD — SO FIX THE LONGEST RUNS FIRST
+#
+#   repairing n consecutive potholes costs n + 1, i.e. 1 per pothole plus a
+#   fixed 1 for the operation itself. the per-pothole part is unavoidable, so
+#   the only lever is how many operations get paid for — and that is
+#   minimised by covering whole runs, longest ones first.
+#
+#   walk the runs in descending length : if the budget covers len + 1, take
+#   the whole run; otherwise the leftover pays for a PARTIAL run of
+#   (budget - 1) potholes, and nothing is left afterwards.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def maxPotholes(self, road, budget):
+        runs = []
+        cur = 0
+        for ch in road:
+            if ch == 'x':
+                cur += 1
+            elif cur:
+                runs.append(cur)
+                cur = 0
+        if cur:
+            runs.append(cur)
+
+        runs.sort(reverse=True)
+        fixed = 0
+        for length in runs:
+            if budget <= 1:
+                break
+            if length + 1 <= budget:
+                budget -= length + 1
+                fixed += length
+            else:
+                fixed += budget - 1        # partial run with what is left
+                budget = 0
+                break
+        return fixed

--- a/leetcode_python/Greedy/minimum-deletions-to-make-string-k-special.py
+++ b/leetcode_python/Greedy/minimum-deletions-to-make-string-k-special.py
@@ -1,0 +1,73 @@
+"""
+
+3085. Minimum Deletions to Make String K-Special
+Medium
+
+You are given a string word and an integer k.
+
+We consider word to be k-special if |freq(word[i]) - freq(word[j])| <= k for all indices i and j in the string.
+
+Here, freq(x) denotes the frequency of the character x in word, and |y| denotes the absolute value of y.
+
+Return the minimum number of characters you need to delete to make word k-special.
+
+
+Example 1:
+
+Input: word = "aabcaba", k = 0
+Output: 3
+Explanation: We can make word 0-special by deleting 2 occurrences of "a" and 1 occurrence of "c". Therefore, word becomes equal to "baba" where freq('a') == freq('b') == 2.
+
+Example 2:
+
+Input: word = "dabdcbdcdcd", k = 2
+Output: 2
+Explanation: We can make word 2-special by deleting 1 occurrence of "a" and 1 occurrence of "d". Therefore, word becomes equal to "bdcbdcdcd" where freq('b') == 2, freq('c') == 3, and freq('d') == 4.
+
+Example 3:
+
+Input: word = "aaabaaa", k = 2
+Output: 1
+Explanation: We can make word 2-special by deleting 1 occurrence of "b". Therefore, word becomes equal to "aaaaaa" where each letter's frequency is now uniformly 6.
+
+
+Constraints:
+
+1 <= word.length <= 10^5
+0 <= k <= 10^5
+word consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : FIX THE SURVIVING *MINIMUM* FREQUENCY AND CHARGE EVERY LETTER
+#
+#   in the final string all kept frequencies lie inside a band [b, b + k].
+#   only 26 letters exist, and the band's floor b can be taken to be one of
+#   the ORIGINAL frequencies (pushing b lower never helps), so there are at
+#   most 26 candidates to try.
+#
+#   for a candidate b, each letter with frequency f pays :
+#       f < b       -> delete all f of them (it cannot reach the band)
+#       f > b + k   -> delete f - (b + k) to bring it down to the ceiling
+#       otherwise   -> nothing
+#
+#   the answer is the cheapest candidate.
+#
+# time = O(n + 26^2), space = O(1)
+from collections import Counter
+
+
+class Solution(object):
+    def minimumDeletions(self, word, k):
+        freqs = list(Counter(word).values())
+        best = float('inf')
+        for b in freqs:
+            cost = 0
+            for f in freqs:
+                if f < b:
+                    cost += f
+                elif f > b + k:
+                    cost += f - (b + k)
+            best = min(best, cost)
+        return best

--- a/leetcode_python/Greedy/minimum-rectangles-to-cover-points.py
+++ b/leetcode_python/Greedy/minimum-rectangles-to-cover-points.py
@@ -1,0 +1,79 @@
+"""
+
+3111. Minimum Rectangles to Cover Points
+Medium
+
+You are given a 2D integer array points, where points[i] = [xi, yi]. You are also given an integer w. Your task is to cover all the given points with rectangles.
+
+Each rectangle has its lower end at some point (x1, 0) and its upper end at some point (x2, y2), where x1 <= x2, y2 >= 0, and the condition x2 - x1 <= w must be satisfied for each rectangle.
+
+A point is considered covered by a rectangle if it lies within or on the boundary of the rectangle.
+
+Return an integer denoting the minimum number of rectangles needed so that each point is covered by at least one rectangle.
+
+Note: A point may be covered by more than one rectangle.
+
+
+Example 1:
+
+Input: points = [[2,1],[1,0],[1,4],[1,8],[3,5],[4,6]], w = 1
+Output: 2
+Explanation:
+The image above shows one possible placement of rectangles to cover the points:
+A rectangle with a lower end at (1, 0) and its upper end at (2, 8)
+A rectangle with a lower end at (3, 0) and its upper end at (4, 8)
+
+Example 2:
+
+Input: points = [[0,0],[1,1],[2,2],[3,3],[4,4],[5,5],[6,6]], w = 2
+Output: 3
+Explanation:
+The image above shows one possible placement of rectangles to cover the points:
+A rectangle with a lower end at (0, 0) and its upper end at (2, 2)
+A rectangle with a lower end at (3, 0) and its upper end at (5, 5)
+A rectangle with a lower end at (6, 0) and its upper end at (6, 6)
+
+Example 3:
+
+Input: points = [[2,3],[1,2]], w = 0
+Output: 2
+Explanation:
+The image above shows one possible placement of rectangles to cover the points:
+A rectangle with a lower end at (1, 0) and its upper end at (1, 2)
+A rectangle with a lower end at (2, 0) and its upper end at (2, 3)
+
+
+Constraints:
+
+1 <= points.length <= 10^5
+points[i].length == 2
+0 <= xi == points[i][0] <= 10^9
+0 <= yi == points[i][1] <= 10^9
+0 <= w <= 10^9
+
+"""
+
+# V0
+# IDEA : y IS IRRELEVANT — IT IS A 1-D INTERVAL COVER ON THE x AXIS
+#
+#   a rectangle reaches from y = 0 up to any height, so it can always be made
+#   tall enough. the only real constraint is the width : one rectangle covers
+#   an x-interval of length at most w.
+#
+#   so sort the x-coordinates and sweep : open a rectangle at the first
+#   uncovered x, and let it absorb everything up to x + w; the next x beyond
+#   that starts a new rectangle. that greedy is optimal because the leftmost
+#   uncovered point must be covered by SOME rectangle, and starting one
+#   exactly there reaches as far right as any rectangle covering it could.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def minRectanglesToCoverPoints(self, points, w):
+        xs = sorted(p[0] for p in points)
+        res = 0
+        limit = -1                       # right edge of the open rectangle
+        for x in xs:
+            if x > limit:
+                res += 1
+                limit = x + w
+        return res

--- a/leetcode_python/Greedy/replace-question-marks-in-string-to-minimize-its-value.py
+++ b/leetcode_python/Greedy/replace-question-marks-in-string-to-minimize-its-value.py
@@ -1,0 +1,93 @@
+"""
+
+3081. Replace Question Marks in String to Minimize Its Value
+Medium
+
+You are given a string s. s[i] is either a lowercase English letter or '?'.
+
+For a string t having length m containing only lowercase English letters, we define the function cost(i) for an index i as the number of characters equal to t[i] that appeared before it, i.e. in the range [0, i - 1].
+
+The value of t is the sum of cost(i) for all indices i.
+
+For example, for the string t = "aab":
+
+cost(0) = 0
+cost(1) = 1
+cost(2) = 0
+Hence, the value of "aab" is 0 + 1 + 0 = 1.
+
+Your task is to replace all occurrences of '?' in s with any lowercase English letter so that the value of s is minimized.
+
+Return a string denoting the modified string with replaced occurrences of '?'. If there are multiple strings resulting in the minimum value, return the lexicographically smallest one.
+
+
+Example 1:
+
+Input: s = "???"
+Output: "abc"
+Explanation: In this example, we can replace the occurrences of '?' to make s equal to "abc".
+For "abc", cost(0) = 0, cost(1) = 0, and cost(2) = 0.
+The value of "abc" is 0.
+Some other modifications of s that have a value of 0 are "cba", "abz", and, "hey".
+Among all of them, we choose the lexicographically smallest.
+
+Example 2:
+
+Input: s = "a?a?"
+Output: "abac"
+Explanation: In this example, the occurrences of '?' can be replaced to make s equal to "abac".
+For "abac", cost(0) = 0, cost(1) = 0, cost(2) = 1, and cost(3) = 0.
+The value of "abac" is 1.
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s[i] is either a lowercase English letter or '?'.
+
+"""
+
+# V0
+# IDEA : THE VALUE ONLY DEPENDS ON THE MULTISET; THE ORDER ONLY ON TIE-BREAKING
+#
+#   a letter appearing f times contributes 0 + 1 + ... + (f-1) to the value
+#   no matter WHERE its copies sit. so minimising the value is purely about
+#   which letters to hand to the '?'s : each new copy of a letter currently
+#   at count c costs c, so always spend on the rarest letter — a min-heap
+#   keyed by (count, letter).
+#
+#   that fixes the multiset of replacements but not their placement, and
+#   placement is exactly what the lexicographic tie-break controls. since any
+#   arrangement of the SAME multiset has the same value, sort the chosen
+#   letters ascending and drop them into the '?' slots left to right.
+#
+# time = O(n log 26), space = O(n)
+import heapq
+
+
+class Solution(object):
+    def minimizeStringValue(self, s):
+        count = [0] * 26
+        for ch in s:
+            if ch != '?':
+                count[ord(ch) - 97] += 1
+
+        heap = [(count[i], i) for i in range(26)]
+        heapq.heapify(heap)
+
+        chosen = []
+        for _ in range(s.count('?')):
+            c, i = heapq.heappop(heap)
+            chosen.append(chr(97 + i))
+            heapq.heappush(heap, (c + 1, i))
+
+        chosen.sort()
+        out = []
+        t = 0
+        for ch in s:
+            if ch == '?':
+                out.append(chosen[t])
+                t += 1
+            else:
+                out.append(ch)
+        return ''.join(out)

--- a/leetcode_python/Heap/mark-elements-on-array-by-performing-queries.py
+++ b/leetcode_python/Heap/mark-elements-on-array-by-performing-queries.py
@@ -1,0 +1,86 @@
+"""
+
+3080. Mark Elements on Array by Performing Queries
+Medium
+
+You are given a 0-indexed array nums of size n consisting of positive integers.
+
+You are also given a 2D array queries of size m where queries[i] = [index_i, k_i].
+
+Initially all elements of the array are unmarked.
+
+You need to apply m queries on the array in order, where on the ith query you do the following:
+
+Mark the element at index index_i if it is not already marked.
+Then mark k_i unmarked elements in the array with the smallest values. If multiple such elements exist, mark the ones with the smallest indices. And if less than k_i unmarked elements exist, then mark all of them.
+
+Return an array answer of size m where answer[i] is the sum of unmarked elements in the array after the ith query.
+
+
+Example 1:
+
+Input: nums = [1,2,2,1,2,3,1], queries = [[1,2],[3,3],[4,2]]
+Output: [8,3,0]
+Explanation: We do the following queries on the array:
+Mark the element at index 1, and 2 of the smallest unmarked elements with the smallest indices if they exist, the marked elements now are nums = [1,2,2,1,2,3,1]. The sum of unmarked elements is 2 + 2 + 3 + 1 = 8.
+Mark the element at index 3, since it is already marked we skip it. Then we mark 3 of the smallest unmarked elements with the smallest indices, the marked elements now are nums = [1,2,2,1,2,3,1]. The sum of unmarked elements is 3.
+Mark the element at index 4, since it is already marked we skip it. Then we mark 2 of the smallest unmarked elements with the smallest indices if they exist, the marked elements now are nums = [1,2,2,1,2,3,1]. The sum of unmarked elements is 0.
+
+Example 2:
+
+Input: nums = [1,4,2,3], queries = [[0,1]]
+Output: [7]
+Explanation: We do one query which is mark the element at index 0 and mark the smallest element among unmarked elements. The marked elements will be nums = [1,4,2,3], and the sum of unmarked elements is 4 + 3 = 7.
+
+
+Constraints:
+
+n == nums.length
+m == queries.length
+1 <= m <= n <= 10^5
+1 <= nums[i] <= 10^5
+queries[i].length == 2
+0 <= index_i, k_i <= n - 1
+
+"""
+
+# V0
+# IDEA : MIN-HEAP BY (VALUE, INDEX) + LAZY SKIPPING OF ALREADY-MARKED ENTRIES
+#
+#   "smallest value, then smallest index" is exactly the tuple order of
+#   (value, index), so one heap built over all elements serves every query.
+#
+#   an element can also be marked directly by index, which would leave a
+#   stale entry in the heap — so instead of removing it, keep a `marked`
+#   flag array and pop-and-discard stale tops when they surface.
+#
+#   a running `total` of the unmarked sum turns each answer into an O(1)
+#   read : subtract a value the moment its element is marked, wherever the
+#   marking came from.
+#
+# time = O((n + sum of k) log n), space = O(n)
+import heapq
+
+
+class Solution(object):
+    def unmarkedSumArray(self, nums, queries):
+        n = len(nums)
+        heap = [(v, i) for i, v in enumerate(nums)]
+        heapq.heapify(heap)
+        marked = [False] * n
+        total = sum(nums)
+
+        res = []
+        for idx, k in queries:
+            if not marked[idx]:
+                marked[idx] = True
+                total -= nums[idx]
+            while k > 0 and heap:
+                v, i = heapq.heappop(heap)
+                if marked[i]:
+                    continue                 # stale entry, already handled
+                marked[i] = True
+                total -= v
+                k -= 1
+            res.append(total)
+        return res

--- a/leetcode_python/Heap/minimum-operations-to-exceed-threshold-value-ii.py
+++ b/leetcode_python/Heap/minimum-operations-to-exceed-threshold-value-ii.py
@@ -1,0 +1,75 @@
+"""
+
+3066. Minimum Operations to Exceed Threshold Value II
+Medium
+
+You are given a 0-indexed integer array nums, and an integer k.
+
+In one operation, you will:
+
+Take the two smallest integers x and y in nums.
+Remove x and y from nums.
+Add min(x, y) * 2 + max(x, y) anywhere in the array.
+
+Note that you can only apply the described operation if nums contains at least two elements.
+
+Return the minimum number of operations needed so that all elements of the array are greater than or equal to k.
+
+
+Example 1:
+
+Input: nums = [2,11,10,1,3], k = 10
+Output: 2
+Explanation: In the first operation, we remove elements 1 and 2, then add 1 * 2 + 2 to nums. nums becomes equal to [4, 11, 10, 3].
+In the second operation, we remove elements 3 and 4, then add 3 * 2 + 4 to nums. nums becomes equal to [10, 11, 10].
+At this stage, all the elements of nums are greater than or equal to 10 so we can stop.
+It can be shown that 2 is the minimum number of operations needed so that all elements of the array are greater than or equal to 10.
+
+Example 2:
+
+Input: nums = [1,1,2,4,9], k = 20
+Output: 4
+Explanation: After one operation, nums becomes equal to [2, 4, 9, 3].
+After two operations, nums becomes equal to [7, 4, 9].
+After three operations, nums becomes equal to [15, 9].
+After four operations, nums becomes equal to [33].
+At this stage, all the elements of nums are greater than or equal to 20 so we can stop.
+It can be shown that 4 is the minimum number of operations needed so that all elements of the array are greater than or equal to 20.
+
+
+Constraints:
+
+2 <= nums.length <= 2 * 10^5
+1 <= nums[i] <= 10^9
+1 <= k <= 10^9
+The input is generated such that an answer always exists.
+
+"""
+
+# V0
+# IDEA : MIN-HEAP — THE OPERATION IS FORCED, SO JUST SIMULATE IT
+#
+#   there is no choice to make : the two smallest elements are always the
+#   ones consumed, and the replacement 2*min + max is strictly larger than
+#   both, so the array's minimum only ever rises.
+#
+#   that means the stopping test is simply "is the smallest element >= k",
+#   which a min-heap answers in O(1) and updates in O(log n).
+#
+#   heapify first (O(n)) rather than pushing one by one.
+#
+# time = O(n log n), space = O(n)
+import heapq
+
+
+class Solution(object):
+    def minOperations(self, nums, k):
+        heap = list(nums)
+        heapq.heapify(heap)
+        res = 0
+        while heap[0] < k:
+            x = heapq.heappop(heap)
+            y = heapq.heappop(heap)
+            heapq.heappush(heap, x * 2 + y)     # x is the smaller of the two
+            res += 1
+        return res

--- a/leetcode_python/Linked_list/linked-list-frequency.py
+++ b/leetcode_python/Linked_list/linked-list-frequency.py
@@ -1,0 +1,69 @@
+"""
+
+3063. Linked List Frequency
+Medium
+🔒 (premium)
+
+Given the head of a linked list containing k distinct elements, return the head to a linked list of length k containing the frequency of each distinct element in the given linked list in any order.
+
+
+Example 1:
+
+Input: head = [1,1,2,1,2,3]
+Output: [3,2,1]
+Explanation: There are 3 distinct elements in the list. The frequency of 1 is 3, the frequency of 2 is 2 and the frequency of 3 is 1. Hence, we return 3 -> 2 -> 1.
+Note that 1 -> 2 -> 3, 2 -> 1 -> 3, 3 -> 2 -> 1, and 3 -> 1 -> 2 are also valid answers.
+
+Example 2:
+
+Input: head = [1,1,2,2,2]
+Output: [2,3]
+Explanation: There are 2 distinct elements in the list. The frequency of 1 is 2 and the frequency of 2 is 3. Hence, we return 2 -> 3.
+
+Example 3:
+
+Input: head = [6,5,4,3,2,1]
+Output: [1,1,1,1,1,1]
+Explanation: There are 6 distinct elements in the list. The frequency of each of them is 1. Hence, we return 1 -> 1 -> 1 -> 1 -> 1 -> 1.
+
+
+Constraints:
+
+The number of nodes in the list is in the range [1, 10^5].
+1 <= Node.val <= 10^5
+
+"""
+
+# V0
+# IDEA : COUNT INTO A HASH MAP, THEN REBUILD A LIST FROM THE COUNTS
+#
+#   the output order is free, so nothing has to be preserved from the input —
+#   one pass to tally the values, then one pass over the tallies building
+#   fresh nodes.
+#
+#   a dummy head keeps the append loop free of "is this the first node"
+#   special-casing.
+#
+# time = O(n), space = O(k)
+from collections import Counter
+
+
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def frequenciesOfElements(self, head):
+        cnt = Counter()
+        node = head
+        while node:
+            cnt[node.val] += 1
+            node = node.next
+
+        dummy = ListNode(0)
+        tail = dummy
+        for c in cnt.values():
+            tail.next = ListNode(c)
+            tail = tail.next
+        return dummy.next

--- a/leetcode_python/Linked_list/winner-of-the-linked-list-game.py
+++ b/leetcode_python/Linked_list/winner-of-the-linked-list-game.py
@@ -1,0 +1,93 @@
+"""
+
+3062. Winner of the Linked List Game
+Easy
+🔒 (premium)
+
+You are given the head of a linked list of even length containing integers.
+
+Each odd-indexed node contains an odd integer and each even-indexed node contains an even integer.
+
+We call each even-indexed node and its next node a pair, e.g., the nodes with indices 0 and 1 are a pair, the nodes with indices 2 and 3 are a pair, and so on.
+
+For every pair, we compare the values of the nodes in the pair:
+
+If the odd-indexed node is higher, the "Odd" team gets a point.
+If the even-indexed node is higher, the "Even" team gets a point.
+
+Return the name of the team with the higher points, if the points are equal, return "Tie".
+
+
+Example 1:
+
+Input: head = [2,1]
+Output: "Even"
+Explanation: There is only one pair in this linked list and that is (2,1). Since 2 > 1, the Even team gets the point.
+Hence, the answer would be "Even".
+
+Example 2:
+
+Input: head = [2,5,4,7,20,5]
+Output: "Odd"
+Explanation: There are 3 pairs in this linked list. Let's investigate each pair individually:
+(2,5) -> Since 2 < 5, The Odd team gets the point.
+(4,7) -> Since 4 < 7, The Odd team gets the point.
+(20,5) -> Since 20 > 5, The Even team gets the point.
+The Odd team earned 2 points while the Even team got 1 point and the Odd team has the higher points.
+Hence, the answer would be "Odd".
+
+Example 3:
+
+Input: head = [4,5,2,1]
+Output: "Tie"
+Explanation: There are 2 pairs in this linked list. Let's investigate each pair individually:
+(4,5) -> Since 4 < 5, the Odd team gets the point.
+(2,1) -> Since 2 > 1, the Even team gets the point.
+Both teams have equal points.
+Hence, the answer would be "Tie".
+
+
+Constraints:
+
+The number of nodes in the list is in the range [2, 100].
+The number of nodes in the list is even.
+1 <= Node.val <= 100
+The value of each odd-indexed node is odd.
+The value of each even-indexed node is even.
+
+"""
+
+# V0
+# IDEA : WALK TWO NODES AT A TIME AND KEEP A RUNNING SCORE DIFFERENCE
+#
+#   the list length is guaranteed even, so every step consumes a complete
+#   pair (even node, odd node) — no leftover to guard against.
+#
+#   one signed counter is enough : +1 when the even member wins, -1 when the
+#   odd one does. the sign at the end names the winner, 0 means a tie.
+#
+#   NOTE : the values can never be equal — one is even and the other odd —
+#          so a pair always awards a point.
+#
+# time = O(n), space = O(1)
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def gameResult(self, head):
+        diff = 0
+        node = head
+        while node and node.next:
+            if node.val > node.next.val:
+                diff += 1
+            else:
+                diff -= 1
+            node = node.next.next
+
+        if diff > 0:
+            return "Even"
+        if diff < 0:
+            return "Odd"
+        return "Tie"

--- a/leetcode_python/Math/count-substrings-starting-and-ending-with-given-character.py
+++ b/leetcode_python/Math/count-substrings-starting-and-ending-with-given-character.py
@@ -1,0 +1,44 @@
+"""
+
+3084. Count Substrings Starting and Ending with Given Character
+Medium
+
+You are given a string s and a character c. Return the total number of substrings of s that start and end with c.
+
+
+Example 1:
+
+Input: s = "abada", c = "a"
+Output: 6
+Explanation: Substrings starting and ending with "a" are: "abada", "abada", "abada", "abada", "abada", "abada".
+
+Example 2:
+
+Input: s = "zzz", c = "z"
+Output: 6
+Explanation: There are a total of 6 substrings in s and all start and end with "z".
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s and c consist only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : PICK AN ORDERED PAIR OF c-POSITIONS (THE SAME ONE TWICE IS ALLOWED)
+#
+#   a qualifying substring is fully determined by which occurrence of c it
+#   starts at and which it ends at, with start <= end. with m occurrences
+#   that is
+#
+#       m choose 2  +  m   =   m * (m + 1) / 2
+#
+#   the "+ m" being the single-character substrings.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def countSubstrings(self, s, c):
+        m = s.count(c)
+        return m * (m + 1) // 2

--- a/leetcode_python/Math/find-the-index-of-permutation.py
+++ b/leetcode_python/Math/find-the-index-of-permutation.py
@@ -1,0 +1,85 @@
+"""
+
+3109. Find the Index of Permutation
+Medium
+🔒 (premium)
+
+Given an array perm of length n which is a permutation of [1, 2, ..., n], return the index of perm in the lexicographically sorted array of all of the permutations of [1, 2, ..., n].
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: perm = [1,2]
+Output: 0
+Explanation:
+There are only two permutations in the following order:
+[1,2], [2,1]
+And [1,2] is at index 0.
+
+Example 2:
+
+Input: perm = [3,1,2]
+Output: 4
+Explanation:
+There are only six permutations in the following order:
+[1,2,3], [1,3,2], [2,1,3], [2,3,1], [3,1,2], [3,2,1]
+And [3,1,2] is at index 4.
+
+
+Constraints:
+
+1 <= n == perm.length <= 10^5
+perm is a permutation of [1, 2, ..., n].
+
+"""
+
+# V0
+# IDEA : FACTORIAL NUMBER SYSTEM — COUNT THE PERMUTATIONS SKIPPED AT EACH SLOT
+#
+#   fixing the first i positions, every permutation that puts a SMALLER
+#   unused value at position i comes earlier, and each such choice admits
+#   (n - i - 1)! completions. so
+#
+#       index = sum over i of  (unused values below perm[i]) * (n - i - 1)!
+#
+#   "unused values below x" is a prefix count over the values not yet
+#   consumed, which a Fenwick tree answers in O(log n) : start with every
+#   value present and remove each one as it is used.
+#
+#   the factorials are precomputed modulo 10^9 + 7.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def getPermutationIndex(self, perm):
+        MOD = 10 ** 9 + 7
+        n = len(perm)
+
+        fact = [1] * (n + 1)
+        for i in range(1, n + 1):
+            fact[i] = fact[i - 1] * i % MOD
+
+        tree = [0] * (n + 1)
+
+        def add(i, v):
+            while i <= n:
+                tree[i] += v
+                i += i & -i
+
+        def query(i):                       # how many values <= i remain
+            s = 0
+            while i > 0:
+                s += tree[i]
+                i -= i & -i
+            return s
+
+        for v in range(1, n + 1):
+            add(v, 1)
+
+        res = 0
+        for i, x in enumerate(perm):
+            smaller = query(x - 1)          # unused values below perm[i]
+            res = (res + smaller * fact[n - i - 1]) % MOD
+            add(x, -1)
+        return res

--- a/leetcode_python/Math/find-the-sum-of-encrypted-integers.py
+++ b/leetcode_python/Math/find-the-sum-of-encrypted-integers.py
@@ -1,0 +1,46 @@
+"""
+
+3079. Find the Sum of Encrypted Integers
+Easy
+
+You are given an integer array nums containing positive integers. We define a function encrypt such that encrypt(x) replaces every digit in x with the largest digit in x.
+
+For example, encrypt(523) = 555 and encrypt(213) = 333.
+
+Return the sum of encrypted elements.
+
+
+Example 1:
+
+Input: nums = [1,2,3]
+Output: 6
+Explanation: The encrypted elements are [1,2,3]. The sum of encrypted elements is 1 + 2 + 3 == 6.
+
+Example 2:
+
+Input: nums = [10,21,31]
+Output: 66
+Explanation: The encrypted elements are [11,22,33]. The sum of encrypted elements is 11 + 22 + 33 == 66.
+
+
+Constraints:
+
+1 <= nums.length <= 50
+1 <= nums[i] <= 1000
+
+"""
+
+# V0
+# IDEA : REPEAT THE LARGEST DIGIT AS MANY TIMES AS THERE ARE DIGITS
+#
+#   encrypt(x) is the string max(str(x)) repeated len(str(x)) times, read
+#   back as an integer — no arithmetic on the digits is needed.
+#
+# time = O(n * digits), space = O(digits)
+class Solution(object):
+    def sumOfEncryptedInt(self, nums):
+        total = 0
+        for x in nums:
+            s = str(x)
+            total += int(max(s) * len(s))
+        return total

--- a/leetcode_python/Math/maximum-prime-difference.py
+++ b/leetcode_python/Math/maximum-prime-difference.py
@@ -1,0 +1,55 @@
+"""
+
+3115. Maximum Prime Difference
+Medium
+
+You are given an integer array nums.
+
+Return an integer that is the maximum distance between the indices of two (not necessarily different) prime numbers in nums.
+
+
+Example 1:
+
+Input: nums = [4,2,9,5,3]
+Output: 3
+Explanation: nums[1], nums[3], and nums[4] are prime. So the answer is |4 - 1| = 3.
+
+Example 2:
+
+Input: nums = [4,8,2,8]
+Output: 0
+Explanation: nums[2] is prime. Because there is just one prime number, the answer is |2 - 2| = 0.
+
+
+Constraints:
+
+1 <= nums.length <= 3 * 10^5
+1 <= nums[i] <= 100
+The input is generated such that the number of prime numbers in the nums is at least one.
+
+"""
+
+# V0
+# IDEA : ONLY THE FIRST AND LAST PRIME POSITIONS MATTER
+#
+#   the widest gap is always between the earliest prime and the latest one,
+#   so a single pass recording those two indices answers it. "not necessarily
+#   different" means a lone prime gives 0, which falls out of first == last.
+#
+#   values are capped at 100, so primality is a set lookup.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maximumPrimeDifference(self, nums):
+        primes = set()
+        for x in range(2, 101):
+            if all(x % d for d in range(2, int(x ** 0.5) + 1)):
+                primes.add(x)
+
+        first = last = -1
+        for i, v in enumerate(nums):
+            if v in primes:
+                if first == -1:
+                    first = i
+                last = i
+        return last - first

--- a/leetcode_python/Math/right-triangles.py
+++ b/leetcode_python/Math/right-triangles.py
@@ -1,0 +1,75 @@
+"""
+
+3128. Right Triangles
+Medium
+
+You are given a 2D boolean matrix grid.
+
+Return an integer that is the number of right triangles that can be made with the 3 elements of grid such that all of them have a value of 1.
+
+Note:
+
+A collection of 3 elements of grid is a right triangle if one of its elements is in the same row with another element and in the same column with the third element. The 3 elements do not have to be next to each other.
+
+
+Example 1:
+
+Input: grid = [[0,1,0],[0,1,1],[0,1,0]]
+Output: 2
+Explanation:
+There are two right triangles.
+
+Example 2:
+
+Input: grid = [[1,0,0,0],[0,1,0,1],[1,0,0,0]]
+Output: 0
+Explanation:
+There are no right triangles.
+
+Example 3:
+
+Input: grid = [[1,0,1],[1,0,0],[1,0,0]]
+Output: 2
+Explanation:
+There are two right triangles.
+
+
+Constraints:
+
+1 <= grid.length <= 1000
+1 <= grid[i].length <= 1000
+0 <= grid[i][j] <= 1
+
+"""
+
+# V0
+# IDEA : COUNT BY THE CORNER — THE CELL THAT SUPPLIES BOTH LEGS
+#
+#   the definition names one distinguished element : the one sharing a row
+#   with the second and a column with the third. treat that as the RIGHT-ANGLE
+#   corner and count each triangle exactly once, from its corner.
+#
+#   for a corner at (i, j) the partners are free to be any other 1 in row i
+#   and any other 1 in column j, so it contributes
+#
+#       (row_ones[i] - 1) * (col_ones[j] - 1)
+#
+#   two O(m*n) passes — one to tally the row and column sums, one to add up
+#   the products.
+#
+# time = O(m * n), space = O(m + n)
+class Solution(object):
+    def numberOfRightTriangles(self, grid):
+        m, n = len(grid), len(grid[0])
+        row_ones = [sum(row) for row in grid]
+        col_ones = [0] * n
+        for i in range(m):
+            for j in range(n):
+                col_ones[j] += grid[i][j]
+
+        res = 0
+        for i in range(m):
+            for j in range(n):
+                if grid[i][j] == 1:
+                    res += (row_ones[i] - 1) * (col_ones[j] - 1)
+        return res

--- a/leetcode_python/Math/water-bottles-ii.py
+++ b/leetcode_python/Math/water-bottles-ii.py
@@ -1,0 +1,61 @@
+"""
+
+3100. Water Bottles II
+Medium
+
+You are given two integers numBottles and numExchange.
+
+numBottles represents the number of full water bottles that you initially have. In one operation, you can perform one of the following operations:
+
+Drink any number of full water bottles turning them into empty bottles.
+Exchange numExchange empty bottles with one full water bottle. Then, increase numExchange by one.
+
+Note that you cannot exchange multiple batches of empty bottles for the same value of numExchange. For example, if numBottles == 3 and numExchange == 1, you cannot exchange 3 empty water bottles for 3 full bottles.
+
+Return the maximum number of water bottles you can drink.
+
+
+Example 1:
+
+Input: numBottles = 13, numExchange = 6
+Output: 15
+Explanation: The table above shows the number of full water bottles, empty water bottles, the value of numExchange, and the number of bottles drunk.
+
+Example 2:
+
+Input: numBottles = 10, numExchange = 3
+Output: 13
+Explanation: The table above shows the number of full water bottles, empty water bottles, the value of numExchange, and the number of bottles drunk.
+
+
+Constraints:
+
+1 <= numBottles <= 100
+1 <= numExchange <= 100
+
+"""
+
+# V0
+# IDEA : DRINK EVERYTHING, THEN EXCHANGE WHILE THE EMPTIES STILL COVER THE PRICE
+#
+#   drinking is free and never hurts, so drink every full bottle immediately;
+#   each one becomes an empty.
+#
+#   then repeat : if the empties cover the current price, pay it, gain one
+#   full bottle, drink it (so the empty count goes down by numExchange and
+#   back up by 1), and the price rises by one for the next round.
+#
+#   the price only grows, so the loop ends quickly — at most O(sqrt(total))
+#   exchanges.
+#
+# time = O(sqrt(numBottles)), space = O(1)
+class Solution(object):
+    def maxBottlesDrunk(self, numBottles, numExchange):
+        drunk = numBottles
+        empty = numBottles
+        while empty >= numExchange:
+            empty -= numExchange
+            numExchange += 1
+            drunk += 1
+            empty += 1                 # the new bottle is drunk right away
+        return drunk

--- a/leetcode_python/Sort/minimum-operations-to-make-median-of-array-equal-to-k.py
+++ b/leetcode_python/Sort/minimum-operations-to-make-median-of-array-equal-to-k.py
@@ -1,0 +1,71 @@
+"""
+
+3107. Minimum Operations to Make Median of Array Equal to K
+Medium
+
+You are given an integer array nums and a non-negative integer k. In one operation, you can increase or decrease any element by 1.
+
+Return the minimum number of operations needed to make the median of nums equal to k.
+
+The median of an array is defined as the middle element of the array when it is sorted in non-decreasing order. If there are two choices for a median, the larger of the two values is taken.
+
+
+Example 1:
+
+Input: nums = [2,5,6,8,5], k = 4
+Output: 2
+Explanation:
+We can subtract one from nums[1] and nums[4] to obtain [2, 4, 6, 8, 4]. The median of the resulting array is equal to k.
+
+Example 2:
+
+Input: nums = [2,5,6,8,5], k = 7
+Output: 3
+Explanation:
+We can add one to nums[1] twice and add one to nums[2] once. The resulting array is [2, 7, 7, 8, 5].
+
+Example 3:
+
+Input: nums = [1,2,3,4,5,6], k = 4
+Output: 0
+Explanation:
+The median of the array is already equal to k.
+
+
+Constraints:
+
+1 <= nums.length <= 2 * 10^5
+1 <= nums[i] <= 10^9
+1 <= k <= 10^9
+
+"""
+
+# V0
+# IDEA : SORT, THEN ONLY THE WRONG SIDE OF THE MEDIAN SLOT NEEDS FIXING
+#
+#   after sorting, the median lives at index m = n // 2 (that index is the
+#   LARGER of the two middles when n is even, which is the rule here).
+#
+#   for the median to read k :
+#       nums[m] itself must become k             -> |nums[m] - k| moves
+#       everything left of m must be <= k        -> pull down any that exceed
+#       everything right of m must be >= k       -> push up any that fall short
+#
+#   elements already on the correct side cost nothing, and moving them
+#   further would only waste operations.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def minOperationsToMakeMedianK(self, nums, k):
+        arr = sorted(nums)
+        n = len(arr)
+        m = n // 2
+
+        res = abs(arr[m] - k)
+        for i in range(m):
+            if arr[i] > k:
+                res += arr[i] - k
+        for i in range(m + 1, n):
+            if arr[i] < k:
+                res += k - arr[i]
+        return res

--- a/leetcode_python/Stack/find-the-number-of-subarrays-where-boundary-elements-are-maximum.py
+++ b/leetcode_python/Stack/find-the-number-of-subarrays-where-boundary-elements-are-maximum.py
@@ -1,0 +1,85 @@
+"""
+
+3113. Find the Number of Subarrays Where Boundary Elements Are Maximum
+Hard
+
+You are given an array of positive integers nums.
+
+Return the number of subarrays of nums, where the first and the last elements of the subarray are equal to the largest element in the subarray.
+
+
+Example 1:
+
+Input: nums = [1,4,3,3,2]
+Output: 6
+Explanation:
+There are 6 subarrays which have the first and the last elements equal to the largest element of the subarray:
+subarray [1,4,3,3,2], with its largest element 1. The first element is 1 and the last element is also 1.
+subarray [1,4,3,3,2], with its largest element 4. The first element is 4 and the last element is also 4.
+subarray [1,4,3,3,2], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [1,4,3,3,2], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [1,4,3,3,2], with its largest element 2. The first element is 2 and the last element is also 2.
+subarray [1,4,3,3,2], with its largest element 3. The first element is 3 and the last element is also 3.
+Hence, we return 6.
+
+Example 2:
+
+Input: nums = [3,3,3]
+Output: 6
+Explanation:
+There are 6 subarrays which have the first and the last elements equal to the largest element of the subarray:
+subarray [3,3,3], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [3,3,3], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [3,3,3], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [3,3,3], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [3,3,3], with its largest element 3. The first element is 3 and the last element is also 3.
+subarray [3,3,3], with its largest element 3. The first element is 3 and the last element is also 3.
+Hence, we return 6.
+
+Example 3:
+
+Input: nums = [1]
+Output: 1
+Explanation:
+There is a single subarray of nums which is [1], with its largest element 1. The first element is 1 and the last element is also 1.
+Hence, we return 1.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : MONOTONIC STACK OF (VALUE, HOW MANY COPIES ARE STILL "VISIBLE")
+#
+#   a valid subarray is a pair of equal values i < j such that nothing
+#   strictly larger sits between them. so for each element, count how many
+#   earlier equal values are still unblocked.
+#
+#   a non-increasing stack keeps exactly the unblocked candidates : when a
+#   new value arrives, every smaller value on the stack is now shadowed and
+#   pops off. what remains on top is either the same value — whose stored
+#   count says how many copies are visible, all of which pair with the new
+#   element — or a larger one.
+#
+#   so each element contributes (visible copies of its value) + 1, the +1
+#   being the length-1 subarray.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def numberOfSubarrays(self, nums):
+        stack = []                       # (value, count of visible copies)
+        res = 0
+        for x in nums:
+            while stack and stack[-1][0] < x:
+                stack.pop()
+            if stack and stack[-1][0] == x:
+                stack[-1][1] += 1
+                res += stack[-1][1]      # pairs with each visible copy, plus itself
+            else:
+                stack.append([x, 1])
+                res += 1
+        return res

--- a/leetcode_python/String/existence-of-a-substring-in-a-string-and-its-reverse.py
+++ b/leetcode_python/String/existence-of-a-substring-in-a-string-and-its-reverse.py
@@ -1,0 +1,51 @@
+"""
+
+3083. Existence of a Substring in a String and Its Reverse
+Easy
+
+Given a string s, find any substring of length 2 which is also present in the reverse of s.
+
+Return true if such a substring exists, and false otherwise.
+
+
+Example 1:
+
+Input: s = "leetcode"
+Output: true
+Explanation: Substring "ee" is of length 2 which is also present in reverse(s) == "edocteel".
+
+Example 2:
+
+Input: s = "abcba"
+Output: true
+Explanation: All of the substrings of length 2 "ab", "bc", "cb", "ba" are also present in reverse(s) == "abcba".
+
+Example 3:
+
+Input: s = "abcd"
+Output: false
+Explanation: There is no substring of length 2 in s, which is also present in the reverse of s.
+
+
+Constraints:
+
+1 <= s.length <= 100
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : A LENGTH-2 SUBSTRING IS IN reverse(s) IFF ITS REVERSE IS IN s
+#
+#   "xy" appears in reverse(s) exactly when "yx" appears in s, so the whole
+#   question collapses to : does s contain some pair and also that pair
+#   flipped ?
+#
+#   collect every adjacent pair into a set and look for any whose reverse is
+#   also there — one pass, no string reversal needed at all.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def isSubstringPresent(self, s):
+        pairs = set(s[i:i + 2] for i in range(len(s) - 1))
+        return any(p[::-1] in pairs for p in pairs)

--- a/leetcode_python/String/find-longest-self-contained-substring.py
+++ b/leetcode_python/String/find-longest-self-contained-substring.py
@@ -1,0 +1,76 @@
+"""
+
+3104. Find Longest Self-Contained Substring
+Hard
+🔒 (premium)
+
+Given a string s, your task is to find the length of the longest self-contained substring of s.
+
+A substring t of a string s is called self-contained if t != s and for every character in t, it doesn't exist in the rest of s.
+
+Return the length of the longest self-contained substring of s if it exists, otherwise, return -1.
+
+
+Example 1:
+
+Input: s = "abba"
+Output: 2
+Explanation:
+Let's check the substring "bb". You can see that no other "b" is outside of this substring. Hence the answer is 2.
+
+Example 2:
+
+Input: s = "abab"
+Output: -1
+Explanation:
+Every substring we choose does not satisfy the described property (there is some character which is inside and outside that substring).
+
+
+Constraints:
+
+2 <= s.length <= 5 * 10^4
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : THE START MUST BE A FIRST OCCURRENCE — SO THERE ARE AT MOST 26 STARTS
+#
+#   for t = s[i..j] to be self-contained, EVERY letter inside must have all
+#   its occurrences inside :
+#       first[c] >= i   and   last[c] <= j   for each letter c in t
+#
+#   apply that to the letter at position i itself : first[s[i]] >= i, and it
+#   obviously occurs at i, so first[s[i]] == i. the start is always a letter's
+#   FIRST occurrence — at most 26 candidates.
+#
+#   from each such start, walk j rightwards carrying
+#       mn = min first[c] over the letters seen
+#       mx = max last[c]  over the letters seen
+#   the moment mn < i the window has swallowed a letter that also lives to
+#   the left, and no larger j can recover — stop. whenever mx <= j the window
+#   is self-contained, so record its length (excluding the whole string,
+#   since t != s).
+#
+# time = O(26 * n), space = O(1)
+class Solution(object):
+    def maxSubstringLength(self, s):
+        n = len(s)
+        first, last = {}, {}
+        for i, ch in enumerate(s):
+            if ch not in first:
+                first[ch] = i
+            last[ch] = i
+
+        res = -1
+        for start in sorted(set(first[c] for c in first)):
+            mn, mx = n, -1
+            for j in range(start, n):
+                ch = s[j]
+                mn = min(mn, first[ch])
+                mx = max(mx, last[ch])
+                if mn < start:
+                    break                     # a letter also lives to the left
+                if mx <= j and (j - start + 1) < n:
+                    res = max(res, j - start + 1)
+        return res

--- a/leetcode_python/String/score-of-a-string.py
+++ b/leetcode_python/String/score-of-a-string.py
@@ -1,0 +1,41 @@
+"""
+
+3110. Score of a String
+Easy
+
+You are given a string s. The score of a string is defined as the sum of the absolute difference between the ASCII values of adjacent characters.
+
+Return the score of s.
+
+
+Example 1:
+
+Input: s = "hello"
+Output: 13
+Explanation:
+The ASCII values of the characters in s are: 'h' = 104, 'e' = 101, 'l' = 108, 'l' = 108, 'o' = 111. So, the score of s would be |104 - 101| + |101 - 108| + |108 - 108| + |108 - 111| = 3 + 7 + 0 + 3 = 13.
+
+Example 2:
+
+Input: s = "zaz"
+Output: 50
+Explanation:
+The ASCII values of the characters in s are: 'z' = 122, 'a' = 97, 'z' = 122. So, the score of s would be |122 - 97| + |97 - 122| = 25 + 25 = 50.
+
+
+Constraints:
+
+2 <= s.length <= 100
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : SUM |ord(s[i]) - ord(s[i-1])| OVER THE ADJACENT PAIRS
+#
+#   a direct reading of the definition — zip(s, s[1:]) walks the pairs.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def scoreOfString(self, s):
+        return sum(abs(ord(a) - ord(b)) for a, b in zip(s, s[1:]))

--- a/leetcode_python/String/shortest-uncommon-substring-in-an-array.py
+++ b/leetcode_python/String/shortest-uncommon-substring-in-an-array.py
@@ -1,0 +1,71 @@
+"""
+
+3076. Shortest Uncommon Substring in an Array
+Medium
+
+You are given an array arr of size n consisting of non-empty strings.
+
+Find a string array answer of size n such that:
+
+answer[i] is the shortest substring of arr[i] that does not occur as a substring in any other string in arr. If multiple such substrings exist, answer[i] should be the lexicographically smallest. And if no such substring exists, answer[i] should be an empty string.
+
+Return the array answer.
+
+
+Example 1:
+
+Input: arr = ["cab","ad","bad","c"]
+Output: ["ab","","ba",""]
+Explanation: We have the following:
+- For the string "cab", the shortest substring that does not occur in any other string is either "ca" or "ab", we choose the lexicographically smaller substring, which is "ab".
+- For the string "ad", there is no substring that does not occur in any other string.
+- For the string "bad", the shortest substring that does not occur in any other string is "ba".
+- For the string "c", there is no substring that does not occur in any other string.
+
+Example 2:
+
+Input: arr = ["abc","bcd","abcd"]
+Output: ["","","abcd"]
+Explanation: We have the following:
+- For the string "abc", there is no substring that does not occur in any other string.
+- For the string "bcd", there is no substring that does not occur in any other string.
+- For the string "abcd", the shortest substring that does not occur in any other string is "abcd".
+
+
+Constraints:
+
+n == arr.length
+2 <= n <= 100
+1 <= arr[i].length <= 20
+arr[i] consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : THE INPUT IS TINY — ENUMERATE SUBSTRINGS SHORTEST-FIRST
+#
+#   a 20-character string has at most 20*21/2 = 210 substrings, and there are
+#   at most 100 strings, so testing everything is cheap.
+#
+#   iterating lengths from 1 upwards, and left-to-right within a length,
+#   would give the first hit in length order but NOT in lexicographic order
+#   among equals — so collect all candidates of the current length, and take
+#   min() of the ones that appear nowhere else. the first length with any
+#   survivor wins.
+#
+# time = O(n^2 * L^3), space = O(L^2)
+class Solution(object):
+    def shortestSubstrings(self, arr):
+        n = len(arr)
+        res = []
+        for i, s in enumerate(arr):
+            others = [arr[j] for j in range(n) if j != i]
+            found = ""
+            for length in range(1, len(s) + 1):
+                cands = [s[t:t + length] for t in range(len(s) - length + 1)]
+                unique = [c for c in cands if all(c not in o for o in others)]
+                if unique:
+                    found = min(unique)
+                    break
+            res.append(found)
+        return res

--- a/leetcode_python/slide_window/minimum-moves-to-pick-k-ones.py
+++ b/leetcode_python/slide_window/minimum-moves-to-pick-k-ones.py
@@ -1,0 +1,99 @@
+"""
+
+3086. Minimum Moves to Pick K Ones
+Hard
+
+You are given a binary array nums of length n, a positive integer k and a non-negative integer maxChanges.
+
+Alice plays a game, where the goal is for Alice to pick up k ones from nums using the minimum number of moves. When the game starts, Alice picks up any index aliceIndex in the range [0, n - 1] and stands there. If nums[aliceIndex] == 1 , Alice picks up the one and nums[aliceIndex] becomes 0 (this does not count as a move). After this, Alice can make any number of moves (including zero) where in each move Alice must perform exactly one of the following actions:
+
+Select any index j != aliceIndex such that nums[j] == 0 and set nums[j] = 1. This action can be performed at most maxChanges times.
+Select any two adjacent indices x and y (|x - y| == 1) such that nums[x] == 1, nums[y] == 0, then swap their values (set nums[y] = 1 and nums[x] = 0). If y == aliceIndex, Alice picks up the one after this move and nums[y] becomes 0.
+
+Return the minimum number of moves required by Alice to pick exactly k ones.
+
+
+Example 1:
+
+Input: nums = [1,1,0,0,0,1,1,0,0,1], k = 3, maxChanges = 1
+Output: 3
+Explanation: Alice can pick up 3 ones in 3 moves, if Alice performs the following actions in each move when standing at aliceIndex == 1:
+At the start Alice picks up the one and nums[1] becomes 0. nums becomes [1,0,0,0,0,1,1,0,0,1].
+Select j == 2 and perform an action of the first type. nums becomes [1,0,1,0,0,1,1,0,0,1]
+Select x == 2 and y == 1, and perform an action of the second type. nums becomes [1,1,0,0,0,1,1,0,0,1]. As y == aliceIndex, Alice picks up the one and nums becomes [1,0,0,0,0,1,1,0,0,1].
+Select x == 0 and y == 1, and perform an action of the second type. nums becomes [0,1,0,0,0,1,1,0,0,1]. As y == aliceIndex, Alice picks up the one and nums becomes [0,0,0,0,0,1,1,0,0,1].
+Note that it may be possible for Alice to pick up 3 ones using some other sequence of 3 moves.
+
+Example 2:
+
+Input: nums = [0,0,0,0], k = 2, maxChanges = 3
+Output: 4
+Explanation: Alice can pick up 2 ones in 4 moves, if Alice performs the following actions in each move when standing at aliceIndex == 0:
+Select j == 1 and perform an action of the first type. nums becomes [0,1,0,0].
+Select x == 1 and y == 0, and perform an action of the second type. nums becomes [1,0,0,0]. As y == aliceIndex, Alice picks up the one and nums becomes [0,0,0,0].
+Select j == 1 again and perform an action of the first type. nums becomes [0,1,0,0].
+Select x == 1 and y == 0, and perform an action of the second type. nums becomes [1,0,0,0]. As y == aliceIndex, Alice picks up the one and nums becomes [0,0,0,0].
+
+
+Constraints:
+
+2 <= n <= 10^5
+0 <= nums[i] <= 1
+1 <= k <= 10^5
+0 <= maxChanges <= 10^5
+maxChanges + sum(nums) >= k
+
+"""
+
+# V0
+# IDEA : PRICE EVERY ONE, THEN NOTICE ONLY ~4 SPLITS BETWEEN REAL/CREATED MATTER
+#
+#   costs, from Alice's standing index :
+#       a real one AT her index      -> 0 moves (free pickup)
+#       a real one at distance d     -> d moves (swap it along, one per step)
+#       a created one (maxChanges)   -> 2 moves (set it adjacent, swap it in)
+#
+#   so if she collects r real ones and creates x = k - r, the total is
+#       2 * x  +  (sum of distances from her index to those r ones)
+#   and for a fixed r the best real ones are a CONTIGUOUS block of ones with
+#   Alice standing at its median — the classic minimum-sum-of-distances
+#   arrangement, computed for every window with prefix sums.
+#
+#   the search over r collapses : a created one costs 2, so it matches or
+#   beats any real one at distance >= 2. only three real ones can be cheaper
+#   than that — the one under her feet (0) and its two neighbours (1 each) —
+#   so beyond max(0, k - maxChanges) real ones there is no point taking more
+#   than 3 extra. that leaves at most four values of r to try.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def minimumMoves(self, nums, k, maxChanges):
+        pos = [i for i, v in enumerate(nums) if v == 1]
+        m = len(pos)
+
+        pre = [0] * (m + 1)
+        for i, p in enumerate(pos):
+            pre[i + 1] = pre[i] + p
+
+        def window_cost(r):
+            """min total distance to gather r ones, standing at their median."""
+            if r == 0:
+                return 0
+            best = float('inf')
+            for lo in range(m - r + 1):
+                hi = lo + r - 1
+                mid = lo + r // 2
+                med = pos[mid]
+                # right part minus left part, each measured against the median
+                right = (pre[hi + 1] - pre[mid]) - med * (hi - mid + 1)
+                left = med * (mid - lo) - (pre[mid] - pre[lo])
+                best = min(best, left + right)
+            return best
+
+        base = max(0, k - maxChanges)          # real ones we are forced to take
+        res = float('inf')
+        for r in range(base, min(m, base + 3) + 1):
+            if r > k:
+                break
+            res = min(res, 2 * (k - r) + window_cost(r))
+        return res

--- a/leetcode_python/slide_window/shortest-subarray-with-or-at-least-k-ii.py
+++ b/leetcode_python/slide_window/shortest-subarray-with-or-at-least-k-ii.py
@@ -1,0 +1,83 @@
+"""
+
+3097. Shortest Subarray With OR at Least K II
+Medium
+
+You are given an array nums of non-negative integers and an integer k.
+
+An array is called special if the bitwise OR of all of its elements is at least k.
+
+Return the length of the shortest special non-empty subarray of nums, or return -1 if no special subarray exists.
+
+
+Example 1:
+
+Input: nums = [1,2,3], k = 2
+Output: 1
+Explanation: The subarray [3] has OR value of 3. Hence, we return 1.
+
+Example 2:
+
+Input: nums = [2,1,8], k = 10
+Output: 3
+Explanation: The subarray [2,1,8] has OR value of 11. Hence, we return 3.
+
+Example 3:
+
+Input: nums = [1,2], k = 0
+Output: 1
+Explanation: The subarray [1] has OR value of 1. Hence, we return 1.
+
+
+Constraints:
+
+1 <= nums.length <= 2 * 10^5
+0 <= nums[i] <= 10^9
+0 <= k <= 10^9
+
+"""
+
+# V0
+# IDEA : SLIDING WINDOW WITH A COUNTER PER BIT (OR IS NOT INVERTIBLE)
+#
+#   the OR of a window only grows as it widens, so the window is monotone and
+#   two pointers apply : extend right until the OR reaches k, then shrink
+#   from the left while it still does.
+#
+#   the catch is that OR cannot be "undone" when an element leaves — losing
+#   a 1 bit only matters if no OTHER element in the window still has it. so
+#   keep a count of how many window elements set each of the 30 bits; a bit
+#   is present in the OR exactly while its count is non-zero.
+#
+#   rebuilding the OR from those counts is 30 cheap steps per move.
+#
+# time = O(30 * n), space = O(1)
+class Solution(object):
+    def minimumSubarrayLength(self, nums, k):
+        BITS = 32
+        cnt = [0] * BITS
+        cur = 0
+
+        def add(x, delta):
+            for b in range(BITS):
+                if (x >> b) & 1:
+                    cnt[b] += delta
+
+        def value():
+            v = 0
+            for b in range(BITS):
+                if cnt[b]:
+                    v |= 1 << b
+            return v
+
+        best = float('inf')
+        left = 0
+        for right, x in enumerate(nums):
+            add(x, 1)
+            cur = value()
+            while left <= right and cur >= k:
+                best = min(best, right - left + 1)
+                add(nums[left], -1)
+                left += 1
+                cur = value()
+        return -1 if best == float('inf') else best


### PR DESCRIPTION
Second tranche of the LC 3001-Latest coverage gap vs kamyu104/LeetCode-Solutions, continuing where batch11 (3001-3049) stopped. Covers 50 problems from 3062 to 3129, including 8 premium/locked ones (3062, 3063, 3073, 3078, 3088, 3104, 3109, 3119).

Skipped in this range, deliberately:
- LC 3050-3061, 3087, 3089, 3103, 3118, 3124, 3126 are database problems and belong in leetcode_SQL, not here.
- LC 3064 and 3094 ("Guess the Number Using Bitwise Questions" I/II) are interactive problems whose judge-side API signature I could not confirm; rather than invent one, 3128 and 3129 were taken instead.

Same convention as the rest of the directory: problem docstring, then a V0 solution with an IDEA block explaining the approach and a time/space complexity comment.

Verified:
- all 50 files parse cleanly
- all 50 run correctly against every example in their problem statement (128 assertions)
- 26 of them additionally cross-checked against independent brute-force references on randomized inputs: 3067, 3068, 3072, 3073, 3077, 3078, 3080, 3081, 3082, 3085, 3086, 3088, 3095, 3097, 3098, 3102, 3104, 3106, 3107, 3108, 3109, 3111, 3113, 3116, 3117, 3119, 3129 — 3109 is checked exhaustively against itertools.permutations for every n <= 7, and 3129 against full enumeration for every (zero, one, limit) <= 6
- timed at full constraints: 3097 (2e5), 3072/3073/3080/3086/3102/3108/ 3109/3113 (1e5), 3077 (n*k ~ 1e6), 3128 (1000x1000), 3098 (n=50, k=25 worst case), 3116 (15 coins, k=2e9), plus adversarial shapes for 3088 (half the string one letter) and 3104 (26 clean blocks)