### PR TITLE
feat(leetcode_python): add 24 solutions for LC 2848-3000

### DIFF
--- a/leetcode_python/Array/change-data-type.py
+++ b/leetcode_python/Array/change-data-type.py
@@ -1,0 +1,68 @@
+"""
+
+2886. Change Data Type
+Easy
+
+DataFrame students
++-------------+--------+
+| Column Name | Type   |
++-------------+--------+
+| student_id  | int    |
+| name        | object |
+| age         | int    |
+| grade       | float  |
++-------------+--------+
+
+Write a solution to correct the errors:
+
+The grade column is stored as floats, convert it to integers.
+
+The result format is in the following example.
+
+
+Example 1:
+
+Input:
+DataFrame students:
++------------+------+-----+-------+
+| student_id | name | age | grade |
++------------+------+-----+-------+
+| 1          | Ava  | 6   | 73.0  |
+| 2          | Kate | 15  | 87.0  |
++------------+------+-----+-------+
+Output:
++------------+------+-----+-------+
+| student_id | name | age | grade |
++------------+------+-----+-------+
+| 1          | Ava  | 6   | 73    |
+| 2          | Kate | 15  | 87    |
++------------+------+-----+-------+
+Explanation:
+The data types of the column grade is converted to int.
+
+"""
+
+import pandas as pd
+
+# V0
+# IDEA : PANDAS astype ON A SINGLE COLUMN
+#
+#   Series.astype(int) recasts the whole column in one vectorised pass; only
+#   `grade` is touched, so student_id / name / age keep their dtypes.
+#
+#   NOTE : astype(int) TRUNCATES toward zero rather than rounding, which is fine
+#          here because the problem guarantees the floats are whole numbers
+#          (73.0, 87.0) that were merely stored in the wrong dtype.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    # NOTE : LeetCode's pandas track submits a bare module-level function
+    #        (aliased below); the class keeps this file in line with the
+    #        rest of the directory.
+    def changeDatatype(self, students):
+        students["grade"] = students["grade"].astype(int)
+        return students
+
+
+def changeDatatype(students):
+    return Solution().changeDatatype(students)

--- a/leetcode_python/Array/determine-if-a-cell-is-reachable-at-a-given-time.py
+++ b/leetcode_python/Array/determine-if-a-cell-is-reachable-at-a-given-time.py
@@ -1,0 +1,60 @@
+"""
+
+2849. Determine if a Cell Is Reachable at a Given Time
+Medium
+
+You are given four integers sx, sy, fx, fy, and a non-negative integer t.
+
+In an infinite 2D grid, you start at the cell (sx, sy). Each second, you must move to any of its adjacent cells.
+
+Return true if you can reach cell (fx, fy) after exactly t seconds, or false otherwise.
+
+A cell's adjacent cells are the 8 cells around it that share at least one corner with it. You can visit the same cell several times.
+
+
+Example 1:
+
+Input: sx = 2, sy = 4, fx = 7, fy = 7, t = 6
+Output: true
+Explanation: Starting at cell (2, 4), we can reach cell (7, 7) in exactly 6 seconds by going through the cells depicted in the picture above.
+
+Example 2:
+
+Input: sx = 3, sy = 1, fx = 7, fy = 3, t = 3
+Output: false
+Explanation: Starting at cell (3, 1), it takes at least 4 seconds to reach cell (7, 3) by going through the cells depicted in the picture above. Hence, we cannot reach cell (7, 3) at the third second.
+
+
+Constraints:
+
+1 <= sx, sy, fx, fy <= 10^9
+0 <= t <= 10^9
+
+"""
+
+# V0
+# IDEA : MATH (Chebyshev distance + a single degenerate case)
+#
+#   with 8-directional moves one step changes x by at most 1 AND y by at
+#   most 1 simultaneously, so the minimum number of steps between two cells
+#   is the Chebyshev distance max(|dx|, |dy|).
+#
+#   any surplus time can always be burnt: step off to a neighbour and step
+#   back (2 seconds), or if dx != dy simply "waste" a diagonal-vs-straight
+#   choice (1 second). Concretely, once t >= max(|dx|, |dy|) and the cells
+#   differ, every larger t is reachable too, because the grid is infinite
+#   and we can detour by one cell.
+#
+#   NOTE : the ONLY unreachable-with-slack case is start == finish with
+#          t == 1 — we must move every second, so we cannot stand still for
+#          exactly one second and end where we began. t == 0 is fine (no
+#          move made) and t >= 2 is fine (step away, step back).
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def isReachableAtTime(self, sx, sy, fx, fy, t):
+        if sx == fx and sy == fy:
+            return t != 1
+        dx = abs(sx - fx)
+        dy = abs(sy - fy)
+        return max(dx, dy) <= t

--- a/leetcode_python/Array/drop-duplicate-rows.py
+++ b/leetcode_python/Array/drop-duplicate-rows.py
@@ -1,0 +1,75 @@
+"""
+
+2882. Drop Duplicate Rows
+Easy
+
+DataFrame customers
++-------------+--------+
+| Column Name | Type   |
++-------------+--------+
+| customer_id | int    |
+| name        | object |
+| email       | object |
++-------------+--------+
+
+There are some duplicate rows in the DataFrame based on the email column.
+
+Write a solution to remove these duplicate rows and keep only the first occurrence.
+
+The result format is in the following example.
+
+
+Example 1:
+
+Input:
++-------------+---------+---------------------+
+| customer_id | name    | email               |
++-------------+---------+---------------------+
+| 1           | Ella    | emily@example.com   |
+| 2           | David   | michael@example.com |
+| 3           | Zachary | sarah@example.com   |
+| 4           | Alice   | john@example.com    |
+| 5           | Finn    | john@example.com    |
+| 6           | Violet  | alice@example.com   |
++-------------+---------+---------------------+
+Output:
++-------------+---------+---------------------+
+| customer_id | name    | email               |
++-------------+---------+---------------------+
+| 1           | Ella    | emily@example.com   |
+| 2           | David   | michael@example.com |
+| 3           | Zachary | sarah@example.com   |
+| 4           | Alice   | john@example.com    |
+| 6           | Violet  | alice@example.com   |
++-------------+---------+---------------------+
+Explanation:
+Alice (customer_id = 4) and Finn (customer_id = 5) both use john@example.com,
+so only the first occurrence of this email is retained.
+
+"""
+
+import pandas as pd
+
+# V0
+# IDEA : PANDAS drop_duplicates ON A SUBSET OF COLUMNS
+#
+#   de-duplication is keyed on `email` ALONE, not on the whole row — the other
+#   columns (customer_id, name) differ between the two john@example.com rows,
+#   so a plain drop_duplicates() would keep both. Passing subset=["email"]
+#   restricts the key to that one column.
+#
+#   NOTE : `keep="first"` is the pandas default and is exactly what the problem
+#          asks for (keep the earliest occurrence), so it can be left implicit.
+#          The surviving rows keep their original index labels.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    # NOTE : LeetCode's pandas track submits a bare module-level function
+    #        (aliased below); the class keeps this file in line with the
+    #        rest of the directory.
+    def dropDuplicateEmails(self, customers):
+        return customers.drop_duplicates(subset=["email"])
+
+
+def dropDuplicateEmails(customers):
+    return Solution().dropDuplicateEmails(customers)

--- a/leetcode_python/Array/drop-missing-data.py
+++ b/leetcode_python/Array/drop-missing-data.py
@@ -1,0 +1,69 @@
+"""
+
+2883. Drop Missing Data
+Easy
+
+DataFrame students
++-------------+--------+
+| Column Name | Type   |
++-------------+--------+
+| student_id  | int    |
+| name        | object |
+| age         | int    |
++-------------+--------+
+
+There are some rows having missing values in the name column.
+
+Write a solution to remove the rows with missing values.
+
+The result format is in the following example.
+
+
+Example 1:
+
+Input:
++------------+---------+-----+
+| student_id | name    | age |
++------------+---------+-----+
+| 32         | Piper   | 5   |
+| 217        | None    | 19  |
+| 779        | Georgia | 20  |
+| 849        | Willow  | 14  |
++------------+---------+-----+
+Output:
++------------+---------+-----+
+| student_id | name    | age |
++------------+---------+-----+
+| 32         | Piper   | 5   |
+| 779        | Georgia | 20  |
+| 849        | Willow  | 14  |
++------------+---------+-----+
+Explanation:
+Student with id 217 has an empty value in the name column, so it will be removed.
+
+"""
+
+import pandas as pd
+
+# V0
+# IDEA : PANDAS dropna RESTRICTED TO THE `name` COLUMN
+#
+#   only missing values in `name` should drop a row — a NaN sitting in
+#   student_id or age must NOT. dropna(subset=["name"]) scopes the null test
+#   to that single column.
+#
+#   NOTE : in an object-dtype column, the Python `None` shown in the example is
+#          what pandas treats as missing, so both `None` and `NaN` are caught.
+#          The equivalent boolean-mask form is students[students["name"].notna()].
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    # NOTE : LeetCode's pandas track submits a bare module-level function
+    #        (aliased below); the class keeps this file in line with the
+    #        rest of the directory.
+    def dropMissingData(self, students):
+        return students.dropna(subset=["name"])
+
+
+def dropMissingData(students):
+    return Solution().dropMissingData(students)

