### PR TITLE
feat(leetcode_python): add 50 solutions for LC 3186-3256

### DIFF
--- a/leetcode_python/Array/alternating-groups-i.py
+++ b/leetcode_python/Array/alternating-groups-i.py
@@ -1,0 +1,51 @@
+"""
+
+3206. Alternating Groups I
+Easy
+
+There is a circle of red and blue tiles. You are given an array of integers colors. The color of tile i is represented by colors[i]:
+
+colors[i] == 0 means that tile i is red.
+colors[i] == 1 means that tile i is blue.
+
+Every 3 contiguous tiles in the circle with alternating colors (the middle tile has a different color from its left and right tiles) is called an alternating group.
+
+Return the number of alternating groups.
+
+Note that since colors represents a circle, the first and the last tiles are considered to be next to each other.
+
+
+Example 1:
+
+Input: colors = [1,1,1]
+Output: 0
+
+Example 2:
+
+Input: colors = [0,1,0,0,1]
+Output: 3
+
+
+Constraints:
+
+3 <= colors.length <= 100
+0 <= colors[i] <= 1
+
+
+"""
+
+# V0
+# IDEA : CHECK EVERY WINDOW OF THREE, WRAPPING WITH MODULO
+#
+#   a window centred at i alternates exactly when its middle differs from
+#   BOTH neighbours, i.e. colors[i-1] != colors[i] != colors[i+1]. the circle
+#   is handled by reading the indices modulo n, so every tile gets to be a
+#   centre.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def numberOfAlternatingGroups(self, colors):
+        n = len(colors)
+        return sum(1
+                   for i in range(n)
+                   if colors[(i - 1) % n] != colors[i] != colors[(i + 1) % n])

--- a/leetcode_python/Array/count-submatrices-with-equal-frequency-of-x-and-y.py
+++ b/leetcode_python/Array/count-submatrices-with-equal-frequency-of-x-and-y.py
@@ -1,0 +1,70 @@
+"""
+
+3212. Count Submatrices With Equal Frequency of X and Y
+Medium
+
+Given a 2D character matrix grid, where grid[i][j] is either 'X', 'Y', or '.', return the number of submatrices that contain:
+
+grid[0][0]
+an equal frequency of 'X' and 'Y'.
+at least one 'X'.
+
+
+Example 1:
+
+Input: grid = [["X","Y","."],["Y",".","."]]
+Output: 3
+Explanation:
+
+Example 2:
+
+Input: grid = [["X","X"],["X","Y"]]
+Output: 0
+Explanation:
+No submatrix has an equal frequency of 'X' and 'Y'.
+
+Example 3:
+
+Input: grid = [[".","."],[".","."]]
+Output: 0
+Explanation:
+No submatrix has at least one 'X'.
+
+
+Constraints:
+
+1 <= grid.length, grid[i].length <= 1000
+grid[i][j] is either 'X', 'Y', or '.'.
+
+"""
+
+# V0
+# IDEA : "CONTAINS grid[0][0]" MEANS IT IS A PREFIX RECTANGLE
+#
+#   a submatrix holding the top-left cell must start at (0, 0), so it is
+#   fully described by its bottom-right corner — one candidate per cell.
+#
+#   two 2D prefix-sum tables (one counting 'X', one counting 'Y') then answer
+#   each candidate in O(1), and the conditions become
+#       cntX == cntY   and   cntX > 0
+#   (the second clause is the "at least one X" requirement, which also rules
+#   out the empty all-dots case).
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def numberOfSubmatrices(self, grid):
+        m, n = len(grid), len(grid[0])
+        px = [[0] * (n + 1) for _ in range(m + 1)]
+        py = [[0] * (n + 1) for _ in range(m + 1)]
+        res = 0
+
+        for i in range(m):
+            row = grid[i]
+            for j in range(n):
+                x = 1 if row[j] == 'X' else 0
+                y = 1 if row[j] == 'Y' else 0
+                px[i + 1][j + 1] = x + px[i][j + 1] + px[i + 1][j] - px[i][j]
+                py[i + 1][j + 1] = y + py[i][j + 1] + py[i + 1][j] - py[i][j]
+                if px[i + 1][j + 1] and px[i + 1][j + 1] == py[i + 1][j + 1]:
+                    res += 1
+        return res