--- a/leetcode_python/Array/find-indices-with-index-and-value-difference-i.py
+++ b/leetcode_python/Array/find-indices-with-index-and-value-difference-i.py
@@ -1,0 +1,84 @@
+"""
+
+2903. Find Indices With Index and Value Difference I
+Easy
+
+You are given a 0-indexed integer array nums having length n, an integer indexDifference, and an integer valueDifference.
+
+Your task is to find two indices i and j, both in the range [0, n - 1], that satisfy the following conditions:
+
+- abs(i - j) >= indexDifference, and
+- abs(nums[i] - nums[j]) >= valueDifference
+
+Return an integer array answer, where answer = [i, j] if there are two such indices, and answer = [-1, -1] otherwise. If there are multiple choices for the two indices, return any of them.
+
+Note: i and j may be equal.
+
+
+Example 1:
+
+Input: nums = [5,1,4,1], indexDifference = 2, valueDifference = 4
+Output: [0,3]
+Explanation: In this example, i = 0 and j = 3 can be selected.
+abs(0 - 3) >= 2 and abs(nums[0] - nums[3]) >= 4.
+Hence, a valid answer is [0,3].
+[3,0] is also a valid answer.
+
+Example 2:
+
+Input: nums = [2,1], indexDifference = 0, valueDifference = 0
+Output: [0,0]
+Explanation: In this example, i = 0 and j = 0 can be selected.
+abs(0 - 0) >= 0 and abs(nums[0] - nums[0]) >= 0.
+Hence, a valid answer is [0,0].
+Other valid answers are [0,1], [1,0], and [1,1].
+
+Example 3:
+
+Input: nums = [1,2,3], indexDifference = 2, valueDifference = 4
+Output: [-1,-1]
+Explanation: In this example, it can be shown that it is impossible to find two indices that satisfy both conditions.
+Hence, [-1,-1] is returned.
+
+
+Constraints:
+
+1 <= n == nums.length <= 100
+0 <= nums[i] <= 50
+0 <= indexDifference <= 100
+0 <= valueDifference <= 50
+
+"""
+
+# V0
+# IDEA : SLIDING "GAP" + RUNNING MIN / MAX INDEX
+#
+#   abs() on both sides means we only ever need, for a right end i, the
+#   SMALLEST and the LARGEST value among the indices that are already far
+#   enough away from i (i.e. all j <= i - indexDifference).
+#     -> if nums[i] - nums[mi] >= valueDifference, [mi, i] works
+#     -> if nums[mx] - nums[i] >= valueDifference, [mx, i] works
+#   one of those two must trigger whenever ANY valid pair ending at i exists,
+#   because the best |difference| against a fixed nums[i] is achieved either
+#   at the running min or at the running max.
+#
+#   NOTE : indexDifference can be 0, so i and j may be the same index; the
+#          loop below naturally allows j == i since j = i - 0 = i.
+#   NOTE : indexDifference can exceed n - 1, in which case the loop body never
+#          runs and we correctly fall through to [-1, -1].
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def findIndices(self, nums, indexDifference, valueDifference):
+        mi = mx = 0
+        for i in range(indexDifference, len(nums)):
+            j = i - indexDifference
+            if nums[j] < nums[mi]:
+                mi = j
+            if nums[j] > nums[mx]:
+                mx = j
+            if nums[i] - nums[mi] >= valueDifference:
+                return [mi, i]
+            if nums[mx] - nums[i] >= valueDifference:
+                return [mx, i]
+        return [-1, -1]

--- a/leetcode_python/Array/find-indices-with-index-and-value-difference-ii.py
+++ b/leetcode_python/Array/find-indices-with-index-and-value-difference-ii.py
@@ -1,0 +1,87 @@
+"""
+
+2905. Find Indices With Index and Value Difference II
+Medium
+
+You are given a 0-indexed integer array nums having length n, an integer indexDifference, and an integer valueDifference.
+
+Your task is to find two indices i and j, both in the range [0, n - 1], that satisfy the following conditions:
+
+- abs(i - j) >= indexDifference, and
+- abs(nums[i] - nums[j]) >= valueDifference
+
+Return an integer array answer, where answer = [i, j] if there are two such indices, and answer = [-1, -1] otherwise. If there are multiple choices for the two indices, return any of them.
+
+Note: i and j may be equal.
+
+
+Example 1:
+
+Input: nums = [5,1,4,1], indexDifference = 2, valueDifference = 4
+Output: [0,3]
+Explanation: In this example, i = 0 and j = 3 can be selected.
+abs(0 - 3) >= 2 and abs(nums[0] - nums[3]) >= 4.
+Hence, a valid answer is [0,3].
+[3,0] is also a valid answer.
+
+Example 2:
+
+Input: nums = [2,1], indexDifference = 0, valueDifference = 0
+Output: [0,0]
+Explanation: In this example, i = 0 and j = 0 can be selected.
+abs(0 - 0) >= 0 and abs(nums[0] - nums[0]) >= 0.
+Hence, a valid answer is [0,0].
+Other valid answers are [0,1], [1,0], and [1,1].
+
+Example 3:
+
+Input: nums = [1,2,3], indexDifference = 2, valueDifference = 4
+Output: [-1,-1]
+Explanation: In this example, it can be shown that it is impossible to find two indices that satisfy both conditions.
+Hence, [-1,-1] is returned.
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^5
+0 <= nums[i] <= 10^9
+0 <= indexDifference <= 10^5
+0 <= valueDifference <= 10^9
+
+"""
+
+# V0
+# IDEA : SLIDING "GAP" + RUNNING MIN / MAX INDEX
+#
+#   same problem as LC 2903 but with n up to 10^5, so the O(n^2) brute force
+#   is out and we need the single pass.
+#
+#   walk the right end i from indexDifference to n - 1. every index
+#   j <= i - indexDifference is "far enough" from i, so keep only the two
+#   candidates that can ever matter against a fixed nums[i] :
+#     mi = index of the min value seen among those j
+#     mx = index of the max value seen among those j
+#   then nums[i] - nums[mi] and nums[mx] - nums[i] are the two largest
+#   achievable differences, and if neither reaches valueDifference no pair
+#   ending at i can.
+#
+#   NOTE : mi / mx must be updated with j = i - indexDifference BEFORE the
+#          checks, otherwise the newly eligible index is missed (this is also
+#          what makes i == j work when indexDifference == 0).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def findIndices(self, nums, indexDifference, valueDifference):
+        n = len(nums)
+        mi = mx = 0
+        for i in range(indexDifference, n):
+            j = i - indexDifference
+            if nums[j] < nums[mi]:
+                mi = j
+            if nums[j] > nums[mx]:
+                mx = j
+            if nums[i] - nums[mi] >= valueDifference:
+                return [mi, i]
+            if nums[mx] - nums[i] >= valueDifference:
+                return [mx, i]
+        return [-1, -1]

--- a/leetcode_python/Array/maximum-area-of-longest-diagonal-rectangle.py
+++ b/leetcode_python/Array/maximum-area-of-longest-diagonal-rectangle.py
@@ -1,0 +1,58 @@
+"""
+
+3000. Maximum Area of Longest Diagonal Rectangle
+Easy
+
+You are given a 2D 0-indexed integer array dimensions.
+
+For all indices i, 0 <= i < dimensions.length, dimensions[i][0] represents the length and dimensions[i][1] represents the width of the rectangle i.
+
+Return the area of the rectangle having the longest diagonal. If there are multiple rectangles with the longest diagonal, return the area of the rectangle having the maximum area.
+
+
+Example 1:
+
+Input: dimensions = [[9,3],[8,6]]
+Output: 48
+Explanation:
+For index = 0, length = 9 and width = 3. Diagonal length = sqrt(9 * 9 + 3 * 3) = sqrt(90) = 9.487.
+For index = 1, length = 8 and width = 6. Diagonal length = sqrt(8 * 8 + 6 * 6) = sqrt(100) = 10.
+So, the rectangle at index 1 has a greater diagonal length therefore we return area = 8 * 6 = 48.
+
+Example 2:
+
+Input: dimensions = [[3,4],[4,3]]
+Output: 12
+Explanation: Length of diagonal is the same for both which is 5, so maximum area = 12.
+
+
+Constraints:
+
+1 <= dimensions.length <= 100
+dimensions[i].length == 2
+1 <= dimensions[i][0], dimensions[i][1] <= 100
+
+"""
+
+# V0
+# IDEA : GREEDY ONE PASS ON (DIAGONAL^2, AREA)
+#
+#   compare rectangles by the tuple (l*l + w*w, l*w) and keep the best.
+#
+#   NOTE : compare the SQUARED diagonal, never sqrt(...) - the squared form
+#          keeps everything in exact integer arithmetic, so two rectangles
+#          with an equal diagonal really do compare equal (a float sqrt
+#          could break the tie the wrong way).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def areaOfMaxDiagonal(self, dimensions):
+        best_diag = 0
+        best_area = 0
+        for l, w in dimensions:
+            diag = l * l + w * w
+            area = l * w
+            if diag > best_diag or (diag == best_diag and area > best_area):
+                best_diag = diag
+                best_area = area
+        return best_area

--- a/leetcode_python/Array/maximum-value-of-an-ordered-triplet-i.py
+++ b/leetcode_python/Array/maximum-value-of-an-ordered-triplet-i.py
@@ -1,0 +1,71 @@
+"""
+
+2873. Maximum Value of an Ordered Triplet I
+Easy
+
+You are given a 0-indexed integer array nums.
+
+Return the maximum value over all triplets of indices (i, j, k) such that i < j < k. If all such triplets have a negative value, return 0.
+
+The value of a triplet of indices (i, j, k) is equal to (nums[i] - nums[j]) * nums[k].
+
+
+Example 1:
+
+Input: nums = [12,6,1,2,7]
+Output: 77
+Explanation: The value of the triplet (0, 2, 4) is (nums[0] - nums[2]) * nums[4] = 77.
+It can be shown that there are no ordered triplets of indices with a value greater than 77.
+
+Example 2:
+
+Input: nums = [1,10,3,4,19]
+Output: 133
+Explanation: The value of the triplet (1, 2, 4) is (nums[1] - nums[2]) * nums[4] = 133.
+It can be shown that there are no ordered triplets of indices with a value greater than 133.
+
+Example 3:
+
+Input: nums = [1,2,3]
+Output: 0
+Explanation: The only ordered triplet of indices (0, 1, 2) has a negative value of (nums[0] - nums[1]) * nums[2] = -3. Hence, the answer would be 0.
+
+
+Constraints:
+
+3 <= nums.length <= 100
+1 <= nums[i] <= 10^6
+
+"""
+
+# V0
+# IDEA : ONE PASS, KEEP PREFIX MAX + BEST PREFIX DIFFERENCE
+#
+#   Walk k from left to right and keep two running quantities over the part of
+#   the array strictly BEFORE k:
+#     mx      = max(nums[i])                 for i < k
+#     mx_diff = max(nums[i] - nums[j])       for i < j < k
+#   Then the best triplet ending at k is mx_diff * nums[k].
+#
+#   NOTE : the update order inside the loop matters, and it is exactly the
+#          reverse of the index order (k, then j, then i):
+#            1) answer uses mx_diff built from indices < k
+#            2) mx_diff then absorbs the current x as a candidate j
+#            3) mx then absorbs the current x as a candidate i
+#          Doing it in any other order would let one index be reused.
+#
+#   NOTE : all nums[i] >= 1, so a negative mx_diff can never help. Seeding
+#          ans / mx / mx_diff at 0 both clamps the answer at 0 (as the problem
+#          asks) and keeps the first two iterations from producing a triplet.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maximumTripletValue(self, nums):
+        ans = 0
+        mx = 0          # max nums[i] seen so far
+        mx_diff = 0     # max (nums[i] - nums[j]) with i < j seen so far
+        for x in nums:
+            ans = max(ans, mx_diff * x)
+            mx_diff = max(mx_diff, mx - x)
+            mx = max(mx, x)
+        return ans

--- a/leetcode_python/Array/minimum-array-length-after-pair-removals.py
+++ b/leetcode_python/Array/minimum-array-length-after-pair-removals.py
@@ -1,0 +1,83 @@
+"""
+
+2856. Minimum Array Length After Pair Removals
+Medium
+
+Given an integer array num sorted in non-decreasing order.
+
+You can perform the following operation any number of times:
+
+Choose two indices, i and j, where nums[i] < nums[j].
+Then, remove the elements at indices i and j from nums. The remaining elements retain their original order, and the array is re-indexed.
+
+Return the minimum length of nums after applying the operation zero or more times.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4]
+Output: 0
+
+Example 2:
+
+Input: nums = [1,1,2,2,3,3]
+Output: 0
+
+Example 3:
+
+Input: nums = [1000000000,1000000000]
+Output: 2
+Explanation: Since both numbers are equal, they cannot be removed.
+
+Example 4:
+
+Input: nums = [2,3,4,4,4]
+Output: 1
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+nums is sorted in non-decreasing order.
+
+"""
+
+# V0
+# IDEA : MAJORITY-ELEMENT COUNTING (greedy pairing argument)
+#
+#   only equal values block a removal, so think of the array as groups of
+#   equal values with sizes c_1, c_2, ... and let mx = max(c_i), n = len(nums).
+#
+#   - if mx * 2 <= n, no single value dominates: we can always pair items
+#     from two different groups (repeatedly pop from the two currently
+#     largest groups), so we remove everything except a leftover element
+#     when n is odd -> answer n % 2.
+#   - if mx * 2 > n, the dominant group has more members than all the other
+#     groups combined. Every removal consumes at most one of them, so at
+#     best all (n - mx) other elements are paired off against dominant ones,
+#     leaving mx - (n - mx) = 2 * mx - n elements -> answer 2 * mx - n.
+#
+#   NOTE : nums is already SORTED, so equal values are contiguous and the
+#          largest group size can be found with one linear scan — no hash
+#          map and no heap needed, which matters at n = 10^5.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minLengthAfterRemovals(self, nums):
+        n = len(nums)
+        mx = 0
+        run = 0
+        prev = None
+        for x in nums:
+            if x == prev:
+                run += 1
+            else:
+                run = 1
+                prev = x
+            if run > mx:
+                mx = run
+
+        if mx * 2 > n:
+            return 2 * mx - n
+        return n % 2