--- a/leetcode_python/Array/find-the-minimum-area-to-cover-all-ones-ii.py
+++ b/leetcode_python/Array/find-the-minimum-area-to-cover-all-ones-ii.py
@@ -1,0 +1,113 @@
+"""
+
+3197. Find the Minimum Area to Cover All Ones II
+Hard
+
+You are given a 2D binary array grid. You need to find 3 non-overlapping rectangles having non-zero areas with horizontal and vertical sides such that all the 1's in grid lie inside these rectangles.
+
+Return the minimum possible sum of the area of these rectangles.
+
+Note that the rectangles are allowed to touch.
+
+
+Example 1:
+
+Input: grid = [[1,0,1],[1,1,1]]
+Output: 5
+Explanation:
+The 1's at (0, 0) and (1, 0) are covered by a rectangle of area 2.
+The 1's at (0, 2) and (1, 2) are covered by a rectangle of area 2.
+The 1 at (1, 1) is covered by a rectangle of area 1.
+
+Example 2:
+
+Input: grid = [[1,0,1,0],[0,1,0,1]]
+Output: 5
+Explanation:
+The 1's at (0, 0) and (0, 2) are covered by a rectangle of area 3.
+The 1 at (1, 1) is covered by a rectangle of area 1.
+The 1 at (1, 3) is covered by a rectangle of area 1.
+
+
+Constraints:
+
+1 <= grid.length, grid[i].length <= 30
+grid[i][j] is either 0 or 1.
+The input is generated such that there are at least three 1's in grid.
+
+"""
+
+# V0
+# IDEA : THREE NON-OVERLAPPING RECTANGLES = TWO GUILLOTINE CUTS, SIX SHAPES
+#
+#   three axis-aligned rectangles that do not overlap and together cover the
+#   grid's 1s can always be laid out by cutting the board twice :
+#
+#       two horizontal cuts        (three stacked bands)
+#       two vertical cuts          (three side-by-side strips)
+#       one horizontal cut, then a vertical cut on the top part
+#       one horizontal cut, then a vertical cut on the bottom part
+#       one vertical cut, then a horizontal cut on the left part
+#       one vertical cut, then a horizontal cut on the right part
+#
+#   for any region the best rectangle is the bounding box of the 1s inside
+#   it, so the whole search is "enumerate the cuts, add three bounding-box
+#   areas". with a 30x30 grid that is at most a few hundred thousand region
+#   scans once the bounding box is memoised per rectangle of the grid.
+#
+#   an EMPTY region contributes 0 — every 1 still lands somewhere.
+#
+# time = O(m * n * (m + n) * ...) — small for 30x30, space = O(m * n)
+class Solution(object):
+    def minimumSum(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        memo = {}
+
+        def area(r1, r2, c1, c2):
+            """bounding-box area of the 1s inside rows [r1,r2), cols [c1,c2)"""
+            key = (r1, r2, c1, c2)
+            if key in memo:
+                return memo[key]
+            top, bot, left, right = m, -1, n, -1
+            for i in range(r1, r2):
+                row = grid[i]
+                for j in range(c1, c2):
+                    if row[j]:
+                        if i < top:
+                            top = i
+                        if i > bot:
+                            bot = i
+                        if j < left:
+                            left = j
+                        if j > right:
+                            right = j
+            res = 0 if bot == -1 else (bot - top + 1) * (right - left + 1)
+            memo[key] = res
+            return res
+
+        best = float('inf')
+
+        # three horizontal bands
+        for a in range(1, m):
+            for b in range(a + 1, m):
+                best = min(best, area(0, a, 0, n) + area(a, b, 0, n) + area(b, m, 0, n))
+
+        # three vertical strips
+        for a in range(1, n):
+            for b in range(a + 1, n):
+                best = min(best, area(0, m, 0, a) + area(0, m, a, b) + area(0, m, b, n))
+
+        # one horizontal cut, then split one side vertically
+        for a in range(1, m):
+            for c in range(1, n):
+                best = min(best, area(0, a, 0, c) + area(0, a, c, n) + area(a, m, 0, n))
+                best = min(best, area(0, a, 0, n) + area(a, m, 0, c) + area(a, m, c, n))
+
+        # one vertical cut, then split one side horizontally
+        for c in range(1, n):
+            for a in range(1, m):
+                best = min(best, area(0, a, 0, c) + area(a, m, 0, c) + area(0, m, c, n))
+                best = min(best, area(0, m, 0, c) + area(0, a, c, n) + area(a, m, c, n))
+
+        return best

--- a/leetcode_python/Array/find-the-power-of-k-size-subarrays-i.py
+++ b/leetcode_python/Array/find-the-power-of-k-size-subarrays-i.py
@@ -1,0 +1,66 @@
+"""
+
+3254. Find the Power of K-Size Subarrays I
+Medium
+
+You are given an array of integers nums of length n and a positive integer k.
+
+The power of an array is defined as:
+
+Its maximum element if all of its elements are consecutive and sorted in ascending order.
+-1 otherwise.
+
+You need to find the power of all subarrays of nums of size k.
+
+Return an integer array results of size n - k + 1, where results[i] is the power of nums[i..(i + k - 1)].
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,3,2,5], k = 3
+Output: [3,4,-1,-1,-1]
+Explanation:
+There are 5 subarrays of nums of size 3:
+[1, 2, 3] with the maximum element 3.
+[2, 3, 4] with the maximum element 4.
+[3, 4, 3] whose elements are not consecutive.
+[4, 3, 2] whose elements are not sorted.
+[3, 2, 5] whose elements are not consecutive.
+
+Example 2:
+
+Input: nums = [2,2,2,2,2], k = 4
+Output: [-1,-1]
+
+Example 3:
+
+Input: nums = [3,2,3,2,3,2], k = 2
+Output: [-1,3,-1,3,-1]
+
+
+Constraints:
+
+1 <= n == nums.length <= 500
+1 <= nums[i] <= 10^5
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : "CONSECUTIVE AND ASCENDING" JUST MEANS EVERY STEP IS EXACTLY +1
+#
+#   a window qualifies iff nums[t+1] == nums[t] + 1 throughout it, and then
+#   its maximum is its LAST element.
+#
+#   n is only 500 here, so checking each window directly is fine; the sequel
+#   (LC 3255) does it with a running streak length instead.
+#
+# time = O(n * k), space = O(n)
+class Solution(object):
+    def resultsArray(self, nums, k):
+        n = len(nums)
+        res = []
+        for i in range(n - k + 1):
+            ok = all(nums[t + 1] == nums[t] + 1 for t in range(i, i + k - 1))
+            res.append(nums[i + k - 1] if ok else -1)
+        return res

--- a/leetcode_python/Array/maximum-value-sum-by-placing-three-rooks-i.py
+++ b/leetcode_python/Array/maximum-value-sum-by-placing-three-rooks-i.py
@@ -1,0 +1,83 @@
+"""
+
+3256. Maximum Value Sum by Placing Three Rooks I
+Hard
+
+You are given a m x n 2D array board representing a chessboard, where board[i][j] represents the value of the cell (i, j).
+
+Rooks in the same row or column attack each other. You need to place three rooks on the chessboard such that the rooks do not attack each other.
+
+Return the maximum sum of the cell values on which the rooks are placed.
+
+
+Example 1:
+
+Input: board = [[-3,1,1,1],[-3,1,-3,1],[-3,2,1,1]]
+Output: 4
+Explanation:
+We can place the rooks in the cells (0, 2), (1, 3), and (2, 1) for a sum of 1 + 1 + 2 = 4.
+
+Example 2:
+
+Input: board = [[1,2,3],[4,5,6],[7,8,9]]
+Output: 15
+Explanation:
+We can place the rooks in the cells (0, 0), (1, 1), and (2, 2) for a sum of 1 + 5 + 9 = 15.
+
+Example 3:
+
+Input: board = [[1,1,1],[1,1,1],[1,1,1]]
+Output: 3
+Explanation:
+We can place the rooks in the cells (0, 2), (1, 1), and (2, 0) for a sum of 1 + 1 + 1 = 3.
+
+
+Constraints:
+
+3 <= m == board.length <= 100
+3 <= n == board[i].length <= 100
+-10^9 <= board[i][j] <= 10^9
+
+"""
+
+# V0
+# IDEA : ONLY EACH ROW'S TOP THREE CELLS CAN EVER BE USED
+#
+#   the three rooks occupy three distinct rows and three distinct columns. so
+#   fix the rows first — then within a chosen row, the cell picked is the
+#   best one whose column is free. at most two columns are blocked by the
+#   other rooks, so the winner is always among that row's THREE largest
+#   cells.
+#
+#   keeping the top three per row shrinks the search to
+#       C(m, 3) row triples x 27 cell combinations
+#   which for m = 100 is about 4 million checks — and each combination is
+#   valid only when its three columns differ.
+#
+# time = O(m * n + m^3), space = O(m)
+import itertools
+
+
+class Solution(object):
+    def maximumValueSum(self, board):
+        m, n = len(board), len(board[0])
+
+        # per row : the three highest cells as (value, column)
+        top = []
+        for i in range(m):
+            best = sorted(((board[i][j], j) for j in range(n)), reverse=True)[:3]
+            top.append(best)
+
+        res = float('-inf')
+        for r1, r2, r3 in itertools.combinations(range(m), 3):
+            for a in top[r1]:
+                for b in top[r2]:
+                    if b[1] == a[1]:
+                        continue
+                    for c in top[r3]:
+                        if c[1] == a[1] or c[1] == b[1]:
+                            continue
+                        total = a[0] + b[0] + c[0]
+                        if total > res:
+                            res = total
+        return res

--- a/leetcode_python/Array/minimum-array-changes-to-make-differences-equal.py
+++ b/leetcode_python/Array/minimum-array-changes-to-make-differences-equal.py
@@ -1,0 +1,90 @@
+"""
+
+3224. Minimum Array Changes to Make Differences Equal
+Medium
+
+You are given an integer array nums of size n where n is even, and an integer k.
+
+You can perform some changes on the array, where in one change you can replace any element in the array with any integer in the range from 0 to k.
+
+You need to perform some changes (possibly none) such that the final array satisfies the following condition:
+
+There exists an integer X such that abs(a[i] - a[n - i - 1]) = X for all (0 <= i < n).
+
+Return the minimum number of changes required to satisfy the above condition.
+
+
+Example 1:
+
+Input: nums = [1,0,1,2,4,3], k = 4
+Output: 2
+Explanation:
+We can perform the following changes:
+Replace nums[1] by 2. The resulting array is nums = [1,2,1,2,4,3].
+Replace nums[3] by 3. The resulting array is nums = [1,2,1,3,4,3].
+The integer X will be 2.
+
+Example 2:
+
+Input: nums = [0,1,2,3,3,6,5,4], k = 6
+Output: 2
+Explanation:
+We can perform the following operations:
+Replace nums[3] by 0. The resulting array is nums = [0,1,2,0,3,6,5,4].
+Replace nums[4] by 4. The resulting array is nums = [0,1,2,0,4,6,5,4].
+The integer X will be 4.
+
+
+Constraints:
+
+2 <= n == nums.length <= 10^5
+n is even.
+0 <= nums[i] <= k <= 10^5
+
+"""
+
+# V0
+# IDEA : SCORE EVERY CANDIDATE X AT ONCE WITH A DIFFERENCE ARRAY
+#
+#   the pairs (nums[i], nums[n-1-i]) are independent, and for a target gap X
+#   a pair costs
+#       0  if its current gap already equals X
+#       1  if ONE element can be rewritten to reach X
+#       2  otherwise
+#
+#   changing a single element of the pair (a, b) can produce any gap up to
+#       reach = max(max(a, b), k - min(a, b))
+#   — push the larger one up to k, or drag the smaller one down to 0. so a
+#   pair costs at most 1 for every X <= reach, and 2 beyond that.
+#
+#   so tally, over all pairs, how many have each exact gap (cnt) and how many
+#   have each reach (a suffix count via a difference array). then for each X
+#
+#       cost(X) = (reachable - cnt[X]) * 1 + (pairs - reachable) * 2
+#
+#   and the answer is the smallest of them.
+#
+# time = O(n + k), space = O(k)
+class Solution(object):
+    def minChanges(self, nums, k):
+        n = len(nums)
+        pairs = n // 2
+        cnt = [0] * (k + 2)              # pairs whose gap is exactly X
+        reach_at_least = [0] * (k + 2)   # difference array over reach
+
+        for i in range(pairs):
+            a, b = nums[i], nums[n - 1 - i]
+            gap = abs(a - b)
+            reach = max(max(a, b), k - min(a, b))
+            cnt[gap] += 1
+            reach_at_least[0] += 1
+            reach_at_least[reach + 1] -= 1
+
+        best = float('inf')
+        running = 0
+        for X in range(k + 1):
+            running += reach_at_least[X]
+            cost = (running - cnt[X]) + 2 * (pairs - running)
+            if cost < best:
+                best = cost
+        return best

--- a/leetcode_python/Array/minimum-number-of-flips-to-make-binary-grid-palindromic-i.py
+++ b/leetcode_python/Array/minimum-number-of-flips-to-make-binary-grid-palindromic-i.py
@@ -1,0 +1,77 @@
+"""
+
+3239. Minimum Number of Flips to Make Binary Grid Palindromic I
+Medium
+
+You are given an m x n binary matrix grid.
+
+A row or column is considered palindromic if its values read the same forward and backward.
+
+You can flip any number of cells in grid from 0 to 1, or from 1 to 0.
+
+Return the minimum number of cells that need to be flipped to make either all rows palindromic or all columns palindromic.
+
+
+Example 1:
+
+Input: grid = [[1,0,0],[0,0,0],[0,0,1]]
+Output: 2
+Explanation:
+Flipping the highlighted cells makes all the rows palindromic.
+
+Example 2:
+
+Input: grid = [[0,1],[0,1],[0,0]]
+Output: 1
+Explanation:
+Flipping the highlighted cell makes all the columns palindromic.
+
+Example 3:
+
+Input: grid = [[1],[0]]
+Output: 0
+Explanation:
+All rows are already palindromic.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m * n <= 2 * 10^5
+
+"""
+
+# V0
+# IDEA : COUNT THE MISMATCHED MIRROR PAIRS, ONCE PER ORIENTATION
+#
+#   making one row palindromic means every mirrored pair inside it must
+#   agree, and a disagreeing pair costs exactly one flip (change either
+#   side). the pairs are independent, so the row cost is just the number of
+#   mismatched pairs across all rows — and the column cost is the same count
+#   taken down the columns.
+#
+#   the task allows satisfying EITHER orientation, so the answer is the
+#   smaller of the two totals.
+#
+#   odd-length lines have a middle cell with no partner, which never costs
+#   anything.
+#
+# time = O(m * n), space = O(1)
+class Solution(object):
+    def minFlips(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        row_cost = 0
+        for i in range(m):
+            for j in range(n // 2):
+                if grid[i][j] != grid[i][n - 1 - j]:
+                    row_cost += 1
+
+        col_cost = 0
+        for j in range(n):
+            for i in range(m // 2):
+                if grid[i][j] != grid[m - 1 - i][j]:
+                    col_cost += 1
+
+        return min(row_cost, col_cost)

--- a/leetcode_python/Array/minimum-number-of-flips-to-make-binary-grid-palindromic-ii.py
+++ b/leetcode_python/Array/minimum-number-of-flips-to-make-binary-grid-palindromic-ii.py
@@ -1,0 +1,106 @@
+"""
+
+3240. Minimum Number of Flips to Make Binary Grid Palindromic II
+Medium
+
+You are given an m x n binary matrix grid.
+
+A row or column is considered palindromic if its values read the same forward and backward.
+
+You can flip any number of cells in grid from 0 to 1, or from 1 to 0.
+
+Return the minimum number of cells that need to be flipped to make all rows and columns palindromic, and the total number of 1's in grid divisible by 4.
+
+
+Example 1:
+
+Input: grid = [[1,0,0],[0,1,0],[0,0,1]]
+Output: 3
+Explanation:
+
+Example 2:
+
+Input: grid = [[0,1],[0,1],[0,0]]
+Output: 2
+Explanation:
+
+Example 3:
+
+Input: grid = [[1],[1]]
+Output: 2
+Explanation:
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m * n <= 2 * 10^5
+
+"""
+
+# V0
+# IDEA : GROUPS OF FOUR ARE FREE OF THE MOD-4 RULE — ONLY THE MIDDLES MATTER
+#
+#   rows AND columns palindromic ties four cells together :
+#       (i, j), (i, n-1-j), (m-1-i, j), (m-1-i, n-1-j)
+#   they must all agree, costing min(ones, 4 - ones) flips, and afterwards
+#   they hold 0 or 4 ones — either way divisible by 4, so such groups never
+#   affect the parity rule.
+#
+#   what is left is the middle row (odd m) and middle column (odd n), where
+#   cells pair up TWO at a time and so contribute 0 or 2 ones :
+#       a mismatched pair costs 1 and its final value is our choice
+#       a matched 1-1 pair is free but already contributes 2
+#   with `ones2` such 1-1 pairs, the running total is 2*ones2 mod 4, which is
+#   wrong exactly when ones2 is odd. fixing it is free if some mismatched
+#   pair exists (settle it on 1-1 instead of 0-0); otherwise one 1-1 pair
+#   must be zeroed at a cost of 2.
+#
+#   finally the very centre cell (both m and n odd) has no partner, so it
+#   must be 0 — everything else is even.
+#
+# time = O(m * n), space = O(1)
+class Solution(object):
+    def minFlips(self, grid):
+        m, n = len(grid), len(grid[0])
+        cost = 0
+
+        # quadruples
+        for i in range(m // 2):
+            for j in range(n // 2):
+                ones = (grid[i][j] + grid[i][n - 1 - j]
+                        + grid[m - 1 - i][j] + grid[m - 1 - i][n - 1 - j])
+                cost += min(ones, 4 - ones)
+
+        ones2 = 0        # mirrored pairs already holding two 1s
+        diff = 0         # mirrored pairs that disagree
+
+        if m % 2:        # middle row
+            i = m // 2
+            for j in range(n // 2):
+                a, b = grid[i][j], grid[i][n - 1 - j]
+                if a != b:
+                    diff += 1
+                elif a == 1:
+                    ones2 += 1
+
+        if n % 2:        # middle column
+            j = n // 2
+            for i in range(m // 2):
+                a, b = grid[i][j], grid[m - 1 - i][j]
+                if a != b:
+                    diff += 1
+                elif a == 1:
+                    ones2 += 1
+
+        cost += diff
+        if ones2 % 2:
+            if diff == 0:
+                cost += 2                     # zero out one 1-1 pair
+            # else: settle a mismatched pair on 1-1 instead, same cost
+
+        if m % 2 and n % 2:
+            cost += grid[m // 2][n // 2]      # the centre must end up 0
+
+        return cost

--- a/leetcode_python/Array/snake-in-matrix.py
+++ b/leetcode_python/Array/snake-in-matrix.py
@@ -1,0 +1,55 @@
+"""
+
+3248. Snake in Matrix
+Medium
+
+There is a snake in an n x n matrix grid and can move in four possible directions. Each cell in the grid is identified by the position: grid[i][j] = (i * n) + j.
+
+The snake starts at cell 0 and follows a sequence of commands.
+
+You are given an integer n representing the size of the grid and an array of strings commands where each command[i] is either "UP", "RIGHT", "DOWN", and "LEFT". It's guaranteed that the snake will remain within the grid boundaries throughout its movement.
+
+Return the position of the final cell where the snake ends up after executing commands.
+
+
+Example 1:
+
+Input: n = 2, commands = ["RIGHT","DOWN"]
+Output: 3
+Explanation:
+
+Example 2:
+
+Input: n = 3, commands = ["DOWN","RIGHT","UP"]
+Output: 1
+Explanation:
+
+
+Constraints:
+
+2 <= n <= 10
+1 <= commands.length <= 100
+commands consists only of "UP", "RIGHT", "DOWN", and "LEFT".
+The input is generated such that the snake will not move outside of the boundaries.
+
+"""
+
+# V0
+# IDEA : TRACK (row, col) AND ENCODE AT THE END
+#
+#   the cell id is i * n + j, so keeping the coordinates and converting once
+#   at the end avoids any modular arithmetic mid-walk.
+#
+#   the statement guarantees the snake never leaves the board, so no bounds
+#   checks are needed.
+#
+# time = O(len(commands)), space = O(1)
+class Solution(object):
+    def finalPositionOfSnake(self, n, commands):
+        moves = {"UP": (-1, 0), "DOWN": (1, 0), "LEFT": (0, -1), "RIGHT": (0, 1)}
+        i = j = 0
+        for c in commands:
+            di, dj = moves[c]
+            i += di
+            j += dj
+        return i * n + j

--- a/leetcode_python/Backtracking/generate-binary-strings-without-adjacent-zeros.py
+++ b/leetcode_python/Backtracking/generate-binary-strings-without-adjacent-zeros.py
@@ -1,0 +1,63 @@
+"""
+
+3211. Generate Binary Strings Without Adjacent Zeros
+Medium
+
+You are given a positive integer n.
+
+A binary string x is valid if all substrings of x of length 2 contain at least one "1".
+
+Return all valid strings with length n, in any order.
+
+
+Example 1:
+
+Input: n = 3
+Output: ["010","011","101","110","111"]
+Explanation:
+The valid strings of length 3 are: "010", "011", "101", "110", and "111".
+
+Example 2:
+
+Input: n = 1
+Output: ["0","1"]
+Explanation:
+The valid strings of length 1 are: "0" and "1".
+
+
+Constraints:
+
+1 <= n <= 18
+
+"""
+
+# V0
+# IDEA : BACKTRACK, REFUSING TO PLACE A '0' AFTER A '0'
+#
+#   "every length-2 substring holds a 1" is the same as "no two adjacent
+#   zeros", so the only rule while building left to right is : a '0' may
+#   follow anything except another '0'.
+#
+#   the count of such strings is a Fibonacci number, so n = 18 yields a few
+#   thousand results — small enough to list them all.
+#
+# time = O(n * number of valid strings), space = O(n) recursion
+class Solution(object):
+    def validStrings(self, n):
+        res = []
+        cur = []
+
+        def build(i):
+            if i == n:
+                res.append(''.join(cur))
+                return
+            if not cur or cur[-1] == '1':
+                cur.append('0')
+                build(i + 1)
+                cur.pop()
+            cur.append('1')
+            build(i + 1)
+            cur.pop()
+
+        build(0)
+        return res

--- a/leetcode_python/Binary_Search/minimum-number-of-increasing-subsequence-to-be-removed.py
+++ b/leetcode_python/Binary_Search/minimum-number-of-increasing-subsequence-to-be-removed.py
@@ -1,0 +1,72 @@
+"""
+
+3231. Minimum Number of Increasing Subsequence to Be Removed
+Hard
+🔒 (premium)
+
+Given an array of integers nums, you are allowed to perform the following operation any number of times:
+
+Remove a strictly increasing subsequence from the array.
+
+Your task is to find the minimum number of operations required to make the array empty.
+
+
+Example 1:
+
+Input: nums = [5,3,1,4,2]
+Output: 3
+Explanation:
+We remove subsequences [1, 2], [3, 4], [5].
+
+Example 2:
+
+Input: nums = [1,2,3,4,5]
+Output: 1
+Explanation:
+We remove the subsequence [1, 2, 3, 4, 5].
+
+Example 3:
+
+Input: nums = [5,4,3,2,1]
+Output: 5
+Explanation:
+We remove the subsequences [5], [4], [3], [2], [1].
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : DILWORTH — THE ANSWER IS THE LONGEST NON-INCREASING SUBSEQUENCE
+#
+#   order the positions by "i before j and nums[i] < nums[j]". a strictly
+#   increasing subsequence is a CHAIN in that order, so the question is the
+#   minimum number of chains covering everything.
+#
+#   Dilworth's theorem says that equals the largest ANTICHAIN — a set of
+#   positions no two of which are comparable, i.e. a longest NON-INCREASING
+#   subsequence.
+#
+#   that length comes from patience sorting : negate the values to turn
+#   "non-increasing" into "non-decreasing", then keep the usual tails array
+#   with bisect_RIGHT (equal values may extend a pile).
+#
+# time = O(n log n), space = O(n)
+import bisect
+
+
+class Solution(object):
+    def minOperations(self, nums):
+        tails = []
+        for x in nums:
+            v = -x                              # non-increasing -> non-decreasing
+            pos = bisect.bisect_right(tails, v)
+            if pos == len(tails):
+                tails.append(v)
+            else:
+                tails[pos] = v
+        return len(tails)

--- a/leetcode_python/Bit_Manipulation/number-of-bit-changes-to-make-two-integers-equal.py
+++ b/leetcode_python/Bit_Manipulation/number-of-bit-changes-to-make-two-integers-equal.py
@@ -1,0 +1,56 @@
+"""
+
+3226. Number of Bit Changes to Make Two Integers Equal
+Easy
+
+You are given two positive integers n and k.
+
+You can choose any bit in the binary representation of n that is equal to 1 and change it to 0.
+
+Return the number of changes needed to make n equal to k. If it is impossible, return -1.
+
+
+Example 1:
+
+Input: n = 13, k = 4
+Output: 2
+Explanation:
+Initially, the binary representations of n and k are n = (1101)2 and k = (0100)2.
+We can change the first and fourth bits of n. The resulting integer is n = (0100)2 = k.
+
+Example 2:
+
+Input: n = 21, k = 21
+Output: 0
+Explanation:
+n and k are already equal, so no changes are needed.
+
+Example 3:
+
+Input: n = 14, k = 13
+Output: -1
+Explanation:
+It is not possible to make n equal to k.
+
+
+Constraints:
+
+1 <= n, k <= 10^6
+
+"""
+
+# V0
+# IDEA : ONLY 1 -> 0 IS ALLOWED, SO k'S BITS MUST BE A SUBSET OF n'S
+#
+#   bits can be cleared but never set, so k is reachable only when every bit
+#   of k is already present in n — i.e. (n & k) == k. otherwise -1.
+#
+#   when it is reachable, the bits to clear are exactly those set in n and
+#   not in k, which is n XOR k, so the answer is its popcount.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def minChanges(self, n, k):
+        if (n & k) != k:
+            return -1
+        return bin(n ^ k).count('1')

--- a/leetcode_python/Bit_Manipulation/number-of-subarrays-with-and-value-of-k.py
+++ b/leetcode_python/Bit_Manipulation/number-of-subarrays-with-and-value-of-k.py
@@ -1,0 +1,66 @@
+"""
+
+3209. Number of Subarrays With AND Value of K
+Hard
+
+Given an array of integers nums and an integer k, return the number of subarrays of nums where the bitwise AND of the elements of the subarray equals k.
+
+
+Example 1:
+
+Input: nums = [1,1,1], k = 1
+Output: 6
+Explanation:
+All subarrays contain only 1's.
+
+Example 2:
+
+Input: nums = [1,1,2], k = 1
+Output: 3
+Explanation:
+Subarrays having an AND value of 1 are: [1,1,2], [1,1,2], [1,1,2].
+
+Example 3:
+
+Input: nums = [1,2,3], k = 2
+Output: 2
+Explanation:
+Subarrays having an AND value of 2 are: [1,2,3], [1,2,3].
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i], k <= 10^9
+
+"""
+
+# V0
+# IDEA : THE ANDs OF ALL SUBARRAYS ENDING AT i FORM AT MOST ~30 DISTINCT VALUES
+#
+#   extending a subarray leftwards can only CLEAR bits, so the ANDs of the
+#   subarrays ending at index i form a chain that loses bits and never gains
+#   any — at most 31 distinct values for 30-bit numbers.
+#
+#   so carry a small map {AND value -> how many subarrays ending here produce
+#   it}. moving to the next element ANDs every key with nums[i] (merging the
+#   collisions by adding counts) and adds the single-element subarray.
+#
+#   the answer accumulates the count stored under k at each step.
+#
+# time = O(30 * n), space = O(30)
+from collections import defaultdict
+
+
+class Solution(object):
+    def countSubarrays(self, nums, k):
+        res = 0
+        prev = {}
+        for x in nums:
+            cur = defaultdict(int)
+            cur[x] += 1
+            for v, c in prev.items():
+                cur[v & x] += c
+            res += cur.get(k, 0)
+            prev = cur
+        return res

--- a/leetcode_python/Breadth-First-Search/find-minimum-diameter-after-merging-two-trees.py
+++ b/leetcode_python/Breadth-First-Search/find-minimum-diameter-after-merging-two-trees.py
@@ -1,0 +1,100 @@
+"""
+
+3203. Find Minimum Diameter After Merging Two Trees
+Hard
+
+There exist two undirected trees with n and m nodes, numbered from 0 to n - 1 and from 0 to m - 1, respectively. You are given two 2D integer arrays edges1 and edges2 of lengths n - 1 and m - 1, respectively, where edges1[i] = [ai, bi] indicates that there is an edge between nodes ai and bi in the first tree and edges2[i] = [ui, vi] indicates that there is an edge between nodes ui and vi in the second tree.
+
+You must connect one node from the first tree with another node from the second tree with an edge.
+
+Return the minimum possible diameter of the resulting tree.
+
+The diameter of a tree is the length of the longest path between any two nodes in the tree.
+
+
+Example 1:
+
+Input: edges1 = [[0,1],[0,2],[0,3]], edges2 = [[0,1]]
+Output: 3
+Explanation:
+We can obtain a tree of diameter 3 by connecting node 0 from the first tree with any node from the second tree.
+
+Example 2:
+
+Input: edges1 = [[0,1],[0,2],[0,3],[2,4],[2,5],[3,6],[2,7]], edges2 = [[0,1],[0,2],[0,3],[2,4],[2,5],[3,6],[2,7]]
+Output: 5
+Explanation:
+We can obtain a tree of diameter 5 by connecting node 0 from the first tree with node 0 from the second tree.
+
+
+Constraints:
+
+1 <= n, m <= 10^5
+edges1.length == n - 1
+edges2.length == m - 1
+edges1[i].length == edges2[i].length == 2
+edges1[i] = [ai, bi]
+0 <= ai, bi < n
+edges2[i] = [ui, vi]
+0 <= ui, vi < m
+The input is generated such that edges1 and edges2 represent valid trees.
+
+"""
+
+# V0
+# IDEA : JOIN THE TWO *CENTRES* — THE ANSWER IS A MAX OF THREE TERMS
+#
+#   the merged tree's longest path is one of :
+#       a path living entirely in tree 1        -> d1
+#       a path living entirely in tree 2        -> d2
+#       a path crossing the new edge            -> ecc1 + 1 + ecc2
+#   where ecc is the largest distance from the chosen endpoint to anywhere in
+#   its own tree.
+#
+#   we get to choose the endpoints, and the best possible eccentricity in a
+#   tree is its RADIUS, ceil(d / 2), attained at the centre. so
+#
+#       answer = max(d1, d2, ceil(d1/2) + ceil(d2/2) + 1)
+#
+#   and the diameters come from the classic double BFS : farthest node from
+#   any start, then farthest from that node.
+#
+# time = O(n + m), space = O(n + m)
+from collections import deque
+
+
+class Solution(object):
+    def minimumDiameterAfterMerge(self, edges1, edges2):
+
+        def diameter(edges):
+            n = len(edges) + 1
+            if n == 1:
+                return 0
+            adj = [[] for _ in range(n)]
+            for a, b in edges:
+                adj[a].append(b)
+                adj[b].append(a)
+
+            def bfs(src):
+                dist = [-1] * n
+                dist[src] = 0
+                q = deque([src])
+                far = src
+                while q:
+                    u = q.popleft()
+                    if dist[u] > dist[far]:
+                        far = u
+                    for v in adj[u]:
+                        if dist[v] == -1:
+                            dist[v] = dist[u] + 1
+                            q.append(v)
+                return far, dist[far]
+
+            a, _ = bfs(0)
+            _, d = bfs(a)
+            return d
+
+        d1 = diameter(edges1)
+        d2 = diameter(edges2)
+        cross = (d1 + 1) // 2 + (d2 + 1) // 2 + 1
+        return max(d1, d2, cross)

--- a/leetcode_python/Breadth-First-Search/shortest-distance-after-road-addition-queries-i.py
+++ b/leetcode_python/Breadth-First-Search/shortest-distance-after-road-addition-queries-i.py
@@ -1,0 +1,79 @@
+"""
+
+3243. Shortest Distance After Road Addition Queries I
+Medium
+
+You are given an integer n and a 2D integer array queries.
+
+There are n cities numbered from 0 to n - 1. Initially, there is a unidirectional road from city i to city i + 1 for all 0 <= i < n - 1.
+
+queries[i] = [u_i, v_i] represents the addition of a new unidirectional road from city u_i to city v_i. After each query, you need to find the length of the shortest path from city 0 to city n - 1.
+
+Return an array answer where for each i in the range [0, queries.length - 1], answer[i] is the length of the shortest path from city 0 to city n - 1 after processing the first i + 1 queries.
+
+
+Example 1:
+
+Input: n = 5, queries = [[2,4],[0,2],[0,4]]
+Output: [3,2,1]
+Explanation:
+After the addition of the road from 2 to 4, the length of the shortest path from 0 to 4 is 3.
+After the addition of the road from 0 to 2, the length of the shortest path from 0 to 4 is 2.
+After the addition of the road from 0 to 4, the length of the shortest path from 0 to 4 is 1.
+
+Example 2:
+
+Input: n = 4, queries = [[0,3],[0,2]]
+Output: [1,1]
+Explanation:
+After the addition of the road from 0 to 3, the length of the shortest path from 0 to 3 is 1.
+After the addition of the road from 0 to 2, the length of the shortest path remains 1.
+
+
+Constraints:
+
+3 <= n <= 500
+1 <= queries.length <= 500
+queries[i].length == 2
+0 <= queries[i][0] < queries[i][1] < n
+1 < queries[i][1] - queries[i][0]
+There are no repeated roads among the queries.
+
+"""
+
+# V0
+# IDEA : ALL EDGES COST 1 — SO ONE BFS PER QUERY IS ENOUGH AT THIS SIZE
+#
+#   the graph stays unweighted no matter how many shortcuts are added, so a
+#   plain BFS from city 0 gives the distance to n-1.
+#
+#   n and the query count are both capped at 500, so re-running the BFS after
+#   each addition is 500 * (500 + 1000) steps — well within budget. the
+#   sequel (LC 3244) removes that slack and needs the non-crossing structure.
+#
+# time = O(q * (n + q)), space = O(n + q)
+from collections import deque
+
+
+class Solution(object):
+    def shortestDistanceAfterQueries(self, n, queries):
+        adj = [[] for _ in range(n)]
+        for i in range(n - 1):
+            adj[i].append(i + 1)
+
+        res = []
+        for u, v in queries:
+            adj[u].append(v)
+            dist = [-1] * n
+            dist[0] = 0
+            q = deque([0])
+            while q:
+                cur = q.popleft()
+                if cur == n - 1:
+                    break
+                for nxt in adj[cur]:
+                    if dist[nxt] == -1:
+                        dist[nxt] = dist[cur] + 1
+                        q.append(nxt)
+            res.append(dist[n - 1])
+        return res

--- a/leetcode_python/Depth-First-Search/count-the-number-of-good-nodes.py
+++ b/leetcode_python/Depth-First-Search/count-the-number-of-good-nodes.py
@@ -1,0 +1,94 @@
+"""
+
+3249. Count the Number of Good Nodes
+Medium
+
+There is an undirected tree with n nodes labeled from 0 to n - 1, and rooted at node 0. You are given a 2D integer array edges of length n - 1, where edges[i] = [ai, bi] indicates that there is an edge between nodes ai and bi in the tree.
+
+A node is good if all the subtrees rooted at its children have the same size.
+
+Return the number of good nodes in the given tree.
+
+A subtree of treeName is a tree consisting of a node in treeName and all of its descendants.
+
+
+Example 1:
+
+Input: edges = [[0,1],[0,2],[1,3],[1,4],[2,5],[2,6]]
+Output: 7
+Explanation:
+All of the nodes of the given tree are good.
+
+Example 2:
+
+Input: edges = [[0,1],[1,2],[2,3],[3,4],[0,5],[1,6],[2,7],[3,8]]
+Output: 6
+Explanation:
+There are 6 good nodes in the given tree.
+
+
+Constraints:
+
+2 <= n <= 10^5
+edges.length == n - 1
+edges[i].length == 2
+0 <= edges[i][0], edges[i][1] <= n - 1
+The input is generated such that edges represents a valid tree.
+
+"""
+
+# V0
+# IDEA : POST-ORDER SUBTREE SIZES, THEN COMPARE EACH NODE'S CHILDREN
+#
+#   subtree sizes come from one bottom-up pass :
+#       size[u] = 1 + sum of children sizes
+#   and a node is good when all its children carry the SAME size. leaves have
+#   no children, so they are vacuously good.
+#
+#   the traversal is iterative — a 10^5-node path would exceed python's
+#   recursion limit. reversing the DFS discovery order gives a valid
+#   post-order, since a parent always appears before its children.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def countGoodNodes(self, edges):
+        n = len(edges) + 1
+        adj = [[] for _ in range(n)]
+        for u, v in edges:
+            adj[u].append(v)
+            adj[v].append(u)
+
+        parent = [-1] * n
+        order = []
+        stack = [0]
+        seen = [False] * n
+        seen[0] = True
+        while stack:
+            u = stack.pop()
+            order.append(u)
+            for v in adj[u]:
+                if not seen[v]:
+                    seen[v] = True
+                    parent[v] = u
+                    stack.append(v)
+
+        size = [1] * n
+        for u in reversed(order):
+            if parent[u] != -1:
+                size[parent[u]] += size[u]
+
+        res = 0
+        for u in range(n):
+            first = None
+            good = True
+            for v in adj[u]:
+                if v == parent[u]:
+                    continue
+                if first is None:
+                    first = size[v]
+                elif size[v] != first:
+                    good = False
+                    break
+            if good:
+                res += 1
+        return res

--- a/leetcode_python/Depth-First-Search/time-taken-to-mark-all-nodes.py
+++ b/leetcode_python/Depth-First-Search/time-taken-to-mark-all-nodes.py
@@ -1,0 +1,130 @@
+"""
+
+3241. Time Taken to Mark All Nodes
+Hard
+
+There exists an undirected tree with n nodes numbered 0 to n - 1. You are given a 2D integer array edges of length n - 1, where edges[i] = [ui, vi] indicates that there is an edge between nodes ui and vi in the tree.
+
+Initially, all nodes are unmarked. For each node i:
+
+If i is odd, the node will get marked at time x if there is at least one node adjacent to it which was marked at time x - 1.
+If i is even, the node will get marked at time x if there is at least one node adjacent to it which was marked at time x - 2.
+
+Return an array times where times[i] is the time when all nodes get marked in the tree, if you mark node i at time t = 0.
+
+Note that the answer for each times[i] is independent, i.e. when you mark node i all other nodes are unmarked.
+
+
+Example 1:
+
+Input: edges = [[0,1],[0,2]]
+Output: [2,4,3]
+Explanation:
+For i = 0:
+    Node 1 is marked at t = 1, and Node 2 at t = 2.
+For i = 1:
+    Node 0 is marked at t = 2, and Node 2 at t = 4.
+For i = 2:
+    Node 0 is marked at t = 2, and Node 1 at t = 3.
+
+Example 2:
+
+Input: edges = [[0,1]]
+Output: [1,2]
+Explanation:
+For i = 0:
+    Node 1 is marked at t = 1.
+For i = 1:
+    Node 0 is marked at t = 2.
+
+Example 3:
+
+Input: edges = [[2,4],[0,1],[2,3],[0,2]]
+Output: [4,6,3,5,5]
+Explanation:
+
+
+Constraints:
+
+2 <= n <= 10^5
+edges.length == n - 1
+edges[i].length == 2
+0 <= edges[i][0], edges[i][1] <= n - 1
+The input is generated such that edges represents a valid tree.
+
+"""
+
+# V0
+# IDEA : REROOTING — ONE DOWNWARD PASS, THEN PUSH THE ANSWER OUTWARDS
+#
+#   marking spreads along edges with a per-node delay : entering node v costs
+#   1 if v is odd and 2 if it is even. so from a fixed root the finishing
+#   time is the deepest weighted path, computed bottom-up as
+#
+#       down[u] = max over children v of (down[v] + cost(v))
+#
+#   answering for EVERY start would be n separate passes, so reroot instead :
+#   carry `up[u]` — the best time reachable by leaving u through its parent —
+#   and combine it with the children when descending. a node's contribution
+#   to its own child must be excluded, which is why the TOP TWO child values
+#   are kept: the best one for every child except the one that produced it,
+#   which falls back to the runner-up.
+#
+#   both passes are iterative; a 10^5-node path would overflow python's
+#   recursion.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def timeTaken(self, edges):
+        n = len(edges) + 1
+        adj = [[] for _ in range(n)]
+        for u, v in edges:
+            adj[u].append(v)
+            adj[v].append(u)
+
+        def cost(v):
+            return 1 if v % 2 else 2
+
+        # iterative DFS order from root 0
+        parent = [-1] * n
+        order = []
+        stack = [0]
+        seen = [False] * n
+        seen[0] = True
+        while stack:
+            u = stack.pop()
+            order.append(u)
+            for v in adj[u]:
+                if not seen[v]:
+                    seen[v] = True
+                    parent[v] = u
+                    stack.append(v)
+
+        down = [0] * n
+        for u in reversed(order):                 # children before parents
+            p = parent[u]
+            if p != -1:
+                cand = down[u] + cost(u)
+                if cand > down[p]:
+                    down[p] = cand
+
+        up = [0] * n
+        res = [0] * n
+        for u in order:                           # parents before children
+            # the two best child contributions, so a child can be excluded
+            b1 = b2 = 0
+            for v in adj[u]:
+                if v == parent[u]:
+                    continue
+                cand = down[v] + cost(v)
+                if cand > b1:
+                    b1, b2 = cand, b1
+                elif cand > b2:
+                    b2 = cand
+            res[u] = max(up[u], b1)
+            for v in adj[u]:
+                if v == parent[u]:
+                    continue
+                other = b2 if (down[v] + cost(v)) == b1 else b1
+                up[v] = max(up[u], other) + cost(u)
+        return res

--- a/leetcode_python/Design/design-neighbor-sum-service.py
+++ b/leetcode_python/Design/design-neighbor-sum-service.py
@@ -1,0 +1,86 @@
+"""
+
+3242. Design Neighbor Sum Service
+Easy
+
+You are given a n x n 2D array grid containing distinct elements in the range [0, n^2 - 1].
+
+Implement the NeighborSum class:
+
+NeighborSum(int [][]grid) initializes the object.
+int adjacentSum(int value) returns the sum of elements which are adjacent neighbors of value, that is either to the top, left, right, or bottom of value in grid.
+int diagonalSum(int value) returns the sum of elements which are diagonal neighbors of value, that is either to the top-left, top-right, bottom-left, or bottom-right of value in grid.
+
+
+Example 1:
+
+Input:
+["NeighborSum", "adjacentSum", "adjacentSum", "diagonalSum", "diagonalSum"]
+[[[[0, 1, 2], [3, 4, 5], [6, 7, 8]]], [1], [4], [4], [8]]
+Output: [null, 6, 16, 16, 4]
+Explanation:
+The adjacent neighbors of 1 are 0, 2, and 4.
+The adjacent neighbors of 4 are 1, 3, 5, and 7.
+The diagonal neighbors of 4 are 0, 2, 6, and 8.
+The diagonal neighbor of 8 is 4.
+
+Example 2:
+
+Input:
+["NeighborSum", "adjacentSum", "diagonalSum"]
+[[[[1, 2, 0, 3], [4, 7, 15, 6], [8, 9, 10, 11], [12, 13, 14, 5]]], [15], [9]]
+Output: [null, 23, 45]
+Explanation:
+The adjacent neighbors of 15 are 0, 10, 7, and 6.
+The diagonal neighbors of 9 are 4, 12, 14, and 15.
+
+
+Constraints:
+
+3 <= n == grid.length == grid[i].length <= 10
+0 <= grid[i][j] <= n^2 - 1
+All grid[i][j] are distinct.
+value in adjacentSum and diagonalSum will be in the range [0, n^2 - 1].
+At most 2 * n^2 calls will be made to adjacentSum and diagonalSum.
+
+"""
+
+# V0
+# IDEA : INDEX THE VALUES ONCE, THEN EACH QUERY IS FOUR BOUNDED LOOKUPS
+#
+#   the values are distinct, so a dict from value to its (row, col) is well
+#   defined and built once in the constructor. after that both queries walk
+#   the same four offsets, differing only in which set of offsets they use,
+#   and skip whatever falls off the board.
+#
+# time = O(n^2) to build, O(1) per query, space = O(n^2)
+class NeighborSum(object):
+
+    def __init__(self, grid):
+        self.grid = grid
+        self.n = len(grid)
+        self.pos = {}
+        for i, row in enumerate(grid):
+            for j, v in enumerate(row):
+                self.pos[v] = (i, j)
+
+    def _sum(self, value, offsets):
+        i, j = self.pos[value]
+        total = 0
+        for di, dj in offsets:
+            a, b = i + di, j + dj
+            if 0 <= a < self.n and 0 <= b < self.n:
+                total += self.grid[a][b]
+        return total
+
+    def adjacentSum(self, value):
+        return self._sum(value, ((-1, 0), (1, 0), (0, -1), (0, 1)))
+
+    def diagonalSum(self, value):
+        return self._sum(value, ((-1, -1), (-1, 1), (1, -1), (1, 1)))
+
+
+# Your NeighborSum object will be instantiated and called as such:
+# obj = NeighborSum(grid)
+# param_1 = obj.adjacentSum(value)
+# param_2 = obj.diagonalSum(value)

--- a/leetcode_python/Design/peaks-in-array.py
+++ b/leetcode_python/Design/peaks-in-array.py
@@ -1,0 +1,112 @@
+"""
+
+3187. Peaks in Array
+Hard
+
+A peak in an array arr is an element that is greater than its previous and next element in arr.
+
+You are given an integer array nums and a 2D integer array queries.
+
+You have to process queries of two types:
+
+queries[i] = [1, l_i, r_i], determine the count of peak elements in the subarray nums[l_i..r_i].
+queries[i] = [2, index_i, val_i], change nums[index_i] to val_i.
+
+Return an array answer containing the results of the queries of the first type in order.
+
+Notes:
+
+The first and the last element of an array or a subarray cannot be a peak.
+
+
+Example 1:
+
+Input: nums = [3,1,4,2,5], queries = [[2,3,4],[1,0,4]]
+Output: [0]
+Explanation:
+First query: We change nums[3] to 4 and nums becomes [3,1,4,4,5].
+Second query: The number of peaks in the [3,1,4,4,5] is 0.
+
+Example 2:
+
+Input: nums = [4,1,4,2,1,5], queries = [[2,2,4],[1,0,2],[1,0,4]]
+Output: [0,1]
+Explanation:
+First query: nums[2] should become 4, but it is already set to 4.
+Second query: The number of peaks in the [4,1,4] is 0.
+Third query: The second 4 is a peak in the [4,1,4,2,1].
+
+
+Constraints:
+
+3 <= nums.length <= 10^5
+1 <= nums[i] <= 10^5
+1 <= queries.length <= 10^5
+queries[i][0] == 1 or queries[i][0] == 2
+For all i that:
+    queries[i][0] == 1: 0 <= queries[i][1] <= queries[i][2] <= nums.length - 1
+    queries[i][0] == 2: 0 <= queries[i][1] <= nums.length - 1, 1 <= queries[i][2] <= 10^5
+
+"""
+
+# V0
+# IDEA : A FENWICK TREE OVER "IS THIS INDEX A PEAK", REPAIRED LOCALLY ON UPDATES
+#
+#   being a peak is a purely LOCAL property — index i depends only on
+#   nums[i-1], nums[i], nums[i+1]. so keep a 0/1 flag per index in a Fenwick
+#   tree and a range query becomes a prefix-sum difference.
+#
+#   writing nums[p] can only disturb the flags of p-1, p and p+1, so an
+#   update recomputes exactly those three.
+#
+#   the query excludes the subarray's own endpoints (they can never be
+#   peaks), so it sums the flags over [l+1, r-1] — empty when r - l < 2.
+#
+# time = O((n + q) log n), space = O(n)
+class Solution(object):
+    def countOfPeaks(self, nums, queries):
+        n = len(nums)
+        tree = [0] * (n + 1)
+
+        def add(i, delta):
+            i += 1
+            while i <= n:
+                tree[i] += delta
+                i += i & -i
+
+        def prefix(i):                      # sum of flags over [0, i]
+            s = 0
+            i += 1
+            while i > 0:
+                s += tree[i]
+                i -= i & -i
+            return s
+
+        flag = [0] * n
+
+        def is_peak(i):
+            return 1 if 0 < i < n - 1 and nums[i] > nums[i - 1] and nums[i] > nums[i + 1] else 0
+
+        for i in range(n):
+            flag[i] = is_peak(i)
+            if flag[i]:
+                add(i, 1)
+
+        res = []
+        for q in queries:
+            if q[0] == 1:
+                l, r = q[1], q[2]
+                if r - l < 2:
+                    res.append(0)
+                else:
+                    res.append(prefix(r - 1) - prefix(l))
+            else:
+                p, val = q[1], q[2]
+                nums[p] = val
+                for i in (p - 1, p, p + 1):
+                    if 0 <= i < n:
+                        cur = is_peak(i)
+                        if cur != flag[i]:
+                            add(i, cur - flag[i])
+                            flag[i] = cur
+        return res

--- a/leetcode_python/Dynamic_Programming/construct-string-with-minimum-cost-easy.py
+++ b/leetcode_python/Dynamic_Programming/construct-string-with-minimum-cost-easy.py
@@ -1,0 +1,77 @@
+"""
+
+3253. Construct String with Minimum Cost (Easy)
+Medium
+🔒 (premium)
+
+You are given a string target, an array of strings words, and an integer array costs, both arrays of the same length.
+
+Imagine an empty string s.
+
+You can perform the following operation any number of times (including zero):
+
+Choose an index i in the range [0, words.length - 1].
+Append words[i] to s.
+The cost of operation is costs[i].
+
+Return the minimum cost to make s equal to target. If it's not possible, return -1.
+
+
+Example 1:
+
+Input: target = "abcdef", words = ["abdef","abc","d","def","ef"], costs = [100,1,1,10,5]
+Output: 7
+Explanation:
+The minimum cost can be achieved by performing the following operations:
+Select index 1 and append "abc" to s at a cost of 1, resulting in s = "abc".
+Select index 2 and append "d" to s at a cost of 1, resulting in s = "abcd".
+Select index 4 and append "ef" to s at a cost of 5, resulting in s = "abcdef".
+
+Example 2:
+
+Input: target = "aaaa", words = ["z","zz","zzz"], costs = [1,10,100]
+Output: -1
+Explanation:
+It is impossible to make s equal to target, so we return -1.
+
+
+Constraints:
+
+1 <= target.length <= 2000
+1 <= words.length == costs.length <= 50
+1 <= words[i].length <= target.length
+target and words[i] consist only of lowercase English letters.
+1 <= costs[i] <= 10^4
+
+"""
+
+# V0
+# IDEA : DP OVER PREFIXES, TESTING EACH WORD AS THE LAST PIECE
+#
+#   dp[i] = cheapest way to build target[:i], so
+#       dp[i] = min over words w with target[i-len(w):i] == w of
+#                   dp[i - len(w)] + cost(w)
+#
+#   with only 50 words and a 2000-character target, the direct slice
+#   comparison is affordable — the harder sibling (LC 3213) pushes both to
+#   5*10^4 and needs a rolling hash keyed by word length.
+#
+#   dp starts at infinity everywhere except dp[0] = 0, and an unreachable
+#   dp[n] means the target cannot be assembled at all.
+#
+# time = O(n * m * L), space = O(n)
+class Solution(object):
+    def minimumCost(self, target, words, costs):
+        n = len(target)
+        INF = float('inf')
+        dp = [INF] * (n + 1)
+        dp[0] = 0
+
+        pairs = [(w, c) for w, c in zip(words, costs) if len(w) <= n]
+        for i in range(1, n + 1):
+            for w, c in pairs:
+                L = len(w)
+                if L <= i and dp[i - L] != INF and target[i - L:i] == w:
+                    if dp[i - L] + c < dp[i]:
+                        dp[i] = dp[i - L] + c
+        return -1 if dp[n] == INF else dp[n]

--- a/leetcode_python/Dynamic_Programming/construct-string-with-minimum-cost.py
+++ b/leetcode_python/Dynamic_Programming/construct-string-with-minimum-cost.py
@@ -1,0 +1,108 @@
+"""
+
+3213. Construct String with Minimum Cost
+Hard
+
+You are given a string target, an array of strings words, and an integer array costs, both arrays of the same length.
+
+Imagine an empty string s.
+
+You can perform the following operation any number of times (including zero):
+
+Choose an index i in the range [0, words.length - 1].
+Append words[i] to s.
+The cost of operation is costs[i].
+
+Return the minimum cost to make s equal to target. If it's not possible, return -1.
+
+
+Example 1:
+
+Input: target = "abcdef", words = ["abdef","abc","d","def","ef"], costs = [100,1,1,10,5]
+Output: 7
+Explanation:
+The minimum cost can be achieved by performing the following operations:
+Select index 1 and append "abc" to s at a cost of 1, resulting in s = "abc".
+Select index 2 and append "d" to s at a cost of 1, resulting in s = "abcd".
+Select index 4 and append "ef" to s at a cost of 5, resulting in s = "abcdef".
+
+Example 2:
+
+Input: target = "aaaa", words = ["z","zz","zzz"], costs = [1,10,100]
+Output: -1
+Explanation:
+It is impossible to make s equal to target, so we return -1.
+
+
+Constraints:
+
+1 <= target.length <= 5 * 10^4
+1 <= words.length == costs.length <= 5 * 10^4
+1 <= words[i].length <= target.length
+The total sum of words[i].length is less than or equal to 5 * 10^4
+target and words[i] consist only of lowercase English letters.
+1 <= costs[i] <= 10^4
+
+"""
+
+# V0
+# IDEA : DP OVER PREFIXES, WITH A ROLLING HASH SO EACH WORD LENGTH IS O(1)
+#
+#   dp[i] = cheapest way to build target[:i], so
+#       dp[i] = min over words w that end at i of  dp[i - len(w)] + cost(w)
+#
+#   the saving comes from the "total word length <= 5*10^4" guarantee : the
+#   number of DISTINCT word lengths L satisfies 1+2+...+L <= 5*10^4, so
+#   L <= 316. that bounds the transitions per position.
+#
+#   to test "does target[i-len : i] equal some word of this length" in O(1),
+#   precompute a polynomial rolling hash of target and store, per length, a
+#   map {hash -> cheapest cost}. duplicate words collapse to their minimum
+#   cost automatically.
+#
+#   NOTE : two moduli would make a collision essentially impossible; one
+#          64-bit modulus is used here for brevity.
+#
+# time = O(n * distinct lengths), space = O(n + total word length)
+class Solution(object):
+    def minimumCost(self, target, words, costs):
+        MOD = (1 << 61) - 1
+        BASE = 131
+
+        n = len(target)
+        # prefix hashes of target
+        h = [0] * (n + 1)
+        pw = [1] * (n + 1)
+        for i, ch in enumerate(target):
+            h[i + 1] = (h[i] * BASE + ord(ch)) % MOD
+            pw[i + 1] = pw[i] * BASE % MOD
+
+        def sub_hash(lo, hi):                    # hash of target[lo:hi]
+            return (h[hi] - h[lo] * pw[hi - lo]) % MOD
+
+        by_len = {}                              # length -> {hash: min cost}
+        for w, c in zip(words, costs):
+            L = len(w)
+            if L > n:
+                continue
+            hw = 0
+            for ch in w:
+                hw = (hw * BASE + ord(ch)) % MOD
+            table = by_len.setdefault(L, {})
+            if hw not in table or c < table[hw]:
+                table[hw] = c
+
+        lengths = sorted(by_len)
+        INF = float('inf')
+        dp = [INF] * (n + 1)
+        dp[0] = 0
+        for i in range(1, n + 1):
+            for L in lengths:
+                if L > i:
+                    break
+                if dp[i - L] == INF:
+                    continue
+                c = by_len[L].get(sub_hash(i - L, i))
+                if c is not None and dp[i - L] + c < dp[i]:
+                    dp[i] = dp[i - L] + c
+        return -1 if dp[n] == INF else dp[n]

--- a/leetcode_python/Dynamic_Programming/count-the-number-of-inversions.py
+++ b/leetcode_python/Dynamic_Programming/count-the-number-of-inversions.py
@@ -1,0 +1,110 @@
+"""
+
+3193. Count the Number of Inversions
+Hard
+
+You are given an integer n and a 2D array requirements, where requirements[i] = [end_i, cnt_i] represents the end index and the inversion count of each requirement.
+
+A pair of indices (i, j) from an integer array nums is called an inversion if:
+
+i < j and nums[i] > nums[j]
+
+Return the number of permutations perm of [0, 1, 2, ..., n - 1] such that for all requirements[i], perm[0..end_i] has exactly cnt_i inversions.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: n = 3, requirements = [[2,2],[0,0]]
+Output: 2
+Explanation:
+The two permutations are:
+[2, 0, 1]
+    Prefix [2, 0, 1] has inversions (0, 1) and (0, 2).
+    Prefix [2] has 0 inversions.
+[1, 2, 0]
+    Prefix [1, 2, 0] has inversions (0, 2) and (1, 2).
+    Prefix [1] has 0 inversions.
+
+Example 2:
+
+Input: n = 3, requirements = [[2,2],[1,1],[0,0]]
+Output: 1
+Explanation:
+The only satisfying permutation is [2, 0, 1]:
+Prefix [2, 0, 1] has inversions (0, 1) and (0, 2).
+Prefix [2, 0] has an inversion (0, 1).
+Prefix [2] has 0 inversions.
+
+Example 3:
+
+Input: n = 2, requirements = [[0,0],[1,0]]
+Output: 1
+Explanation:
+The only satisfying permutation is [0, 1]:
+Prefix [0] has 0 inversions.
+Prefix [0, 1] has an inversion (0, 1).
+
+
+Constraints:
+
+2 <= n <= 300
+1 <= requirements.length <= n
+requirements[i] = [end_i, cnt_i]
+0 <= end_i <= n - 1
+0 <= cnt_i <= 400
+The input is generated such that there is at least one i such that end_i == n - 1.
+The input is generated such that all end_i are unique.
+
+"""
+
+# V0
+# IDEA : BUILD THE PERMUTATION LEFT TO RIGHT, COUNTING INVERSIONS AS THEY APPEAR
+#
+#   think of the permutation as being built one position at a time, deciding
+#   the RELATIVE RANK of each new element among those placed so far. dropping
+#   a new element into rank r among i existing ones creates exactly (i - r)
+#   new inversions, and r ranges over 0..i — so the prefix of length i+1 can
+#   gain any number of inversions from 0 to i.
+#
+#       dp[i][k] = permutations of the first i+1 positions with k inversions
+#       dp[i][k] = sum over t = 0..min(i, k) of dp[i-1][k - t]
+#
+#   that inner sum is a sliding window over dp[i-1], so prefix sums make each
+#   row O(maxCnt).
+#
+#   a requirement at end = i simply erases every dp[i][k] with k != cnt.
+#
+#   cnt is capped at 400, and any prefix needing more inversions than that is
+#   irrelevant, so the table stays 300 x 401.
+#
+# time = O(n * maxCnt), space = O(maxCnt)
+class Solution(object):
+    def numberOfPermutations(self, n, requirements):
+        MOD = 10 ** 9 + 7
+        req = {end: cnt for end, cnt in requirements}
+        cap = max(req.values())
+
+        dp = [0] * (cap + 1)
+        dp[0] = 1
+        if 0 in req and req[0] != 0:
+            return 0                              # a single element has 0 inversions
+
+        for i in range(1, n):
+            pre = [0] * (cap + 2)
+            for k in range(cap + 1):
+                pre[k + 1] = (pre[k] + dp[k]) % MOD
+            nxt = [0] * (cap + 1)
+            for k in range(cap + 1):
+                lo = max(0, k - i)                # new inversions t <= i
+                nxt[k] = (pre[k + 1] - pre[lo]) % MOD
+            if i in req:
+                c = req[i]
+                keep = nxt[c] if c <= cap else 0
+                nxt = [0] * (cap + 1)
+                if c <= cap:
+                    nxt[c] = keep
+            dp = nxt
+
+        return dp[req[n - 1]] % MOD

--- a/leetcode_python/Dynamic_Programming/find-the-count-of-monotonic-pairs-i.py
+++ b/leetcode_python/Dynamic_Programming/find-the-count-of-monotonic-pairs-i.py
@@ -1,0 +1,87 @@
+"""
+
+3250. Find the Count of Monotonic Pairs I
+Hard
+
+You are given an array of positive integers nums of length n.
+
+We call a pair of non-negative integer arrays (arr1, arr2) monotonic if:
+
+The lengths of both arrays are n.
+arr1 is monotonically non-decreasing, in other words, arr1[0] <= arr1[1] <= ... <= arr1[n - 1].
+arr2 is monotonically non-increasing, in other words, arr2[0] >= arr2[1] >= ... >= arr2[n - 1].
+arr1[i] + arr2[i] == nums[i] for all indices 0 <= i <= n - 1.
+
+Return the count of monotonic pairs.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [2,3,2]
+Output: 4
+Explanation:
+The good pairs are:
+([0, 1, 1], [2, 2, 1])
+([0, 1, 2], [2, 2, 0])
+([0, 2, 2], [2, 1, 0])
+([1, 2, 2], [1, 1, 0])
+
+Example 2:
+
+Input: nums = [5,5,5,5]
+Output: 126
+
+
+Constraints:
+
+1 <= n == nums.length <= 2000
+1 <= nums[i] <= 50
+
+"""
+
+# V0
+# IDEA : arr2 IS DETERMINED BY arr1 — SO COUNT THE VALID arr1 SEQUENCES
+#
+#   arr2[i] = nums[i] - arr1[i], so the pair is decided entirely by arr1, and
+#   the two monotonicity rules turn into constraints on consecutive arr1
+#   values :
+#
+#       arr1[i] >= arr1[i-1]                        (arr1 non-decreasing)
+#       nums[i] - arr1[i] <= nums[i-1] - arr1[i-1]  (arr2 non-increasing)
+#         <=>  arr1[i] >= arr1[i-1] + nums[i] - nums[i-1]
+#
+#   so with dp[i][v] = ways where arr1[i] = v,
+#       dp[i][v] = sum of dp[i-1][p] over p <= min(v, v - (nums[i]-nums[i-1]))
+#   which a prefix sum over the previous row answers in O(1) per v.
+#
+#   arr1[i] also has to stay inside [0, nums[i]] so that arr2 stays
+#   non-negative.
+#
+# time = O(n * max value), space = O(max value)
+class Solution(object):
+    def countOfPairs(self, nums):
+        MOD = 10 ** 9 + 7
+        n = len(nums)
+        top = max(nums)
+
+        dp = [0] * (top + 1)
+        for v in range(nums[0] + 1):
+            dp[v] = 1
+
+        for i in range(1, n):
+            pre = [0] * (top + 2)
+            for v in range(top + 1):
+                pre[v + 1] = (pre[v] + dp[v]) % MOD
+            delta = nums[i] - nums[i - 1]
+            nxt = [0] * (top + 1)
+            for v in range(nums[i] + 1):
+                bound = min(v, v - delta)          # largest allowed arr1[i-1]
+                if bound < 0:
+                    continue
+                bound = min(bound, top)
+                nxt[v] = pre[bound + 1]
+            dp = nxt
+
+        return sum(dp) % MOD

--- a/leetcode_python/Dynamic_Programming/find-the-count-of-monotonic-pairs-ii.py
+++ b/leetcode_python/Dynamic_Programming/find-the-count-of-monotonic-pairs-ii.py
@@ -1,0 +1,86 @@
+"""
+
+3251. Find the Count of Monotonic Pairs II
+Hard
+
+You are given an array of positive integers nums of length n.
+
+We call a pair of non-negative integer arrays (arr1, arr2) monotonic if:
+
+The lengths of both arrays are n.
+arr1 is monotonically non-decreasing, in other words, arr1[0] <= arr1[1] <= ... <= arr1[n - 1].
+arr2 is monotonically non-increasing, in other words, arr2[0] >= arr2[1] >= ... >= arr2[n - 1].
+arr1[i] + arr2[i] == nums[i] for all indices 0 <= i <= n - 1.
+
+Return the count of monotonic pairs.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [2,3,2]
+Output: 4
+Explanation:
+The good pairs are:
+([0, 1, 1], [2, 2, 1])
+([0, 1, 2], [2, 2, 0])
+([0, 2, 2], [2, 1, 0])
+([1, 2, 2], [1, 1, 0])
+
+Example 2:
+
+Input: nums = [5,5,5,5]
+Output: 126
+
+
+Constraints:
+
+1 <= n == nums.length <= 2000
+1 <= nums[i] <= 1000
+
+"""
+
+# V0
+# IDEA : SAME PREFIX-SUM DP AS LC 3250 — IT WAS ALREADY O(n * max)
+#
+#   arr2 is pinned by arr1 (arr2[i] = nums[i] - arr1[i]), and the two
+#   monotonicity rules combine into a single lower bound on each step :
+#
+#       arr1[i] >= arr1[i-1] + max(0, nums[i] - nums[i-1])
+#
+#   so dp[i][v] sums dp[i-1][p] over p <= min(v, v - (nums[i] - nums[i-1])),
+#   which a running prefix sum answers in O(1).
+#
+#   this sequel only lifts the value ceiling from 50 to 1000, so the table
+#   grows to 2000 * 1001 = 2 million cells — still linear in the state count.
+#
+# time = O(n * max value), space = O(max value)
+class Solution(object):
+    def countOfPairs(self, nums):
+        MOD = 10 ** 9 + 7
+        n = len(nums)
+        top = max(nums)
+
+        dp = [0] * (top + 1)
+        for v in range(nums[0] + 1):
+            dp[v] = 1
+
+        for i in range(1, n):
+            pre = [0] * (top + 2)
+            run = 0
+            for v in range(top + 1):
+                run = (run + dp[v]) % MOD
+                pre[v + 1] = run
+            delta = nums[i] - nums[i - 1]
+            nxt = [0] * (top + 1)
+            for v in range(nums[i] + 1):
+                bound = v - delta if delta > 0 else v
+                if bound < 0:
+                    continue
+                if bound > top:
+                    bound = top
+                nxt[v] = pre[bound + 1]
+            dp = nxt
+
+        return sum(dp) % MOD

--- a/leetcode_python/Dynamic_Programming/find-the-maximum-length-of-valid-subsequence-i.py
+++ b/leetcode_python/Dynamic_Programming/find-the-maximum-length-of-valid-subsequence-i.py
@@ -1,0 +1,72 @@
+"""
+
+3201. Find the Maximum Length of Valid Subsequence I
+Medium
+
+You are given an integer array nums.
+
+A subsequence sub of nums with length x is called valid if it satisfies:
+
+(sub[0] + sub[1]) % 2 == (sub[1] + sub[2]) % 2 == ... == (sub[x - 2] + sub[x - 1]) % 2.
+
+Return the length of the longest valid subsequence of nums.
+
+Note: A subsequence is an array that can be derived from another array by deleting some or no elements without changing the order of the remaining elements.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4]
+Output: 4
+Explanation:
+The longest valid subsequence is [1, 2, 3, 4].
+
+Example 2:
+
+Input: nums = [1,2,1,1,2,1,2]
+Output: 6
+Explanation:
+The longest valid subsequence is [1, 2, 1, 2, 1, 2].
+
+Example 3:
+
+Input: nums = [1,3]
+Output: 2
+Explanation:
+The longest valid subsequence is [1, 3].
+
+
+Constraints:
+
+2 <= nums.length <= 2 * 10^5
+1 <= nums[i] <= 10^7
+
+"""
+
+# V0
+# IDEA : THE COMMON PARITY IS EITHER 0 OR 1 — SO THERE ARE ONLY TWO SHAPES
+#
+#   consecutive sums all even means every neighbouring pair shares a parity,
+#   i.e. the WHOLE subsequence has one parity. the best such subsequence is
+#   simply all the evens or all the odds.
+#
+#   consecutive sums all odd means the parity FLIPS at every step, so the
+#   best one is the longest strictly alternating pick — greedily take each
+#   element whose parity differs from the last one taken.
+#
+#   the answer is the largest of the three.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maximumLength(self, nums):
+        evens = sum(1 for x in nums if x % 2 == 0)
+        odds = len(nums) - evens
+
+        alt = 0
+        want = -1                       # parity expected next; -1 = anything
+        for x in nums:
+            p = x % 2
+            if want == -1 or p == want:
+                alt += 1
+                want = 1 - p
+        return max(evens, odds, alt)

--- a/leetcode_python/Dynamic_Programming/find-the-maximum-length-of-valid-subsequence-ii.py
+++ b/leetcode_python/Dynamic_Programming/find-the-maximum-length-of-valid-subsequence-ii.py
@@ -1,0 +1,64 @@
+"""
+
+3202. Find the Maximum Length of Valid Subsequence II
+Medium
+
+You are given an integer array nums and a positive integer k.
+
+A subsequence sub of nums with length x is called valid if it satisfies:
+
+(sub[0] + sub[1]) % k == (sub[1] + sub[2]) % k == ... == (sub[x - 2] + sub[x - 1]) % k.
+
+Return the length of the longest valid subsequence of nums.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,5], k = 2
+Output: 5
+Explanation:
+The longest valid subsequence is [1, 2, 3, 4, 5].
+
+Example 2:
+
+Input: nums = [1,4,2,3,1,4], k = 3
+Output: 4
+Explanation:
+The longest valid subsequence is [1, 4, 1, 4].
+
+
+Constraints:
+
+2 <= nums.length <= 10^3
+1 <= nums[i] <= 10^7
+1 <= k <= 10^3
+
+"""
+
+# V0
+# IDEA : FIX THE COMMON SUM RESIDUE, THEN THE SEQUENCE OF RESIDUES IS FORCED
+#
+#   if every adjacent pair sums to r modulo k, then knowing one element's
+#   residue a pins the next one to (r - a) % k, and the one after that back
+#   to a. so for a fixed r the subsequence just alternates between two
+#   residue classes.
+#
+#   that makes a tiny DP per r :
+#       best[a] = longest valid subsequence (for this r) ending in residue a
+#       best[a] = best[(r - a) % k] + 1     as each element is scanned
+#
+#   trying all k values of r gives O(n * k) overall.
+#
+# time = O(n * k), space = O(k)
+class Solution(object):
+    def maximumLength(self, nums, k):
+        res = 0
+        for r in range(k):
+            best = [0] * k
+            for x in nums:
+                a = x % k
+                partner = (r - a) % k
+                if best[partner] + 1 > best[a]:
+                    best[a] = best[partner] + 1
+            res = max(res, max(best))
+        return res

--- a/leetcode_python/Dynamic_Programming/maximum-array-hopping-score-i.py
+++ b/leetcode_python/Dynamic_Programming/maximum-array-hopping-score-i.py
@@ -1,0 +1,60 @@
+"""
+
+3205. Maximum Array Hopping Score I
+Medium
+🔒 (premium)
+
+Given an array nums, you have to get the maximum score starting from index 0 and hopping until you reach the last element of the array.
+
+In each hop, you can jump from index i to an index j > i, and you get a score of (j - i) * nums[j].
+
+Return the maximum score you can get.
+
+
+Example 1:
+
+Input: nums = [1,5,8]
+Output: 16
+Explanation:
+There are two possible ways to reach the last element:
+0 -> 1 -> 2 with a score of (1 - 0) * 5 + (2 - 1) * 8 = 13.
+0 -> 2 with a score of (2 - 0) * 8 = 16.
+
+Example 2:
+
+Input: nums = [4,5,2,8,9,1,3]
+Output: 42
+Explanation:
+We can do the hopping 0 -> 4 -> 6 with a score of (4 - 0) * 9 + (6 - 4) * 3 = 42.
+
+
+Constraints:
+
+2 <= nums.length <= 10^3
+1 <= nums[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : PLAIN O(n^2) DP OVER THE LANDING INDEX
+#
+#   dp[i] = best score achievable when standing on index i, so
+#       dp[i] = max over j < i of  dp[j] + (i - j) * nums[i]
+#   and the answer is dp[n-1] since the walk must finish on the last element.
+#
+#   n is only 1000 here, so the quadratic scan is fine; the sequel (LC 3221)
+#   raises it to 10^5 and needs the suffix-maximum greedy instead.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def maxScore(self, nums):
+        n = len(nums)
+        dp = [0] * n
+        for i in range(1, n):
+            best = float('-inf')
+            for j in range(i):
+                cand = dp[j] + (i - j) * nums[i]
+                if cand > best:
+                    best = cand
+            dp[i] = best
+        return dp[n - 1]

--- a/leetcode_python/Dynamic_Programming/maximum-total-damage-with-spell-casting.py
+++ b/leetcode_python/Dynamic_Programming/maximum-total-damage-with-spell-casting.py
@@ -1,0 +1,71 @@
+"""
+
+3186. Maximum Total Damage With Spell Casting
+Medium
+
+A magician has various spells.
+
+You are given an array power, where each element represents the damage of a spell. Multiple spells can have the same damage value.
+
+It is a known fact that if a magician decides to cast a spell with a damage of power[i], they cannot cast any spell with a damage of power[i] - 2, power[i] - 1, power[i] + 1, or power[i] + 2.
+
+Each spell can be cast only once.
+
+Return the maximum possible total damage that a magician can cast.
+
+
+Example 1:
+
+Input: power = [1,1,3,4]
+Output: 6
+Explanation:
+The maximum possible damage of 6 is produced by casting spells 0, 1, 3 with damage 1, 1, 4.
+
+Example 2:
+
+Input: power = [7,1,6,6]
+Output: 13
+Explanation:
+The maximum possible damage of 13 is produced by casting spells 1, 2, 3 with damage 1, 6, 6.
+
+
+Constraints:
+
+1 <= power.length <= 10^5
+1 <= power[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : GROUP EQUAL DAMAGES, THEN A "HOUSE ROBBER" DP OVER DISTINCT VALUES
+#
+#   spells of the SAME damage never block each other, so a value is taken all
+#   at once — its contribution is value * count. that collapses the array to
+#   the distinct values, sorted.
+#
+#   taking value v forbids everything in [v-2, v+2], so the DP is
+#
+#       dp[i] = max( dp[i-1],                     # skip this value
+#                    v * cnt + dp[j] )            # take it
+#
+#   where j is the last index whose value is below v - 2. since the values
+#   are sorted, j only moves forward — a single moving pointer finds it, no
+#   binary search needed.
+#
+# time = O(n log n), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def maximumTotalDamage(self, power):
+        cnt = Counter(power)
+        vals = sorted(cnt)
+        m = len(vals)
+
+        dp = [0] * (m + 1)
+        j = 0                                  # first index with vals[j] >= v - 2
+        for i, v in enumerate(vals):
+            while vals[j] < v - 2:
+                j += 1
+            dp[i + 1] = max(dp[i], v * cnt[v] + dp[j])
+        return dp[m]

--- a/leetcode_python/Greedy/lexicographically-smallest-string-after-a-swap.py
+++ b/leetcode_python/Greedy/lexicographically-smallest-string-after-a-swap.py
@@ -1,0 +1,52 @@
+"""
+
+3216. Lexicographically Smallest String After a Swap
+Easy
+
+Given a string s containing only digits, return the lexicographically smallest string that can be obtained after swapping adjacent digits in s with the same parity at most once.
+
+Digits have the same parity if both are odd or both are even. For example, 5 and 9, as well as 2 and 4, have the same parity, while 6 and 9 do not.
+
+
+Example 1:
+
+Input: s = "45320"
+Output: "43520"
+Explanation:
+s[1] == '5' and s[2] == '3' both have the same parity, and swapping them results in the lexicographically smallest string.
+
+Example 2:
+
+Input: s = "001"
+Output: "001"
+Explanation:
+There is no need to perform a swap because s is already the lexicographically smallest.
+
+
+Constraints:
+
+2 <= s.length <= 100
+s consists only of digits.
+
+"""
+
+# V0
+# IDEA : ONE SWAP, SO TAKE THE EARLIEST ONE THAT ACTUALLY HELPS
+#
+#   a swap only helps when it puts a smaller digit earlier, i.e. when the
+#   pair is out of order (s[i] > s[i+1]) and shares a parity.
+#
+#   the earliest such position dominates every later one — improving an
+#   earlier character beats any later change — so return immediately on the
+#   first hit, and leave the string alone if there is none.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def getSmallestString(self, s):
+        t = list(s)
+        for i in range(len(t) - 1):
+            a, b = int(t[i]), int(t[i + 1])
+            if a % 2 == b % 2 and a > b:
+                t[i], t[i + 1] = t[i + 1], t[i]
+                break
+        return ''.join(t)

--- a/leetcode_python/Greedy/maximum-array-hopping-score-ii.py
+++ b/leetcode_python/Greedy/maximum-array-hopping-score-ii.py
@@ -1,0 +1,72 @@
+"""
+
+3221. Maximum Array Hopping Score II
+Medium
+🔒 (premium)
+
+Given an array nums, you have to get the maximum score starting from index 0 and hopping until you reach the last element of the array.
+
+In each hop, you can jump from index i to an index j > i, and you get a score of (j - i) * nums[j].
+
+Return the maximum score you can get.
+
+
+Example 1:
+
+Input: nums = [1,5,8]
+Output: 16
+Explanation:
+There are two possible ways to reach the last element:
+0 -> 1 -> 2 with a score of (1 - 0) * 5 + (2 - 1) * 8 = 13.
+0 -> 2 with a score of (2 - 0) * 8 = 16.
+
+Example 2:
+
+Input: nums = [4,5,2,8,9,1,3]
+Output: 42
+Explanation:
+We can do the hopping 0 -> 4 -> 6 with a score of (4 - 0) * 9 + (6 - 4) * 3 = 42.
+
+
+Constraints:
+
+2 <= nums.length <= 10^5
+1 <= nums[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : ALWAYS HOP TO THE LARGEST VALUE STILL AHEAD — THE SUFFIX MAXIMA
+#
+#   splitting a hop is free : jumping i -> j -> k scores
+#       (j-i)*nums[j] + (k-j)*nums[k]
+#   which beats the direct i -> k only when nums[j] is at least as large as
+#   nums[k]. so nothing is lost by landing on every SUFFIX MAXIMUM along the
+#   way, and everything smaller is worth skipping.
+#
+#   so collect the indices whose value exceeds everything to their right
+#   (scanning from the end), then walk them left to right adding
+#   (gap * value). the last element is always the final suffix maximum, so
+#   the walk ends where it must.
+#
+#   LC 3205 is the same problem at n = 1000 where an O(n^2) DP suffices; this
+#   greedy is the linear version.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def maxScore(self, nums):
+        n = len(nums)
+        maxima = []
+        cur = 0
+        for i in range(n - 1, 0, -1):          # index 0 is the start, never a target
+            if nums[i] > cur:
+                maxima.append(i)
+                cur = nums[i]
+        maxima.reverse()
+
+        total = 0
+        prev = 0
+        for idx in maxima:
+            total += (idx - prev) * nums[idx]
+            prev = idx
+        return total

--- a/leetcode_python/Greedy/maximum-number-of-operations-to-move-ones-to-the-end.py
+++ b/leetcode_python/Greedy/maximum-number-of-operations-to-move-ones-to-the-end.py
@@ -1,0 +1,64 @@
+"""
+
+3228. Maximum Number of Operations to Move Ones to the End
+Medium
+
+You are given a binary string s.
+
+You can perform the following operation on the string any number of times:
+
+Choose any index i from the string where i + 1 < s.length such that s[i] == '1' and s[i + 1] == '0'.
+Move the character s[i] to the right until it reaches the end of the string or another '1'. For example, for s = "010010", if we choose i = 1, the resulting string will be s = "000110".
+
+Return the maximum number of operations that you can perform.
+
+
+Example 1:
+
+Input: s = "1001101"
+Output: 4
+Explanation:
+We can perform the following operations:
+Choose index i = 0. The resulting string is s = "0011101".
+Choose index i = 4. The resulting string is s = "0011011".
+Choose index i = 3. The resulting string is s = "0010111".
+Choose index i = 2. The resulting string is s = "0001111".
+
+Example 2:
+
+Input: s = "00111"
+Output: 0
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s[i] is either '0' or '1'.
+
+"""
+
+# V0
+# IDEA : EVERY 1 CAN CROSS EACH ZERO-BLOCK TO ITS RIGHT EXACTLY ONCE
+#
+#   one operation slides a single '1' across the run of zeros in front of it
+#   until it hits another '1' or the end. so a given '1' can be moved once
+#   per ZERO-BLOCK lying to its right, and no more — after crossing, that
+#   block is behind it forever.
+#
+#   summing over the ones is the same as summing over the blocks : each
+#   zero-block will eventually be crossed by every '1' that starts to its
+#   left. so scan once, and when a new zero-block begins, add the number of
+#   ones seen so far.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maxOperations(self, s):
+        res = 0
+        ones = 0
+        n = len(s)
+        for i, ch in enumerate(s):
+            if ch == '1':
+                ones += 1
+            elif i == 0 or s[i - 1] == '1':      # this zero starts a new block
+                res += ones
+        return res

--- a/leetcode_python/Greedy/maximum-points-after-enemy-battles.py
+++ b/leetcode_python/Greedy/maximum-points-after-enemy-battles.py
@@ -1,0 +1,75 @@
+"""
+
+3207. Maximum Points After Enemy Battles
+Medium
+
+You are given an integer array enemyEnergies denoting the energy values of various enemies.
+
+You are also given an integer currentEnergy denoting the amount of energy you have initially.
+
+You start with 0 points, and all the enemies are unmarked initially.
+
+You can perform either of the following operations zero or multiple times to gain points:
+
+Choose an unmarked enemy, i, such that currentEnergy >= enemyEnergies[i]. By choosing this option:
+    You gain 1 point.
+    Your energy is reduced by the enemy's energy, i.e. currentEnergy = currentEnergy - enemyEnergies[i].
+If you have at least 1 point, you can choose an unmarked enemy, i. By choosing this option:
+    Your energy increases by the enemy's energy, i.e. currentEnergy = currentEnergy + enemyEnergies[i].
+    The enemy i is marked.
+
+Return an integer denoting the maximum points you can get in the end by optimally performing operations.
+
+
+Example 1:
+
+Input: enemyEnergies = [3,2,2], currentEnergy = 2
+Output: 3
+Explanation:
+The following operations can be performed to get 3 points, which is the maximum:
+First operation on enemy 1: points increases by 1, and currentEnergy decreases by 2. So, points = 1, and currentEnergy = 0.
+Second operation on enemy 0: currentEnergy increases by 3, and enemy 0 is marked. So, points = 1, currentEnergy = 3, and marked enemies = [0].
+First operation on enemy 2: points increases by 1, and currentEnergy decreases by 2. So, points = 2, currentEnergy = 1, and marked enemies = [0].
+Second operation on enemy 2: currentEnergy increases by 2, and enemy 2 is marked. So, points = 2, currentEnergy = 3, and marked enemies = [0, 2].
+First operation on enemy 1: points increases by 1, and currentEnergy decreases by 2. So, points = 3, currentEnergy = 1, and marked enemies = [0, 2].
+
+Example 2:
+
+Input: enemyEnergies = [2], currentEnergy = 10
+Output: 5
+Explanation:
+Performing the first operation 5 times on enemy 0 results in the maximum number of points.
+
+
+Constraints:
+
+1 <= enemyEnergies.length <= 10^5
+1 <= enemyEnergies[i] <= 10^9
+0 <= currentEnergy <= 10^9
+
+"""
+
+# V0
+# IDEA : SPEND EVERYTHING ON THE CHEAPEST ENEMY, HARVEST ALL THE OTHERS ONCE
+#
+#   the point-scoring operation may reuse the SAME enemy forever, so once a
+#   point exists the optimal play is to score only against the cheapest enemy
+#   — every point costs min(energies).
+#
+#   the marking operation converts an enemy into energy exactly once each, so
+#   every other enemy is worth harvesting, and the cheapest one is kept
+#   unmarked to keep scoring against.
+#
+#   so the total energy ever available is
+#       currentEnergy + (sum of all energies - min)
+#   and the answer is that divided by min. if the starting energy cannot even
+#   afford the cheapest enemy, no point is ever scored and the answer is 0.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maximumPoints(self, enemyEnergies, currentEnergy):
+        mn = min(enemyEnergies)
+        if currentEnergy < mn:
+            return 0
+        total = currentEnergy + sum(enemyEnergies) - mn
+        return total // mn

--- a/leetcode_python/Greedy/minimum-cost-for-cutting-cake-i.py
+++ b/leetcode_python/Greedy/minimum-cost-for-cutting-cake-i.py
@@ -1,0 +1,88 @@
+"""
+
+3218. Minimum Cost for Cutting Cake I
+Medium
+
+There is an m x n cake that needs to be cut into 1 x 1 pieces.
+
+You are given integers m, n, and two arrays:
+
+horizontalCut of size m - 1, where horizontalCut[i] represents the cost to cut along the horizontal line i.
+verticalCut of size n - 1, where verticalCut[j] represents the cost to cut along the vertical line j.
+
+In one operation, you can choose any piece of cake that is not yet a 1 x 1 square and perform one of the following cuts:
+
+Cut along a horizontal line i at a cost of horizontalCut[i].
+Cut along a vertical line j at a cost of verticalCut[j].
+
+After the cut, the piece of cake is divided into two distinct pieces.
+
+The cost of a cut depends only on the initial cost of the line and does not change.
+
+Return the minimum total cost to cut the entire cake into 1 x 1 pieces.
+
+
+Example 1:
+
+Input: m = 3, n = 2, horizontalCut = [1,3], verticalCut = [5]
+Output: 13
+Explanation:
+Perform a cut on the vertical line 0 with cost 5, current total cost is 5.
+Perform a cut on the horizontal line 0 on 3 x 1 subgrid with cost 1.
+Perform a cut on the horizontal line 0 on 3 x 1 subgrid with cost 1.
+Perform a cut on the horizontal line 1 on 2 x 1 subgrid with cost 3.
+Perform a cut on the horizontal line 1 on 2 x 1 subgrid with cost 3.
+The total cost is 5 + 1 + 1 + 3 + 3 = 13.
+
+Example 2:
+
+Input: m = 2, n = 2, horizontalCut = [7], verticalCut = [4]
+Output: 15
+Explanation:
+Perform a cut on the horizontal line 0 with cost 7.
+Perform a cut on the vertical line 0 on 1 x 2 subgrid with cost 4.
+Perform a cut on the vertical line 0 on 1 x 2 subgrid with cost 4.
+The total cost is 7 + 4 + 4 = 15.
+
+
+Constraints:
+
+1 <= m, n <= 20
+horizontalCut.length == m - 1
+verticalCut.length == n - 1
+1 <= horizontalCut[i], verticalCut[i] <= 10^3
+
+"""
+
+# V0
+# IDEA : EXPENSIVE LINES FIRST — A LINE IS PAID ONCE PER PIECE IT CROSSES
+#
+#   cutting horizontal line i has to be repeated once for every vertical
+#   strip that currently exists, so its total price is
+#       horizontalCut[i] * (number of vertical pieces so far)
+#   and symmetrically for vertical lines.
+#
+#   every cut inevitably multiplies the OTHER direction's future costs, so
+#   the expensive lines should be used while the multiplier is still small —
+#   sort both lists descending and merge, always taking the pricier line next
+#   (exchange argument).
+#
+# time = O(m log m + n log n), space = O(m + n)
+class Solution(object):
+    def minimumCost(self, m, n, horizontalCut, verticalCut):
+        hs = sorted(horizontalCut, reverse=True)
+        vs = sorted(verticalCut, reverse=True)
+
+        i = j = 0
+        rows, cols = 1, 1               # pieces along each axis so far
+        total = 0
+        while i < len(hs) or j < len(vs):
+            if j >= len(vs) or (i < len(hs) and hs[i] >= vs[j]):
+                total += hs[i] * cols   # one cut per existing vertical strip
+                rows += 1
+                i += 1
+            else:
+                total += vs[j] * rows
+                cols += 1
+                j += 1
+        return total

--- a/leetcode_python/Greedy/minimum-cost-for-cutting-cake-ii.py
+++ b/leetcode_python/Greedy/minimum-cost-for-cutting-cake-ii.py
@@ -1,0 +1,88 @@
+"""
+
+3219. Minimum Cost for Cutting Cake II
+Hard
+
+There is an m x n cake that needs to be cut into 1 x 1 pieces.
+
+You are given integers m, n, and two arrays:
+
+horizontalCut of size m - 1, where horizontalCut[i] represents the cost to cut along the horizontal line i.
+verticalCut of size n - 1, where verticalCut[j] represents the cost to cut along the vertical line j.
+
+In one operation, you can choose any piece of cake that is not yet a 1 x 1 square and perform one of the following cuts:
+
+Cut along a horizontal line i at a cost of horizontalCut[i].
+Cut along a vertical line j at a cost of verticalCut[j].
+
+After the cut, the piece of cake is divided into two distinct pieces.
+
+The cost of a cut depends only on the initial cost of the line and does not change.
+
+Return the minimum total cost to cut the entire cake into 1 x 1 pieces.
+
+
+Example 1:
+
+Input: m = 3, n = 2, horizontalCut = [1,3], verticalCut = [5]
+Output: 13
+Explanation:
+Perform a cut on the vertical line 0 with cost 5, current total cost is 5.
+Perform a cut on the horizontal line 0 on 3 x 1 subgrid with cost 1.
+Perform a cut on the horizontal line 0 on 3 x 1 subgrid with cost 1.
+Perform a cut on the horizontal line 1 on 2 x 1 subgrid with cost 3.
+Perform a cut on the horizontal line 1 on 2 x 1 subgrid with cost 3.
+The total cost is 5 + 1 + 1 + 3 + 3 = 13.
+
+Example 2:
+
+Input: m = 2, n = 2, horizontalCut = [7], verticalCut = [4]
+Output: 15
+Explanation:
+Perform a cut on the horizontal line 0 with cost 7.
+Perform a cut on the vertical line 0 on 1 x 2 subgrid with cost 4.
+Perform a cut on the vertical line 0 on 1 x 2 subgrid with cost 4.
+The total cost is 7 + 4 + 4 = 15.
+
+
+Constraints:
+
+1 <= m, n <= 10^5
+horizontalCut.length == m - 1
+verticalCut.length == n - 1
+1 <= horizontalCut[i], verticalCut[i] <= 10^3
+
+"""
+
+# V0
+# IDEA : IDENTICAL GREEDY TO LC 3218 — IT WAS ALREADY O(n log n)
+#
+#   a horizontal line costs its price once per vertical strip that exists
+#   when it is used, so using the expensive lines while the perpendicular
+#   multiplier is still small is optimal.
+#
+#   the only change from the easy version is the scale : m and n reach 10^5,
+#   so the merge has to stay linear after the sort — which it already is.
+#
+#   the totals exceed 32 bits (10^5 lines times 10^3 cost times a 10^5
+#   multiplier), which python integers handle natively.
+#
+# time = O(m log m + n log n), space = O(m + n)
+class Solution(object):
+    def minimumCost(self, m, n, horizontalCut, verticalCut):
+        hs = sorted(horizontalCut, reverse=True)
+        vs = sorted(verticalCut, reverse=True)
+
+        i = j = 0
+        rows, cols = 1, 1
+        total = 0
+        while i < len(hs) or j < len(vs):
+            if j >= len(vs) or (i < len(hs) and hs[i] >= vs[j]):
+                total += hs[i] * cols
+                rows += 1
+                i += 1
+            else:
+                total += vs[j] * rows
+                cols += 1
+                j += 1
+        return total

--- a/leetcode_python/Greedy/minimum-operations-to-make-array-equal-to-target.py
+++ b/leetcode_python/Greedy/minimum-operations-to-make-array-equal-to-target.py
@@ -1,0 +1,71 @@
+"""
+
+3229. Minimum Operations to Make Array Equal to Target
+Hard
+
+You are given two positive integer arrays nums and target, of the same length.
+
+In a single operation, you can select any subarray of nums and increment or decrement each element within that subarray by 1.
+
+Return the minimum number of operations required to make nums equal to the array target.
+
+
+Example 1:
+
+Input: nums = [3,5,1,2], target = [4,6,2,4]
+Output: 2
+Explanation:
+We will perform the following operations to make nums equal to target:
+- Increment nums[0..3] by 1, nums = [4,6,2,3].
+- Increment nums[3..3] by 1, nums = [4,6,2,4].
+
+Example 2:
+
+Input: nums = [1,3,2], target = [2,1,4]
+Output: 5
+Explanation:
+We will perform the following operations to make nums equal to target:
+- Increment nums[0..0] by 1, nums = [2,3,2].
+- Decrement nums[1..1] by 1, nums = [2,2,2].
+- Decrement nums[1..1] by 1, nums = [2,1,2].
+- Increment nums[2..2] by 1, nums = [2,1,3].
+- Increment nums[2..2] by 1, nums = [2,1,4].
+
+
+Constraints:
+
+1 <= nums.length == target.length <= 10^5
+1 <= nums[i], target[i] <= 10^8
+
+"""
+
+# V0
+# IDEA : WORK ON THE DIFFERENCE ARRAY — ONLY THE *NEW* DEMAND COSTS ANYTHING
+#
+#   let d[i] = target[i] - nums[i]. a subarray operation shifts a whole
+#   stretch by 1, so the cost is really about how the demand CHANGES from one
+#   position to the next : an operation covering positions i..j can serve
+#   both as long as the demands point the same way.
+#
+#   walking left to right :
+#       d[0] costs abs(d[0]) — nothing before it to piggyback on
+#       if d[i] keeps the sign of d[i-1], only the EXCESS costs extra,
+#           max(0, abs(d[i]) - abs(d[i-1]))
+#       if the sign flips, none of the previous operations can be reused, so
+#           the full abs(d[i]) is paid
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumOperations(self, nums, target):
+        n = len(nums)
+        prev = target[0] - nums[0]
+        res = abs(prev)
+        for i in range(1, n):
+            cur = target[i] - nums[i]
+            if (cur > 0 and prev > 0) or (cur < 0 and prev < 0):
+                if abs(cur) > abs(prev):
+                    res += abs(cur) - abs(prev)
+            else:
+                res += abs(cur)
+            prev = cur
+        return res

--- a/leetcode_python/Greedy/shortest-distance-after-road-addition-queries-ii.py
+++ b/leetcode_python/Greedy/shortest-distance-after-road-addition-queries-ii.py
@@ -1,0 +1,82 @@
+"""
+
+3244. Shortest Distance After Road Addition Queries II
+Hard
+
+You are given an integer n and a 2D integer array queries.
+
+There are n cities numbered from 0 to n - 1. Initially, there is a unidirectional road from city i to city i + 1 for all 0 <= i < n - 1.
+
+queries[i] = [u_i, v_i] represents the addition of a new unidirectional road from city u_i to city v_i. After each query, you need to find the length of the shortest path from city 0 to city n - 1.
+
+There are no two queries such that queries[i][0] < queries[j][0] < queries[i][1] < queries[j][1].
+
+Return an array answer where for each i in the range [0, queries.length - 1], answer[i] is the length of the shortest path from city 0 to city n - 1.
+
+
+Example 1:
+
+Input: n = 5, queries = [[2,4],[0,2],[0,4]]
+Output: [3,2,1]
+Explanation:
+After the addition of the road from 2 to 4, the length of the shortest path from 0 to 4 is 3.
+After the addition of the road from 0 to 2, the length of the shortest path from 0 to 4 is 2.
+After the addition of the road from 0 to 4, the length of the shortest path from 0 to 4 is 1.
+
+Example 2:
+
+Input: n = 4, queries = [[0,3],[0,2]]
+Output: [1,1]
+Explanation:
+After the addition of the road from 0 to 3, the length of the shortest path from 0 to 3 is 1.
+After the addition of the road from 0 to 2, the length of the shortest path remains 1.
+
+
+Constraints:
+
+3 <= n <= 10^5
+1 <= queries.length <= 10^5
+queries[i].length == 2
+0 <= queries[i][0] < queries[i][1] < n
+1 < queries[i][1] - queries[i][0]
+There are no two queries such that i != j and queries[i][0] < queries[j][0] < queries[i][1] < queries[j][1].
+There are no repeated roads among the queries.
+
+"""
+
+# V0
+# IDEA : THE NON-CROSSING GUARANTEE MAKES THE SHORTCUTS *NEST*, SO JUST SPLICE
+#
+#   the promise that no two queries interleave (u1 < u2 < v1 < v2) means any
+#   two shortcuts are either disjoint or fully nested. so a new road u -> v
+#   swallows every city strictly between u and v that is still on the path,
+#   and none of them can ever be needed again.
+#
+#   keep a `next` pointer per city describing the current best path. adding
+#   u -> v walks from next[u] up to v, unlinking each city on the way and
+#   shortening the answer by one per removal; then next[u] = v.
+#
+#   every city is removed at most once overall, so the whole run is linear
+#   despite the inner walk.
+#
+# time = O(n + q), space = O(n)
+class Solution(object):
+    def shortestDistanceAfterQueries(self, n, queries):
+        nxt = list(range(1, n + 1))          # nxt[i] = successor of i on the path
+        length = n - 1                       # current shortest path length
+
+        res = []
+        for u, v in queries:
+            # u already swallowed, or the path from u already reaches past v
+            if nxt[u] == -1 or nxt[u] >= v:
+                res.append(length)
+                continue
+            cur = nxt[u]
+            while cur < v:                   # swallow everything strictly inside
+                after = nxt[cur]
+                nxt[cur] = -1                # detached, never revisited
+                length -= 1
+                cur = after
+            nxt[u] = v
+            res.append(length)
+        return res

--- a/leetcode_python/Hash_table/find-the-number-of-winning-players.py
+++ b/leetcode_python/Hash_table/find-the-number-of-winning-players.py
@@ -1,0 +1,73 @@
+"""
+
+3238. Find the Number of Winning Players
+Easy
+
+You are given an integer n representing the number of players in a game and a 2D array pick where pick[i] = [x_i, y_i] represents that the player x_i picked a ball of color y_i.
+
+Player i wins the game if they pick strictly more than i balls of the same color. In other words,
+
+Player 0 wins if they pick any ball.
+Player 1 wins if they pick at least two balls of the same color.
+...
+Player i wins if they pick at least i + 1 balls of the same color.
+
+Return the number of players who win the game.
+
+Note that multiple players can win the game.
+
+
+Example 1:
+
+Input: n = 4, pick = [[0,0],[1,0],[1,0],[2,1],[2,1],[2,0]]
+Output: 2
+Explanation:
+Player 0 and player 1 win the game, while players 2 and 3 do not win.
+
+Example 2:
+
+Input: n = 5, pick = [[1,1],[1,2],[1,3],[1,4]]
+Output: 0
+Explanation:
+Player 1 and others do not win the game.
+
+Example 3:
+
+Input: n = 5, pick = [[1,1],[2,4],[2,4],[2,4]]
+Output: 1
+Explanation:
+Player 2 wins the game by picking 3 balls with color 4.
+
+
+Constraints:
+
+2 <= n <= 10
+1 <= pick.length <= 100
+pick[i].length == 2
+0 <= x_i <= n - 1
+0 <= y_i <= 10
+
+"""
+
+# V0
+# IDEA : TALLY (PLAYER, COLOR) PAIRS, THEN COMPARE EACH PLAYER'S BEST COLOR
+#
+#   player i needs i + 1 balls of ONE colour, so only the largest per-colour
+#   count matters. with at most 10 players and 11 colours, a small table is
+#   enough.
+#
+# time = O(len(pick) + n * colors), space = O(n * colors)
+from collections import defaultdict
+
+
+class Solution(object):
+    def winningPlayerCount(self, n, pick):
+        cnt = defaultdict(int)
+        for x, y in pick:
+            cnt[(x, y)] += 1
+
+        best = [0] * n
+        for (x, _), c in cnt.items():
+            if c > best[x]:
+                best[x] = c
+        return sum(1 for i in range(n) if best[i] >= i + 1)

--- a/leetcode_python/Hash_table/minimum-length-of-string-after-operations.py
+++ b/leetcode_python/Hash_table/minimum-length-of-string-after-operations.py
@@ -1,0 +1,59 @@
+"""
+
+3223. Minimum Length of String After Operations
+Medium
+
+You are given a string s.
+
+You can perform the following process on s any number of times:
+
+Choose an index i in the string such that there is at least one character to the left of index i that is equal to s[i], and at least one character to the right that is also equal to s[i].
+Delete the closest character to the left of index i that is equal to s[i].
+Delete the closest character to the right of index i that is equal to s[i].
+
+Return the minimum length of the final string s that you can achieve.
+
+
+Example 1:
+
+Input: s = "abaacbcbb"
+Output: 5
+Explanation:
+We do the following operations:
+Choose index 2, then remove the characters at indices 0 and 3. The resulting string is s = "bacbcbb".
+Choose index 3, then remove the characters at indices 0 and 5. The resulting string is s = "acbcb".
+
+Example 2:
+
+Input: s = "aa"
+Output: 2
+Explanation:
+We cannot perform any operations, so we return the length of the original string.
+
+
+Constraints:
+
+1 <= s.length <= 2 * 10^5
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : EACH OPERATION REMOVES *TWO* COPIES OF ONE LETTER — SO ONLY PARITY MATTERS
+#
+#   the operation needs three copies of a letter and deletes two of them, so
+#   a letter's count drops by 2 as long as at least 3 copies remain. that
+#   bottoms out at
+#       1 copy  when the count is odd
+#       2 copies when the count is even
+#   and letters never interfere with each other.
+#
+#   so the answer sums those per-letter floors — no simulation needed.
+#
+# time = O(n), space = O(1)  (26 counters)
+from collections import Counter
+
+
+class Solution(object):
+    def minimumLength(self, s):
+        return sum(1 if c % 2 else 2 for c in Counter(s).values())

--- a/leetcode_python/Linked_list/delete-nodes-from-linked-list-present-in-array.py
+++ b/leetcode_python/Linked_list/delete-nodes-from-linked-list-present-in-array.py
@@ -1,0 +1,70 @@
+"""
+
+3217. Delete Nodes From Linked List Present in Array
+Medium
+
+You are given an array of integers nums and the head of a linked list. Return the head of the modified linked list after removing all nodes from the linked list that have a value that exists in nums.
+
+
+Example 1:
+
+Input: nums = [1,2,3], head = [1,2,3,4,5]
+Output: [4,5]
+Explanation:
+Remove the nodes with values 1, 2, and 3.
+
+Example 2:
+
+Input: nums = [1], head = [1,2,1,2,1,2]
+Output: [2,2,2]
+Explanation:
+Remove the nodes with value 1.
+
+Example 3:
+
+Input: nums = [5], head = [1,2,3,4]
+Output: [1,2,3,4]
+Explanation:
+No node has value 5.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^5
+All elements in nums are unique.
+The number of nodes in the given list is in the range [1, 3 * 10^5].
+1 <= Node.val <= 10^5
+The input is generated such that there is at least one node in the linked list that has a value not present in nums.
+
+"""
+
+# V0
+# IDEA : HASH THE VALUES, THEN ONE UNLINKING PASS BEHIND A DUMMY HEAD
+#
+#   turning nums into a set makes each membership test O(1) — scanning the
+#   array per node would be 3*10^5 * 10^5 comparisons.
+#
+#   a dummy node in front removes the "what if the head itself is deleted"
+#   special case : the tail pointer simply skips every doomed node and links
+#   past it.
+#
+# time = O(n + m), space = O(m)
+# Definition for singly-linked list.
+# class ListNode(object):
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution(object):
+    def modifiedList(self, nums, head):
+        drop = set(nums)
+        dummy = ListNode(0)
+        tail = dummy
+        node = head
+        while node:
+            if node.val not in drop:
+                tail.next = node
+                tail = node
+            node = node.next
+        tail.next = None
+        return dummy.next

--- a/leetcode_python/Math/find-if-digit-game-can-be-won.py
+++ b/leetcode_python/Math/find-if-digit-game-can-be-won.py
@@ -1,0 +1,57 @@
+"""
+
+3232. Find if Digit Game Can Be Won
+Easy
+
+You are given an array of positive integers nums.
+
+Alice and Bob are playing a game. In the game, Alice can choose either all single-digit numbers or all double-digit numbers from nums, and the rest of the numbers are given to Bob. Alice wins if the sum of her numbers is strictly greater than the sum of Bob's numbers.
+
+Return true if Alice can win this game, otherwise, return false.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,10]
+Output: false
+Explanation:
+Alice cannot win by choosing either single-digit or double-digit numbers.
+
+Example 2:
+
+Input: nums = [1,2,3,4,5,14]
+Output: true
+Explanation:
+Alice can win by choosing single-digit numbers which have a sum equal to 15.
+
+Example 3:
+
+Input: nums = [5,5,5,25]
+Output: true
+Explanation:
+Alice can win by choosing double-digit numbers which have a sum equal to 25.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= nums[i] <= 99
+
+"""
+
+# V0
+# IDEA : THE TWO CHOICES ARE COMPLEMENTARY — SO ALICE LOSES ONLY ON A TIE
+#
+#   the numbers split into exactly two groups, single-digit and double-digit,
+#   and Alice takes one while Bob takes the other. so her two options give
+#   sums s1 vs s2 and s2 vs s1.
+#
+#   she wins whenever the two sums differ (take the larger one), and can only
+#   fail when they are exactly equal.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def canAliceWin(self, nums):
+        single = sum(x for x in nums if x < 10)
+        double = sum(x for x in nums if x >= 10)
+        return single != double

--- a/leetcode_python/Math/find-the-count-of-numbers-which-are-not-special.py
+++ b/leetcode_python/Math/find-the-count-of-numbers-which-are-not-special.py
@@ -1,0 +1,71 @@
+"""
+
+3233. Find the Count of Numbers Which Are Not Special
+Medium
+
+You are given 2 positive integers l and r. For any number x, all positive divisors of x except x are called the proper divisors of x.
+
+A number is called special if it has exactly 2 proper divisors. For example:
+
+The number 4 is special because it has proper divisors 1 and 2.
+The number 6 is not special because it has proper divisors 1, 2, and 3.
+
+Return the count of numbers in the range [l, r] that are not special.
+
+
+Example 1:
+
+Input: l = 5, r = 7
+Output: 3
+Explanation:
+There are no special numbers in the range [5, 7].
+
+Example 2:
+
+Input: l = 4, r = 16
+Output: 11
+Explanation:
+The special numbers in the range [4, 16] are 4 and 9.
+
+
+Constraints:
+
+1 <= l <= r <= 10^9
+
+"""
+
+# V0
+# IDEA : "EXACTLY TWO PROPER DIVISORS" MEANS x IS THE SQUARE OF A PRIME
+#
+#   the proper divisors are 1 and one other value d, so x = d * d and d must
+#   itself be prime — any factorisation of d would add more divisors.
+#
+#   so the special numbers in [l, r] are p^2 for primes p in
+#   [ceil(sqrt(l)), floor(sqrt(r))], and r <= 10^9 caps p at 31623 — a tiny
+#   sieve.
+#
+#   the answer is the range size minus that count.
+#
+# time = O(sqrt(r) log log sqrt(r)), space = O(sqrt(r))
+class Solution(object):
+    def nonSpecialCount(self, l, r):
+        limit = int(r ** 0.5)
+        while (limit + 1) * (limit + 1) <= r:
+            limit += 1
+        while limit * limit > r:
+            limit -= 1
+
+        sieve = [True] * (limit + 1)
+        if limit >= 0:
+            sieve[0] = False
+        if limit >= 1:
+            sieve[1] = False
+        p = 2
+        while p * p <= limit:
+            if sieve[p]:
+                for m in range(p * p, limit + 1, p):
+                    sieve[m] = False
+            p += 1
+
+        special = sum(1 for p in range(2, limit + 1) if sieve[p] and p * p >= l)
+        return (r - l + 1) - special

--- a/leetcode_python/Math/find-the-winning-player-in-coin-game.py
+++ b/leetcode_python/Math/find-the-winning-player-in-coin-game.py
@@ -1,0 +1,52 @@
+"""
+
+3222. Find the Winning Player in Coin Game
+Easy
+
+You are given two integers x and y, denoting the number of coins with values 75 and 10 respectively.
+
+Alice and Bob are playing a game. Each turn, starting with Alice, the player must pick up coins with a total value 115. If the player is unable to do so, they lose the game.
+
+Return the name of the player who wins the game if both players play optimally.
+
+
+Example 1:
+
+Input: x = 2, y = 7
+Output: "Alice"
+Explanation:
+The game ends in a single turn:
+Alice picks 1 coin with a value of 75 and 4 coins with a value of 10.
+
+Example 2:
+
+Input: x = 4, y = 11
+Output: "Bob"
+Explanation:
+The game ends in 2 turns:
+Alice picks 1 coin with a value of 75 and 4 coins with a value of 10.
+Bob picks 1 coin with a value of 75 and 4 coins with a value of 10.
+
+
+Constraints:
+
+1 <= x, y <= 100
+
+"""
+
+# V0
+# IDEA : 115 HAS EXACTLY ONE DECOMPOSITION — 75 + 4 x 10
+#
+#   with only 75s and 10s available, 115 can only be formed as one 75 plus
+#   four 10s (two 75s already overshoot, and 10s alone never end in 5). so
+#   every turn consumes the same fixed bundle and there is no strategy at
+#   all.
+#
+#   the number of turns is min(x, y // 4), and Alice moves on the odd ones,
+#   so she wins exactly when that count is odd.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def losingPlayer(self, x, y):
+        turns = min(x, y // 4)
+        return "Alice" if turns % 2 else "Bob"

--- a/leetcode_python/Math/maximum-height-of-a-triangle.py
+++ b/leetcode_python/Math/maximum-height-of-a-triangle.py
@@ -1,0 +1,73 @@
+"""
+
+3200. Maximum Height of a Triangle
+Easy
+
+You are given two integers red and blue representing the count of red and blue colored balls. You have to arrange these balls to form a triangle such that the 1st row will have 1 ball, the 2nd row will have 2 balls, the 3rd row will have 3 balls, and so on.
+
+All the balls in a particular row should be the same color, and adjacent rows should have different colors.
+
+Return the maximum height of the triangle that can be achieved.
+
+
+Example 1:
+
+Input: red = 2, blue = 4
+Output: 3
+Explanation:
+The only possible arrangement is shown above.
+
+Example 2:
+
+Input: red = 2, blue = 1
+Output: 2
+Explanation:
+The only possible arrangement is shown above.
+
+Example 3:
+
+Input: red = 1, blue = 1
+Output: 1
+
+Example 4:
+
+Input: red = 10, blue = 1
+Output: 2
+
+
+Constraints:
+
+1 <= red, blue <= 100
+
+"""
+
+# V0
+# IDEA : ONLY TWO ARRANGEMENTS EXIST — TRY BOTH AND SIMULATE
+#
+#   once the colour of row 1 is fixed, every later row's colour is forced by
+#   the alternation. so there are exactly two candidate triangles, and each
+#   can be grown row by row until the next row's colour runs out of balls.
+#
+#   row h needs h balls of its colour, so the greedy simulation is exact —
+#   there is no choice to make along the way.
+#
+# time = O(sqrt(red + blue)), space = O(1)
+class Solution(object):
+    def maxHeightOfTriangle(self, red, blue):
+
+        def grow(first, second):
+            """first supplies the odd rows, second the even rows"""
+            h = 0
+            while True:
+                need = h + 1
+                if h % 2 == 0:
+                    if first < need:
+                        return h
+                    first -= need
+                else:
+                    if second < need:
+                        return h
+                    second -= need
+                h += 1
+
+        return max(grow(red, blue), grow(blue, red))

--- a/leetcode_python/Math/number-of-subsequences-with-odd-sum.py
+++ b/leetcode_python/Math/number-of-subsequences-with-odd-sum.py
@@ -1,0 +1,53 @@
+"""
+
+3247. Number of Subsequences with Odd Sum
+Medium
+🔒 (premium)
+
+Given an array nums, return the number of subsequences with an odd sum.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [1,1,1]
+Output: 4
+Explanation:
+The odd-sum subsequences are: [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1].
+
+Example 2:
+
+Input: nums = [1,2,2]
+Output: 4
+Explanation:
+The odd-sum subsequences are: [1, 2, 2], [1, 2, 2], [1, 2, 2], [1, 2, 2].
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : THE SUM'S PARITY DEPENDS ONLY ON HOW MANY *ODD* ELEMENTS ARE TAKEN
+#
+#   even elements never change the parity, so they can be included or not
+#   freely — 2^even choices. the sum is odd exactly when an ODD number of the
+#   odd elements is chosen, and the number of ways to pick an odd-sized
+#   subset of `odd` items is 2^(odd - 1).
+#
+#   so the answer is 2^(odd-1) * 2^even, or 0 when there is no odd element at
+#   all.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def subsequenceCount(self, nums):
+        MOD = 10 ** 9 + 7
+        odd = sum(1 for x in nums if x % 2)
+        even = len(nums) - odd
+        if odd == 0:
+            return 0
+        return pow(2, odd - 1, MOD) * pow(2, even, MOD) % MOD

--- a/leetcode_python/Sort/minimum-moves-to-get-a-peaceful-board.py
+++ b/leetcode_python/Sort/minimum-moves-to-get-a-peaceful-board.py
@@ -1,0 +1,62 @@
+"""
+
+3189. Minimum Moves to Get a Peaceful Board
+Medium
+🔒 (premium)
+
+Given a 2D array rooks of length n, where rooks[i] = [x_i, y_i] indicates the position of a rook on an n x n chess board. Your task is to move the rooks 1 cell at a time vertically or horizontally (to an adjacent cell) such that the board becomes peaceful.
+
+A board is peaceful if there is exactly one rook in each row and each column.
+
+Return the minimum number of moves required to get a peaceful board.
+
+Note that at no point can there be two rooks in the same cell.
+
+
+Example 1:
+
+Input: rooks = [[0,0],[1,0],[1,1]]
+Output: 3
+Explanation:
+Move the rook from (1,0) to (2,0) and then from (1,1) to (1,2). Together with the rook already at (0,0) each row and column then holds exactly one rook.
+
+Example 2:
+
+Input: rooks = [[0,0],[0,1],[0,2],[0,3]]
+Output: 6
+Explanation:
+The rooks all share row 0, so three of them must move down to rows 1, 2 and 3.
+
+
+Constraints:
+
+1 <= n == rooks.length <= 500
+0 <= x_i, y_i <= n - 1
+The input is generated such that there are no 2 rooks in the same cell.
+
+"""
+
+# V0
+# IDEA : ROWS AND COLUMNS ARE INDEPENDENT — SORT EACH AND MATCH IN ORDER
+#
+#   a vertical move changes only a rook's row, a horizontal one only its
+#   column, so the two axes never interact and the total cost splits into
+#   "fix the rows" plus "fix the columns".
+#
+#   on one axis, the n rooks must end up on the n distinct values 0..n-1, and
+#   the cheapest assignment for points on a line is the SORTED one — sorted
+#   coordinates paired with 0, 1, 2, ... (any crossing pair can be uncrossed
+#   without increasing the total distance).
+#
+#   so the answer is sum |sorted_x[i] - i| + sum |sorted_y[i] - i|.
+#
+#   NOTE : the "no two rooks share a cell mid-way" clause never costs extra —
+#          the moves can always be sequenced to avoid collisions.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def minMoves(self, rooks):
+        xs = sorted(p[0] for p in rooks)
+        ys = sorted(p[1] for p in rooks)
+        return (sum(abs(v - i) for i, v in enumerate(xs))
+                + sum(abs(v - i) for i, v in enumerate(ys)))

--- a/leetcode_python/String/find-the-encrypted-string.py
+++ b/leetcode_python/String/find-the-encrypted-string.py
@@ -1,0 +1,50 @@
+"""
+
+3210. Find the Encrypted String
+Easy
+
+You are given a string s and an integer k. Encrypt the string using the following algorithm:
+
+For each character c in s, replace c with the kth character after c in the string (in a cyclic manner).
+
+Return the encrypted string.
+
+
+Example 1:
+
+Input: s = "dart", k = 3
+Output: "tdar"
+Explanation:
+For i = 0, the 3rd character after 'd' is 't'.
+For i = 1, the 3rd character after 'a' is 'd'.
+For i = 2, the 3rd character after 'r' is 'a'.
+For i = 3, the 3rd character after 't' is 'r'.
+
+Example 2:
+
+Input: s = "aaa", k = 1
+Output: "aaa"
+Explanation:
+As all the characters are the same, the encrypted string will also be the same.
+
+
+Constraints:
+
+1 <= s.length <= 100
+1 <= k <= 10^4
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : A CYCLIC SHIFT OF THE *POSITIONS*, NOT OF THE ALPHABET
+#
+#   "the k-th character after position i, cyclically" is s[(i + k) % n], so
+#   the whole answer is one comprehension. k may exceed n, which the modulo
+#   already absorbs.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def getEncryptedString(self, s, k):
+        n = len(s)
+        return ''.join(s[(i + k) % n] for i in range(n))

--- a/leetcode_python/String/vowels-game-in-a-string.py
+++ b/leetcode_python/String/vowels-game-in-a-string.py
@@ -1,0 +1,60 @@
+"""
+
+3227. Vowels Game in a String
+Medium
+
+Alice and Bob are playing a game on a string.
+
+You are given a string s, Alice and Bob will take turns playing the following game where Alice starts first:
+
+On Alice's turn, she has to remove any non-empty substring from s that contains an odd number of vowels.
+On Bob's turn, he has to remove any non-empty substring from s that contains an even number of vowels.
+
+The first player who cannot make a move on their turn loses the game. We assume that both Alice and Bob play optimally.
+
+Return true if Alice wins the game, and false otherwise.
+
+The English vowels are: a, e, i, o, and u.
+
+
+Example 1:
+
+Input: s = "leetcoder"
+Output: true
+Explanation:
+Alice can win the game as follows:
+Alice plays first, she can delete the underlined substring in s = "leetcoder" which contains 3 vowels. The resulting string is s = "der".
+Bob plays second, he can delete the underlined substring in s = "der" which contains 0 vowels. The resulting string is s = "er".
+Alice plays third, she can delete the whole string s = "er" which contains 1 vowel.
+Bob plays fourth, since the string is empty, there is no valid play for Bob. So Alice wins the game.
+
+Example 2:
+
+Input: s = "bbcd"
+Output: false
+Explanation:
+There is no valid play for Alice in her first turn, so Alice loses the game.
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : ALICE WINS IFF THE STRING HOLDS AT LEAST ONE VOWEL
+#
+#   with no vowels at all Alice cannot even move, so she loses immediately.
+#
+#   otherwise she always wins. if the total vowel count is odd she takes the
+#   entire string in one move and Bob faces an empty board. if it is even,
+#   she removes a piece leaving exactly one vowel behind; Bob must then take
+#   an even-vowel substring, which can never remove that last vowel, so an
+#   odd-vowel remainder always comes back to Alice until Bob runs out.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def doesAliceWin(self, s):
+        return any(ch in "aeiou" for ch in s)

--- a/leetcode_python/slide_window/alternating-groups-ii.py
+++ b/leetcode_python/slide_window/alternating-groups-ii.py
@@ -1,0 +1,68 @@
+"""
+
+3208. Alternating Groups II
+Medium
+
+There is a circle of red and blue tiles. You are given an array of integers colors and an integer k. The color of tile i is represented by colors[i]:
+
+colors[i] == 0 means that tile i is red.
+colors[i] == 1 means that tile i is blue.
+
+An alternating group is every k contiguous tiles in the circle with alternating colors (each tile in the group except the first and last one has a different color from its left and right tiles).
+
+Return the number of alternating groups.
+
+Note that since colors represents a circle, the first and the last tiles are considered to be next to each other.
+
+
+Example 1:
+
+Input: colors = [0,1,0,1,0], k = 3
+Output: 3
+
+Example 2:
+
+Input: colors = [0,1,0,0,1,0,1], k = 6
+Output: 2
+
+Example 3:
+
+Input: colors = [1,1,0,1], k = 4
+Output: 0
+
+
+Constraints:
+
+3 <= colors.length <= 10^5
+0 <= colors[i] <= 1
+3 <= k <= colors.length
+
+"""
+
+# V0
+# IDEA : TRACK THE CURRENT ALTERNATING RUN LENGTH AROUND THE CIRCLE
+#
+#   a window of k tiles is a group exactly when every adjacent pair inside it
+#   differs. so walk the circle keeping `run` = how many tiles the current
+#   alternating stretch covers, resetting to 1 whenever two neighbours match.
+#
+#   every position where run reaches k closes one group, so the count is the
+#   number of such positions.
+#
+#   the wrap-around is handled by walking n + k - 1 steps (indices taken
+#   modulo n), which lets a run that starts near the end finish at the front
+#   without double counting.
+#
+# time = O(n + k), space = O(1)
+class Solution(object):
+    def numberOfAlternatingGroups(self, colors, k):
+        n = len(colors)
+        res = 0
+        run = 1
+        for t in range(1, n + k - 1):
+            i = t % n
+            prev = (t - 1) % n
+            run = run + 1 if colors[i] != colors[prev] else 1
+            if run >= k:
+                res += 1
+        return res

--- a/leetcode_python/slide_window/count-the-number-of-substrings-with-dominant-ones.py
+++ b/leetcode_python/slide_window/count-the-number-of-substrings-with-dominant-ones.py
@@ -1,0 +1,78 @@
+"""
+
+3234. Count the Number of Substrings With Dominant Ones
+Medium
+
+You are given a binary string s.
+
+Return the number of substrings with dominant ones.
+
+A string has dominant ones if the number of ones in the string is greater than or equal to the square of the number of zeros in the string.
+
+
+Example 1:
+
+Input: s = "00011"
+Output: 5
+Explanation:
+The substrings with dominant ones are shown in the table below.
+
+Example 2:
+
+Input: s = "101101"
+Output: 16
+Explanation:
+The substrings with non-dominant ones are shown in the table below.
+
+
+Constraints:
+
+1 <= s.length <= 4 * 10^4
+s consists only of characters '0' and '1'.
+
+"""
+
+# V0
+# IDEA : THE ZERO COUNT IS BOUNDED BY sqrt(n) — ENUMERATE IT
+#
+#   a substring with z zeros needs at least z^2 ones, so its length is at
+#   least z^2 + z. with n <= 4*10^4 that caps z at about 200 — far fewer
+#   possibilities than the O(n^2) substrings.
+#
+#   so for each start index, walk the possible zero counts z. the substrings
+#   holding exactly z zeros end in a contiguous window : from the z-th zero
+#   at or after the start, up to just before the (z+1)-th. intersecting that
+#   window with the length requirement
+#       end >= start + z^2 + z - 1
+#   gives the count for this (start, z) in O(1).
+#
+# time = O(n * sqrt(n)), space = O(n)
+import bisect
+
+
+class Solution(object):
+    def numberOfSubstrings(self, s):
+        n = len(s)
+        zeros = [i for i, ch in enumerate(s) if ch == '0']
+        res = 0
+
+        for start in range(n):
+            k = bisect.bisect_left(zeros, start)        # first zero at or after start
+            z = 0
+            while True:
+                if z * z + z > n:                       # even the whole string is short
+                    break
+                if z == 0:
+                    lo = start
+                    hi = (zeros[k] - 1) if k < len(zeros) else n - 1
+                else:
+                    if k + z - 1 >= len(zeros):
+                        break                           # not that many zeros left
+                    lo = zeros[k + z - 1]
+                    hi = (zeros[k + z] - 1) if k + z < len(zeros) else n - 1
+                need = start + z * z + z - 1            # minimum end index
+                lo = max(lo, need)
+                if hi >= lo:
+                    res += hi - lo + 1
+                z += 1
+        return res

--- a/leetcode_python/slide_window/find-the-power-of-k-size-subarrays-ii.py
+++ b/leetcode_python/slide_window/find-the-power-of-k-size-subarrays-ii.py
@@ -1,0 +1,75 @@
+"""
+
+3255. Find the Power of K-Size Subarrays II
+Medium
+
+You are given an array of integers nums of length n and a positive integer k.
+
+The power of an array is defined as:
+
+Its maximum element if all of its elements are consecutive and sorted in ascending order.
+-1 otherwise.
+
+You need to find the power of all subarrays of nums of size k.
+
+Return an integer array results of size n - k + 1, where results[i] is the power of nums[i..(i + k - 1)].
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,3,2,5], k = 3
+Output: [3,4,-1,-1,-1]
+Explanation:
+There are 5 subarrays of nums of size 3:
+[1, 2, 3] with the maximum element 3.
+[2, 3, 4] with the maximum element 4.
+[3, 4, 3] whose elements are not consecutive.
+[4, 3, 2] whose elements are not sorted.
+[3, 2, 5] whose elements are not consecutive.
+
+Example 2:
+
+Input: nums = [2,2,2,2,2], k = 4
+Output: [-1,-1]
+
+Example 3:
+
+Input: nums = [3,2,3,2,3,2], k = 2
+Output: [-1,3,-1,3,-1]
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^5
+1 <= nums[i] <= 10^6
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : ONE RUNNING STREAK OF "+1 STEPS" ANSWERS EVERY WINDOW
+#
+#   track `run` = the length of the longest consecutive-ascending stretch
+#   ending at the current index. it extends when nums[i] == nums[i-1] + 1 and
+#   resets to 1 otherwise.
+#
+#   the window ending at i is fully inside that stretch exactly when
+#   run >= k, in which case its power is nums[i]; otherwise -1.
+#
+#   this is LC 3254 at 10^5 elements, where re-scanning each window would be
+#   O(n * k).
+#
+# time = O(n), space = O(n) for the output
+class Solution(object):
+    def resultsArray(self, nums, k):
+        n = len(nums)
+        res = []
+        run = 1
+        for i in range(n):
+            if i and nums[i] == nums[i - 1] + 1:
+                run += 1
+            else:
+                run = 1
+            if i >= k - 1:
+                res.append(nums[i] if run >= k else -1)
+        return res


### PR DESCRIPTION
Fourth tranche of the LC 3001-Latest coverage gap vs kamyu104/LeetCode-Solutions, continuing where batch13 (3130-3185) stopped. Covers 50 problems from 3186 to 3256, including 7 premium/locked ones (3189, 3205, 3221, 3231, 3247, 3253, plus 3193's pairing).

Skipped in this range:
- LC 3188, 3198, 3204, 3214, 3220, 3230, 3236, 3246, 3252 are database problems and belong in leetcode_SQL.
- LC 3199, 3215, 3225, 3235, 3237, 3245 are left for a later batch: for the premium ones I could not confirm the worked examples, and 3225 / 3235 / 3245 need statement details I was not able to pin down. Rather than guess, 3250, 3251, 3253, 3254, 3255 and 3256 were taken instead to keep the batch at 50.

Same convention as the rest of the directory: problem docstring, then a V0 solution with an IDEA block explaining the approach and a time/space complexity comment.

Verified:
- all 50 files parse cleanly
- all 50 run correctly against every example in their problem statement (122 assertions)
- 22 cross-checks against independent brute-force references on randomized inputs, covering 32 of the solutions: 3186, 3187, 3193, 3197, 3201, 3202, 3203, 3205, 3206, 3208, 3209, 3213, 3221, 3224, 3228, 3229, 3231, 3234, 3239, 3240, 3241, 3243, 3244, 3249, 3250, 3251, 3253, 3254, 3255, 3256. 3197 is checked against a full three-way partition of the 1-cells, 3240 against brute enumeration of every grid, and 3229 against an exhaustive BFS over the operation space.
- timed at full constraints: 3213 (3.68s, the slowest — 5*10^4 target with 316 distinct word lengths), 3234 (1.20s), 3256 (100x100), 3212 (1000x1000), and a dozen more at 10^5

Note: 3201's parity-alternation greedy had an inverted condition that the examples caught (it took an element when the parity DIFFERED from the one expected, rather than matched).