--- a/leetcode_python/Array/minimum-operations-to-maximize-last-elements-in-arrays.py
+++ b/leetcode_python/Array/minimum-operations-to-maximize-last-elements-in-arrays.py
@@ -1,0 +1,104 @@
+"""
+
+2934. Minimum Operations to Maximize Last Elements in Arrays
+Medium
+
+You are given two 0-indexed integer arrays, nums1 and nums2, both having length n.
+
+You are allowed to perform a series of operations (possibly none).
+
+In an operation, you select an index i in the range [0, n - 1] and swap the values of nums1[i] and nums2[i].
+
+Your task is to find the minimum number of operations required to satisfy the following conditions:
+
+nums1[n - 1] is equal to the maximum value among all elements of nums1, i.e., nums1[n - 1] = max(nums1[0], nums1[1], ..., nums1[n - 1]).
+nums2[n - 1] is equal to the maximum value among all elements of nums2, i.e., nums2[n - 1] = max(nums2[0], nums2[1], ..., nums2[n - 1]).
+
+Return an integer denoting the minimum number of operations needed to meet both conditions, or -1 if it is impossible to satisfy both conditions.
+
+
+Example 1:
+
+Input: nums1 = [1,2,7], nums2 = [4,5,3]
+Output: 1
+Explanation: In this example, an operation can be performed using index i = 2.
+When nums1[2] and nums2[2] are swapped, nums1 becomes [1,2,3] and nums2 becomes [4,5,7].
+Both conditions are now satisfied.
+It can be shown that the minimum number of operations needed to be performed is 1.
+So, the answer is 1.
+
+Example 2:
+
+Input: nums1 = [2,3,4,5,9], nums2 = [8,8,4,4,4]
+Output: 2
+Explanation: In this example, the following operations can be performed:
+First operation using index i = 4.
+When nums1[4] and nums2[4] are swapped, nums1 becomes [2,3,4,5,4], and nums2 becomes [8,8,4,4,9].
+Another operation using index i = 3.
+When nums1[3] and nums2[3] are swapped, nums1 becomes [2,3,4,4,4], and nums2 becomes [8,8,4,5,9].
+Both conditions are now satisfied.
+It can be shown that the minimum number of operations needed to be performed is 2.
+So, the answer is 2.
+
+Example 3:
+
+Input: nums1 = [1,5,4], nums2 = [2,5,3]
+Output: -1
+Explanation: In this example, it is not possible to satisfy both conditions.
+So, the answer is -1.
+
+
+Constraints:
+
+1 <= n == nums1.length == nums2.length <= 1000
+1 <= nums1[i] <= 10^9
+1 <= nums2[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : CASE SPLIT ON THE LAST INDEX + GREEDY SCAN
+#
+#   the two "tail" values are the only ones the conditions compare against, so
+#   the whole problem collapses to two independent scenarios:
+#     (1) leave index n-1 alone   -> targets (x, y) = (nums1[-1], nums2[-1])
+#     (2) swap index n-1          -> targets (x, y) = (nums2[-1], nums1[-1]), cost 1
+#
+#   for a fixed pair of targets each of the first n-1 columns is decided on its
+#   own: keep it if nums1[i] <= x and nums2[i] <= y, else swap it if the mirrored
+#   test nums1[i] <= y and nums2[i] <= x holds, else the scenario is impossible.
+#
+#   NOTE : the column test is greedy-safe because columns never interact — the
+#          targets are frozen the moment we choose whether to touch index n-1.
+#   NOTE : "no swap" is preferred when both tests pass, which is why the first
+#          branch is checked first (a swap there could only add cost).
+#   NOTE : n == 1 falls out for free: no column is scanned, so both scenarios
+#          cost 0 and the answer is min(0, 0 + 1) = 0.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minOperations(self, nums1, nums2):
+        n = len(nums1)
+
+        def scan(x, y):
+            # min swaps among the first n-1 columns, or -1 if impossible
+            cnt = 0
+            for i in range(n - 1):
+                a, b = nums1[i], nums2[i]
+                if a <= x and b <= y:
+                    continue
+                if a <= y and b <= x:
+                    cnt += 1
+                    continue
+                return -1
+            return cnt
+
+        keep = scan(nums1[-1], nums2[-1])
+        swap = scan(nums2[-1], nums1[-1])
+        if keep == -1 and swap == -1:
+            return -1
+        if keep == -1:
+            return swap + 1
+        if swap == -1:
+            return keep
+        return min(keep, swap + 1)

--- a/leetcode_python/Array/minimum-right-shifts-to-sort-the-array.py
+++ b/leetcode_python/Array/minimum-right-shifts-to-sort-the-array.py
@@ -1,0 +1,71 @@
+"""
+
+2855. Minimum Right Shifts to Sort the Array
+Easy
+
+You are given a 0-indexed array nums of length n containing distinct positive integers. Return the minimum number of right shifts required to sort nums and -1 if this is not possible.
+
+A right shift is defined as shifting the element at index i to index (i + 1) % n, for all indices.
+
+
+Example 1:
+
+Input: nums = [3,4,5,1,2]
+Output: 2
+Explanation:
+After the first right shift, nums = [2,3,4,5,1].
+After the second right shift, nums = [1,2,3,4,5].
+Now nums is sorted; therefore the answer is 2.
+
+Example 2:
+
+Input: nums = [1,3,5]
+Output: 0
+Explanation: nums is already sorted therefore, the answer is 0.
+
+Example 3:
+
+Input: nums = [2,1,4]
+Output: -1
+Explanation: It's impossible to sort the array using right shifts.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= nums[i] <= 100
+nums contains distinct integers.
+
+"""
+
+# V0
+# IDEA : COUNT THE "DROPS" (rotated sorted array detection)
+#
+#   a right shift is a cyclic rotation, so nums can be sorted by right
+#   shifts iff nums is a rotation of its sorted order — i.e. iff walking
+#   the array CYCLICALLY there is at most one index i with
+#   nums[i] > nums[(i + 1) % n] (a "drop").
+#
+#   - 0 drops -> already sorted, answer 0.
+#   - 1 drop at index i -> the sorted array starts at index i + 1, and
+#     bringing index i + 1 to position 0 takes n - (i + 1) right shifts.
+#   - 2 or more drops -> impossible, answer -1.
+#
+#   NOTE : the wrap-around comparison nums[n-1] vs nums[0] MUST be included,
+#          otherwise [3,4,5,1,2] and [2,1,4] look alike from the inside.
+#          With the wrap included, the "already sorted" case naturally has
+#          exactly one drop at i = n - 1, which yields n - n = 0 shifts.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumRightShifts(self, nums):
+        n = len(nums)
+        drops = []
+        for i in range(n):
+            if nums[i] > nums[(i + 1) % n]:
+                drops.append(i)
+        if not drops:
+            return 0
+        if len(drops) > 1:
+            return -1
+        return (n - 1 - drops[0]) % n

--- a/leetcode_python/Array/modify-columns.py
+++ b/leetcode_python/Array/modify-columns.py
@@ -1,0 +1,73 @@
+"""
+
+2884. Modify Columns
+Easy
+
+DataFrame employees
++-------------+--------+
+| Column Name | Type   |
++-------------+--------+
+| name        | object |
+| salary      | int    |
++-------------+--------+
+
+A company intends to give its employees a pay rise.
+
+Write a solution to modify the salary column by multiplying each salary by 2.
+
+The result format is in the following example.
+
+
+Example 1:
+
+Input:
+DataFrame employees
++---------+--------+
+| name    | salary |
++---------+--------+
+| Jack    | 19666  |
+| Piper   | 74754  |
+| Mia     | 62509  |
+| Ulysses | 54866  |
++---------+--------+
+Output:
++---------+--------+
+| name    | salary |
++---------+--------+
+| Jack    | 39332  |
+| Piper   | 149508 |
+| Mia     | 125018 |
+| Ulysses | 109732 |
++---------+--------+
+Explanation:
+Every salary has been doubled.
+
+"""
+
+import pandas as pd
+
+# V0
+# IDEA : VECTORISED COLUMN ARITHMETIC (in-place column assignment)
+#
+#   a pandas Series multiplies elementwise, so the whole column doubles in one
+#   vectorised pass — no apply()/loop needed.
+#
+#   NOTE : the problem says "modify", i.e. mutate the given DataFrame and return
+#          it (the column order / dtype must stay int). Assigning back with
+#          employees["salary"] = employees["salary"] * 2 is preferred over the
+#          `*=` shorthand: the explicit assignment always writes through to the
+#          DataFrame, while in-place ops on a Series view can be a no-op under
+#          copy-on-write semantics.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    # NOTE : LeetCode's pandas track submits a bare module-level function
+    #        (aliased below); the class keeps this file in line with the
+    #        rest of the directory.
+    def modifySalaryColumn(self, employees):
+        employees["salary"] = employees["salary"] * 2
+        return employees
+
+
+def modifySalaryColumn(employees):
+    return Solution().modifySalaryColumn(employees)

--- a/leetcode_python/Array/points-that-intersect-with-cars.py
+++ b/leetcode_python/Array/points-that-intersect-with-cars.py
@@ -1,0 +1,59 @@
+"""
+
+2848. Points That Intersect With Cars
+Easy
+
+You are given a 0-indexed 2D integer array nums representing the coordinates of the cars parking on a number line. For any index i, nums[i] = [start_i, end_i] where start_i is the starting point of the ith car and end_i is the ending point of the ith car.
+
+Return the number of integer points on the line that are covered with any part of a car.
+
+
+Example 1:
+
+Input: nums = [[3,6],[1,5],[4,7]]
+Output: 7
+Explanation: All the points from 1 to 7 intersect at least one car, therefore the answer would be 7.
+
+Example 2:
+
+Input: nums = [[1,3],[5,8]]
+Output: 7
+Explanation: Points intersecting at least one car are 1, 2, 3, 5, 6, 7, 8. There are a total of 7 points, therefore the answer would be 7.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+nums[i].length == 2
+1 <= start_i <= end_i <= 100
+
+"""
+
+# V0
+# IDEA : DIFFERENCE ARRAY (line sweep over a tiny coordinate range)
+#
+#   every car covers the closed integer interval [start, end]. Instead of
+#   marking each covered point per car (which double counts overlaps), we
+#   record +1 at `start` and -1 at `end + 1`, then walk a running prefix sum:
+#   a point is covered iff the prefix sum there is > 0.
+#
+#   NOTE : the interval is CLOSED on both ends, so the "-1" must land at
+#          end + 1, not at end. Coordinates go up to 100, hence a size 102
+#          array so `end + 1` (max 101) is always in range.
+#
+# time = O(n + M), space = O(M)  (M = 102, the coordinate range)
+class Solution(object):
+    def numberOfPoints(self, nums):
+        M = 102
+        diff = [0] * M
+        for start, end in nums:
+            diff[start] += 1
+            diff[end + 1] -= 1
+
+        ans = 0
+        running = 0
+        for x in diff:
+            running += x
+            if running > 0:
+                ans += 1
+        return ans

--- a/leetcode_python/Array/rename-columns.py
+++ b/leetcode_python/Array/rename-columns.py
@@ -1,0 +1,82 @@
+"""
+
+2885. Rename Columns
+Easy
+
+DataFrame students
++-------------+--------+
+| Column Name | Type   |
++-------------+--------+
+| id          | int    |
+| first       | object |
+| last        | object |
+| age         | int    |
++-------------+--------+
+
+Write a solution to rename the columns as follows:
+
+- id to student_id
+- first to first_name
+- last to last_name
+- age to age_in_years
+
+The result format is in the following example.
+
+
+Example 1:
+
+Input:
++----+---------+----------+-----+
+| id | first   | last     | age |
++----+---------+----------+-----+
+| 1  | Mason   | King     | 6   |
+| 2  | Ava     | Wright   | 7   |
+| 3  | Taylor  | Hall     | 16  |
+| 4  | Georgia | Thompson | 18  |
+| 5  | Thomas  | Moore    | 10  |
++----+---------+----------+-----+
+Output:
++------------+------------+-----------+--------------+
+| student_id | first_name | last_name | age_in_years |
++------------+------------+-----------+--------------+
+| 1          | Mason      | King      | 6            |
+| 2          | Ava        | Wright    | 7            |
+| 3          | Taylor     | Hall      | 16           |
+| 4          | Georgia    | Thompson  | 18           |
+| 5          | Thomas     | Moore     | 10           |
++------------+------------+-----------+--------------+
+Explanation:
+The column names are changed accordingly.
+
+"""
+
+import pandas as pd
+
+# V0
+# IDEA : PANDAS rename WITH AN OLD -> NEW COLUMN MAPPING
+#
+#   DataFrame.rename(columns=mapping) relabels the column axis without touching
+#   any of the data, so both column order and row order are preserved.
+#
+#   NOTE : rename is a LOOKUP, not a positional rewrite — that matters here
+#          because assigning students.columns = [...] would silently mis-label
+#          the frame if the incoming column order ever differed.
+#
+# time = O(m) for m columns, space = O(m)
+class Solution(object):
+    # NOTE : LeetCode's pandas track submits a bare module-level function
+    #        (aliased below); the class keeps this file in line with the
+    #        rest of the directory.
+    def renameColumns(self, students):
+        return students.rename(
+            columns={
+                "id": "student_id",
+                "first": "first_name",
+                "last": "last_name",
+                "age": "age_in_years",
+            }
+        )
+
+
+def renameColumns(students):
+    return Solution().renameColumns(students)

--- a/leetcode_python/Bit_Manipulation/check-if-bitwise-or-has-trailing-zeros.py
+++ b/leetcode_python/Bit_Manipulation/check-if-bitwise-or-has-trailing-zeros.py
@@ -1,0 +1,62 @@
+"""
+
+2980. Check if Bitwise OR Has Trailing Zeros
+Easy
+
+You are given an array of positive integers nums.
+
+You have to check if it is possible to select two or more elements in the array such that the bitwise OR of the selected elements has at least one trailing zero in its binary representation.
+
+For example, the binary representation of 5, which is "101", does not have any trailing zeros, whereas the binary representation of 4, which is "100", has two trailing zeros.
+
+Return true if it is possible to select two or more elements whose bitwise OR has trailing zeros, return false otherwise.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,5]
+Output: true
+Explanation: If we select the elements 2 and 4, their bitwise OR is 6, which has the binary representation "110" with one trailing zero.
+
+Example 2:
+
+Input: nums = [2,4,8,16]
+Output: true
+Explanation: If we select the elements 2 and 4, their bitwise OR is 6, which has the binary representation "110" with one trailing zero.
+Other possible ways to select elements to have trailing zeroes in the binary representation of their bitwise OR are: (2, 8), (2, 16), (4, 8), (4, 16), (8, 16), (2, 4, 8), (2, 4, 16), (2, 8, 16), (4, 8, 16), and (2, 4, 8, 16).
+
+Example 3:
+
+Input: nums = [1,3,5,7,9]
+Output: false
+Explanation: There is no possible way to select two or more elements to have trailing zeros in the binary representation of their bitwise OR.
+
+
+Constraints:
+
+2 <= nums.length <= 100
+1 <= nums[i] <= 100
+
+"""
+
+# V0
+# IDEA : BIT MANIPULATION (COUNT EVEN NUMBERS)
+#
+#   an OR has a trailing zero <=> its lowest bit is 0 <=> EVERY selected
+#   element has lowest bit 0 (OR turns a bit on, never off).
+#
+#   so the whole question collapses to: "are there >= 2 even numbers?"
+#
+#   NOTE : we only ever need TWO of them. picking exactly two evens is
+#          always optimal, so no subset enumeration is required.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def hasTrailingZeros(self, nums):
+        even = 0
+        for x in nums:
+            if x % 2 == 0:
+                even += 1
+                if even >= 2:
+                    return True
+        return False

--- a/leetcode_python/Bit_Manipulation/maximum-strong-pair-xor-ii.py
+++ b/leetcode_python/Bit_Manipulation/maximum-strong-pair-xor-ii.py
@@ -1,0 +1,114 @@
+"""
+
+2935. Maximum Strong Pair XOR II
+Hard
+
+You are given a 0-indexed integer array nums. A pair of integers x and y is called a strong pair if it satisfies the condition:
+
+|x - y| <= min(x, y)
+
+You need to select two integers from nums such that they form a strong pair and their bitwise XOR is the maximum among all strong pairs in the array.
+
+Return the maximum XOR value out of all possible strong pairs in the array nums.
+
+Note that you can pick the same integer twice to form a pair.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,5]
+Output: 7
+Explanation: There are 11 strong pairs in the array nums: (1, 1), (1, 2), (2, 2), (2, 3), (2, 4), (3, 3), (3, 4), (3, 5), (4, 4), (4, 5) and (5, 5).
+The maximum XOR possible from these pairs is 3 XOR 4 = 7.
+
+Example 2:
+
+Input: nums = [10,100]
+Output: 0
+Explanation: There are 2 strong pairs in the array nums: (10, 10) and (100, 100).
+The maximum XOR possible from these pairs is 10 XOR 10 = 0 since the pair (100, 100) also gives 100 XOR 100 = 0.
+
+Example 3:
+
+Input: nums = [500,520,2500,3000]
+Output: 1020
+Explanation: There are 6 strong pairs in the array nums: (500, 500), (500, 520), (520, 520), (2500, 2500), (2500, 3000) and (3000, 3000).
+The maximum XOR possible from these pairs is 500 XOR 520 = 1020 since the only other non-zero XOR value is 2500 XOR 3000 = 636.
+
+
+Constraints:
+
+1 <= nums.length <= 5 * 10^4
+1 <= nums[i] <= 2^20 - 1
+
+"""
+
+# V0
+# IDEA : SORT + SLIDING WINDOW OVER A COUNTING BINARY TRIE
+#
+#   assume x <= y. then |x - y| <= min(x, y) becomes y - x <= x, i.e. y <= 2 * x.
+#   so after sorting, the partners allowed for a given y form a contiguous
+#   suffix window [i .. current] where 2 * nums[i] >= y.
+#
+#   slide that window while inserting / removing values in a binary trie keyed by
+#   the 20 bits of each number (nums[i] < 2^20). querying the trie greedily walks
+#   the opposite bit whenever a live child exists, giving max(y ^ z) over the
+#   window in O(20).
+#
+#   NOTE : removal must be lazy-by-count, not by pruning — a node stays allocated
+#          but its `cnt` drops to 0, so the query has to test `cnt` and not just
+#          "child exists".
+#   NOTE : insert y BEFORE shrinking the window, so the pair (y, y) -> 0 is always
+#          available and the window is never empty.
+#   NOTE : duplicates are fine — cnt is a multiplicity, not a flag.
+#
+# time = O(n * log n + n * 20), space = O(n * 20)
+class Solution(object):
+    def maximumStrongPairXor(self, nums):
+        BITS = 20
+
+        # flat-array trie: children[node][bit] -> node id (0 == absent)
+        children = [[0, 0]]
+        cnt = [0]
+
+        def insert(x):
+            node = 0
+            for i in range(BITS, -1, -1):
+                v = (x >> i) & 1
+                if children[node][v] == 0:
+                    children.append([0, 0])
+                    cnt.append(0)
+                    children[node][v] = len(cnt) - 1
+                node = children[node][v]
+                cnt[node] += 1
+
+        def remove(x):
+            node = 0
+            for i in range(BITS, -1, -1):
+                v = (x >> i) & 1
+                node = children[node][v]
+                cnt[node] -= 1
+
+        def query(x):
+            node = 0
+            best = 0
+            for i in range(BITS, -1, -1):
+                v = (x >> i) & 1
+                other = children[node][v ^ 1]
+                if other and cnt[other]:
+                    best |= 1 << i
+                    node = other
+                else:
+                    node = children[node][v]
+            return best
+
+        nums = sorted(nums)
+        ans = 0
+        lo = 0
+        for y in nums:
+            insert(y)
+            while y > nums[lo] * 2:
+                remove(nums[lo])
+                lo += 1
+            ans = max(ans, query(y))
+        return ans

--- a/leetcode_python/Bit_Manipulation/sum-of-values-at-indices-with-k-set-bits.py
+++ b/leetcode_python/Bit_Manipulation/sum-of-values-at-indices-with-k-set-bits.py
@@ -1,0 +1,75 @@
+"""
+
+2859. Sum of Values at Indices With K Set Bits
+Easy
+
+You are given a 0-indexed integer array nums and an integer k.
+
+Return an integer that denotes the sum of elements in nums whose corresponding indices have exactly k set bits in their binary representation.
+
+The set bits in an integer are the 1's present when it is written in binary.
+
+For example, the binary representation of 21 is 10101, which has 3 set bits.
+
+
+Example 1:
+
+Input: nums = [5,10,1,5,2], k = 1
+Output: 13
+Explanation: The binary representation of the indices are:
+0 = 000
+1 = 001
+2 = 010
+3 = 011
+4 = 100
+Indices 1, 2, and 4 have k = 1 set bits in their binary representation.
+Hence, the answer is nums[1] + nums[2] + nums[4] = 13.
+
+Example 2:
+
+Input: nums = [4,3,2,1], k = 2
+Output: 1
+Explanation: The binary representation of the indices are:
+0 = 00
+1 = 01
+2 = 10
+3 = 11
+Only index 3 has k = 2 set bits in its binary representation.
+Hence, the answer is nums[3] = 1.
+
+
+Constraints:
+
+1 <= nums.length <= 1000
+1 <= nums[i] <= 10^5
+0 <= k <= 10
+
+"""
+
+# V0
+# IDEA : POPCOUNT VIA `n & (n - 1)` BIT TRICK
+#
+#   Walk every index, count its set bits, and accumulate nums[i] when the count
+#   equals k.
+#
+#   To count set bits we repeatedly clear the LOWEST set bit with `x &= x - 1`,
+#   which runs once per 1-bit rather than once per bit position.
+#
+#   NOTE : k == 0 is allowed, and only index 0 has zero set bits — the loop
+#          handles that naturally (no special case needed).
+#   NOTE : bin(i).count('1') is the idiomatic one-liner, but the mask trick keeps
+#          this Python 2/3 friendly and allocation free.
+#
+# time = O(n * log n), space = O(1)
+class Solution(object):
+    def sumIndicesWithKSetBits(self, nums, k):
+        res = 0
+        for i in range(len(nums)):
+            x = i
+            bits = 0
+            while x:
+                x &= x - 1
+                bits += 1
+            if bits == k:
+                res += nums[i]
+        return res

--- a/leetcode_python/Dynamic_Programming/minimum-edge-reversals-so-every-node-is-reachable.py
+++ b/leetcode_python/Dynamic_Programming/minimum-edge-reversals-so-every-node-is-reachable.py
@@ -1,0 +1,117 @@
+"""
+
+2858. Minimum Edge Reversals So Every Node Is Reachable
+Hard
+
+There is a simple directed graph with n nodes labeled from 0 to n - 1. The graph would form a tree if its edges were bi-directional.
+
+You are given an integer n and a 2D integer array edges, where edges[i] = [ui, vi] represents a directed edge going from node ui to node vi.
+
+An edge reversal changes the direction of an edge, i.e., a directed edge going from node ui to node vi becomes a directed edge going from node vi to node ui.
+
+For every node i in the range [0, n - 1], your task is to independently calculate the minimum number of edge reversals required so it is possible to reach any other node starting from node i through a sequence of directed edges.
+
+Return an integer array answer, where answer[i] is the minimum number of edge reversals required so it is possible to reach any other node starting from node i through a sequence of directed edges.
+
+
+Example 1:
+
+Input: n = 4, edges = [[2,0],[2,1],[1,3]]
+Output: [1,1,0,2]
+Explanation: The image above shows the graph formed by the edges.
+For node 0: after reversing the edge [2,0], it is possible to reach any other node starting from node 0.
+So, answer[0] = 1.
+For node 1: after reversing the edge [2,1], it is possible to reach any other node starting from node 1.
+So, answer[1] = 1.
+For node 2: it is already possible to reach any other node starting from node 2.
+So, answer[2] = 0.
+For node 3: after reversing the edges [1,3] and [2,1], it is possible to reach any other node starting from node 3.
+So, answer[3] = 2.
+
+Example 2:
+
+Input: n = 3, edges = [[1,2],[2,0]]
+Output: [2,0,1]
+Explanation: The image above shows the graph formed by the edges.
+For node 0: after reversing the edges [2,0] and [1,2], it is possible to reach any other node starting from node 0.
+So, answer[0] = 2.
+For node 1: it is already possible to reach any other node starting from node 1.
+So, answer[1] = 0.
+For node 2: after reversing the edge [1, 2], it is possible to reach any other node starting from node 2.
+So, answer[2] = 1.
+
+
+Constraints:
+
+2 <= n <= 10^5
+edges.length == n - 1
+edges[i].length == 2
+0 <= ui == edges[i][0] < n
+0 <= vi == edges[i][1] < n
+ui != vi
+The input is generated such that if the edges were bi-directional, the graph would be a tree.
+
+"""
+
+# V0
+# IDEA : RE-ROOTING DP (TREE DP) ON THE UNDIRECTED TREE
+#
+#   Treat every directed edge as an undirected edge carrying a cost:
+#     - walking it in its natural direction  (u -> v) costs 0
+#     - walking it against its direction     (v -> u) costs 1  (we must reverse it)
+#
+#   Because the underlying graph is a tree, "reach every other node from i"
+#   means "orient every edge away from i", so answer[i] is simply the number of
+#   edges that point *towards* i on the unique root-to-node paths — i.e. the sum
+#   of walking costs from i to all other nodes... which for a tree collapses to a
+#   single count per edge.
+#
+#   Step 1 : root the tree at 0 and count how many edges must be flipped -> ans[0].
+#   Step 2 : re-root. Moving the root from u to an adjacent node v across an edge
+#            whose walking cost (as seen from u) is c:
+#              - c == 0 (edge u->v) : from v that edge now points backwards -> +1
+#              - c == 1 (edge v->u) : from v that edge is already fine       -> -1
+#            so  ans[v] = ans[u] + 1 - 2 * c
+#
+#   NOTE : n can be 10^5, so both traversals are written ITERATIVELY (an explicit
+#          stack) — a recursive DFS would blow Python's recursion limit on a path
+#          shaped tree.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def minEdgeReversals(self, n, edges):
+        # adj[u] = list of (neighbour, cost of walking u -> neighbour)
+        adj = [[] for _ in range(n)]
+        for u, v in edges:
+            adj[u].append((v, 0))
+            adj[v].append((u, 1))
+
+        ans = [0] * n
+
+        # ---- step 1 : cost of rooting the tree at node 0 ----
+        total = 0
+        visited = [False] * n
+        visited[0] = True
+        stack = [0]
+        while stack:
+            u = stack.pop()
+            for v, c in adj[u]:
+                if not visited[v]:
+                    visited[v] = True
+                    total += c
+                    stack.append(v)
+        ans[0] = total
+
+        # ---- step 2 : re-root from 0 to every other node ----
+        visited = [False] * n
+        visited[0] = True
+        stack = [0]
+        while stack:
+            u = stack.pop()
+            for v, c in adj[u]:
+                if not visited[v]:
+                    visited[v] = True
+                    ans[v] = ans[u] + 1 - 2 * c
+                    stack.append(v)
+
+        return ans

--- a/leetcode_python/Dynamic_Programming/subarrays-distinct-element-sum-of-squares-i.py
+++ b/leetcode_python/Dynamic_Programming/subarrays-distinct-element-sum-of-squares-i.py
@@ -1,0 +1,74 @@
+"""
+
+2913. Subarrays Distinct Element Sum of Squares I
+Easy
+
+You are given a 0-indexed integer array nums.
+
+The distinct count of a subarray of nums is defined as:
+
+Let nums[i..j] be a subarray of nums consisting of all the indices from i to j
+such that 0 <= i <= j < nums.length. Then the number of distinct values in
+nums[i..j] is called the distinct count of nums[i..j].
+
+Return the sum of the squares of distinct counts of all subarrays of nums.
+
+A subarray is a contiguous non-empty sequence of elements within an array.
+
+
+Example 1:
+
+Input: nums = [1,2,1]
+Output: 15
+Explanation: Six possible subarrays are:
+[1]: 1 distinct value
+[2]: 1 distinct value
+[1]: 1 distinct value
+[1,2]: 2 distinct values
+[2,1]: 2 distinct values
+[1,2,1]: 2 distinct values
+The sum of the squares of the distinct counts in all subarrays is equal to
+1^2 + 1^2 + 1^2 + 2^2 + 2^2 + 2^2 = 15.
+
+Example 2:
+
+Input: nums = [1,1]
+Output: 3
+Explanation: Three possible subarrays are:
+[1]: 1 distinct value
+[1]: 1 distinct value
+[1,1]: 1 distinct value
+The sum of the squares of the distinct counts in all subarrays is equal to
+1^2 + 1^2 + 1^2 = 3.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+1 <= nums[i] <= 100
+
+"""
+
+# V0
+# IDEA : BRUTE FORCE ENUMERATION + INCREMENTAL DISTINCT COUNT
+#
+#   n <= 100, so O(n^2) enumeration of every (i, j) pair is plenty.
+#
+#   Fix the left endpoint i and sweep the right endpoint j to the right.
+#   Keep a `seen` set of the values in nums[i..j]: extending j by one can only
+#   grow the distinct count by 0 or 1, so we never rebuild the set from scratch.
+#
+#   NOTE : the contribution of each subarray is len(seen) ** 2, NOT len(seen),
+#          so every single-element subarray still contributes 1.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def sumCounts(self, nums):
+        res = 0
+        n = len(nums)
+        for i in range(n):
+            seen = set()
+            for j in range(i, n):
+                seen.add(nums[j])
+                res += len(seen) * len(seen)
+        return res

--- a/leetcode_python/Greedy/happy-students.py
+++ b/leetcode_python/Greedy/happy-students.py
@@ -1,0 +1,77 @@
+"""
+
+2860. Happy Students
+Medium
+
+You are given a 0-indexed integer array nums of length n where n is the total number of students in the class. The class teacher tries to select a group of students so that all the students remain happy.
+
+The ith student will become happy if one of these two conditions is met:
+
+The student is selected and the total number of selected students is strictly greater than nums[i].
+The student is not selected and the total number of selected students is strictly less than nums[i].
+
+Return the number of ways to select a group of students so that everyone remains happy.
+
+
+Example 1:
+
+Input: nums = [1,1]
+Output: 2
+Explanation:
+The two possible ways are:
+The class teacher selects no student.
+The class teacher selects both students to form the group.
+If the class teacher selects just one student to form a group then the both students will not be happy. Therefore, there are only two possible ways.
+
+Example 2:
+
+Input: nums = [6,0,3,3,6,7,2,7]
+Output: 3
+Explanation:
+The three possible ways are:
+The class teacher selects the student with index = 1 to form the group.
+The class teacher selects the students with index = 1, 2, 3, 6 to form the group.
+The class teacher selects all the students to form the group.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+0 <= nums[i] < nums.length
+
+"""
+
+# V0
+# IDEA : SORT + ENUMERATE THE GROUP SIZE
+#
+#   The happiness rule only depends on the group SIZE k, never on which students
+#   are picked. Given k, a student is happy iff:
+#     - selected     and nums[i] < k
+#     - not selected and nums[i] > k
+#   So for a fixed k the selection is forced: pick exactly the students whose
+#   value is < k. That is consistent only if exactly k students satisfy
+#   nums[i] < k, and nobody sits on the boundary nums[i] == k.
+#
+#   After sorting, "the k smallest are all < k and the rest are all > k" becomes
+#   two O(1) checks:
+#     - k == 0  or  nums[k - 1] < k     (everyone selected is below the size)
+#     - k == n  or  nums[k]     > k     (everyone left out is above the size)
+#
+#   NOTE : k ranges over 0..n INCLUSIVE — the empty group and the whole class are
+#          both legitimate candidates.
+#   NOTE : nums[i] == k can never work, since that student is unhappy whether
+#          selected or not; the strict comparisons above rule it out.
+#
+# time = O(n * log n), space = O(1) beyond the sort
+class Solution(object):
+    def countWays(self, nums):
+        nums.sort()
+        n = len(nums)
+        res = 0
+        for k in range(n + 1):
+            if k > 0 and nums[k - 1] >= k:
+                continue
+            if k < n and nums[k] <= k:
+                continue
+            res += 1
+        return res

--- a/leetcode_python/Greedy/minimum-number-of-changes-to-make-binary-string-beautiful.py
+++ b/leetcode_python/Greedy/minimum-number-of-changes-to-make-binary-string-beautiful.py
@@ -1,0 +1,78 @@
+"""
+
+2914. Minimum Number of Changes to Make Binary String Beautiful
+Medium
+
+You are given a 0-indexed binary string s having an even length.
+
+A string is beautiful if it's possible to partition it into one or more
+substrings such that:
+
+Each substring has an even length.
+Each substring contains only 1's or only 0's.
+
+You can change any character in s to 0 or 1.
+
+Return the minimum number of changes required to make the string s beautiful.
+
+
+Example 1:
+
+Input: s = "1001"
+Output: 2
+Explanation: We change s[1] to 1 and s[3] to 0 to get string "1100".
+It can be seen that the string "1100" is beautiful because we can partition it
+into "11|00".
+It can be proven that 2 is the minimum number of changes needed to make the
+string beautiful.
+
+Example 2:
+
+Input: s = "10"
+Output: 1
+Explanation: We change s[1] to 1 to get string "11".
+It can be seen that the string "11" is beautiful because we can partition it
+into "11".
+It can be proven that 1 is the minimum number of changes needed to make the
+string beautiful.
+
+Example 3:
+
+Input: s = "0000"
+Output: 0
+Explanation: We don't need to make any changes as the string "0000" is
+beautiful already.
+
+
+Constraints:
+
+2 <= s.length <= 10^5
+s has an even length.
+s[i] is either '0' or '1'.
+
+"""
+
+# V0
+# IDEA : GREEDY / PAIRING (fixed blocks of 2)
+#
+#   Any partition into even-length uniform blocks can be refined into blocks of
+#   EXACTLY length 2 (an even uniform block of length 2m splits into m blocks of
+#   2 that are all uniform). So "beautiful" is equivalent to:
+#
+#       s[0] == s[1], s[2] == s[3], s[4] == s[5], ...
+#
+#   The pairs (0,1), (2,3), ... are disjoint and independent, so the greedy is
+#   forced: a pair whose two characters differ costs exactly 1 change, and a
+#   pair already equal costs 0.
+#
+#   NOTE : the block boundaries are FIXED at the even indices — we do not get to
+#          choose where the cuts go, because a length-2 refinement always exists.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minChanges(self, s):
+        res = 0
+        for i in range(1, len(s), 2):
+            if s[i] != s[i - 1]:
+                res += 1
+        return res

--- a/leetcode_python/Greedy/the-wording-game.py
+++ b/leetcode_python/Greedy/the-wording-game.py
@@ -1,0 +1,112 @@
+"""
+
+2868. The Wording Game
+Hard
+
+Alice and Bob each have a lexicographically sorted array of strings named a and b respectively.
+
+They are playing a wording game with the following rules:
+
+On each turn, the current player should play a word from their list such that the new word is closely greater than the last played word; then it's the other player's turn.
+If a player can't play a word on their turn, they lose.
+
+Alice starts the game by playing her lexicographically smallest word.
+
+Given a and b, return true if Alice can win knowing that both players play their best, and false otherwise.
+
+A word w is closely greater than a word z if the following conditions are met:
+
+w is lexicographically greater than z.
+If w1 is the first letter of w and z1 is the first letter of z, w1 should either be equal to z1 or be the letter after z1 in the alphabet.
+For example, the word "care" is closely greater than "book" and "car", but is not closely greater than "ant" or "cook".
+
+A string s is lexicographically greater than a string t if in the first position where s and t differ, string s has a letter that appears later in the alphabet than the corresponding letter in t. If the first min(s.length, t.length) characters do not differ, then the longer string is the lexicographically greater one.
+
+
+Example 1:
+
+Input: a = ["avokado","dabar"], b = ["brazil"]
+Output: false
+Explanation: Alice must start the game by playing the word "avokado" since it's her smallest word, then Bob plays his only word, "brazil", which he can play because its first letter, 'b', is the letter after Alice's word's first letter, 'a'.
+Alice can't play a word since the first letter of the only word left is not equal to 'b' or the letter after 'b', 'c'.
+So, Alice loses, and the game ends.
+
+Example 2:
+
+Input: a = ["ananas","atlas","banana"], b = ["albatros","cikla","nogomet"]
+Output: true
+Explanation: Alice must start the game by playing the word "ananas".
+Bob can't play a word since the only word he has that starts with the letter 'a' or 'b' is "albatros", which is smaller than Alice's word.
+So Alice wins, and the game ends.
+
+Example 3:
+
+Input: a = ["hrvatska","zastava"], b = ["bijeli","galeb"]
+Output: true
+Explanation: Alice must start the game by playing the word "hrvatska".
+Bob can't play a word since the first letter of both of his words are smaller than the first letter of Alice's word, 'h'.
+So Alice wins, and the game ends.
+
+
+Constraints:
+
+1 <= a.length, b.length <= 10^5
+a[i] and b[i] consist only of lowercase English letters.
+a and b are lexicographically sorted.
+All the words in a and b combined are distinct.
+The sum of the lengths of all the words in a and b combined does not exceed 10^6.
+
+"""
+
+# V0
+# IDEA : GREEDY SIMULATION + TWO POINTERS
+#
+#   Both lists are already sorted, and the played word strictly increases, so a
+#   word that is unplayable now can never become playable later (it is either
+#   already too small, or its first letter is >= 2 letters ahead — and every
+#   word after it in the sorted list starts with a letter that is at least as
+#   far ahead). That means each player only ever scans forward: one monotone
+#   pointer per list.
+#
+#   NOTE : the optimal move is always the SMALLEST playable word. Playing a
+#          bigger word only shifts the "first letter window" further along,
+#          which throws away your own future words without taking anything
+#          away from the opponent (they answer the smallest word with the very
+#          same set of candidates, or more).
+#
+#   NOTE : "closely greater" is w > z AND ord(w[0]) - ord(z[0]) in {0, 1}.
+#          When the first letters differ by exactly 1 the lexicographic check
+#          is automatic, so only the equal-first-letter case needs w > z.
+#
+#   The game ends the moment the player to move has no playable word left:
+#   Bob stuck -> Alice wins, Alice stuck -> Alice loses.
+#
+# time = O(m + n), space = O(1)
+class Solution(object):
+    def canAliceWin(self, a, b):
+        def closely_greater(w, z):
+            gap = ord(w[0]) - ord(z[0])
+            if gap == 1:
+                return True
+            return gap == 0 and w > z
+
+        i, j = 1, 0            # next candidate index for Alice / Bob
+        word = a[0]            # Alice opens with her smallest word
+        alice_turn = False     # Bob moves next
+
+        while True:
+            if alice_turn:
+                while i < len(a) and not closely_greater(a[i], word):
+                    i += 1
+                if i == len(a):
+                    return False
+                word = a[i]
+                i += 1
+            else:
+                while j < len(b) and not closely_greater(b[j], word):
+                    j += 1
+                if j == len(b):
+                    return True
+                word = b[j]
+                j += 1
+            alice_turn = not alice_turn

--- a/leetcode_python/Math/maximum-number-of-alloys.py
+++ b/leetcode_python/Math/maximum-number-of-alloys.py
@@ -1,0 +1,109 @@
+"""
+
+2861. Maximum Number of Alloys
+Medium
+
+You are the owner of a company that creates alloys using various types of metals. There are n different types of metals available, and you have access to k machines that can be used to create alloys. Each machine requires a specific amount of each metal type to create an alloy.
+
+For the ith machine to create an alloy, it needs composition[i][j] units of metal of type j. Initially, you have stock[i] units of metal type i, and purchasing one unit of metal type i costs cost[i] coins.
+
+Given integers n, k, budget, a 1-indexed 2D array composition, and 1-indexed arrays stock and cost, your goal is to maximize the number of alloys the company can create while staying within the budget of budget coins.
+
+All alloys must be created with the same machine.
+
+Return the maximum number of alloys that the company can create.
+
+
+Example 1:
+
+Input: n = 3, k = 2, budget = 15, composition = [[1,1,1],[1,1,10]], stock = [0,0,0], cost = [1,2,3]
+Output: 2
+Explanation: It is optimal to use the 1st machine to create alloys.
+To create 2 alloys we need to buy the:
+- 2 units of metal of the 1st type.
+- 2 units of metal of the 2nd type.
+- 2 units of metal of the 3rd type.
+In total, we need 2 * 1 + 2 * 2 + 2 * 3 = 12 coins, which is smaller than or equal to budget = 15.
+Notice that we have 0 units of metal of each type and we have to buy all the required units of metal.
+It can be proven that we can create at most 2 alloys.
+
+Example 2:
+
+Input: n = 3, k = 2, budget = 15, composition = [[1,1,1],[1,1,10]], stock = [0,0,100], cost = [1,2,3]
+Output: 5
+Explanation: It is optimal to use the 2nd machine to create alloys.
+To create 5 alloys we need to buy:
+- 5 units of metal of the 1st type.
+- 5 units of metal of the 2nd type.
+- 0 units of metal of the 3rd type.
+In total, we need 5 * 1 + 5 * 2 + 0 * 3 = 15 coins, which is smaller than or equal to budget = 15.
+It can be proven that we can create at most 5 alloys.
+
+Example 3:
+
+Input: n = 2, k = 3, budget = 10, composition = [[2,1],[1,2],[1,1]], stock = [1,1], cost = [5,5]
+Output: 2
+Explanation: It is optimal to use the 3rd machine to create alloys.
+To create 2 alloys we need to buy the:
+- 1 unit of metal of the 1st type.
+- 1 unit of metal of the 2nd type.
+In total, we need 1 * 5 + 1 * 5 = 10 coins, which is smaller than or equal to budget = 10.
+It can be proven that we can create at most 2 alloys.
+
+
+Constraints:
+
+1 <= n, k <= 100
+0 <= budget <= 10^8
+composition.length == k
+composition[i].length == n
+1 <= composition[i][j] <= 100
+stock.length == cost.length == n
+0 <= stock[i] <= 10^8
+1 <= cost[i] <= 100
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH ON THE ANSWER, PER MACHINE
+#
+#   Feasibility is MONOTONIC : if a machine can produce x alloys within budget it
+#   can also produce anything below x (the required purchase only grows with x).
+#   So binary search the largest feasible x for each machine and keep the best.
+#
+#   Cost of x alloys on machine m:
+#       sum over metals j of max(0, composition[m][j] * x - stock[j]) * cost[j]
+#
+#   Search range : [0, max(stock) + budget].
+#   NOTE : that upper bound is safe because composition[m][j] >= 1 and
+#          cost[j] >= 1, so producing x alloys costs at least x - stock[j] coins
+#          for every j — beyond max(stock) + budget nothing is affordable.
+#   NOTE : the cost accumulator is compared against `budget` and can be broken out
+#          of early; Python ints are arbitrary precision so there is no overflow
+#          to guard against here (a fixed-width port would need 64-bit).
+#
+# time = O(k * n * log(max_stock + budget)), space = O(1)
+class Solution(object):
+    def maxNumberOfAlloys(self, n, k, budget, composition, stock, cost):
+        def can_make(comp, x):
+            spent = 0
+            for j in range(n):
+                need = comp[j] * x - stock[j]
+                if need > 0:
+                    spent += need * cost[j]
+                    if spent > budget:
+                        return False
+            return True
+
+        res = 0
+        hi_cap = max(stock) + budget
+        for comp in composition:
+            lo, hi = res, hi_cap
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if can_make(comp, mid):
+                    lo = mid
+                else:
+                    hi = mid - 1
+            res = lo
+        return res

--- a/leetcode_python/Two_Pointers/shortest-and-lexicographically-smallest-beautiful-string.py
+++ b/leetcode_python/Two_Pointers/shortest-and-lexicographically-smallest-beautiful-string.py
@@ -1,0 +1,93 @@
+"""
+
+2904. Shortest and Lexicographically Smallest Beautiful String
+Medium
+
+You are given a binary string s and a positive integer k.
+
+A substring of s is beautiful if the number of 1's in it is exactly k.
+
+Let len be the length of the shortest beautiful substring.
+
+Return the lexicographically smallest beautiful substring of string s with length equal to len. If s doesn't contain a beautiful substring, return an empty string.
+
+A string a is lexicographically larger than a string b (of the same length) if in the first position where a and b differ, a has a character strictly larger than the corresponding character in b.
+
+- For example, "abcd" is lexicographically larger than "abcc" because the first position they differ is at the fourth character, and d is greater than c.
+
+
+Example 1:
+
+Input: s = "100011001", k = 3
+Output: "11001"
+Explanation: There are 7 beautiful substrings in this example:
+1. The substring "100011001".
+2. The substring "100011001".
+3. The substring "100011001".
+4. The substring "100011001".
+5. The substring "100011001".
+6. The substring "100011001".
+7. The substring "100011001".
+The length of the shortest beautiful substring is 5.
+The lexicographically smallest beautiful substring with length 5 is the substring "11001".
+
+Example 2:
+
+Input: s = "1011", k = 2
+Output: "11"
+Explanation: There are 3 beautiful substrings in this example:
+1. The substring "1011".
+2. The substring "1011".
+3. The substring "1011".
+The length of the shortest beautiful substring is 2.
+The lexicographically smallest beautiful substring with length 2 is the substring "11".
+
+Example 3:
+
+Input: s = "000", k = 1
+Output: ""
+Explanation: There are no beautiful substrings in this example.
+
+
+Constraints:
+
+1 <= s.length <= 100
+1 <= k <= s.length
+
+"""
+
+# V0
+# IDEA : TWO POINTERS (SLIDING WINDOW PINNED TO '1' BOUNDARIES)
+#
+#   a candidate answer never wants a leading '0' : dropping it keeps the same
+#   count of 1's and makes the string both shorter AND lexicographically
+#   smaller. so the window is shrunk whenever
+#     - it holds more than k ones      (too many, must drop from the left), or
+#     - its left char is '0' and the window is not a single char
+#   which pins the left end onto a '1' (or onto j itself).
+#
+#   after each expansion, if the window holds exactly k ones it is a minimal
+#   beautiful window ending at j; compare it with the best so far by
+#   (length, then lexicographic order).
+#
+#   NOTE : the "shorter wins" test must come before the lexicographic one —
+#          "11" beats "0111" even though '0' < '1'; the comparison is only
+#          between strings of EQUAL length.
+#   NOTE : returning "" when no window ever reaches k ones falls out for free.
+#
+# time = O(n^2)  (slicing the window is O(n) per step), space = O(n)
+class Solution(object):
+    def shortestBeautifulSubstring(self, s, k):
+        n = len(s)
+        i = cnt = 0
+        ans = ""
+        for j in range(n):
+            cnt += s[j] == "1"
+            while cnt > k or (i < j and s[i] == "0"):
+                cnt -= s[i] == "1"
+                i += 1
+            if cnt == k:
+                t = s[i:j + 1]
+                if not ans or len(t) < len(ans) or (len(t) == len(ans) and t < ans):
+                    ans = t
+        return ans


### PR DESCRIPTION
Work-in-progress from an earlier session that was written but never committed. Closes part of the coverage gap against kamyu104/LeetCode-Solutions, tracked in doc/lc-coverage-kamyu/. Rebased onto current master; none of the 24 filenames collide with anything already there.

Verification, before committing:
  - 51 worked examples parsed out of the docstrings run green (19 algorithm files; the 5 pandas files below are excluded, see caveat)
  - 17 cross-checked against independent brute forces on randomised inputs: 2848, 2849, 2855, 2856, 2858, 2859, 2860, 2861, 2873, 2903, 2905, 2913, 2914, 2935, 2980, 3000
  - full-constraint timing; slowest is 2935 at 0.26s, all others under 0.05s

Caveat: the 5 pandas problems (2877 change-data-type, 2884 modify-columns, 2885 rename-columns, 2886 drop-duplicate-rows, 2887 drop-missing-data) could not be executed here because pandas is not installed in this environment, so they are reviewed but not run. They are also filed under Array/ for want of a better existing category.