### PR TITLE
feat(leetcode_python): add 56 solutions for LC 3563-3626

### DIFF
--- a/leetcode_python/Array/maximize-count-of-distinct-primes-after-split.py
+++ b/leetcode_python/Array/maximize-count-of-distinct-primes-after-split.py
@@ -1,0 +1,194 @@
+"""
+
+3569. Maximize Count of Distinct Primes After Split
+Hard
+
+You are given an integer array nums having length n and a 2D integer array
+queries where queries[i] = [idx, val].
+
+For each query:
+
+1. Update nums[idx] = val.
+2. Choose an integer k with 1 <= k < n to split the array into the non-empty
+   prefix nums[0..k-1] and suffix nums[k..n-1] such that the sum of the
+   counts of distinct prime values in each part is maximum.
+
+Note: The changes made to the array in one query persist into the next
+query.
+
+Return an array containing the result for each query, in the order they are
+given.
+
+
+Example 1:
+
+Input: nums = [2,1,3,1,2], queries = [[1,2],[3,3]]
+Output: [3,4]
+Explanation:
+- Initially nums = [2, 1, 3, 1, 2].
+- After 1st query, nums = [2, 2, 3, 1, 2]. Split nums into [2] and
+  [2, 3, 1, 2]. [2] consists of 1 distinct prime and [2, 3, 1, 2] consists
+  of 2 distinct primes. Hence, the answer for this query is 1 + 2 = 3.
+- After 2nd query, nums = [2, 2, 3, 3, 2]. Split nums into [2, 2, 3] and
+  [3, 2] with an answer of 2 + 2 = 4.
+- The output is [3, 4].
+
+Example 2:
+
+Input: nums = [2,1,4], queries = [[0,1]]
+Output: [0]
+Explanation:
+- Initially nums = [2, 1, 4].
+- After 1st query, nums = [1, 1, 4]. There are no prime numbers in nums,
+  hence the answer for this query is 0.
+- The output is [0].
+
+
+Constraints:
+
+2 <= n == nums.length <= 5 * 10^4
+1 <= queries.length <= 5 * 10^4
+1 <= nums[i] <= 10^5
+0 <= queries[i][0] < nums.length
+1 <= queries[i][1] <= 10^5
+
+"""
+
+# V0
+# IDEA : REWRITE THE SPLIT VALUE AS "TOTAL PRIMES + INTERVAL COVERAGE",
+#        THEN A RANGE-ADD / GLOBAL-MAX SEGMENT TREE
+#
+#   a distinct prime p only cares about where it first and last occurs.
+#   for a split at k it is counted in the prefix iff first[p] < k, and in
+#   the suffix iff last[p] >= k. since first[p] <= last[p], at least one of
+#   the two always holds — so every prime present contributes at least 1,
+#   independent of k, and contributes a *second* point exactly when
+#   first[p] < k <= last[p].
+#
+#   so answer = P + max over k in [1, n-1] of "how many primes have k inside
+#   (first[p], last[p]]", where P is the number of distinct primes present.
+#   the search over k collapses into a classic stabbing problem: each prime
+#   occurring at two or more indices lays down the interval
+#   [first[p] + 1, last[p]] and we want the point covered most often.
+#
+#   an update touches at most two prime values (the one leaving the cell and
+#   the one entering it), and each of those shifts a single interval — so
+#   keep every prime's occurrence indices in a set with lazily-cleaned min /
+#   max heaps, retract the old interval with a range -1 and lay down the new
+#   one with a range +1. a bottom-up lazy segment tree holds the coverage
+#   profile and its root is the running maximum, read off in O(1).
+#
+# time = O((n + q) * log n + V log log V), space = O(n + V)
+class Solution(object):
+    def maximumCount(self, nums, queries):
+        import heapq
+
+        LIMIT = 100001
+        sieve = bytearray([1]) * LIMIT
+        sieve[0] = sieve[1] = 0
+        i = 2
+        while i * i < LIMIT:
+            if sieve[i]:
+                sieve[i * i::i] = bytearray(len(range(i * i, LIMIT, i)))
+            i += 1
+
+        n = len(nums)
+
+        # segment tree over the split points k = 1 .. n - 1, stored at
+        # positions 0 .. n - 2; supports range add and O(1) global max
+        size = 1
+        while size < n - 1:
+            size <<= 1
+        tree = [0] * (2 * size)
+        lazy = [0] * size
+
+        def modify(lo, hi, delta):
+            # add delta to every position in [lo, hi]
+            l = lo + size
+            r = hi + size + 1
+            left, right = l, r - 1
+            while l < r:
+                if l & 1:
+                    tree[l] += delta
+                    if l < size:
+                        lazy[l] += delta
+                    l += 1
+                if r & 1:
+                    r -= 1
+                    tree[r] += delta
+                    if r < size:
+                        lazy[r] += delta
+                l >>= 1
+                r >>= 1
+            for x in (left, right):
+                while x > 1:
+                    x >>= 1
+                    a, b = tree[x << 1], tree[x << 1 | 1]
+                    tree[x] = (a if a > b else b) + lazy[x]
+
+        where = {}       # prime -> set of indices currently holding it
+        lows = {}        # prime -> min-heap of candidate indices
+        highs = {}       # prime -> max-heap (negated) of candidate indices
+        distinct = [0]   # number of distinct primes present
+
+        def span(p):
+            # current [first + 1, last] as segment-tree positions, or None
+            s = where.get(p)
+            if not s:
+                return None
+            h = lows[p]
+            while h[0] not in s:
+                heapq.heappop(h)
+            first = h[0]
+            g = highs[p]
+            while -g[0] not in s:
+                heapq.heappop(g)
+            last = -g[0]
+            return (first, last - 1) if first < last else None
+
+        def relay(p, before, after):
+            if before == after:
+                return
+            if before is not None:
+                modify(before[0], before[1], -1)
+            if after is not None:
+                modify(after[0], after[1], 1)
+
+        def attach(p, idx):
+            s = where.get(p)
+            if s is None:
+                s = where[p] = set()
+                lows[p] = []
+                highs[p] = []
+            before = span(p)
+            if not s:
+                distinct[0] += 1
+            s.add(idx)
+            heapq.heappush(lows[p], idx)
+            heapq.heappush(highs[p], -idx)
+            relay(p, before, span(p))
+
+        def detach(p, idx):
+            s = where[p]
+            before = span(p)
+            s.discard(idx)
+            if not s:
+                distinct[0] -= 1
+            relay(p, before, span(p))
+
+        cur = list(nums)
+        for idx, v in enumerate(cur):
+            if sieve[v]:
+                attach(v, idx)
+
+        res = []
+        for idx, val in queries:
+            old = cur[idx]
+            if old != val:
+                if sieve[old]:
+                    detach(old, idx)
+                cur[idx] = val
+                if sieve[val]:
+                    attach(val, idx)
+            res.append(distinct[0] + tree[1])
+        return res

--- a/leetcode_python/Array/maximum-product-of-first-and-last-elements-of-a-subsequence.py
+++ b/leetcode_python/Array/maximum-product-of-first-and-last-elements-of-a-subsequence.py
@@ -1,0 +1,74 @@
+"""
+
+3584. Maximum Product of First and Last Elements of a Subsequence
+Medium
+
+You are given an integer array nums and an integer m.
+
+Return the maximum product of the first and last elements of any subsequence of nums of size m.
+
+
+Example 1:
+
+Input: nums = [-1,-9,2,3,-2,-3,1], m = 1
+Output: 81
+Explanation:
+The subsequence [-9] has the largest product of the first and last elements: -9 * -9 = 81. Therefore, the answer is 81.
+
+Example 2:
+
+Input: nums = [1,3,-5,5,6,-4], m = 3
+Output: 20
+Explanation:
+The subsequence [-5, 6, -4] has the largest product of the first and last elements.
+
+Example 3:
+
+Input: nums = [2,-1,2,-6,5,2,-5,7], m = 2
+Output: 35
+Explanation:
+The subsequence [5, 7] has the largest product of the first and last elements.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+-10^5 <= nums[i] <= 10^5
+1 <= m <= nums.length
+
+"""
+
+# V0
+# IDEA : ONLY THE TWO ENDPOINTS MATTER, SO SLIDE A GAP OF m-1
+#
+#   the middle m-2 picks are irrelevant to the score; a subsequence of size
+#   m exists with endpoints i and j exactly when j - i >= m - 1. so the task
+#   collapses to "maximise nums[i] * nums[j] over all pairs at least m-1
+#   apart".
+#
+#   because of negative values the best partner for nums[j] is either the
+#   running maximum or the running minimum of the allowed prefix, and both
+#   are maintained in O(1) as j advances.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def maximumProduct(self, nums, m):
+        n = len(nums)
+        hi = float('-inf')
+        lo = float('inf')
+        ans = float('-inf')
+        for j in range(m - 1, n):
+            i = j - m + 1
+            v = nums[i]
+            if v > hi:
+                hi = v
+            if v < lo:
+                lo = v
+            b = nums[j]
+            c1 = hi * b
+            c2 = lo * b
+            if c1 > ans:
+                ans = c1
+            if c2 > ans:
+                ans = c2
+        return ans

--- a/leetcode_python/Array/minimize-maximum-component-cost.py
+++ b/leetcode_python/Array/minimize-maximum-component-cost.py
@@ -1,0 +1,91 @@
+"""
+
+3613. Minimize Maximum Component Cost
+Medium
+
+You are given an undirected connected graph with n nodes labeled from 0 to n - 1
+and a 2D integer array edges where edges[i] = [ui, vi, wi] denotes an undirected
+edge between node ui and node vi with weight wi, and an integer k.
+
+You are allowed to remove any number of edges from the graph such that the
+resulting graph has at most k connected components.
+
+The cost of a component is defined as the maximum edge weight in that component.
+If a component has no edges, its cost is 0.
+
+Return the minimum possible value of the maximum cost among all components after
+such removals.
+
+
+Example 1:
+
+Input: n = 5, edges = [[0,1,4],[1,2,3],[1,3,2],[3,4,6]], k = 2
+Output: 4
+Explanation:
+Remove the edge between nodes 3 and 4 (weight 6).
+The resulting components have costs of 0 and 4, so the overall maximum cost is 4.
+
+Example 2:
+
+Input: n = 4, edges = [[0,1,5],[1,2,5],[2,3,5]], k = 1
+Output: 5
+Explanation:
+No edge can be removed, since allowing only one component (k = 1) requires the
+graph to stay fully connected.
+That single component's cost equals its largest edge weight, which is 5.
+
+
+Constraints:
+
+1 <= n <= 5 * 10^4
+0 <= edges.length <= 10^5
+edges[i].length == 3
+0 <= ui, vi < n
+1 <= wi <= 10^6
+1 <= k <= n
+The input graph is connected.
+"""
+
+# V0
+# IDEA : KRUSKAL — GROW FROM THE CHEAPEST EDGE UNTIL K COMPONENTS REMAIN
+#
+#   the cost we pay is the heaviest edge we choose to keep, so read the problem
+#   the other way round: pick a budget w, keep only the edges of weight <= w,
+#   and ask how many components that leaves. that count is non-increasing in w,
+#   so the answer is the smallest budget whose count reaches k or fewer — and
+#   keeping *every* edge within budget is never worse than keeping some, since
+#   extra edges under the cap only merge components without raising the cost.
+#
+#   that makes a single kruskal sweep enough. add edges in ascending weight;
+#   each one that merges two components drops the count by exactly one, so the
+#   first merge that brings the count down to k is reached at the smallest
+#   possible budget, and its weight is the answer.
+#
+#   the two degenerate ends fall out naturally: k == n lets every node stand
+#   alone for cost 0, and an edgeless graph likewise costs 0.
+#
+# time = O(m * log(m) + (n + m) * alpha(n)), space = O(n)
+class Solution(object):
+    def minCost(self, n, edges, k):
+        if k >= n:
+            return 0
+
+        parent = list(range(n))
+
+        def find(x):
+            root = x
+            while parent[root] != root:
+                root = parent[root]
+            while parent[x] != root:
+                parent[x], x = root, parent[x]
+            return root
+
+        cnt = n
+        for u, v, w in sorted(edges, key=lambda e: e[2]):
+            ru, rv = find(u), find(v)
+            if ru != rv:
+                parent[ru] = rv
+                cnt -= 1
+                if cnt <= k:
+                    return w
+        return 0

--- a/leetcode_python/Array/minimum-absolute-difference-in-sliding-submatrix.py
+++ b/leetcode_python/Array/minimum-absolute-difference-in-sliding-submatrix.py
@@ -1,0 +1,85 @@
+"""
+
+3567. Minimum Absolute Difference in Sliding Submatrix
+Medium
+
+You are given an m x n integer matrix grid and an integer k.
+
+For every contiguous k x k submatrix of grid, compute the minimum absolute difference between any two distinct values within that submatrix.
+
+Return a 2D array ans of size (m - k + 1) x (n - k + 1), where ans[i][j] is the minimum absolute difference in the submatrix whose top-left corner is (i, j) in grid.
+
+Note: If all elements in the submatrix have the same value, the answer will be 0.
+
+
+Example 1:
+
+Input: grid = [[1,8],[3,-2]], k = 2
+Output: [[2]]
+Explanation:
+There is only one possible k x k submatrix: [[1, 8], [3, -2]].
+Distinct values in the submatrix are [1, 8, 3, -2].
+The minimum absolute difference in the submatrix is |1 - 3| = 2. Thus, the answer is [[2]].
+
+Example 2:
+
+Input: grid = [[3,-1]], k = 1
+Output: [[0,0]]
+Explanation:
+Both k x k submatrix has only one distinct element. Thus, the answer is [[0, 0]].
+
+Example 3:
+
+Input: grid = [[1,-2,3],[2,3,5]], k = 2
+Output: [[1,2]]
+Explanation:
+There are two possible k x k submatrix:
+First: [[1, -2], [2, 3]].
+Distinct values in the submatrix are [1, -2, 2, 3].
+The minimum absolute difference in the submatrix is |1 - 2| = 1.
+Second: [[-2, 3], [3, 5]].
+Distinct values in the submatrix are [-2, 3, 5].
+The minimum absolute difference in the submatrix is |3 - 5| = 2.
+Thus, the answer is [[1, 2]].
+
+
+Constraints:
+
+1 <= m == grid.length <= 30
+1 <= n == grid[i].length <= 30
+-10^5 <= grid[i][j] <= 10^5
+1 <= k <= min(m, n)
+
+"""
+
+# V0
+# IDEA : BRUTE FORCE PER WINDOW + SORT THE DISTINCT VALUES
+#
+#   after sorting, the closest pair of distinct values is always a pair of
+#   neighbours in the sorted order, so one linear scan over the sorted
+#   distinct list gives the minimum gap. duplicates are dropped first
+#   because the problem asks for *distinct* values (otherwise every repeated
+#   value would trivially answer 0).
+#
+#   the grid is at most 30 x 30, so re-collecting each k x k window is
+#   cheap enough.
+#
+# time = O(m * n * k^2 * log(k^2)), space = O(k^2)
+class Solution(object):
+    def minAbsDiff(self, grid, k):
+        m, n = len(grid), len(grid[0])
+        ans = [[0] * (n - k + 1) for _ in range(m - k + 1)]
+        for i in range(m - k + 1):
+            for j in range(n - k + 1):
+                vals = set()
+                for r in range(i, i + k):
+                    row = grid[r]
+                    for c in range(j, j + k):
+                        vals.add(row[c])
+                if len(vals) < 2:
+                    ans[i][j] = 0
+                    continue
+                sv = sorted(vals)
+                best = min(sv[t + 1] - sv[t] for t in range(len(sv) - 1))
+                ans[i][j] = best
+        return ans

--- a/leetcode_python/Array/minimum-moves-to-reach-target-in-grid.py
+++ b/leetcode_python/Array/minimum-moves-to-reach-target-in-grid.py
@@ -1,0 +1,118 @@
+"""
+
+3609. Minimum Moves to Reach Target in Grid
+Hard
+
+You are given four integers sx, sy, tx, and ty, representing two points (sx, sy)
+and (tx, ty) on an infinitely large 2D grid.
+
+You start at (sx, sy).
+
+At any point (x, y), define m = max(x, y). You can either:
+
+Move to (x + m, y), or
+Move to (x, y + m).
+
+Return the minimum number of moves required to reach (tx, ty). If it is
+impossible to reach the target, return -1.
+
+
+Example 1:
+
+Input: sx = 1, sy = 2, tx = 5, ty = 4
+Output: 2
+Explanation:
+The optimal path is:
+Move 1: max(1, 2) = 2. Increase the y-coordinate by 2, moving from (1, 2) to
+(1, 2 + 2) = (1, 4).
+Move 2: max(1, 4) = 4. Increase the x-coordinate by 4, moving from (1, 4) to
+(1 + 4, 4) = (5, 4).
+Thus, the minimum number of moves to reach (5, 4) is 2.
+
+Example 2:
+
+Input: sx = 0, sy = 1, tx = 2, ty = 3
+Output: 3
+Explanation:
+The optimal path is:
+Move 1: max(0, 1) = 1. Increase the x-coordinate by 1, moving from (0, 1) to
+(0 + 1, 1) = (1, 1).
+Move 2: max(1, 1) = 1. Increase the x-coordinate by 1, moving from (1, 1) to
+(1 + 1, 1) = (2, 1).
+Move 3: max(2, 1) = 2. Increase the y-coordinate by 2, moving from (2, 1) to
+(2, 1 + 2) = (2, 3).
+Thus, the minimum number of moves to reach (2, 3) is 3.
+
+Example 3:
+
+Input: sx = 1, sy = 1, tx = 2, ty = 2
+Output: -1
+Explanation:
+It is impossible to reach (2, 2) from (1, 1) using the allowed moves. Thus, the
+answer is -1.
+
+
+Constraints:
+
+0 <= sx <= tx <= 10^9
+0 <= sy <= ty <= 10^9
+"""
+
+# V0
+# IDEA : BACKWARD WALK — THE PREDECESSOR IS FORCED
+#
+#   forward the branching factor is 2, but backwards it collapses. suppose we
+#   stand at (X, Y) with X > Y. the last move cannot have been a y-step: a
+#   y-step lands on y + max(X, y), which is >= X either way (it is y + X if
+#   X >= y, and 2y > X if y > X), contradicting X > Y. so the last move grew x,
+#   and the only question is which coordinate was the max back then.
+#
+#   both readings are pinned down. if the predecessor had x <= Y then
+#   X = x + Y, giving (X - Y, Y), which is legal exactly when X <= 2Y. if it
+#   had x >= Y then X = 2x, giving (X/2, Y), legal exactly when X >= 2Y and X
+#   is even. the two windows only overlap at X = 2Y where they name the same
+#   point, so the predecessor is unique — there is nothing to search, and an
+#   odd X with X > 2Y simply has no predecessor at all.
+#
+#   the tie X == Y > 0 is the one fork: x + max(x, X) = X forces x = 0, so the
+#   predecessors are (0, X) and (X, 0). from either one a coordinate is stuck
+#   at 0 forever afterwards, so the fork is decided by the start, not searched:
+#   take (0, X) if sx == 0, (X, 0) if sy == 0, and otherwise the target is
+#   unreachable. (both zero means the start is (0, 0), from which every move is
+#   a self-loop.)
+#
+#   the descent alternates euclidean subtraction with halving, so it burns
+#   through the coordinates in logarithmic time, and since the chain is unique
+#   the step count it reports is not just minimal but the only possible one.
+#
+# time = O(log(tx) + log(ty)), space = O(1)
+class Solution(object):
+    def minMoves(self, sx, sy, tx, ty):
+        steps = 0
+        while (tx, ty) != (sx, sy):
+            # forward moves never decrease a coordinate
+            if tx < sx or ty < sy:
+                return -1
+            if tx > ty:
+                if tx > 2 * ty:
+                    if tx % 2:
+                        return -1
+                    tx //= 2
+                else:
+                    tx -= ty
+            elif ty > tx:
+                if ty > 2 * tx:
+                    if ty % 2:
+                        return -1
+                    ty //= 2
+                else:
+                    ty -= tx
+            else:
+                if sx == 0:
+                    tx = 0
+                elif sy == 0:
+                    ty = 0
+                else:
+                    return -1
+            steps += 1
+        return steps

--- a/leetcode_python/Array/minimum-time-for-k-connected-components.py
+++ b/leetcode_python/Array/minimum-time-for-k-connected-components.py
@@ -1,0 +1,106 @@
+"""
+
+3608. Minimum Time for K Connected Components
+Medium
+
+You are given an integer n and an undirected graph with n nodes labeled from 0
+to n - 1. This is represented by a 2D array edges, where
+edges[i] = [ui, vi, timei] indicates an undirected edge between nodes ui and vi
+that can be removed at timei.
+
+You are also given an integer k.
+
+Initially, the graph may be connected or disconnected. Your task is to find the
+minimum time t such that after removing all edges with time <= t, the graph
+contains at least k connected components.
+
+Return the minimum time t.
+
+A connected component is a subgraph of a graph in which there exists a path
+between any two vertices, and no vertex of the subgraph shares an edge with a
+vertex outside of the subgraph.
+
+
+Example 1:
+
+Input: n = 2, edges = [[0,1,3]], k = 2
+Output: 3
+Explanation:
+Initially, there is one connected component {0, 1}.
+At time = 1 or 2, the graph remains unchanged.
+At time = 3, edge [0, 1] is removed, resulting in k = 2 connected components
+{0}, {1}. Thus, the answer is 3.
+
+Example 2:
+
+Input: n = 3, edges = [[0,1,2],[1,2,4]], k = 3
+Output: 4
+Explanation:
+Initially, there is one connected component {0, 1, 2}.
+At time = 2, edge [0, 1] is removed, resulting in two connected components {0},
+{1, 2}.
+At time = 4, edge [1, 2] is removed, resulting in k = 3 connected components
+{0}, {1}, {2}. Thus, the answer is 4.
+
+Example 3:
+
+Input: n = 3, edges = [[0,2,5]], k = 2
+Output: 0
+Explanation:
+Since there are already k = 2 disconnected components {1}, {0, 2}, no edge
+removal is needed. Thus, the answer is 0.
+
+
+Constraints:
+
+1 <= n <= 10^5
+0 <= edges.length <= 10^5
+edges[i] = [ui, vi, timei]
+0 <= ui, vi < n
+ui != vi
+1 <= timei <= 10^9
+1 <= k <= n
+There are no duplicate edges.
+"""
+
+# V0
+# IDEA : REVERSE KRUSKAL — ADD EDGES BACK FROM THE LATEST TIME DOWN
+#
+#   surviving at threshold t means "time > t", so the surviving edge set only
+#   ever grows as t shrinks, and therefore the component count f(t) is
+#   monotonically non-decreasing in t. that monotonicity is what lets us look
+#   for a single cutoff instead of testing every t.
+#
+#   deleting edges from a union-find is awkward, so run time backwards: sort
+#   edges by time and re-insert them from the largest time downwards. right
+#   after inserting the edge of time t we hold exactly the graph "time >= t",
+#   and just before inserting it we hold a subset of "time > t".
+#
+#   so the first moment the live count drops below k, at edge time t, pins the
+#   answer from both sides: f(t) >= (count before the insert) >= k, while every
+#   smaller threshold keeps at least the edges we have now, hence gives a count
+#   <= (count after the insert) < k. if the count never falls below k even with
+#   every edge present, the graph already has k components and t = 0 works.
+#
+# time = O(m * log(m) + (n + m) * alpha(n)), space = O(n)
+class Solution(object):
+    def minTime(self, n, edges, k):
+        parent = list(range(n))
+
+        def find(x):
+            root = x
+            while parent[root] != root:
+                root = parent[root]
+            while parent[x] != root:
+                parent[x], x = root, parent[x]
+            return root
+
+        cnt = n
+        for u, v, t in sorted(edges, key=lambda e: -e[2]):
+            ru, rv = find(u), find(v)
+            if ru != rv:
+                parent[ru] = rv
+                cnt -= 1
+                if cnt < k:
+                    return t
+        return 0

--- a/leetcode_python/Array/number-of-student-replacements.py
+++ b/leetcode_python/Array/number-of-student-replacements.py
@@ -1,0 +1,66 @@
+"""
+
+3616. Number of Student Replacements
+Medium
+
+You are given an integer array ranks where ranks[i] represents the rank of the
+ith student arriving in order. A lower number indicates a better rank.
+
+Initially, the first student is selected by default.
+
+A replacement occurs when a student with a strictly better rank arrives and
+replaces the current selection.
+
+Return the total number of replacements made.
+
+
+Example 1:
+
+Input: ranks = [4,1,2]
+Output: 1
+Explanation:
+The first student with ranks[0] = 4 is initially selected.
+The second student with ranks[1] = 1 is better than the current selection, so a
+replacement occurs.
+The third student has a worse rank, so no replacement occurs.
+Thus, the number of replacements is 1.
+
+Example 2:
+
+Input: ranks = [2,2,3]
+Output: 0
+Explanation:
+The first student with ranks[0] = 2 is initially selected.
+Neither of ranks[1] = 2 or ranks[2] = 3 is better than the current selection.
+Thus, the number of replacements is 0.
+
+
+Constraints:
+
+1 <= ranks.length <= 10^5
+1 <= ranks[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : COUNT STRICT PREFIX MINIMA
+#
+#   the selected student is always the best rank seen so far, so the running
+#   state is nothing more than a prefix minimum. a replacement happens exactly
+#   when the arriving rank strictly beats that prefix minimum — i.e. when it
+#   is a new strict record low.
+#
+#   so the answer is simply the number of strict prefix minima after the
+#   first element. no need to model the "selection" at all; ties change
+#   nothing because a replacement requires a strictly better rank.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def totalReplacements(self, ranks):
+        best = ranks[0]
+        res = 0
+        for r in ranks:
+            if r < best:
+                best = r
+                res += 1
+        return res

--- a/leetcode_python/Array/process-string-with-special-operations-i.py
+++ b/leetcode_python/Array/process-string-with-special-operations-i.py
@@ -1,0 +1,85 @@
+"""
+
+3612. Process String with Special Operations I
+Medium
+
+You are given a string s consisting of lowercase English letters and the special
+characters: *, #, and %.
+
+Build a new string result by processing s according to the following rules from
+left to right:
+
+If the letter is a lowercase English letter append it to result.
+A '*' removes the last character from result, if it exists.
+A '#' duplicates the current result and appends it to itself.
+A '%' reverses the current result.
+
+Return the final string result after processing all characters in s.
+
+
+Example 1:
+
+Input: s = "a#b%*"
+Output: "ba"
+Explanation:
+
+i   s[i]   Operation                   Current result
+0   'a'    Append 'a'                  "a"
+1   '#'    Duplicate result            "aa"
+2   'b'    Append 'b'                  "aab"
+3   '%'    Reverse result              "baa"
+4   '*'    Remove the last character   "ba"
+
+Thus, the final result is "ba".
+
+Example 2:
+
+Input: s = "z*#"
+Output: ""
+Explanation:
+
+i   s[i]   Operation                   Current result
+0   'z'    Append 'z'                  "z"
+1   '*'    Remove the last character   ""
+2   '#'    Duplicate the string        ""
+
+Thus, the final result is "".
+
+
+Constraints:
+
+1 <= s.length <= 20
+s consists of only lowercase English letters and special characters *, #, and %.
+"""
+
+# V0
+# IDEA : DIRECT SIMULATION ON A CHARACTER LIST
+#
+#   nothing here needs to be outsmarted: the operations are applied strictly
+#   left to right and each one is a total function of the current result, so
+#   replaying them literally is already the definition of the answer.
+#
+#   the only thing worth checking is that the size stays sane. '#' is the sole
+#   growth operator and it doubles, so with n <= 20 the result can never exceed
+#   2^20 characters — small enough that the naive doubling, reversal and pop are
+#   all affordable. (the sequel, LC 3614, raises the bound and forces the
+#   backwards index-chasing approach instead.)
+#
+#   the '*' rule is guarded rather than exceptional: popping an empty result is
+#   defined as a no-op, so an unmatched '*' is silently absorbed.
+#
+# time = O(2^n), space = O(2^n)
+class Solution(object):
+    def processStr(self, s):
+        res = []
+        for c in s:
+            if c == '*':
+                if res:
+                    res.pop()
+            elif c == '#':
+                res.extend(res)
+            elif c == '%':
+                res.reverse()
+            else:
+                res.append(c)
+        return ''.join(res)

--- a/leetcode_python/Array/process-string-with-special-operations-ii.py
+++ b/leetcode_python/Array/process-string-with-special-operations-ii.py
@@ -1,0 +1,135 @@
+"""
+
+3614. Process String with Special Operations II
+Hard
+
+You are given a string s consisting of lowercase English letters and the
+special characters: '*', '#', and '%'.
+
+You are also given an integer k.
+
+Build a new string result by processing s according to the following rules from
+left to right:
+
+If the letter is a lowercase English letter append it to result.
+A '*' removes the last character from result, if it exists.
+A '#' duplicates the current result and appends it to itself.
+A '%' reverses the current result.
+
+Return the kth character of the final string result. If k is out of the bounds
+of result, return '.'.
+
+
+Example 1:
+
+Input: s = "a#b%*", k = 1
+Output: "a"
+Explanation:
+
+i    s[i]   Operation                     Current result
+0    'a'    Append 'a'                    "a"
+1    '#'    Duplicate result              "aa"
+2    'b'    Append 'b'                    "aab"
+3    '%'    Reverse result                "baa"
+4    '*'    Remove the last character     "ba"
+
+The final result is "ba". The character at index k = 1 is 'a'.
+
+Example 2:
+
+Input: s = "cd%#*#", k = 3
+Output: "d"
+Explanation:
+
+i    s[i]   Operation                     Current result
+0    'c'    Append 'c'                    "c"
+1    'd'    Append 'd'                    "cd"
+2    '%'    Reverse result                "dc"
+3    '#'    Duplicate result              "dcdc"
+4    '*'    Remove the last character     "dcd"
+5    '#'    Duplicate result              "dcddcd"
+
+The final result is "dcddcd". The character at index k = 3 is 'd'.
+
+Example 3:
+
+Input: s = "z*#", k = 0
+Output: "."
+Explanation:
+
+i    s[i]   Operation                     Current result
+0    'z'    Append 'z'                    "z"
+1    '*'    Remove the last character     ""
+2    '#'    Duplicate the string          ""
+
+The final result is "". Since index k = 0 is out of bounds, the output is '.'.
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s consists of only lowercase English letters and special characters '*', '#',
+and '%'.
+0 <= k <= 10^15
+The length of result after processing s will not exceed 10^15.
+
+"""
+
+# V0
+# IDEA : LENGTH SWEEP FORWARD, THEN WALK THE INDEX BACKWARDS
+#
+#   the string itself can reach 10^15 characters, so it can never be built.
+#   but the *length* after each operation is cheap to track forward, and once
+#   the lengths are known every operation can be inverted on a single index.
+#
+#   run forward once to get the final length m; if k >= m the answer is '.'.
+#   then walk the operations in reverse, carrying (k, m) = "the character we
+#   want sits at index k of the string of length m that exists at this point".
+#   each op is undone locally:
+#
+#     '#' : the string was the first half doubled, so the previous length is
+#           m/2 and an index in the second half maps back to k - m/2 in the
+#           first half — the two halves are identical, so either origin is
+#           equally valid.
+#     '%' : reversal is its own inverse on positions, k -> m - 1 - k.
+#     '*' : the previous string was one longer, and our index survived the
+#           deletion untouched (only the tail was dropped).
+#     letter : the previous string was one shorter; if k lands exactly on the
+#           newly appended slot, that letter is the answer, otherwise the
+#           index is unaffected.
+#
+#   the invariant k < m holds at every step, which is also why undoing '*'
+#   never needs a special case for a deletion on an empty string: such a step
+#   leaves m = 0, and no valid index can be pointing into it.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def processStr(self, s, k):
+        m = 0
+        for c in s:
+            if c == "*":
+                if m > 0:
+                    m -= 1
+            elif c == "#":
+                m *= 2
+            elif c != "%":
+                m += 1
+
+        if k >= m:
+            return "."
+
+        for i in range(len(s) - 1, -1, -1):
+            c = s[i]
+            if c == "*":
+                m += 1
+            elif c == "#":
+                m //= 2
+                if k >= m:
+                    k -= m
+            elif c == "%":
+                k = m - 1 - k
+            else:
+                m -= 1
+                if k == m:
+                    return c
+        return "."

--- a/leetcode_python/Backtracking/sequential-grid-path-cover.py
+++ b/leetcode_python/Backtracking/sequential-grid-path-cover.py
@@ -1,0 +1,107 @@
+"""
+
+3565. Sequential Grid Path Cover
+Medium
+
+You are given a 2D array grid of size m x n, and an integer k. There are k
+cells in grid containing the values from 1 to k exactly once, and the rest
+of the cells have a value 0.
+
+You can start at any cell, and move from a cell to its neighbors (up, down,
+left, or right). You must find a path in grid which:
+
+Visits each cell in grid exactly once.
+Visits the cells with values from 1 to k in order.
+
+Return a 2D array result of size (m * n) x 2, where result[i] = [xi, yi]
+represents the ith cell visited in the path. If there are multiple such
+paths, you may return any one of them.
+
+If no such path exists, return an empty array.
+
+
+Example 1:
+
+Input: grid = [[0,0,0],[0,1,2]], k = 2
+Output: [[0,0],[1,0],[1,1],[1,2],[0,2],[0,1]]
+Explanation:
+The path starts at [0,0], walks down and across the bottom row (picking up
+1 then 2 in order), then comes back along the top row.
+
+Example 2:
+
+Input: grid = [[1,0,4],[3,0,2]], k = 4
+Output: []
+Explanation:
+There is no possible path that satisfies the conditions.
+
+
+Constraints:
+
+1 <= m == grid.length <= 5
+1 <= n == grid[i].length <= 5
+1 <= k <= m * n
+0 <= grid[i][j] <= k
+grid contains all integers between 1 and k exactly once.
+
+"""
+
+# V0
+# IDEA : BACKTRACKING WITH THE "NEXT WANTED LABEL" AS PART OF THE STATE
+#
+#   the path is a hamiltonian path in the grid graph, so brute force search
+#   is unavoidable; the ordering constraint is what makes it cheap. carry
+#   the next label we still owe, v (starting at 1). a cell may be stepped on
+#   only if it is blank or carries exactly v — a cell holding a label larger
+#   than v would jump the queue, and one holding a smaller label was already
+#   consumed. that single test enforces "1..k in order" locally, so no
+#   global check at the end is needed.
+#
+#   it also prunes the search hard: the moment the walk drifts away from the
+#   next label, every labelled neighbour except one is closed off.
+#
+#   the start cell is likewise restricted to blank or 1, and since the walk
+#   ends only when all m*n cells are on the path, covering every cell exactly
+#   once is guaranteed by construction.
+#
+#   visited is kept as a bitmask over the <= 25 cells, so undoing a step is
+#   a single xor.
+#
+# time = O(m * n * 3^(m * n)) worst case, space = O(m * n)
+class Solution(object):
+    def findPath(self, grid, k):
+        m, n = len(grid), len(grid[0])
+        total = m * n
+        path = []
+        seen = [0]
+
+        def dfs(i, j, v):
+            path.append([i, j])
+            if len(path) == total:
+                return True
+
+            seen[0] |= 1 << (i * n + j)
+            if grid[i][j] == v:
+                v += 1
+
+            for a, b in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                x, y = i + a, j + b
+                if 0 <= x < m and 0 <= y < n:
+                    if seen[0] & (1 << (x * n + y)):
+                        continue
+                    if grid[x][y] == 0 or grid[x][y] == v:
+                        if dfs(x, y, v):
+                            return True
+
+            seen[0] ^= 1 << (i * n + j)
+            path.pop()
+            return False
+
+        for i in range(m):
+            for j in range(n):
+                if grid[i][j] == 0 or grid[i][j] == 1:
+                    if dfs(i, j, 1):
+                        return path
+                    del path[:]
+                    seen[0] = 0
+        return []

--- a/leetcode_python/Binary_Search/minimum-stability-factor-of-array.py
+++ b/leetcode_python/Binary_Search/minimum-stability-factor-of-array.py
@@ -1,0 +1,141 @@
+"""
+
+3605. Minimum Stability Factor of Array
+Hard
+
+You are given an integer array nums and an integer maxC.
+
+A subarray is called stable if the highest common factor (HCF) of all its
+elements is greater than or equal to 2.
+
+The stability factor of an array is defined as the length of its longest
+stable subarray.
+
+You may modify at most maxC elements of the array to any integer.
+
+Return the minimum possible stability factor of the array after at most
+maxC modifications. If no stable subarray remains, return 0.
+
+Note:
+
+The highest common factor (HCF) of an array is the largest integer that
+evenly divides all the array elements.
+A subarray of length 1 is stable if its only element is greater than or
+equal to 2, since HCF([x]) = x.
+
+
+Example 1:
+
+Input: nums = [3,5,10], maxC = 1
+Output: 1
+Explanation:
+The stable subarray [5, 10] has HCF = 5, which has a stability factor of 2.
+Since maxC = 1, one optimal strategy is to change nums[1] to 7, resulting in
+nums = [3, 7, 10].
+Now, no subarray of length greater than 1 has HCF >= 2. Thus, the minimum
+possible stability factor is 1.
+
+Example 2:
+
+Input: nums = [2,6,8], maxC = 2
+Output: 1
+Explanation:
+The subarray [2, 6, 8] has HCF = 2, which has a stability factor of 3.
+Since maxC = 2, one optimal strategy is to change nums[1] to 3 and nums[2]
+to 5, resulting in nums = [2, 3, 5].
+Now, no subarray of length greater than 1 has HCF >= 2. Thus, the minimum
+possible stability factor is 1.
+
+Example 3:
+
+Input: nums = [2,4,9,6], maxC = 1
+Output: 2
+Explanation:
+The stable subarrays are:
+[2, 4] with HCF = 2 and stability factor of 2.
+[9, 6] with HCF = 3 and stability factor of 2.
+Since maxC = 1, the stability factor of 2 cannot be reduced due to two
+separate stable subarrays. Thus, the minimum possible stability factor is 2.
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^5
+1 <= nums[i] <= 10^9
+0 <= maxC <= n
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH THE ANSWER + GREEDY INTERVAL STABBING WITH GCD RUNS
+#
+#   first, a modification is only ever worth spending on turning an element
+#   into 1. writing 1 makes every subarray through that index have hcf 1,
+#   so the index becomes a wall; writing anything >= 2 leaves at least the
+#   singleton stable and can only help the adversary. and since 1 is purely
+#   destructive, no *new* stable subarray can appear — the surviving stable
+#   subarrays are exactly the original ones that dodge every wall.
+#
+#   that turns the problem into a covering question. "the answer is at most
+#   L" means no original stable subarray of length L + 1 survives, i.e.
+#   every stable window [i - L, i] contains a wall. fewer walls are needed
+#   as L grows, so the predicate is monotone and we can binary search L
+#   over [0, n].
+#
+#   for a fixed L the cheapest wall placement is the classic stabbing
+#   greedy: sweep left to right, and the first time we meet a stable window
+#   that no existing wall pierces, put a wall at its rightmost index. that
+#   position covers this window and reaches as far right as legally
+#   possible, so it dominates every other choice for the same window.
+#
+#   what makes the sweep cheap is a gcd fact: as the left end of a subarray
+#   ending at i moves leftwards the gcd only shrinks by divisibility, so it
+#   crosses below 2 exactly once. hence for each i there is a single
+#   frontier lo[i] — the earliest start whose gcd still reaches 2 — and the
+#   window [i - L, i] is stable iff lo[i] <= i - L. those frontiers come
+#   from carrying the list of distinct gcds of subarrays ending at i, which
+#   stays O(log(max)) long because each distinct value at least halves.
+#
+# time = O(n * log(max(nums)) + n * log(n)), space = O(n)
+class Solution(object):
+    def minStable(self, nums, maxC):
+        from math import gcd
+
+        n = len(nums)
+
+        # reach[i] = length - 1 of the longest stable subarray ending at i,
+        #            or -1 when nums[i] == 1 and nothing is stable there
+        reach = [0] * n
+        cur = []  # (gcd, earliest start giving that gcd), gcd >= 2
+        for i in range(n):
+            x = nums[i]
+            nxt = []
+            for g, idx in cur:
+                ng = gcd(g, x)
+                if ng >= 2 and (not nxt or nxt[-1][0] != ng):
+                    nxt.append((ng, idx))
+            if x >= 2 and (not nxt or nxt[-1][0] != x):
+                nxt.append((x, i))
+            cur = nxt
+            reach[i] = i - cur[0][1] if cur else -1
+
+        def feasible(L):
+            walls = 0
+            last = -1
+            for i in range(L, n):
+                left = i - L
+                if reach[i] >= L and last < left:
+                    walls += 1
+                    if walls > maxC:
+                        return False
+                    last = i
+            return True
+
+        lo, hi = 0, n
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if feasible(mid):
+                hi = mid
+            else:
+                lo = mid + 1
+        return lo

--- a/leetcode_python/Bit_Manipulation/partition-array-into-two-equal-product-subsets.py
+++ b/leetcode_python/Bit_Manipulation/partition-array-into-two-equal-product-subsets.py
@@ -1,0 +1,64 @@
+"""
+
+3566. Partition Array into Two Equal Product Subsets
+Medium
+
+You are given an integer array nums containing distinct positive integers and an integer target.
+
+Determine if you can partition nums into two non-empty disjoint subsets, with each element belonging to exactly one subset, such that the product of the elements in each subset is equal to target.
+
+Return true if such a partition exists and false otherwise.
+
+
+Example 1:
+
+Input: nums = [3,1,6,8,4], target = 24
+Output: True
+Explanation: The subsets [3, 8] and [1, 6, 4] each have a product of 24. Hence, the output is true.
+
+Example 2:
+
+Input: nums = [2,5,3,7], target = 15
+Output: False
+Explanation: There is no way to partition nums into two non-empty disjoint subsets such that both subsets have a product of 15. Hence, the output is false.
+
+
+Constraints:
+
+3 <= nums.length <= 12
+1 <= target <= 10^15
+1 <= nums[i] <= 100
+All elements of nums are distinct.
+
+"""
+
+# V0
+# IDEA : BITMASK ENUMERATION OVER EVERY SPLIT
+#
+#   n is at most 12, so all 2^n ways of colouring the elements fit easily.
+#   the two subsets must together use every element, so the split is fully
+#   described by one mask; the complement is the other side.
+#
+#   a quick pre-filter: the whole product has to be target*target,
+#   otherwise no split can work at all.
+#
+# time = O(2^n * n), space = O(1)
+class Solution(object):
+    def checkEqualPartitions(self, nums, target):
+        n = len(nums)
+        total = 1
+        for v in nums:
+            total *= v
+        if total != target * target:
+            return False
+
+        for mask in range(1, (1 << n) - 1):
+            p = 1
+            for i in range(n):
+                if mask >> i & 1:
+                    p *= nums[i]
+                    if p > target:
+                        break
+            if p == target:
+                return True
+        return False

--- a/leetcode_python/Breadth-First-Search/count-islands-with-total-value-divisible-by-k.py
+++ b/leetcode_python/Breadth-First-Search/count-islands-with-total-value-divisible-by-k.py
@@ -1,0 +1,86 @@
+"""
+
+3619. Count Islands With Total Value Divisible by K
+Medium
+
+You are given an m x n matrix grid and a positive integer k. An island is a
+group of positive integers (representing land) that are 4-directionally
+connected (horizontally or vertically).
+
+The total value of an island is the sum of the values of all cells in the
+island.
+
+Return the number of islands with a total value divisible by k.
+
+
+Example 1:
+
+Input: grid = [[0,2,1,0,0],[0,5,0,0,5],[0,0,1,0,0],[0,1,4,7,0],[0,2,0,0,8]],
+k = 5
+Output: 2
+Explanation:
+The grid contains four islands. The islands highlighted in blue have a total
+value that is divisible by 5, while the islands highlighted in red do not.
+
+Example 2:
+
+Input: grid = [[3,0,3,0], [0,3,0,3], [3,0,3,0]], k = 3
+Output: 6
+Explanation:
+The grid contains six islands, each with a total value that is divisible by 3.
+
+
+Constraints:
+
+m == grid.length
+n == grid[i].length
+1 <= m, n <= 1000
+1 <= m * n <= 10^5
+0 <= grid[i][j] <= 10^6
+1 <= k <= 10^6
+
+"""
+
+# V0
+# IDEA : BFS FLOOD FILL, SUMMING EACH COMPONENT AS IT IS CONSUMED
+#
+#   an island is just a connected component of the "positive value" cells
+#   under 4-directional adjacency, so one flood fill per unvisited land cell
+#   enumerates every island exactly once — the fill consumes the whole
+#   component, so no later scan position can restart the same island.
+#
+#   the total value can be accumulated during the very same traversal, since
+#   every cell is dequeued exactly once. marking a cell as visited at the
+#   moment it is *enqueued* (rather than dequeued) is what keeps a cell from
+#   being pushed twice by two different neighbours.
+#
+#   bfs rather than recursion matters here: a single snake-shaped island may
+#   cover all 10^5 cells, which would blow python's recursion limit.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def countIslands(self, grid, k):
+        m, n = len(grid), len(grid[0])
+        seen = [[False] * n for _ in range(m)]
+        res = 0
+
+        for si in range(m):
+            for sj in range(n):
+                if grid[si][sj] <= 0 or seen[si][sj]:
+                    continue
+                seen[si][sj] = True
+                queue = [(si, sj)]
+                total = 0
+                while queue:
+                    nxt = []
+                    for i, j in queue:
+                        total += grid[i][j]
+                        for x, y in ((i - 1, j), (i + 1, j), (i, j - 1), (i, j + 1)):
+                            if 0 <= x < m and 0 <= y < n:
+                                if grid[x][y] > 0 and not seen[x][y]:
+                                    seen[x][y] = True
+                                    nxt.append((x, y))
+                    queue = nxt
+                if total % k == 0:
+                    res += 1
+        return res

--- a/leetcode_python/Breadth-First-Search/minimum-moves-to-clean-the-classroom.py
+++ b/leetcode_python/Breadth-First-Search/minimum-moves-to-clean-the-classroom.py
@@ -1,0 +1,120 @@
+"""
+
+3568. Minimum Moves to Clean the Classroom
+Medium
+
+You are given an m x n grid classroom where a student volunteer is tasked with cleaning up litter scattered around the room. Each cell in the grid is one of the following:
+
+'S': Starting position of the student.
+'L': Litter that must be collected (once collected, the cell becomes an empty cell).
+'R': Reset area that restores the student's energy to full capacity, regardless of their current energy level (can be used multiple times).
+'X': Obstacle the student cannot pass through.
+'.': Empty space.
+
+You are also given an integer energy, representing the maximum energy the student can have. The student starts with this energy from the starting position.
+
+Each move to an adjacent cell (up, down, left, or right) costs 1 unit of energy. If the energy reaches zero, the student can only continue if they are on a reset area 'R', which sets the energy back to the maximum value energy.
+
+Return the minimum number of moves required to collect all litter items, or -1 if it's impossible.
+
+
+Example 1:
+
+Input: classroom = ["S.", "XL"], energy = 2
+Output: 2
+Explanation:
+The student starts at (0, 0) with 2 units of energy.
+Move right to (0, 1), costing 1 unit of energy, leaving 1 unit of energy.
+Move down to (1, 1) to collect the litter 'L'.
+The student collects all the litter using 2 moves. Thus, the output is 2.
+
+Example 2:
+
+Input: classroom = ["LS", "RL"], energy = 4
+Output: 3
+Explanation:
+The student starts at (0, 1) with 4 units of energy.
+Move down to (1, 1) to collect the litter 'L'.
+Move left to (1, 0) which is a reset area 'R', restoring the energy back to full.
+Move up to (0, 0) to collect the remaining litter 'L'.
+The student collects all the litter using 3 moves. Thus, the output is 3.
+
+Example 3:
+
+Input: classroom = ["L.S", "RXL"], energy = 3
+Output: -1
+Explanation:
+No valid path collects all 'L'.
+
+
+Constraints:
+
+1 <= m == classroom.length <= 20
+1 <= n == classroom[i].length <= 20
+classroom[i][j] is one of 'S', 'L', 'R', 'X', or '.'
+1 <= energy <= 50
+There is exactly one 'S' in the grid.
+There are at most 10 'L' cells in the grid.
+
+"""
+
+# V0
+# IDEA : BFS OVER (ROW, COL, COLLECTED-MASK) KEEPING THE BEST ENERGY
+#
+#   at most 10 litters means the "which litter is already picked up" part of
+#   the state is a 10-bit mask. energy is not part of the state key: for the
+#   same (cell, mask) more energy is never worse, so we only re-expand a
+#   state when we reach it with strictly more energy than before.
+#
+#   that dominance rule keeps the search finite while plain BFS layers still
+#   give the minimum number of moves, because every move costs exactly 1.
+#
+# time = O(m * n * 2^L * energy), space = O(m * n * 2^L)
+from collections import deque
+
+
+class Solution(object):
+    def minMoves(self, classroom, energy):
+        m, n = len(classroom), len(classroom[0])
+        litter = {}
+        sr = sc = 0
+        for i in range(m):
+            for j in range(n):
+                ch = classroom[i][j]
+                if ch == 'S':
+                    sr, sc = i, j
+                elif ch == 'L':
+                    litter[(i, j)] = len(litter)
+        full = (1 << len(litter)) - 1
+        if full == 0:
+            return 0
+
+        best = [[[-1] * (full + 1) for _ in range(n)] for _ in range(m)]
+        best[sr][sc][0] = energy
+        q = deque([(sr, sc, 0, energy)])
+        steps = 0
+        while q:
+            for _ in range(len(q)):
+                r, c, mask, e = q.popleft()
+                if e == 0:
+                    continue
+                for dr, dc in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                    nr, nc = r + dr, c + dc
+                    if nr < 0 or nr >= m or nc < 0 or nc >= n:
+                        continue
+                    ch = classroom[nr][nc]
+                    if ch == 'X':
+                        continue
+                    ne = e - 1
+                    nmask = mask
+                    if ch == 'L':
+                        nmask = mask | (1 << litter[(nr, nc)])
+                    elif ch == 'R':
+                        ne = energy
+                    if nmask == full:
+                        return steps + 1
+                    if best[nr][nc][nmask] < ne:
+                        best[nr][nc][nmask] = ne
+                        q.append((nr, nc, nmask, ne))
+            steps += 1
+        return -1

--- a/leetcode_python/Depth-First-Search/kth-smallest-path-xor-sum.py
+++ b/leetcode_python/Depth-First-Search/kth-smallest-path-xor-sum.py
@@ -1,0 +1,215 @@
+"""
+
+3590. Kth Smallest Path XOR Sum
+Hard
+
+You are given an undirected tree rooted at node 0 with n nodes numbered from 0
+to n - 1. Each node i has an integer value vals[i], and its parent is given by
+par[i].
+
+The path XOR sum from the root to a node u is defined as the bitwise XOR of all
+vals[i] for nodes i on the path from the root node to node u, inclusive.
+
+You are given a 2D integer array queries, where queries[j] = [u_j, k_j]. For
+each query, find the k_j-th smallest distinct path XOR sum among all nodes in
+the subtree rooted at u_j. If there are fewer than k_j distinct path XOR sums
+in that subtree, the answer is -1.
+
+Return an integer array where the j-th element is the answer to the j-th query.
+
+In a rooted tree, the subtree of a node v includes v and all nodes whose path
+to the root passes through v, that is, v and its descendants.
+
+
+Example 1:
+
+Input: par = [-1,0,0], vals = [1,1,1], queries = [[0,1],[0,2],[0,3]]
+Output: [0,1,-1]
+Explanation:
+
+Path XORs:
+Node 0: 1
+Node 1: 1 XOR 1 = 0
+Node 2: 1 XOR 1 = 0
+
+Subtree of 0: Subtree rooted at node 0 includes nodes [0, 1, 2] with Path XORs
+= [1, 0, 0]. The distinct XORs are [0, 1].
+
+Queries:
+queries[0] = [0, 1]: The 1st smallest distinct path XOR in the subtree of node
+0 is 0.
+queries[1] = [0, 2]: The 2nd smallest distinct path XOR in the subtree of node
+0 is 1.
+queries[2] = [0, 3]: Since there are only two distinct path XORs in this
+subtree, the answer is -1.
+
+Output: [0, 1, -1]
+
+Example 2:
+
+Input: par = [-1,0,1], vals = [5,2,7], queries = [[0,1],[1,2],[1,3],[2,1]]
+Output: [0,7,-1,0]
+Explanation:
+
+Path XORs:
+Node 0: 5
+Node 1: 5 XOR 2 = 7
+Node 2: 5 XOR 2 XOR 7 = 0
+
+Subtrees and Distinct Path XORs:
+Subtree of 0: Subtree rooted at node 0 includes nodes [0, 1, 2] with Path XORs
+= [5, 7, 0]. The distinct XORs are [0, 5, 7].
+Subtree of 1: Subtree rooted at node 1 includes nodes [1, 2] with Path XORs =
+[7, 0]. The distinct XORs are [0, 7].
+Subtree of 2: Subtree rooted at node 2 includes only node [2] with Path XOR =
+[0]. The distinct XORs are [0].
+
+Queries:
+queries[0] = [0, 1]: The 1st smallest distinct path XOR in the subtree of node
+0 is 0.
+queries[1] = [1, 2]: The 2nd smallest distinct path XOR in the subtree of node
+1 is 7.
+queries[2] = [1, 3]: Since there are only two distinct path XORs, the answer is
+-1.
+queries[3] = [2, 1]: The 1st smallest distinct path XOR in the subtree of node
+2 is 0.
+
+Output: [0, 7, -1, 0]
+
+
+Constraints:
+
+1 <= n == vals.length <= 5 * 10^4
+0 <= vals[i] <= 10^5
+par.length == n
+par[0] == -1
+0 <= par[i] < n for i in [1, n - 1]
+1 <= queries.length <= 5 * 10^4
+queries[j] == [u_j, k_j]
+0 <= u_j < n
+1 <= k_j <= n
+The input is generated such that the parent array par represents a valid tree.
+
+"""
+
+# V0
+# IDEA : MERGEABLE BINARY TRIE OVER THE XOR VALUES, MERGED BOTTOM-UP
+#
+#   answering a query needs an order statistic over the distinct path xors of
+#   one subtree, and a subtree's multiset is just the union of its children's
+#   plus its own value. that suggests a structure that can be unioned cheaply
+#   rather than rebuilt: a binary trie on the 17 bits of the value (vals[i] and
+#   therefore every xor stay below 2^17), where each node stores how many
+#   distinct values live beneath it.
+#
+#   the union is the segment-tree-merge trick. merging two tries walks only the
+#   nodes they have in common and splices the rest in whole; every recursive
+#   step permanently destroys one node, so the total work across the entire
+#   traversal is bounded by the number of nodes ever created, O(n * 17), no
+#   matter how lopsided the tree is. this is what makes it strictly better than
+#   small-to-large, which would re-insert values repeatedly.
+#
+#   distinctness falls out for free at the bottom of the merge: when both sides
+#   reach the same leaf they represent the same value, so one of them is simply
+#   dropped and the count stays 1. every internal count is then recomputed from
+#   its two children, which keeps the subtree counts exactly "distinct values".
+#
+#   with counts in place the k-th smallest is a descent from the root: the zero
+#   branch covers the smaller half of the range, so if k fits inside its count
+#   go left, otherwise subtract that count, set the bit and go right. answering
+#   at the moment the merge for that node finishes means each trie is consumed
+#   exactly once, so the queries are grouped by node and served offline.
+#
+#   the traversal itself is iterative, since a path-shaped tree of 5 * 10^4
+#   nodes would blow the recursion limit.
+#
+# time = O((n + q) * log(max_val)), space = O(n * log(max_val))
+from collections import defaultdict
+
+
+class Solution(object):
+    def kthSmallest(self, par, vals, queries):
+        n = len(par)
+        BITS = 17  # vals[i] <= 10^5 < 2^17, and xor keeps values in range
+
+        children = [[] for _ in range(n)]
+        for i in range(1, n):
+            children[par[i]].append(i)
+
+        # pre-order sweep gives every node's xor from the root
+        xor = [0] * n
+        xor[0] = vals[0]
+        stack = [0]
+        order = []
+        while stack:
+            x = stack.pop()
+            order.append(x)
+            for y in children[x]:
+                xor[y] = xor[x] ^ vals[y]
+                stack.append(y)
+
+        # flat trie storage; node 0 is the shared null node with count 0
+        cap = n * (BITS + 1) + 1
+        zero = [0] * cap
+        one = [0] * cap
+        cnt = [0] * cap
+        used = [1]
+
+        def insert(v):
+            free = used[0]
+            root = free
+            for b in range(BITS - 1, -1, -1):
+                cnt[free] = 1
+                nxt = free + 1
+                if (v >> b) & 1:
+                    one[free] = nxt
+                else:
+                    zero[free] = nxt
+                free = nxt
+            cnt[free] = 1
+            used[0] = free + 1
+            return root
+
+        def merge(a, b, bit):
+            if a == 0:
+                return b
+            if b == 0:
+                return a
+            if bit == 0:
+                return a  # same leaf, same value: keep one copy
+            zero[a] = merge(zero[a], zero[b], bit - 1)
+            one[a] = merge(one[a], one[b], bit - 1)
+            cnt[a] = cnt[zero[a]] + cnt[one[a]]
+            return a
+
+        def kth(root, k):
+            if cnt[root] < k:
+                return -1
+            node = root
+            res = 0
+            for b in range(BITS - 1, -1, -1):
+                lo = zero[node]
+                c = cnt[lo]
+                if k <= c:
+                    node = lo
+                else:
+                    k -= c
+                    res |= 1 << b
+                    node = one[node]
+            return res
+
+        asked = defaultdict(list)
+        for i, (u, k) in enumerate(queries):
+            asked[u].append((k, i))
+
+        ans = [0] * len(queries)
+        root_of = [0] * n
+        for x in reversed(order):  # reverse pre-order is a valid post-order
+            r = insert(xor[x])
+            for y in children[x]:
+                r = merge(r, root_of[y], BITS)
+                root_of[y] = 0
+            root_of[x] = r
+            for k, i in asked[x]:
+                ans[i] = kth(r, k)
+        return ans

--- a/leetcode_python/Depth-First-Search/minimum-increments-to-equalize-leaf-paths.py
+++ b/leetcode_python/Depth-First-Search/minimum-increments-to-equalize-leaf-paths.py
@@ -1,0 +1,105 @@
+"""
+
+3593. Minimum Increments to Equalize Leaf Paths
+Medium
+
+You are given an integer n and an undirected tree rooted at node 0 with n nodes numbered from 0 to n - 1. This is represented by a 2D array edges of length n - 1, where edges[i] = [ui, vi] indicates an edge between nodes ui and vi.
+
+Each node i has an associated cost given by cost[i], representing the cost to traverse that node.
+
+The score of a path is defined as the sum of the costs of all nodes along the path.
+
+Your goal is to make the scores of all root-to-leaf paths equal by increasing the cost of any number of nodes by any non-negative amount.
+
+Return the minimum number of nodes whose cost must be increased to make all root-to-leaf path scores equal.
+
+
+Example 1:
+
+Input: n = 3, edges = [[0,1],[0,2]], cost = [2,1,3]
+Output: 1
+Explanation:
+There are two root-to-leaf paths:
+Path 0 -> 1 has score 2 + 1 = 3.
+Path 0 -> 2 has score 2 + 3 = 5.
+We can raise the cost of node 1 by 2, making all root-to-leaf path scores equal to 5. Thus, the answer is 1.
+
+Example 2:
+
+Input: n = 3, edges = [[0,1],[1,2]], cost = [5,1,4]
+Output: 0
+Explanation:
+There is only one root-to-leaf path, so no operations are needed. Thus, the answer is 0.
+
+Example 3:
+
+Input: n = 5, edges = [[0,4],[0,1],[1,2],[1,3]], cost = [3,4,1,1,7]
+Output: 1
+Explanation:
+There are three root-to-leaf paths:
+Path 0 -> 4 has score 3 + 7 = 10.
+Path 0 -> 1 -> 2 has score 3 + 4 + 1 = 8.
+Path 0 -> 1 -> 3 has score 3 + 4 + 1 = 8.
+We can raise the cost of node 1 by 2, making all root-to-leaf path scores equal to 10. Thus, the answer is 1.
+
+
+Constraints:
+
+2 <= n <= 10^5
+edges.length == n - 1
+edges[i] == [ui, vi]
+0 <= ui, vi < n
+cost.length == n
+1 <= cost[i] <= 10^9
+The input is generated such that edges represents a valid tree.
+
+"""
+
+# V0
+# IDEA : BOTTOM-UP MAX, CHARGING ONE OPERATION PER SHORT CHILD
+#
+#   let f(u) be the largest score among the paths from u down to a leaf.
+#   every child subtree must be lifted to that same f value, and a single
+#   operation on the child's own node can absorb the whole shortfall at once
+#   (the amount raised is unlimited). so a child costs one operation iff it
+#   is strictly below the max — and lifting the child's node keeps all the
+#   deeper paths inside that subtree equal to each other.
+#
+#   a node with 10^5 descendants would blow the recursion limit, so the
+#   post-order traversal is done with an explicit stack.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def minIncrease(self, n, edges, cost):
+        adj = [[] for _ in range(n)]
+        for u, v in edges:
+            adj[u].append(v)
+            adj[v].append(u)
+
+        parent = [-1] * n
+        order = []
+        stack = [0]
+        seen = [False] * n
+        seen[0] = True
+        while stack:
+            u = stack.pop()
+            order.append(u)
+            for w in adj[u]:
+                if not seen[w]:
+                    seen[w] = True
+                    parent[w] = u
+                    stack.append(w)
+
+        best = [0] * n          # max downward path score starting at the node
+        ops = 0
+        for u in reversed(order):
+            mx = 0
+            for w in adj[u]:
+                if w != parent[u]:
+                    if best[w] > mx:
+                        mx = best[w]
+            for w in adj[u]:
+                if w != parent[u] and best[w] < mx:
+                    ops += 1
+            best[u] = cost[u] + mx
+        return ops

--- a/leetcode_python/Depth-First-Search/power-grid-maintenance.py
+++ b/leetcode_python/Depth-First-Search/power-grid-maintenance.py
@@ -1,0 +1,136 @@
+"""
+
+3607. Power Grid Maintenance
+Medium
+
+You are given an integer c representing c power stations, each with a unique
+identifier id from 1 to c (1-based indexing).
+
+These stations are interconnected via n bidirectional cables, represented by a
+2D array connections, where each element connections[i] = [ui, vi] indicates a
+connection between station ui and station vi. Stations that are directly or
+indirectly connected form a power grid.
+
+Initially, all stations are online (operational).
+
+You are also given a 2D array queries, where each query is one of the following
+two types:
+
+[1, x]: A maintenance check is requested for station x. If station x is online,
+it resolves the check by itself. If station x is offline, the check is resolved
+by the operational station with the smallest id in the same power grid as x. If
+no operational station exists in that grid, return -1.
+
+[2, x]: Station x goes offline (i.e., it becomes non-operational).
+
+Return an array of integers representing the results of each query of type
+[1, x] in the order they appear.
+
+Note: The power grid preserves its structure; an offline (non-operational) node
+remains part of its grid and taking it offline does not alter connectivity.
+
+
+Example 1:
+
+Input: c = 5, connections = [[1,2],[2,3],[3,4],[4,5]],
+       queries = [[1,3],[2,1],[1,1],[2,2],[1,2]]
+Output: [3,2,3]
+Explanation:
+Initially, all stations {1, 2, 3, 4, 5} are online and form a single power grid.
+Query [1,3]: Station 3 is online, so the maintenance check is resolved by
+station 3.
+Query [2,1]: Station 1 goes offline. The remaining online stations are
+{2, 3, 4, 5}.
+Query [1,1]: Station 1 is offline, so the check is resolved by the operational
+station with the smallest id among {2, 3, 4, 5}, which is station 2.
+Query [2,2]: Station 2 goes offline. The remaining online stations are {3, 4, 5}.
+Query [1,2]: Station 2 is offline, so the check is resolved by the operational
+station with the smallest id among {3, 4, 5}, which is station 3.
+
+Example 2:
+
+Input: c = 3, connections = [], queries = [[1,1],[2,1],[1,1]]
+Output: [1,-1]
+Explanation:
+There are no connections, so each station is its own isolated grid.
+Query [1,1]: Station 1 is online in its isolated grid, so the maintenance check
+is resolved by station 1.
+Query [2,1]: Station 1 goes offline.
+Query [1,1]: Station 1 is offline and there are no other stations in its grid,
+so the result is -1.
+
+
+Constraints:
+
+1 <= c <= 10^5
+0 <= n == connections.length <= min(10^5, c * (c - 1) / 2)
+connections[i].length == 2
+1 <= ui, vi <= c
+ui != vi
+1 <= queries.length <= 2 * 10^5
+queries[i].length == 2
+queries[i][0] is either 1 or 2.
+1 <= queries[i][1] <= c
+"""
+
+# V0
+# IDEA : UNION-FIND + PER-GRID MIN-HEAP WITH LAZY DELETION
+#
+#   the note in the statement is the whole trick: going offline never breaks a
+#   cable, so the partition into grids is fixed for the entire run. that means
+#   one pass of union-find up front tells us, once and for all, which grid each
+#   station belongs to — the only thing that changes over time is the online
+#   flag.
+#
+#   per grid we need "smallest online id", with deletions only (a station never
+#   comes back). a min-heap of the grid's ids serves this perfectly: ids are
+#   only ever removed, so once we pop an offline id off the top it can never be
+#   needed again. that makes lazy deletion exact rather than merely convenient,
+#   and amortises every id to a single push and a single pop.
+#
+#   the `[1, x]` answer is `x` itself whenever x is online — no heap work at
+#   all — because x is trivially the smallest online id "in the same grid as x"
+#   under the rule stated. otherwise we peel dead entries off that grid's heap.
+#
+# time = O((c + n + q) * log(c)), space = O(c)
+import heapq
+
+
+class Solution(object):
+    def processQueries(self, c, connections, queries):
+        parent = list(range(c + 1))
+
+        def find(x):
+            root = x
+            while parent[root] != root:
+                root = parent[root]
+            while parent[x] != root:
+                parent[x], x = root, parent[x]
+            return root
+
+        for u, v in connections:
+            ru, rv = find(u), find(v)
+            if ru != rv:
+                parent[ru] = rv
+
+        grid = [[] for _ in range(c + 1)]
+        for i in range(1, c + 1):
+            grid[find(i)].append(i)
+        for i in range(1, c + 1):
+            if grid[i]:
+                heapq.heapify(grid[i])
+
+        online = [True] * (c + 1)
+        res = []
+        for kind, x in queries:
+            if kind == 2:
+                online[x] = False
+                continue
+            if online[x]:
+                res.append(x)
+                continue
+            heap = grid[find(x)]
+            while heap and not online[heap[0]]:
+                heapq.heappop(heap)
+            res.append(heap[0] if heap else -1)
+        return res

--- a/leetcode_python/Dynamic_Programming/best-time-to-buy-and-sell-stock-v.py
+++ b/leetcode_python/Dynamic_Programming/best-time-to-buy-and-sell-stock-v.py
@@ -1,0 +1,89 @@
+"""
+
+3573. Best Time to Buy and Sell Stock V
+Medium
+
+You are given an integer array prices where prices[i] is the price of a stock in dollars on the ith day, and an integer k.
+
+You are allowed to make at most k transactions, where each transaction can be either of the following:
+
+Normal transaction: buy on day i, then sell on a later day j where i < j. You profit prices[j] - prices[i].
+Short selling transaction: sell on day i, then buy back on a later day j where i < j. You profit prices[i] - prices[j].
+
+Note that you must complete each transaction before starting another. Additionally, you can't buy or sell on the same day you are completing another transaction.
+
+Return the maximum total profit you can earn by making at most k transactions.
+
+
+Example 1:
+
+Input: prices = [1,7,9,8,2], k = 2
+Output: 14
+Explanation:
+We can make $14 of profit through 2 transactions:
+A normal transaction: buy the stock on day 0 for $1 then sell it on day 2 for $9.
+A short selling transaction: sell the stock on day 3 for $8 then buy back on day 4 for $2.
+
+Example 2:
+
+Input: prices = [12,16,19,19,8,1,19,13,9], k = 3
+Output: 36
+Explanation:
+We can make $36 of profit through 3 transactions:
+A normal transaction: buy the stock on day 0 for $12 then sell it on day 2 for $19.
+A short selling transaction: sell the stock on day 3 for $19 then buy back on day 4 for $8.
+A normal transaction: buy the stock on day 5 for $1 then sell it on day 6 for $19.
+
+
+Constraints:
+
+2 <= prices.length <= 10^3
+1 <= prices[i] <= 10^9
+1 <= k <= prices.length / 2
+
+"""
+
+# V0
+# IDEA : 3-STATE DP (IDLE / LONG OPEN / SHORT OPEN) INDEXED BY TRANSACTION COUNT
+#
+#   at the end of every day the portfolio is in exactly one of three states,
+#   and the profit is fully determined by that state plus how many
+#   transactions have already been closed.
+#
+#   the "no buying and selling on the same day" rule falls out for free by
+#   building the new day's table only from the *previous* day's table: an
+#   open position must have been opened strictly earlier than the day it is
+#   closed.
+#
+#   short selling is just a long trade with the sign flipped, so it reuses
+#   the same recurrence with +p / -p swapped.
+#
+# time = O(n * k), space = O(k)
+class Solution(object):
+    def maximumProfit(self, prices, k):
+        NEG = float('-inf')
+        # idle[j] : best profit with at most j closed transactions, no position
+        idle = [0] * (k + 1)
+        # lng[j] / sht[j] : an open long / short whose close will be trade j
+        lng = [NEG] * (k + 1)
+        sht = [NEG] * (k + 1)
+
+        for p in prices:
+            n_idle = idle[:]
+            n_lng = lng[:]
+            n_sht = sht[:]
+            for j in range(1, k + 1):
+                if idle[j - 1] - p > n_lng[j]:
+                    n_lng[j] = idle[j - 1] - p
+                if idle[j - 1] + p > n_sht[j]:
+                    n_sht[j] = idle[j - 1] + p
+                cand = lng[j] + p
+                if cand > n_idle[j]:
+                    n_idle[j] = cand
+                cand = sht[j] - p
+                if cand > n_idle[j]:
+                    n_idle[j] = cand
+                if n_idle[j - 1] > n_idle[j]:
+                    n_idle[j] = n_idle[j - 1]
+            idle, lng, sht = n_idle, n_lng, n_sht
+        return idle[k]

--- a/leetcode_python/Dynamic_Programming/count-partitions-with-max-min-difference-at-most-k.py
+++ b/leetcode_python/Dynamic_Programming/count-partitions-with-max-min-difference-at-most-k.py
@@ -1,0 +1,90 @@
+"""
+
+3578. Count Partitions With Max-Min Difference at Most K
+Medium
+
+You are given an integer array nums and an integer k. Your task is to partition nums into one or more non-empty contiguous segments such that in each segment, the difference between its maximum and minimum elements is at most k.
+
+Return the total number of ways to partition nums under this condition.
+
+Since the answer may be too large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [9,4,1,3,7], k = 4
+Output: 6
+Explanation:
+There are 6 valid partitions where the difference between the maximum and minimum elements in each segment is at most k = 4:
+[[9], [4], [1], [3], [7]]
+[[9], [4], [1], [3, 7]]
+[[9], [4], [1, 3], [7]]
+[[9], [4, 1], [3], [7]]
+[[9], [4, 1], [3, 7]]
+[[9], [4, 1, 3], [7]]
+
+Example 2:
+
+Input: nums = [3,3,4], k = 0
+Output: 2
+Explanation:
+There are 2 valid partitions that satisfy the given conditions:
+[[3], [3], [4]]
+[[3, 3], [4]]
+
+
+Constraints:
+
+2 <= nums.length <= 5 * 10^4
+1 <= nums[i] <= 10^9
+0 <= k <= 10^9
+
+"""
+
+# V0
+# IDEA : DP OVER PREFIXES + SLIDING WINDOW OF FEASIBLE CUT POINTS
+#
+#   dp[i] counts the partitions of the first i elements. the last segment is
+#   nums[j..i-1] for some j, and it is legal exactly when max-min over that
+#   range is <= k. shrinking j only shrinks the range, so for a fixed i the
+#   legal j form a contiguous suffix [left, i-1] — and `left` never moves
+#   backwards as i grows, which is what makes the two-deque sliding window
+#   valid.
+#
+#   summing dp[left..i-1] is then a prefix-sum lookup, giving overall linear
+#   time.
+#
+# time = O(n), space = O(n)
+from collections import deque
+
+
+class Solution(object):
+    def countPartitions(self, nums, k):
+        MOD = 10 ** 9 + 7
+        n = len(nums)
+        dp = [0] * (n + 1)
+        pre = [0] * (n + 1)   # pre[i] = dp[0] + ... + dp[i]
+        dp[0] = 1
+        pre[0] = 1
+
+        maxq, minq = deque(), deque()
+        left = 0
+        for i in range(1, n + 1):
+            r = i - 1
+            v = nums[r]
+            while maxq and nums[maxq[-1]] <= v:
+                maxq.pop()
+            maxq.append(r)
+            while minq and nums[minq[-1]] >= v:
+                minq.pop()
+            minq.append(r)
+            while nums[maxq[0]] - nums[minq[0]] > k:
+                if maxq[0] == left:
+                    maxq.popleft()
+                if minq[0] == left:
+                    minq.popleft()
+                left += 1
+            total = pre[i - 1] - (pre[left - 1] if left > 0 else 0)
+            dp[i] = total % MOD
+            pre[i] = (pre[i - 1] + dp[i]) % MOD
+        return dp[n]

--- a/leetcode_python/Dynamic_Programming/inverse-coin-change.py
+++ b/leetcode_python/Dynamic_Programming/inverse-coin-change.py
@@ -1,0 +1,89 @@
+"""
+
+3592. Inverse Coin Change
+Medium
+
+You are given a 1-indexed integer array numWays, where numWays[i] represents the number of ways to select a total amount i using an infinite supply of some fixed coin denominations. Each denomination is a positive integer with value at most numWays.length.
+
+However, the exact coin denominations have been lost. Your task is to recover the set of denominations that could have resulted in the given numWays array.
+
+Return a sorted array containing unique integers which represents this set of denominations.
+
+If no such set exists, return an empty array.
+
+
+Example 1:
+
+Input: numWays = [0,1,0,2,0,3,0,4,0,5]
+Output: [2,4,6]
+Explanation:
+
+Amount | Ways | Explanation
+1      | 0    | There is no way to select coins with total value 1.
+2      | 1    | The only way is [2].
+3      | 0    | There is no way to select coins with total value 3.
+4      | 2    | The ways are [2, 2] and [4].
+5      | 0    | There is no way to select coins with total value 5.
+6      | 3    | The ways are [2, 2, 2], [2, 4], and [6].
+7      | 0    | There is no way to select coins with total value 7.
+8      | 4    | The ways are [2, 2, 2, 2], [2, 2, 4], [2, 6], and [4, 4].
+9      | 0    | There is no way to select coins with total value 9.
+10     | 5    | The ways are [2, 2, 2, 2, 2], [2, 2, 2, 4], [2, 4, 4],
+       |      | [2, 2, 6], and [4, 6].
+
+Example 2:
+
+Input: numWays = [1,2,2,3,4]
+Output: [1,2,5]
+Explanation:
+
+Amount | Ways | Explanation
+1      | 1    | The only way is [1].
+2      | 2    | The ways are [1, 1] and [2].
+3      | 2    | The ways are [1, 1, 1] and [1, 2].
+4      | 3    | The ways are [1, 1, 1, 1], [1, 1, 2], and [2, 2].
+5      | 4    | The ways are [1, 1, 1, 1, 1], [1, 1, 1, 2], [1, 2, 2], and [5].
+
+Example 3:
+
+Input: numWays = [1,2,3,4,15]
+Output: []
+Explanation: No set of denomination satisfies this array.
+
+
+Constraints:
+
+1 <= numWays.length <= 100
+0 <= numWays[i] <= 2 * 10^8
+
+"""
+
+# V0
+# IDEA : REBUILD THE COIN-CHANGE DP LEFT TO RIGHT AND READ OFF MISSING COINS
+#
+#   sweep amounts in increasing order maintaining the usual unbounded
+#   knapsack table for the coins discovered so far. when we reach amount i,
+#   every coin smaller than i has already been accounted for, so the table
+#   value dp[i] is final apart from the contribution of a coin worth exactly
+#   i — which would add exactly 1 way (the single-coin multiset).
+#
+#   therefore dp[i] must equal numWays[i] (no coin i) or numWays[i] - 1
+#   (coin i exists). anything else is inconsistent and the answer is [].
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def findCoins(self, numWays):
+        n = len(numWays)
+        dp = [0] * (n + 1)
+        dp[0] = 1
+        coins = []
+        for i in range(1, n + 1):
+            want = numWays[i - 1]
+            if dp[i] == want:
+                continue
+            if dp[i] + 1 != want:
+                return []
+            coins.append(i)
+            for a in range(i, n + 1):
+                dp[a] += dp[a - i]
+        return coins

--- a/leetcode_python/Dynamic_Programming/lexicographically-smallest-string-after-adjacent-removals.py
+++ b/leetcode_python/Dynamic_Programming/lexicographically-smallest-string-after-adjacent-removals.py
@@ -1,0 +1,97 @@
+"""
+
+3563. Lexicographically Smallest String After Adjacent Removals
+Hard
+
+You are given a string s consisting of lowercase English letters.
+
+You can perform the following operation any number of times (including zero):
+
+Remove any pair of adjacent characters in the string that are consecutive in the alphabet, where the alphabet is treated as cyclic ('a' and 'z' are considered consecutive).
+Shift the remaining characters to the left to fill the gap.
+
+Return the lexicographically smallest string that can be obtained after performing the operations optimally.
+
+Note: Consider the alphabet as circular, thus 'a' and 'z' are consecutive.
+
+
+Example 1:
+
+Input: s = "abc"
+Output: "a"
+Explanation:
+Remove "bc" from the string, leaving "a" as the remaining string. No further operations are possible. Thus, the lexicographically smallest achievable string is "a".
+
+Example 2:
+
+Input: s = "bcda"
+Output: ""
+Explanation:
+Remove "cd" from the string, leaving "ba" as the remaining string. Remove "ba" from the string, leaving "" as the remaining string. Thus, the lexicographically smallest achievable string is "".
+
+Example 3:
+
+Input: s = "zdce"
+Output: "zdce"
+Explanation:
+Remove "dc" from the string, leaving "ze" as the remaining string. No further operations are possible on "ze". However, since "ze" is lexicographically larger than "zdce", the smallest achievable string is "zdce".
+
+
+Constraints:
+
+1 <= s.length <= 250
+s consists only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : INTERVAL DP FOR "CAN VANISH" + SUFFIX DP FOR THE SMALLEST TAIL
+#
+#   a whole block s[i..j] can disappear only if s[i] pairs off with some
+#   s[k] (k of opposite parity to i) and both the block strictly inside
+#   (i+1..k-1) and the block after it (k+1..j) vanish on their own — the
+#   removals never interleave across those two blocks, so the recursion is
+#   exact.
+#
+#   with `gone[i][j]` known, scanning right to left gives the answer:
+#   from position i we either keep s[i] and append the best tail of i+1,
+#   or erase a vanishing block s[i..j] and jump to j+1. python's string
+#   comparison is exactly the required lexicographic order (a prefix is
+#   smaller than any extension of it, so "" beats everything).
+#
+# time = O(n^3), space = O(n^2)
+class Solution(object):
+    def lexicographicallySmallestString(self, s):
+        n = len(s)
+
+        def adjacent(a, b):
+            d = abs(ord(a) - ord(b))
+            return d == 1 or d == 25
+
+        # gone[i][j] : s[i..j] (inclusive) can be fully removed
+        gone = [[False] * (n + 1) for _ in range(n + 1)]
+
+        # an empty range (i > j) vanishes trivially
+        def vanish(i, j):
+            if i > j:
+                return True
+            return gone[i][j]
+
+        for length in range(2, n + 1, 2):
+            for i in range(0, n - length + 1):
+                j = i + length - 1
+                ok = False
+                for k in range(i + 1, j + 1, 2):
+                    if adjacent(s[i], s[k]) and vanish(i + 1, k - 1) and vanish(k + 1, j):
+                        ok = True
+                        break
+                gone[i][j] = ok
+
+        best = [""] * (n + 1)
+        for i in range(n - 1, -1, -1):
+            cand = s[i] + best[i + 1]
+            for j in range(i + 1, n, 2):
+                if gone[i][j] and best[j + 1] < cand:
+                    cand = best[j + 1]
+            best[i] = cand
+        return best[0]

--- a/leetcode_python/Dynamic_Programming/longest-palindromic-path-in-graph.py
+++ b/leetcode_python/Dynamic_Programming/longest-palindromic-path-in-graph.py
@@ -1,0 +1,173 @@
+"""
+
+3615. Longest Palindromic Path in Graph
+Hard
+
+You are given an integer n and an undirected graph with n nodes labeled from 0
+to n - 1 and a 2D array edges, where edges[i] = [ui, vi] indicates an edge
+between nodes ui and vi.
+
+You are also given a string label of length n, where label[i] is the character
+associated with node i.
+
+You may start at any node and move to any adjacent node, visiting each node at
+most once.
+
+Return the maximum possible length of a palindrome that can be formed by
+visiting a set of unique nodes along a valid path.
+
+
+Example 1:
+
+Input: n = 3, edges = [[0,1],[1,2]], label = "aba"
+Output: 3
+Explanation:
+The longest palindromic path is from node 0 to node 2 via node 1, following the
+path 0 -> 1 -> 2 forming string "aba".
+This is a valid palindrome of length 3.
+
+Example 2:
+
+Input: n = 3, edges = [[0,1],[0,2]], label = "abc"
+Output: 1
+Explanation:
+No path with more than one node forms a palindrome.
+The best option is any single node, giving a palindrome of length 1.
+
+Example 3:
+
+Input: n = 4, edges = [[0,2],[0,3],[3,1]], label = "bbac"
+Output: 3
+Explanation:
+The longest palindromic path is from node 0 to node 1, following the path
+0 -> 3 -> 1, forming string "bcb".
+This is a valid palindrome of length 3.
+
+
+Constraints:
+
+1 <= n <= 14
+n - 1 <= edges.length <= n * (n - 1) / 2
+edges[i] == [ui, vi]
+0 <= ui, vi <= n - 1
+ui != vi
+label.length == n
+label consists of lowercase English letters.
+There are no duplicate edges.
+
+"""
+
+# V0
+# IDEA : BITMASK DP GROWING THE PALINDROME FROM BOTH ENDS INWARD
+#
+#   a palindromic path p0..p(L-1) pairs up p0 with p(L-1), p1 with p(L-2), and
+#   so on. building it left-to-right is hopeless because the constraint links
+#   the two far ends, but building it *outside-in* makes every constraint
+#   local: pick the matching pair of endpoints first, then repeatedly step
+#   both frontiers one edge inward, always choosing two nodes with the same
+#   letter.
+#
+#   so a state is (u, v, mask): u and v are the two current frontier nodes and
+#   mask is the set of nodes already spent on the two arms. popcount(mask) is
+#   always even and is exactly the number of characters fixed so far — the two
+#   arms are grown in lockstep, so no length bookkeeping is needed.
+#
+#   a state finishes the path in one of two ways, and both are checked in
+#   place: if u and v are adjacent the two arms meet and the palindrome has
+#   even length popcount(mask); if instead some unused node is adjacent to
+#   both, it becomes the single middle character and the length is
+#   popcount(mask) + 1. a lone node is always a palindrome, so 1 is the floor.
+#
+#   the trick that keeps this fast is that the choice of the new v only
+#   depends on the *union* of the neighbourhoods of the current partners of u.
+#   any v in that union came from some concrete partner, so or-ing them all
+#   together loses nothing and collapses the inner double loop over
+#   (partner, new partner) into one precomputed lookup, orAdj[set].
+#
+# time = O(2^n * n^2), space = O(2^n * n)
+class Solution(object):
+    def maxLen(self, n, edges, label):
+        adj = [0] * n
+        for u, v in edges:
+            adj[u] |= 1 << v
+            adj[v] |= 1 << u
+
+        # nodes sharing a letter with node i (i itself included)
+        by_letter = [0] * 26
+        for i in range(n):
+            by_letter[ord(label[i]) - 97] |= 1 << i
+        same = [by_letter[ord(label[i]) - 97] for i in range(n)]
+
+        size = 1 << n
+        full = size - 1
+
+        # or_adj[s] = union of the neighbourhoods of every node in s
+        or_adj = [0] * size
+        for s in range(1, size):
+            low = s & -s
+            or_adj[s] = or_adj[s ^ low] | adj[low.bit_length() - 1]
+
+        pc = [0] * size
+        for s in range(1, size):
+            pc[s] = pc[s >> 1] + (s & 1)
+
+        # reach[mask][u] = bitmask of v with state (u, v, mask) reachable
+        reach = [None] * size
+        for u in range(n):
+            for v in range(u + 1, n):
+                if label[u] == label[v]:
+                    m = (1 << u) | (1 << v)
+                    if reach[m] is None:
+                        reach[m] = [0] * n
+                    reach[m][u] |= 1 << v
+                    reach[m][v] |= 1 << u
+
+        res = 1
+        for mask in range(size):
+            row = reach[mask]
+            if row is None:
+                continue
+            p = pc[mask]
+            avail = full & ~mask
+            for u in range(n):
+                vs = row[u]
+                if not vs:
+                    continue
+                au = adj[u]
+
+                # the two arms meet directly -> even length palindrome
+                if au & vs and p > res:
+                    res = p
+
+                # an unused node adjacent to both arms -> odd length palindrome
+                if p + 1 > res:
+                    b = vs
+                    while b:
+                        low = b & -b
+                        b ^= low
+                        if au & adj[low.bit_length() - 1] & avail:
+                            res = p + 1
+                            break
+
+                # step both frontiers one edge inward
+                orv = or_adj[vs] & avail
+                if not orv:
+                    continue
+                bu = au & avail
+                while bu:
+                    lu = bu & -bu
+                    bu ^= lu
+                    up = lu.bit_length() - 1
+                    cands = orv & same[up] & ~lu
+                    while cands:
+                        lv = cands & -cands
+                        cands ^= lv
+                        nm = mask | lu | lv
+                        nrow = reach[nm]
+                        if nrow is None:
+                            nrow = reach[nm] = [0] * n
+                        nrow[up] |= lv
+                        nrow[lv.bit_length() - 1] |= lu
+            if res == n:
+                return n
+        return res

--- a/leetcode_python/Dynamic_Programming/maximum-good-subtree-score.py
+++ b/leetcode_python/Dynamic_Programming/maximum-good-subtree-score.py
@@ -1,0 +1,207 @@
+"""
+
+3575. Maximum Good Subtree Score
+Hard
+
+You are given an undirected tree rooted at node 0 with n nodes numbered
+from 0 to n - 1. Each node i has an integer value vals[i], and its parent is
+given by par[i].
+
+A subset of nodes within the subtree of a node is called good if every digit
+from 0 to 9 appears at most once in the decimal representation of the values
+of the selected nodes.
+
+The score of a good subset is the sum of the values of its nodes.
+
+Define an array maxScore of length n, where maxScore[u] represents the
+maximum possible sum of values of a good subset of nodes that belong to the
+subtree rooted at node u, including u itself and all its descendants.
+
+Return the sum of all values in maxScore.
+
+Since the answer may be large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: vals = [2,3], par = [-1,0]
+Output: 8
+Explanation:
+- The subtree rooted at node 0 includes nodes {0, 1}. The subset {2, 3} is
+  good as the digits 2 and 3 appear only once. The score of this subset is
+  2 + 3 = 5.
+- The subtree rooted at node 1 includes only node {1}. The subset {3} is
+  good. The score of this subset is 3.
+- The maxScore array is [5, 3], and the sum of all values in maxScore is
+  5 + 3 = 8. Thus, the answer is 8.
+
+Example 2:
+
+Input: vals = [1,5,2], par = [-1,0,0]
+Output: 15
+Explanation:
+- The subtree rooted at node 0 includes nodes {0, 1, 2}. The subset
+  {1, 5, 2} is good as the digits 1, 5 and 2 appear only once. The score of
+  this subset is 1 + 5 + 2 = 8.
+- The subtree rooted at node 1 includes only node {1}. The subset {5} is
+  good. The score of this subset is 5.
+- The subtree rooted at node 2 includes only node {2}. The subset {2} is
+  good. The score of this subset is 2.
+- The maxScore array is [8, 5, 2], and the sum of all values in maxScore is
+  8 + 5 + 2 = 15. Thus, the answer is 15.
+
+Example 3:
+
+Input: vals = [34,1,2], par = [-1,0,1]
+Output: 42
+Explanation:
+- The subtree rooted at node 0 includes nodes {0, 1, 2}. The subset
+  {34, 1, 2} is good as the digits 3, 4, 1 and 2 appear only once. The score
+  of this subset is 34 + 1 + 2 = 37.
+- The subtree rooted at node 1 includes node {1, 2}. The subset {1, 2} is
+  good as the digits 1 and 2 appear only once. The score of this subset is
+  1 + 2 = 3.
+- The subtree rooted at node 2 includes only node {2}. The subset {2} is
+  good. The score of this subset is 2.
+- The maxScore array is [37, 3, 2], and the sum of all values in maxScore is
+  37 + 3 + 2 = 42. Thus, the answer is 42.
+
+Example 4:
+
+Input: vals = [3,22,5], par = [-1,0,1]
+Output: 18
+Explanation:
+- The subtree rooted at node 0 includes nodes {0, 1, 2}. The subset
+  {3, 22, 5} is not good, as digit 2 appears twice. Therefore, the subset
+  {3, 5} is valid. The score of this subset is 3 + 5 = 8.
+- The subtree rooted at node 1 includes nodes {1, 2}. The subset {22, 5} is
+  not good, as digit 2 appears twice. Therefore, the subset {5} is valid.
+  The score of this subset is 5.
+- The subtree rooted at node 2 includes {2}. The subset {5} is good. The
+  score of this subset is 5.
+- The maxScore array is [8, 5, 5], and the sum of all values in maxScore is
+  8 + 5 + 5 = 18. Thus, the answer is 18.
+
+
+Constraints:
+
+1 <= n == vals.length <= 500
+1 <= vals[i] <= 10^9
+par.length == n
+par[0] == -1
+0 <= par[i] < n for i in [1, n - 1]
+The input is generated such that the parent array par represents a valid
+tree.
+
+"""
+
+# V0
+# IDEA : DIGIT-MASK KNAPSACK PER SUBTREE, REUSED VIA SMALL-TO-LARGE MERGING
+#
+#   a value is usable at all only if its own decimal digits are distinct;
+#   otherwise it can never sit in a good subset. every usable value becomes
+#   an item with a 10-bit digit mask, and a good subset is just a collection
+#   of items with pairwise disjoint masks. so maxScore[u] is a 0/1 knapsack
+#   over the items of subtree(u), with "weight" = mask and the constraint
+#   being disjointness: dp[S] = best sum whose digits are exactly S, and an
+#   item (m, v) updates dp[S | m] from dp[S] for every S disjoint from m.
+#
+#   the point that makes this cheap is that such a knapsack is *incremental
+#   and order free* — adding items one at a time, in any order, gives the
+#   same table. so a parent does not have to rebuild from scratch: it can
+#   adopt the finished table of its largest child and then feed in only the
+#   items of its remaining (smaller) children plus its own. that is the
+#   standard small-to-large argument, and it bounds the number of item
+#   insertions by O(n log n) instead of the O(n^2) of "one knapsack per
+#   subtree" (a path-shaped tree is the case it rescues).
+#
+#   note we never have to delete a dominated item: two items with the same
+#   mask collide, so a packing uses at most one of them and automatically
+#   the larger. an empty subset is good, hence dp[0] = 0 and every
+#   maxScore[u] is at least 0.
+#
+# time = O(n log n * 2^10), space = O(n * 2^10)
+class Solution(object):
+    def goodSubtreeSum(self, vals, par):
+        MOD = 10 ** 9 + 7
+        FULL = 1 << 10
+        NEG = -1 << 60
+
+        n = len(vals)
+        kids = [[] for _ in range(n)]
+        for i in range(n):
+            if par[i] >= 0:
+                kids[par[i]].append(i)
+
+        # digit mask of each value, or -1 when a digit repeats
+        masks = []
+        for v in vals:
+            m, x = 0, v
+            while x:
+                bit = 1 << (x % 10)
+                if m & bit:
+                    m = -1
+                    break
+                m |= bit
+                x //= 10
+            masks.append(m)
+
+        # iterative dfs -> preorder plus subtree ranges
+        order = []
+        start = [0] * n
+        stop = [0] * n
+        stack = [(0, False)]
+        while stack:
+            u, done = stack.pop()
+            if done:
+                stop[u] = len(order)
+                continue
+            start[u] = len(order)
+            order.append(u)
+            stack.append((u, True))
+            for c in kids[u]:
+                stack.append((c, False))
+
+        # complementary masks are shared by every insertion of the same mask
+        free = {}
+
+        def absorb(dp, w):
+            m = masks[w]
+            if m < 0:
+                return
+            v = vals[w]
+            spots = free.get(m)
+            if spots is None:
+                spots = free[m] = [s for s in range(FULL) if not (s & m)]
+            for s in spots:
+                base = dp[s]
+                if base >= 0 and base + v > dp[s | m]:
+                    dp[s | m] = base + v
+
+        tables = {}
+        total = 0
+        # a parent always appears before its descendants in preorder, so the
+        # reversed order is a valid bottom-up sweep
+        for u in reversed(order):
+            heavy = -1
+            for c in kids[u]:
+                if heavy < 0 or stop[c] - start[c] > stop[heavy] - start[heavy]:
+                    heavy = c
+
+            if heavy < 0:
+                dp = [NEG] * FULL
+                dp[0] = 0
+            else:
+                dp = tables.pop(heavy)
+
+            absorb(dp, u)
+            for c in kids[u]:
+                if c != heavy:
+                    tables.pop(c, None)
+                    for w in order[start[c]:stop[c]]:
+                        absorb(dp, w)
+
+            total += max(dp)
+            tables[u] = dp
+
+        return total % MOD

--- a/leetcode_python/Dynamic_Programming/minimum-cost-path-with-alternating-directions-ii.py
+++ b/leetcode_python/Dynamic_Programming/minimum-cost-path-with-alternating-directions-ii.py
@@ -1,0 +1,124 @@
+"""
+
+3603. Minimum Cost Path with Alternating Directions II
+Medium
+
+You are given two integers m and n representing the number of rows and
+columns of a grid, respectively.
+
+The cost to enter cell (i, j) is defined as (i + 1) * (j + 1).
+
+You are also given a 2D integer array waitCost where waitCost[i][j] defines
+the cost to wait on that cell.
+
+The path will always begin by entering cell (0, 0) on move 1 and paying the
+entrance cost.
+
+At each step, you follow an alternating pattern:
+
+On odd-numbered seconds, you must move right or down to an adjacent cell,
+paying its entry cost.
+On even-numbered seconds, you must wait in place for exactly one second and
+pay waitCost[i][j] during that second.
+
+Return the minimum total cost required to reach (m - 1, n - 1).
+
+
+Example 1:
+
+Input: m = 1, n = 2, waitCost = [[1,2]]
+Output: 3
+Explanation:
+The optimal path is:
+Start at cell (0, 0) at second 1 with entry cost (0 + 1) * (0 + 1) = 1.
+Second 1: Move right to cell (0, 1) with entry cost (0 + 1) * (1 + 1) = 2.
+Thus, the total cost is 1 + 2 = 3.
+
+Example 2:
+
+Input: m = 2, n = 2, waitCost = [[3,5],[2,4]]
+Output: 9
+Explanation:
+The optimal path is:
+Start at cell (0, 0) at second 1 with entry cost (0 + 1) * (0 + 1) = 1.
+Second 1: Move down to cell (1, 0) with entry cost (1 + 1) * (0 + 1) = 2.
+Second 2: Wait at cell (1, 0), paying waitCost[1][0] = 2.
+Second 3: Move right to cell (1, 1) with entry cost (1 + 1) * (1 + 1) = 4.
+Thus, the total cost is 1 + 2 + 2 + 4 = 9.
+
+Example 3:
+
+Input: m = 2, n = 3, waitCost = [[6,1,4],[3,2,5]]
+Output: 16
+Explanation:
+The optimal path is:
+Start at cell (0, 0) at second 1 with entry cost (0 + 1) * (0 + 1) = 1.
+Second 1: Move right to cell (0, 1) with entry cost (0 + 1) * (1 + 1) = 2.
+Second 2: Wait at cell (0, 1), paying waitCost[0][1] = 1.
+Second 3: Move down to cell (1, 1) with entry cost (1 + 1) * (1 + 1) = 4.
+Second 4: Wait at cell (1, 1), paying waitCost[1][1] = 2.
+Second 5: Move right to cell (1, 2) with entry cost (1 + 1) * (2 + 1) = 6.
+Thus, the total cost is 1 + 2 + 1 + 4 + 2 + 6 = 16.
+
+
+Constraints:
+
+1 <= m, n <= 10^5
+2 <= m * n <= 10^5
+waitCost.length == m
+waitCost[0].length == n
+0 <= waitCost[i][j] <= 10^5
+
+"""
+
+# V0
+# IDEA : GRID DP, WITH THE WAIT COST FOLDED ONTO THE CELL YOU LEAVE
+#
+#   the alternation is not a real constraint here: every odd second is a
+#   move right/down and every even second is a forced wait, so the walk is
+#   just an ordinary monotone lattice path and the waits are bookkeeping
+#   attached to it. what we pay is the entry cost of every cell on the
+#   path, plus one wait for every cell that we *leave* — because a wait
+#   only happens on the second right after arriving somewhere and right
+#   before stepping off again.
+#
+#   two cells escape the wait: the start, since second 1 is a move (we
+#   never idle on (0, 0)), and the destination, since we stop the moment
+#   we enter it. so the wait of a cell should be charged at the moment we
+#   step *out* of it, and (0, 0) is the single exception where that charge
+#   is waived.
+#
+#   with that framing dp[i][j] = cheapest cost of arriving at (i, j),
+#   entry cost of (i, j) included and its own wait not yet paid. a
+#   predecessor contributes its dp value plus its wait, and the answer is
+#   simply dp[m-1][n-1] — the destination's wait never enters.
+#
+#   m * n <= 10^5 but a single dimension may be 10^5, so we roll one row.
+#
+# time = O(m * n), space = O(n)
+class Solution(object):
+    def minCost(self, m, n, waitCost):
+        # the only cell we never pay a wait for on leaving is (0, 0)
+        top = list(waitCost[0])
+        top[0] = 0
+
+        # row 0: the path can only run rightwards
+        prev = [0] * n
+        prev[0] = 1
+        for j in range(1, n):
+            prev[j] = prev[j - 1] + top[j - 1] + (j + 1)
+
+        for i in range(1, m):
+            above = top if i == 1 else waitCost[i - 1]
+            row = waitCost[i]
+            cur = [0] * n
+            # column 0 can only be entered from directly above
+            cur[0] = prev[0] + above[0] + (i + 1)
+            for j in range(1, n):
+                from_up = prev[j] + above[j]
+                from_left = cur[j - 1] + row[j - 1]
+                cur[j] = (from_up if from_up < from_left else from_left) \
+                    + (i + 1) * (j + 1)
+            prev = cur
+
+        return prev[n - 1]

--- a/leetcode_python/Dynamic_Programming/minimum-number-of-primes-to-sum-to-target.py
+++ b/leetcode_python/Dynamic_Programming/minimum-number-of-primes-to-sum-to-target.py
@@ -1,0 +1,84 @@
+"""
+
+3610. Minimum Number of Primes to Sum to Target
+Medium
+
+You are given two integers n and m.
+
+You have to select a multiset of prime numbers from the first m prime numbers
+such that the sum of the selected primes is exactly n. You may use each prime
+number multiple times.
+
+Return the minimum number of prime numbers needed to sum up to n, or -1 if it
+is not possible.
+
+
+Example 1:
+
+Input: n = 10, m = 2
+Output: 4
+Explanation:
+The first 2 primes are [2, 3]. The sum 10 can be formed as 2 + 2 + 3 + 3,
+requiring 4 primes.
+
+Example 2:
+
+Input: n = 15, m = 5
+Output: 3
+Explanation:
+The first 5 primes are [2, 3, 5, 7, 11]. The sum 15 can be formed as 5 + 5 + 5,
+requiring 3 primes.
+
+Example 3:
+
+Input: n = 7, m = 6
+Output: 1
+Explanation:
+The first 6 primes are [2, 3, 5, 7, 11, 13]. The sum 7 can be formed directly by
+prime 7, requiring only 1 prime.
+
+
+Constraints:
+
+1 <= n <= 1000
+1 <= m <= 1000
+"""
+
+# V0
+# IDEA : UNBOUNDED COIN CHANGE OVER THE FIRST M PRIMES
+#
+#   "multiset, each prime reusable" is exactly the unbounded coin-change shape:
+#   order does not matter and supply is unlimited, so f[i] = min over allowed
+#   primes p of f[i - p] + 1 is a complete recurrence — every multiset summing
+#   to i has some largest-indexed member p, and dropping one copy of it leaves
+#   a valid multiset for i - p.
+#
+#   iterating i upwards inside the loop over p is the unbounded (not 0/1)
+#   sweep: f[i - p] may itself already contain copies of p, which is what lets a
+#   prime be reused.
+#
+#   only primes up to n can ever appear, so the sieve never has to reach the
+#   1000th prime unless n allows it — we stop generating as soon as the primes
+#   exceed n, which also caps the work at O(n) per prime regardless of m.
+#
+# time = O(n * min(m, pi(n))), space = O(n)
+class Solution(object):
+    def minNumberOfPrimes(self, n, m):
+        # the first m primes, truncated at n (bigger ones can never be used)
+        primes = []
+        sieve = [True] * (n + 1)
+        for x in range(2, n + 1):
+            if sieve[x]:
+                primes.append(x)
+                if len(primes) == m:
+                    break
+                for y in range(x * x, n + 1, x):
+                    sieve[y] = False
+
+        INF = float('inf')
+        f = [0] + [INF] * n
+        for p in primes:
+            for i in range(p, n + 1):
+                if f[i - p] + 1 < f[i]:
+                    f[i] = f[i - p] + 1
+        return f[n] if f[n] < INF else -1

--- a/leetcode_python/Dynamic_Programming/minimum-steps-to-convert-string-with-operations.py
+++ b/leetcode_python/Dynamic_Programming/minimum-steps-to-convert-string-with-operations.py
@@ -1,0 +1,124 @@
+"""
+
+3579. Minimum Steps to Convert String with Operations
+Hard
+
+You are given two strings, word1 and word2, of equal length. You need to
+transform word1 into word2.
+
+For this, divide word1 into one or more contiguous substrings. For each
+substring substr you can perform the following operations:
+
+1. Replace: Replace the character at any one index of substr with another
+   lowercase English letter.
+2. Swap: Swap any two characters in substr.
+3. Reverse Substring: Reverse substr.
+
+Each of these counts as one operation and each character of each substring
+can be used in each type of operation at most once (i.e. no single index may
+be involved in more than one replace, one swap, or one reverse).
+
+Return the minimum number of operations required to transform word1 into
+word2.
+
+
+Example 1:
+
+Input: word1 = "abcdf", word2 = "dacbe"
+Output: 4
+Explanation:
+Divide word1 into "ab", "c", and "df". The operations are:
+- For the substring "ab",
+  - Perform operation of type 3 on "ab" -> "ba".
+  - Perform operation of type 1 on "ba" -> "da".
+- For the substring "c" do no operations.
+- For the substring "df",
+  - Perform operation of type 1 on "df" -> "bf".
+  - Perform operation of type 1 on "bf" -> "be".
+
+Example 2:
+
+Input: word1 = "abceded", word2 = "baecfef"
+Output: 4
+Explanation:
+Divide word1 into "ab", "ce", and "ded". The operations are:
+- For the substring "ab",
+  - Perform operation of type 2 on "ab" -> "ba".
+- For the substring "ce",
+  - Perform operation of type 2 on "ce" -> "ec".
+- For the substring "ded",
+  - Perform operation of type 1 on "ded" -> "fed".
+  - Perform operation of type 1 on "fed" -> "fef".
+
+Example 3:
+
+Input: word1 = "abcdef", word2 = "fedabc"
+Output: 2
+Explanation:
+Divide word1 into "abcdef". The operations are:
+- For the substring "abcdef",
+  - Perform operation of type 3 on "abcdef" -> "fedcba".
+  - Perform operation of type 2 on "fedcba" -> "fedabc".
+
+
+Constraints:
+
+1 <= word1.length == word2.length <= 100
+word1 and word2 consist only of lowercase English letters.
+
+"""
+
+# V0
+# IDEA : PARTITION DP OVER SUBSTRINGS + GREEDY PAIRING OF MISMATCHES
+#
+#   cutting word1 into pieces is free and pieces never interact, so the
+#   whole thing is a linear partition dp: f[i] = best cost for the first i
+#   characters, f[i] = min over j of f[j] + cost(j, i-1).
+#
+#   inside one piece the cost is exact and needs no search. every index that
+#   already matches is left alone. an index that mismatches must be fixed
+#   either by a replace (1 op for 1 index) or by a swap, and a swap only
+#   helps when it fixes *both* of its endpoints — that happens exactly when
+#   one index needs a -> b while another needs b -> a. so a swap is 1 op for
+#   2 indices and everything else is 1 op for 1 index; the cost is
+#   (#mismatches) - (#such opposite pairs), and pairing greedily by keeping
+#   a running tally of unmatched (a, b) demands is optimal because every
+#   (a, b) is interchangeable with every other (a, b).
+#
+#   reverse is worth at most one use per piece: two reverses cancel, and a
+#   reverse commutes with the swaps/replaces that follow it (relabelling
+#   positions), so "reverse first or not at all" covers every schedule. that
+#   leaves just two candidates per piece, cost(no reverse) and
+#   1 + cost(after reversing).
+#
+# time = O(n^3 + n^2 * |S|), space = O(n + |S|^2)
+class Solution(object):
+    def minOperations(self, word1, word2):
+        n = len(word1)
+
+        def cost(l, r, rev):
+            # min ops to turn word1[l..r] (optionally reversed) into
+            # word2[l..r], not counting the reversal itself
+            cnt = {}
+            res = 0
+            for i in range(l, r + 1):
+                j = r - (i - l) if rev else i
+                a, b = word1[j], word2[i]
+                if a == b:
+                    continue
+                # an outstanding (b, a) demand turns two replaces into one swap
+                if cnt.get((b, a), 0) > 0:
+                    cnt[(b, a)] -= 1
+                else:
+                    cnt[(a, b)] = cnt.get((a, b), 0) + 1
+                    res += 1
+            return res
+
+        f = [float('inf')] * (n + 1)
+        f[0] = 0
+        for i in range(1, n + 1):
+            for j in range(i):
+                t = min(cost(j, i - 1, False), 1 + cost(j, i - 1, True))
+                if f[j] + t < f[i]:
+                    f[i] = f[j] + t
+        return f[n]

--- a/leetcode_python/Dynamic_Programming/once-twice.py
+++ b/leetcode_python/Dynamic_Programming/once-twice.py
@@ -1,0 +1,105 @@
+"""
+
+3595. Once Twice
+Medium
+
+You are given an integer array nums. In this array:
+
+Exactly one element appears once.
+Exactly one element appears twice.
+All other elements appear exactly three times.
+
+Return an integer array of length 2, where the first element is the one that
+appears once, and the second is the one that appears twice.
+
+Your solution must run in O(n) time and O(1) space.
+
+
+Example 1:
+
+Input: nums = [2,2,3,2,5,5,5,7,7]
+Output: [3,7]
+Explanation:
+The element 3 appears once, and the element 7 appears twice. The remaining
+elements each appear three times.
+
+Example 2:
+
+Input: nums = [4,4,6,4,9,9,9,6,8]
+Output: [8,6]
+Explanation:
+The element 8 appears once, and the element 6 appears twice. The remaining
+elements each appear three times.
+
+
+Constraints:
+
+3 <= nums.length <= 10^5
+-2^31 <= nums[i] <= 2^31 - 1
+nums.length is a multiple of 3
+Exactly one element appears once, one element appears twice, and all other
+elements appear three times.
+
+"""
+
+# V0
+# IDEA : BIT-COUNT MOD 3, THEN SPLIT ON A BIT WHERE THE TWO ANSWERS DIFFER
+#
+#   count the 1s at each bit position modulo 3. every value occurring three
+#   times contributes 0 there, so the residue at bit i is (a_i + 2*b_i) % 3,
+#   with a the once-element and b the twice-element. residue 1 means a owns
+#   the bit and b does not, residue 2 means the reverse, and residue 0 is
+#   ambiguous — it covers both "neither owns it" and "both own it" — so a
+#   single pass cannot separate a from b.
+#
+#   what the pass does give is a bit on which a and b differ, and such a bit
+#   must exist: a == b is impossible, because a value appearing once and also
+#   twice would appear three times. splitting the array on that bit sends a
+#   and b to opposite halves while every triple stays intact inside one half,
+#   since all three copies agree on the bit.
+#
+#   each half is then an unambiguous single-number problem. the half holding a
+#   is {a} plus whole triples, so its residues are exactly a's bits; the half
+#   holding b is {b, b} plus whole triples, so residue 2 marks exactly b's
+#   bits.
+#
+#   the mod-3 counting is done with the usual two-register state machine, which
+#   advances every bit position through 00 -> 01 -> 10 -> 00 in lockstep, so no
+#   per-bit array is needed and the space stays O(1). values are folded into
+#   32-bit two's complement on the way in and unfolded on the way out.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def onceTwice(self, nums):
+        MASK32 = (1 << 32) - 1
+
+        # (ones, twos) = bit positions whose count is 1 resp. 2 modulo 3,
+        # restricted to the elements selected by `keep`
+        def count_mod3(keep):
+            ones = twos = 0
+            for v in nums:
+                v &= MASK32
+                if not keep(v):
+                    continue
+                ones = (ones ^ v) & (MASK32 ^ twos)
+                twos = (twos ^ v) & (MASK32 ^ ones)
+            return ones, twos
+
+        def signed(x):
+            return x - (1 << 32) if x >> 31 else x
+
+        ones, twos = count_mod3(lambda v: True)
+
+        # any non-zero residue marks a bit where the two answers disagree
+        diff = ones | twos
+        bit = diff & -diff
+
+        inside = count_mod3(lambda v: v & bit)
+        outside = count_mod3(lambda v: not (v & bit))
+
+        # ones & bit tells which half the once-element landed in
+        if ones & bit:
+            once, twice = inside[0], outside[1]
+        else:
+            once, twice = outside[0], inside[1]
+        return [signed(once), signed(twice)]

--- a/leetcode_python/Dynamic_Programming/partition-array-to-minimize-xor.py
+++ b/leetcode_python/Dynamic_Programming/partition-array-to-minimize-xor.py
@@ -1,0 +1,93 @@
+"""
+
+3599. Partition Array to Minimize XOR
+Medium
+
+You are given an integer array nums and an integer k.
+
+Your task is to partition nums into k non-empty subarrays. For each subarray, compute the bitwise XOR of all its elements.
+
+Return the minimum possible value of the maximum XOR among these k subarrays.
+
+
+Example 1:
+
+Input: nums = [1,2,3], k = 2
+Output: 1
+Explanation:
+The optimal partition is [1] and [2, 3].
+XOR of the first subarray is 1.
+XOR of the second subarray is 2 XOR 3 = 1.
+The maximum XOR among the subarrays is 1, which is the minimum possible.
+
+Example 2:
+
+Input: nums = [2,3,3,2], k = 3
+Output: 2
+Explanation:
+The optimal partition is [2], [3, 3], and [2].
+XOR of the first subarray is 2.
+XOR of the second subarray is 3 XOR 3 = 0.
+XOR of the third subarray is 2.
+The maximum XOR among the subarrays is 2, which is the minimum possible.
+
+Example 3:
+
+Input: nums = [1,1,2,3,1], k = 2
+Output: 0
+Explanation:
+The optimal partition is [1, 1] and [2, 3, 1].
+XOR of the first subarray is 1 XOR 1 = 0.
+XOR of the second subarray is 2 XOR 3 XOR 1 = 0.
+The maximum XOR among the subarrays is 0, which is the minimum possible.
+
+
+Constraints:
+
+1 <= nums.length <= 250
+1 <= nums[i] <= 10^9
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : DP OVER (NUMBER OF PARTS, PREFIX LENGTH), MINIMISING A RUNNING MAX
+#
+#   dp[j][i] = the smallest achievable "maximum segment xor" when the first
+#   i elements are cut into exactly j parts. the last part is nums[t..i-1],
+#   whose xor is prefix[i] ^ prefix[t], and the objective for that choice is
+#   max(dp[j-1][t], that xor).
+#
+#   the objective is a max, so it composes cleanly: extending an optimal
+#   (j-1)-part solution can never be beaten by a worse one, which is what
+#   makes the plain minimisation over t correct.
+#
+# time = O(k * n^2), space = O(n)
+class Solution(object):
+    def minXor(self, nums, k):
+        n = len(nums)
+        INF = float('inf')
+        pre = [0] * (n + 1)
+        for i, v in enumerate(nums):
+            pre[i + 1] = pre[i] ^ v
+
+        prev = [INF] * (n + 1)
+        prev[0] = 0                      # zero parts covering zero elements
+        for j in range(1, k + 1):
+            cur = [INF] * (n + 1)
+            for i in range(j, n - (k - j) + 1):
+                best = INF
+                pi = pre[i]
+                for t in range(j - 1, i):
+                    p = prev[t]
+                    if p == INF:
+                        continue
+                    seg = pi ^ pre[t]
+                    v = p if p > seg else seg
+                    if v < best:
+                        best = v
+                        if best == 0:
+                            break
+                cur[i] = best
+            prev = cur
+        return prev[n]

--- a/leetcode_python/Geometry/find-maximum-area-of-a-triangle.py
+++ b/leetcode_python/Geometry/find-maximum-area-of-a-triangle.py
@@ -1,0 +1,88 @@
+"""
+
+3588. Find Maximum Area of a Triangle
+Medium
+
+You are given a 2D array coords of size n x 2, representing the coordinates of n points in an infinite Cartesian plane.
+
+Find twice the maximum area of a triangle with its corners at any three elements from coords, such that at least one side of this triangle is parallel to the x-axis or y-axis. Formally, if the maximum area of such a triangle is A, return 2 * A.
+
+If no such triangle exists, return -1.
+
+Note that a triangle cannot have zero area.
+
+
+Example 1:
+
+Input: coords = [[1,1],[1,2],[3,2],[3,3]]
+Output: 2
+Explanation:
+The triangle with corners (1, 1), (1, 2), and (3, 2) has a base 1 and height 2. Hence its area is 1/2 * base * height = 1.
+
+Example 2:
+
+Input: coords = [[1,1],[2,2],[3,3]]
+Output: -1
+Explanation:
+The only possible triangle has corners (1, 1), (2, 2), and (3, 3). None of its sides are parallel to the x-axis or the y-axis.
+
+
+Constraints:
+
+1 <= n == coords.length <= 10^5
+1 <= coords[i][0], coords[i][1] <= 10^6
+All coords[i] are unique.
+
+"""
+
+# V0
+# IDEA : THE AXIS-PARALLEL SIDE IS THE BASE; THE APEX IS A GLOBAL EXTREME
+#
+#   fix the base as two points sharing a y value; the widest such pair is
+#   always best because 2*area = base_length * height and the two factors
+#   are independent. the height is the vertical distance from that y to the
+#   apex, so the apex should be whichever of the globally smallest or
+#   largest y is further away.
+#
+#   running the same sweep with the two axes swapped covers vertical sides.
+#   grouping by the shared coordinate and keeping only each group's min/max
+#   is all the bookkeeping required.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def maxArea(self, coords):
+        return max(self._scan(coords, 0, 1), self._scan(coords, 1, 0))
+
+    def _scan(self, coords, base_axis, other_axis):
+        # best base_length * height over sides parallel to `base_axis`
+        groups = {}
+        lo = float('inf')
+        hi = float('-inf')
+        for p in coords:
+            b = p[base_axis]
+            o = p[other_axis]
+            if o < lo:
+                lo = o
+            if o > hi:
+                hi = o
+            if o in groups:
+                mn, mx = groups[o]
+                if b < mn:
+                    mn = b
+                if b > mx:
+                    mx = b
+                groups[o] = (mn, mx)
+            else:
+                groups[o] = (b, b)
+
+        best = -1
+        for o, (mn, mx) in groups.items():
+            base = mx - mn
+            if base == 0:
+                continue
+            height = max(o - lo, hi - o)
+            if height > 0:
+                v = base * height
+                if v > best:
+                    best = v
+        return best

--- a/leetcode_python/Graph/maximize-spanning-tree-stability-with-upgrades.py
+++ b/leetcode_python/Graph/maximize-spanning-tree-stability-with-upgrades.py
@@ -1,0 +1,181 @@
+"""
+
+3600. Maximize Spanning Tree Stability with Upgrades
+Hard
+
+You are given an integer n, representing n nodes numbered from 0 to n - 1
+and a list of edges, where edges[i] = [ui, vi, si, musti]:
+
+ui and vi indicates an undirected edge between nodes ui and vi.
+si is the strength of the edge.
+musti is an integer (0 or 1). If musti == 1, the edge must be included in
+the spanning tree. These edges cannot be upgraded.
+
+You are also given an integer k, the maximum number of upgrades you can
+perform. Each upgrade doubles the strength of an edge, and each eligible
+edge (with musti == 0) can be upgraded at most once.
+
+The stability of a spanning tree is defined as the minimum strength score
+among all edges included in it.
+
+Return the maximum possible stability of any valid spanning tree. If it is
+impossible to connect all nodes, return -1.
+
+Note: A spanning tree of a graph with n nodes is a subset of the edges that
+connects all nodes together (i.e. the graph is connected) without forming
+any cycles, and uses exactly n - 1 edges.
+
+
+Example 1:
+
+Input: n = 3, edges = [[0,1,2,1],[1,2,3,0]], k = 1
+Output: 2
+Explanation:
+Edge [0,1] with strength = 2 must be included in the spanning tree.
+Edge [1,2] is optional and can be upgraded from 3 to 6 using one upgrade.
+The resulting spanning tree includes these two edges with strengths 2 and 6.
+The minimum strength in the spanning tree is 2, which is the maximum
+possible stability.
+
+Example 2:
+
+Input: n = 3, edges = [[0,1,4,0],[1,2,3,0],[0,2,1,0]], k = 2
+Output: 6
+Explanation:
+Since all edges are optional and up to k = 2 upgrades are allowed.
+Upgrade edges [0,1] from 4 to 8 and [1,2] from 3 to 6.
+The resulting spanning tree includes these two edges with strengths 8 and 6.
+The minimum strength in the tree is 6, which is the maximum possible
+stability.
+
+Example 3:
+
+Input: n = 3, edges = [[0,1,1,1],[1,2,1,1],[2,0,1,1]], k = 0
+Output: -1
+Explanation:
+All edges are mandatory and form a cycle, which violates the spanning tree
+property of acyclicity. Thus, the answer is -1.
+
+
+Constraints:
+
+2 <= n <= 10^5
+1 <= edges.length <= 10^5
+edges[i] = [ui, vi, si, musti]
+0 <= ui, vi < n
+ui != vi
+1 <= si <= 10^5
+musti is either 0 or 1
+0 <= k <= n
+There are no duplicate edges.
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH THE STABILITY + UNION-FIND FEASIBILITY CHECK
+#
+#   stability is a min over the chosen edges, so the predicate "some valid
+#   spanning tree has stability >= lim" is monotone in lim: a tree good for
+#   lim is good for every smaller lim too. that is the hook for a binary
+#   search — we only need to decide feasibility for a fixed lim.
+#
+#   for a fixed lim an edge is usable in two ways. it is free if its
+#   strength already reaches lim, and it is upgradable if doubling gets it
+#   there (2 * s >= lim) at the price of one of the k upgrades. so the
+#   question becomes: can we span the graph using the free edges plus at
+#   most k upgradable ones?
+#
+#   here the matroid greedy answers exactly: contract every free edge
+#   first, and whatever number of components c survives forces exactly
+#   c - 1 upgraded edges — no ordering of the upgrades can do better, and
+#   any upgradable edge that still merges two components is as good as any
+#   other. so "add all free edges, then spend upgrades on merging edges
+#   until the graph is one component" is optimal, and feasibility is just
+#   "did we end with one component while staying inside k".
+#
+#   two things bound the search. must-edges cannot be upgraded and are
+#   forced into the tree, so the answer can never exceed the smallest
+#   must-edge strength — that is the search's upper end, and it also means
+#   every must-edge is automatically free at any lim we test, so the check
+#   never wastes an upgrade on one. and the search is only meaningful if
+#   the must-edges form a forest (a cycle among them makes a tree
+#   impossible) and the whole graph is connected; both are rejected up
+#   front with -1.
+#
+#   finally, a forest of must-edges inside a connected usable graph can
+#   always be extended to a full spanning tree, so testing plain
+#   connectivity of the usable edges is enough — we never have to build
+#   the tree explicitly.
+#
+# time = O(m * alpha(n) * log(M)), space = O(n)
+class Solution(object):
+    def maxStability(self, n, edges, k):
+
+        def find(p, x):
+            root = x
+            while p[root] != root:
+                root = p[root]
+            while p[x] != root:
+                p[x], x = root, p[x]
+            return root
+
+        def union(p, rank, a, b):
+            ra, rb = find(p, a), find(p, b)
+            if ra == rb:
+                return False
+            if rank[ra] < rank[rb]:
+                ra, rb = rb, ra
+            p[rb] = ra
+            if rank[ra] == rank[rb]:
+                rank[ra] += 1
+            return True
+
+        # must-edges must form a forest, and the graph must be connected
+        p = list(range(n))
+        rank = [0] * n
+        comps = n
+        cap = float("inf")
+        for u, v, s, must in edges:
+            if must:
+                if s < cap:
+                    cap = s
+                if not union(p, rank, u, v):
+                    return -1
+                comps -= 1
+        for u, v, _, _ in edges:
+            if union(p, rank, u, v):
+                comps -= 1
+        if comps > 1:
+            return -1
+
+        def feasible(lim):
+            p = list(range(n))
+            rank = [0] * n
+            comps = n
+            for u, v, s, _ in edges:
+                if s >= lim and union(p, rank, u, v):
+                    comps -= 1
+            if comps == 1:
+                return True
+            left = k
+            for u, v, s, _ in edges:
+                if left == 0:
+                    break
+                if 2 * s >= lim and union(p, rank, u, v):
+                    comps -= 1
+                    left -= 1
+                    if comps == 1:
+                        return True
+            return comps == 1
+
+        # lim = 1 always works: the graph is connected and every s >= 1.
+        # nothing can beat the strongest edge doubled, nor a must-edge.
+        best = 2 * max(e[2] for e in edges)
+        lo, hi = 1, min(cap, best)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if feasible(mid):
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo

--- a/leetcode_python/Graph/minimum-time-to-reach-destination-in-directed-graph.py
+++ b/leetcode_python/Graph/minimum-time-to-reach-destination-in-directed-graph.py
@@ -1,0 +1,116 @@
+"""
+
+3604. Minimum Time to Reach Destination in Directed Graph
+Medium
+
+You are given an integer n and a directed graph with n nodes labeled from 0
+to n - 1. This is represented by a 2D array edges, where
+edges[i] = [ui, vi, starti, endi] indicates an edge from node ui to vi that
+can only be used at any integer time t such that starti <= t <= endi.
+
+You start at node 0 at time 0.
+
+In one unit of time, you can either:
+
+Wait at your current node without moving, or
+Travel along an outgoing edge from your current node if the current time t
+satisfies starti <= t <= endi.
+
+Return the minimum time required to reach node n - 1. If it is impossible,
+return -1.
+
+
+Example 1:
+
+Input: n = 3, edges = [[0,1,0,1],[1,2,2,5]]
+Output: 3
+Explanation:
+The optimal path is:
+At time t = 0, take the edge (0 -> 1) which is available from 0 to 1. You
+arrive at node 1 at time t = 1, then wait until t = 2.
+At time t = 2, take the edge (1 -> 2) which is available from 2 to 5. You
+arrive at node 2 at time 3.
+Hence, the minimum time to reach node 2 is 3.
+
+Example 2:
+
+Input: n = 4, edges = [[0,1,0,3],[1,3,7,8],[0,2,1,5],[2,3,4,7]]
+Output: 5
+Explanation:
+The optimal path is:
+Wait at node 0 until time t = 1, then take the edge (0 -> 2) which is
+available from 1 to 5. You arrive at node 2 at t = 2.
+Wait at node 2 until time t = 4, then take the edge (2 -> 3) which is
+available from 4 to 7. You arrive at node 3 at t = 5.
+Hence, the minimum time to reach node 3 is 5.
+
+Example 3:
+
+Input: n = 3, edges = [[1,0,1,3],[1,2,3,5]]
+Output: -1
+Explanation:
+Since there is no outgoing edge from node 0, it is impossible to reach node
+2. Hence, the output is -1.
+
+
+Constraints:
+
+1 <= n <= 10^5
+0 <= edges.length <= 10^5
+edges[i] == [ui, vi, starti, endi]
+0 <= ui, vi <= n - 1
+ui != vi
+0 <= starti <= endi <= 10^9
+
+"""
+
+# V0
+# IDEA : DIJKSTRA ON EARLIEST ARRIVAL TIME
+#
+#   the key observation is that arriving at a node earlier is never worse.
+#   waiting is always allowed and free, so any plan that works from node u
+#   at time t also works from u at any time t' < t — you just idle until t.
+#   that makes "earliest arrival time" a well-defined label per node, and
+#   an optimal answer is built from optimal sub-answers.
+#
+#   with that, the relaxation for an edge (u -> v) usable in [s, e] from
+#   arrival time t at u is: the earliest moment we may *depart* is
+#   max(t, s), which is legal only while it stays <= e; departing then
+#   lands us at v at max(t, s) + 1. this is a monotone, non-decreasing
+#   edge rule (the new label is always > the old one), which is exactly
+#   the condition dijkstra needs — so a min-heap over arrival times pops
+#   each node with its final value.
+#
+#   note the availability window makes the effective edge weight depend on
+#   the current time, so a plain BFS or a fixed-weight shortest path will
+#   not do; but since waiting only ever costs time and never unlocks
+#   anything an earlier departure could not reach, greedy still holds.
+#
+# time = O((V + E) * log(V)), space = O(V + E)
+class Solution(object):
+    def minTime(self, n, edges):
+        import heapq
+
+        g = [[] for _ in range(n)]
+        for u, v, s, e in edges:
+            g[u].append((v, s, e))
+
+        INF = float("inf")
+        dist = [INF] * n
+        dist[0] = 0
+        pq = [(0, 0)]
+        while pq:
+            t, u = heapq.heappop(pq)
+            if t > dist[u]:
+                continue
+            if u == n - 1:
+                return t
+            for v, s, e in g[u]:
+                if t > e:
+                    continue
+                nt = (s if s > t else t) + 1
+                if nt < dist[v]:
+                    dist[v] = nt
+                    heapq.heappush(pq, (nt, v))
+
+        return -1

--- a/leetcode_python/Graph/minimum-time-to-transport-all-individuals.py
+++ b/leetcode_python/Graph/minimum-time-to-transport-all-individuals.py
@@ -1,0 +1,182 @@
+"""
+
+3594. Minimum Time to Transport All Individuals
+Hard
+
+You are given n individuals at a base camp who need to cross a river to reach a
+destination using a single boat. The boat can carry at most k people at a time.
+The trip is affected by environmental conditions that vary cyclically over m
+stages.
+
+Each stage j has a speed multiplier mul[j]:
+
+If mul[j] > 1, the trip slows down.
+If mul[j] < 1, the trip speeds up.
+
+Each individual i has a rowing strength represented by time[i], the time (in
+minutes) it takes them to cross alone in neutral conditions.
+
+Rules:
+
+A group g departing at stage j takes time equal to the maximum time[i] among
+its members, multiplied by mul[j] minutes to reach the destination.
+After the group crosses the river in time d, the stage advances by
+floor(d) % m steps.
+If individuals are left behind, one person must return with the boat. Let r be
+the index of the returning person, the return takes time[r] x mul[current_stage],
+defined as return_time, and the stage advances by floor(return_time) % m steps.
+
+Return the minimum total time required to transport all individuals. If it is
+not possible to transport all individuals to the destination, return -1.
+
+
+Example 1:
+
+Input: n = 1, k = 1, m = 2, time = [5], mul = [1.0,1.3]
+Output: 5.00000
+Explanation:
+Individual 0 departs from stage 0, so crossing time = 5 x 1.00 = 5.00 minutes.
+All team members are now at the destination. Thus, the total time taken is
+5.00 minutes.
+
+Example 2:
+
+Input: n = 3, k = 2, m = 3, time = [2,5,8], mul = [1.0,1.5,0.75]
+Output: 14.50000
+Explanation:
+The optimal strategy is:
+Send individuals 0 and 2 from the base camp to the destination from stage 0.
+The crossing time is max(2, 8) x mul[0] = 8 x 1.00 = 8.00 minutes. The stage
+advances by floor(8.00) % 3 = 2, so the next stage is (0 + 2) % 3 = 2.
+Individual 0 returns alone from the destination to the base camp from stage 2.
+The return time is 2 x mul[2] = 2 x 0.75 = 1.50 minutes. The stage advances by
+floor(1.50) % 3 = 1, so the next stage is (2 + 1) % 3 = 0.
+Send individuals 0 and 1 from the base camp to the destination from stage 0.
+The crossing time is max(2, 5) x mul[0] = 5 x 1.00 = 5.00 minutes. The stage
+advances by floor(5.00) % 3 = 2, so the final stage is (0 + 2) % 3 = 2.
+All team members are now at the destination. The total time taken is
+8.00 + 1.50 + 5.00 = 14.50 minutes.
+
+Example 3:
+
+Input: n = 2, k = 1, m = 2, time = [10,10], mul = [2.0,2.0]
+Output: -1.00000
+Explanation:
+Since the boat can only carry one person at a time, it is impossible to
+transport both individuals as one must always return. Thus, the answer is
+-1.00.
+
+
+Constraints:
+
+1 <= n == time.length <= 12
+1 <= k <= 5
+1 <= m <= 5
+1 <= time[i] <= 100
+m == mul.length
+0.5 <= mul[i] <= 2.0
+
+"""
+
+# V0
+# IDEA : DIJKSTRA OVER (CAMP BITMASK, STAGE, BOAT SIDE)
+#
+#   everything the future depends on is captured by three things: who is still
+#   at the base camp, which stage the cycle is in, and which bank the boat is
+#   on. names of the people already across never matter beyond "they are
+#   available to row back", and that is exactly the complement of the camp
+#   mask. so the state graph has only 2^n * m * 2 vertices — at most 40960.
+#
+#   modelling the crossing and the return as two separate edges rather than one
+#   combined move is what keeps the graph small. a combined move would have to
+#   enumerate (group, returner) pairs together, multiplying the two choices;
+#   split apart, the crossing edges cost sum(2^|S|) over the reachable masks and
+#   the return edges cost only n per state.
+#
+#   every edge has strictly positive weight, since time[i] >= 1 and mul >= 0.5,
+#   so dijkstra is valid and the first time the goal is popped the distance is
+#   final. the goal is an empty camp with the boat on the far side, which is
+#   precisely the moment no return is owed. if the goal is never popped the
+#   configuration is unreachable and the answer is -1 — this is what happens for
+#   k == 1 and n >= 2, where every crossing is undone by the forced return.
+#
+#   only the maximum time in a group is charged, so a group is summarised by
+#   that maximum; it is precomputed for all 2^n masks by peeling off the lowest
+#   set bit.
+#
+# time = O(3^n * m * log(2^n * m)), space = O(3^n)
+import heapq
+
+
+class Solution(object):
+    def minTime(self, n, k, m, time, mul):
+        size = 1 << n
+        full = size - 1
+
+        popcount = [0] * size
+        gmax = [0] * size
+        for mask in range(1, size):
+            low = mask & -mask
+            rest = mask ^ low
+            i = low.bit_length() - 1
+            popcount[mask] = popcount[rest] + 1
+            gmax[mask] = time[i] if time[i] > gmax[rest] else gmax[rest]
+
+        # boarding parties of a camp mask, cached because each mask is popped
+        # once per stage
+        parties = [None] * size
+
+        def groups(mask):
+            gs = parties[mask]
+            if gs is None:
+                gs = []
+                sub = mask
+                while sub:
+                    if popcount[sub] <= k:
+                        gs.append(sub)
+                    sub = (sub - 1) & mask
+                parties[mask] = gs
+            return gs
+
+        # state id = (mask * m + stage) * 2 + side, side 0 = boat at the camp
+        INF = float('inf')
+        best = [INF] * (size * m * 2)
+        start = (full * m) * 2
+        best[start] = 0.0
+        pq = [(0.0, start)]
+
+        while pq:
+            d, s = heapq.heappop(pq)
+            if d > best[s]:
+                continue
+            side = s & 1
+            stage = (s >> 1) % m
+            mask = (s >> 1) // m
+
+            # an empty camp with the boat across is the goal, and dijkstra has
+            # already settled its distance
+            if side == 1 and mask == 0:
+                return d
+
+            if side == 0:
+                for grp in groups(mask):
+                    cost = gmax[grp] * mul[stage]
+                    nxt_stage = (stage + int(cost)) % m
+                    nxt_mask = mask ^ grp
+                    t = (((nxt_mask * m) + nxt_stage) << 1) | 1
+                    if d + cost < best[t]:
+                        best[t] = d + cost
+                        heapq.heappush(pq, (d + cost, t))
+            else:
+                across = full ^ mask
+                while across:
+                    low = across & -across
+                    across ^= low
+                    r = low.bit_length() - 1
+                    cost = time[r] * mul[stage]
+                    nxt_stage = (stage + int(cost)) % m
+                    t = ((mask | low) * m + nxt_stage) << 1
+                    if d + cost < best[t]:
+                        best[t] = d + cost
+                        heapq.heappush(pq, (d + cost, t))
+        return -1.0

--- a/leetcode_python/Graph/network-recovery-pathways.py
+++ b/leetcode_python/Graph/network-recovery-pathways.py
@@ -1,0 +1,156 @@
+"""
+
+3620. Network Recovery Pathways
+Hard
+
+You are given a directed acyclic graph of n nodes numbered from 0 to n - 1.
+This is represented by a 2D array edges of length m, where
+edges[i] = [ui, vi, costi] indicates a one-way communication from node ui to
+node vi with a recovery cost of costi.
+
+Some nodes may be offline. You are given a boolean array online where
+online[i] = true means node i is online. Nodes 0 and n - 1 are always online.
+
+A path from 0 to n - 1 is valid if:
+
+All intermediate nodes on the path are online.
+The total recovery cost of all edges on the path does not exceed k.
+
+For each valid path, define its score as the minimum edge-cost along that path.
+
+Return the maximum path score (i.e., the largest minimum-edge cost) among all
+valid paths. If no valid path exists, return -1.
+
+
+Example 1:
+
+Input: edges = [[0,1,5],[1,3,10],[0,2,3],[2,3,4]],
+       online = [true,true,true,true], k = 10
+Output: 3
+Explanation:
+The graph has two possible routes from node 0 to node 3:
+1. Path 0 -> 1 -> 3
+   Total cost = 5 + 10 = 15, which exceeds k (15 > 10), so this path is
+   invalid.
+2. Path 0 -> 2 -> 3
+   Total cost = 3 + 4 = 7 <= k, so this path is valid.
+   The minimum edge-cost along this path is min(3, 4) = 3.
+There are no other valid paths. Hence, the maximum among all valid path-scores
+is 3.
+
+Example 2:
+
+Input: edges = [[0,1,7],[1,4,5],[0,2,6],[2,3,6],[3,4,2],[2,4,6]],
+       online = [true,true,true,false,true], k = 12
+Output: 6
+Explanation:
+Node 3 is offline, so any path passing through 3 is invalid.
+Consider the remaining routes from 0 to 4:
+1. Path 0 -> 1 -> 4
+   Total cost = 7 + 5 = 12 <= k, so this path is valid.
+   The minimum edge-cost along this path is min(7, 5) = 5.
+2. Path 0 -> 2 -> 3 -> 4
+   Node 3 is offline, so this path is invalid regardless of cost.
+3. Path 0 -> 2 -> 4
+   Total cost = 6 + 6 = 12 <= k, so this path is valid.
+   The minimum edge-cost along this path is min(6, 6) = 6.
+Among the two valid paths, their scores are 5 and 6. Therefore, the answer
+is 6.
+
+
+Constraints:
+
+n == online.length
+2 <= n <= 5 * 10^4
+0 <= m == edges.length <= min(10^5, n * (n - 1) / 2)
+edges[i] = [ui, vi, costi]
+0 <= ui, vi < n
+ui != vi
+0 <= costi <= 10^9
+0 <= k <= 5 * 10^13
+online[i] is either true or false, and both online[0] and online[n - 1] are
+true.
+The given graph is a directed acyclic graph.
+
+"""
+
+# V0
+# IDEA : BINARY SEARCH THE SCORE + CHEAPEST PATH ON THE DAG
+#
+#   the two requirements pull in opposite directions: the score wants big
+#   edges, the budget wants a small total. that is the classic signal to fix
+#   the score and only check feasibility.
+#
+#   say we demand a score of at least `mid`. then every edge cheaper than
+#   `mid` is simply unusable, and what is left is a plain question — is the
+#   cheapest 0 -> n-1 path in the surviving graph within budget k? if yes,
+#   that path's minimum edge is >= mid, so the answer is >= mid. if the
+#   cheapest path already blows the budget, no other path can fit either.
+#   so `feasible(mid)` is exactly "answer >= mid", which is monotone, and a
+#   binary search over the distinct edge costs lands on the answer.
+#
+#   the graph is a DAG, so the cheapest path needs no dijkstra: relax the
+#   edges once in topological order and every node is finalised when it is
+#   reached. the topological order does not depend on `mid`, so it is built
+#   once outside the search and each check costs a single O(n + m) sweep.
+#
+#   offline nodes are dropped up front by deleting every edge touching one —
+#   that is enough, because a node only ever appears on a path as an
+#   endpoint of some edge, and nodes 0 and n-1 are guaranteed online.
+#
+# time = O((n + m) * log m), space = O(n + m)
+class Solution(object):
+    def findMaxPathScore(self, edges, online, k):
+        n = len(online)
+
+        adj = [[] for _ in range(n)]
+        indeg = [0] * n
+        costs = set()
+        for u, v, w in edges:
+            if not online[u] or not online[v]:
+                continue
+            adj[u].append((v, w))
+            indeg[v] += 1
+            costs.add(w)
+
+        if not costs:
+            return -1
+
+        # topological order of the surviving DAG (built once)
+        order = []
+        stack = [i for i in range(n) if indeg[i] == 0]
+        while stack:
+            u = stack.pop()
+            order.append(u)
+            for v, _ in adj[u]:
+                indeg[v] -= 1
+                if indeg[v] == 0:
+                    stack.append(v)
+
+        INF = float('inf')
+        target = n - 1
+
+        def feasible(mid):
+            dist = [INF] * n
+            dist[0] = 0
+            for u in order:
+                du = dist[u]
+                if du > k:
+                    continue
+                for v, w in adj[u]:
+                    if w >= mid and du + w < dist[v]:
+                        dist[v] = du + w
+            return dist[target] <= k
+
+        cand = sorted(costs)
+        if not feasible(cand[0]):
+            return -1
+
+        lo, hi = 0, len(cand) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if feasible(cand[mid]):
+                lo = mid
+            else:
+                hi = mid - 1
+        return cand[lo]

--- a/leetcode_python/Greedy/minimum-adjacent-swaps-to-alternate-parity.py
+++ b/leetcode_python/Greedy/minimum-adjacent-swaps-to-alternate-parity.py
@@ -1,0 +1,92 @@
+"""
+
+3587. Minimum Adjacent Swaps to Alternate Parity
+Medium
+
+You are given an array nums of distinct integers.
+
+In one operation, you can swap any two adjacent elements in the array.
+
+An arrangement of the array is considered valid if the parity of adjacent elements alternates, meaning every pair of neighboring elements consists of one even and one odd number.
+
+Return the minimum number of adjacent swaps required to transform nums into any valid arrangement.
+
+If it is impossible to rearrange nums such that no two adjacent elements have the same parity, return -1.
+
+
+Example 1:
+
+Input: nums = [2,4,6,5,7]
+Output: 3
+Explanation:
+Swapping 5 and 6, the array becomes [2,4,5,6,7]
+Swapping 5 and 4, the array becomes [2,5,4,6,7]
+Swapping 6 and 7, the array becomes [2,5,4,7,6]. The array is now a valid
+arrangement. Thus, the answer is 3.
+
+Example 2:
+
+Input: nums = [2,4,5,7]
+Output: 1
+Explanation:
+By swapping 4 and 5, the array becomes [2,5,4,7], which is a valid
+arrangement. Thus, the answer is 1.
+
+Example 3:
+
+Input: nums = [1,2,3]
+Output: 0
+Explanation:
+The array is already a valid arrangement. Thus, no operations are needed.
+
+Example 4:
+
+Input: nums = [4,5,6,8]
+Output: -1
+Explanation:
+No valid arrangement is possible. Thus, the answer is -1.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+1 <= nums[i] <= 10^9
+All elements in nums are distinct.
+
+"""
+
+# V0
+# IDEA : ADJACENT SWAPS = SUM OF |CURRENT INDEX - TARGET INDEX| PER PARITY CLASS
+#
+#   swapping neighbours never reorders two numbers of the same parity
+#   relative to each other in an optimal solution, so the k-th even number
+#   stays the k-th even number. once the starting parity is fixed the target
+#   slots are forced (0, 2, 4, ... for one class), and the minimum number of
+#   adjacent swaps equals the sum of displacements of just one class — the
+#   other class's displacements are the mirror image of the same swaps.
+#
+#   a valid arrangement exists only when the two counts differ by at most 1,
+#   and the majority class must own the even-numbered slots.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def minSwaps(self, nums):
+        odd = []
+        even = []
+        for i, v in enumerate(nums):
+            if v & 1:
+                odd.append(i)
+            else:
+                even.append(i)
+        if abs(len(odd) - len(even)) > 1:
+            return -1
+
+        def cost(pos):
+            return sum(abs(p - 2 * t) for t, p in enumerate(pos))
+
+        best = float('inf')
+        if len(odd) >= len(even):
+            best = min(best, cost(odd))
+        if len(even) >= len(odd):
+            best = min(best, cost(even))
+        return best

--- a/leetcode_python/Greedy/transform-array-to-all-equal-elements.py
+++ b/leetcode_python/Greedy/transform-array-to-all-equal-elements.py
@@ -1,0 +1,73 @@
+"""
+
+3576. Transform Array to All Equal Elements
+Medium
+
+You are given an integer array nums of size n containing only 1 and -1, and an integer k.
+
+You can perform the following operation at most k times:
+
+Choose an index i (0 <= i < n - 1), and multiply both nums[i] and nums[i + 1] by -1.
+
+Note that you can choose the same index i more than once in different operations.
+
+Return true if it is possible to make all elements of the array equal after at most k operations, and false otherwise.
+
+
+Example 1:
+
+Input: nums = [1,-1,1,-1,1], k = 3
+Output: True
+Explanation:
+We can make all elements in the array equal in 2 operations as follows:
+Choose index i = 1, and multiply both nums[1] and nums[2] by -1. Now nums = [1,1,-1,-1,1].
+Choose index i = 2, and multiply both nums[2] and nums[3] by -1. Now nums = [1,1,1,1,1].
+
+Example 2:
+
+Input: nums = [-1,-1,-1,1,1,1], k = 5
+Output: False
+Explanation:
+It is not possible to make all elements equal in at most 5 operations.
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^5
+nums[i] is either -1 or 1.
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : LEFT-TO-RIGHT FORCED SWEEP, ONE TARGET SIGN AT A TIME
+#
+#   index 0 can only ever be touched by the operation at i = 0, so once we
+#   fix the target sign the decision at every position is forced: if
+#   nums[i] already differs from the target, the operation at i must be
+#   applied (and applying it twice is pointless). that makes the number of
+#   operations for a given target unique — no search needed.
+#
+#   after the sweep the last element is whatever it is; if it does not match
+#   the target the sign is unreachable.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def canMakeEqual(self, nums, k):
+        n = len(nums)
+
+        def cost(target):
+            flip = 1
+            used = 0
+            for i in range(n - 1):
+                v = nums[i] * flip
+                if v != target:
+                    used += 1
+                    if used > k:
+                        return None
+                    flip = -1
+                else:
+                    flip = 1
+            return used if nums[n - 1] * flip == target else None
+
+        return cost(1) is not None or cost(-1) is not None

--- a/leetcode_python/Hash_table/check-if-any-element-has-prime-frequency.py
+++ b/leetcode_python/Hash_table/check-if-any-element-has-prime-frequency.py
@@ -1,0 +1,67 @@
+"""
+
+3591. Check if Any Element Has Prime Frequency
+Easy
+
+You are given an integer array nums.
+
+Return true if the frequency of any element of the array is prime, otherwise, return false.
+
+The frequency of an element x is the number of times it occurs in the array.
+
+A prime number is a natural number greater than 1 with only two factors, 1 and itself.
+
+
+Example 1:
+
+Input: nums = [1,2,3,4,5,4]
+Output: True
+Explanation:
+4 appears 2 times. 2 is a prime number.
+
+Example 2:
+
+Input: nums = [1,2,3,4,5]
+Output: False
+Explanation:
+All elements appear only once. 1 is not a prime number.
+
+Example 3:
+
+Input: nums = [2,2,2,4,4]
+Output: True
+Explanation:
+Both 2 and 4 appear 3 and 2 times respectively. Both 3 and 2 are prime numbers.
+
+
+Constraints:
+
+1 <= nums.length <= 100
+0 <= nums[i] <= 100
+
+"""
+
+# V0
+# IDEA : COUNT, THEN TRIAL-DIVIDE THE COUNTS
+#
+#   frequencies are bounded by the array length (100 here), so a plain
+#   trial-division primality test on each distinct frequency is more than
+#   fast enough — no sieve or caching needed.
+#
+# time = O(n * sqrt(n)), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def checkPrimeFrequency(self, nums):
+        def is_prime(x):
+            if x < 2:
+                return False
+            d = 2
+            while d * d <= x:
+                if x % d == 0:
+                    return False
+                d += 1
+            return True
+
+        return any(is_prime(c) for c in Counter(nums).values())

--- a/leetcode_python/Hash_table/count-odd-letters-from-number.py
+++ b/leetcode_python/Hash_table/count-odd-letters-from-number.py
@@ -1,0 +1,72 @@
+"""
+
+3581. Count Odd Letters from Number
+Easy
+
+You are given an integer n perform the following steps:
+
+Convert each digit of n into its lowercase English word (e.g., 4 -> "four",
+1 -> "one").
+Concatenate those words in the original digit order to form a string s.
+
+Return the number of distinct characters in s that appear an odd number of
+times.
+
+
+Example 1:
+
+Input: n = 41
+Output: 5
+Explanation:
+41 -> "fourone"
+Characters with odd frequencies: 'f', 'u', 'r', 'n', 'e'. Thus, the answer
+is 5.
+
+Example 2:
+
+Input: n = 20
+Output: 5
+Explanation:
+20 -> "twozero"
+Characters with odd frequencies: 't', 'w', 'z', 'e', 'r'. Thus, the answer
+is 5.
+
+
+Constraints:
+
+1 <= n <= 10^9
+
+"""
+
+# V0
+# IDEA : XOR PARITY MASK OVER THE 26 LETTERS
+#
+#   only the parity of each letter's count matters, never the count itself,
+#   so a single bit per letter is enough state. toggling that bit on every
+#   occurrence leaves it at 1 exactly when the letter appeared an odd number
+#   of times.
+#
+#   this also removes the need to build the concatenated string at all —
+#   digits can be consumed straight off n, and the order in which they are
+#   consumed is irrelevant because xor is commutative. the answer is then
+#   just the number of set bits in the mask.
+#
+# time = O(log n), space = O(1)
+class Solution(object):
+    def countOddLetters(self, n):
+        words = [
+            "zero", "one", "two", "three", "four",
+            "five", "six", "seven", "eight", "nine",
+        ]
+
+        mask = 0
+        while n:
+            for c in words[n % 10]:
+                mask ^= 1 << (ord(c) - ord('a'))
+            n //= 10
+
+        cnt = 0
+        while mask:
+            mask &= mask - 1
+            cnt += 1
+        return cnt

--- a/leetcode_python/Hash_table/count-special-triplets.py
+++ b/leetcode_python/Hash_table/count-special-triplets.py
@@ -1,0 +1,87 @@
+"""
+
+3583. Count Special Triplets
+Medium
+
+You are given an integer array nums.
+
+A special triplet is defined as a triplet of indices (i, j, k) satisfying:
+
+0 <= i < j < k < n, where n = nums.length
+nums[i] == nums[j] * 2
+nums[k] == nums[j] * 2
+
+Return the total number of special triplets in the array.
+
+Since the answer may be large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: nums = [6,3,6]
+Output: 1
+Explanation:
+The only special triplet is (i, j, k) = (0, 1, 2), where:
+nums[0] = 6, nums[1] = 3, nums[2] = 6
+nums[0] = nums[1] * 2 = 6
+nums[2] = nums[1] * 2 = 6
+
+Example 2:
+
+Input: nums = [0,1,0,0]
+Output: 1
+Explanation:
+The only special triplet is (i, j, k) = (0, 2, 3), where:
+nums[0] = 0, nums[2] = 0, nums[3] = 0
+nums[0] = nums[2] * 2 = 0
+nums[3] = nums[2] * 2 = 0
+
+Example 3:
+
+Input: nums = [8,4,2,8,4]
+Output: 2
+Explanation:
+There are exactly 2 special triplets:
+(i, j, k) = (0, 1, 3)
+nums[0] = 8, nums[1] = 4, nums[3] = 8
+nums[0] = nums[1] * 2 = 8
+nums[3] = nums[1] * 2 = 8
+(i, j, k) = (1, 2, 4)
+nums[1] = 4, nums[2] = 2, nums[4] = 4
+nums[1] = nums[2] * 2 = 4
+nums[4] = nums[2] * 2 = 4
+
+
+Constraints:
+
+3 <= n == nums.length <= 10^5
+0 <= nums[i] <= 10^5
+
+"""
+
+# V0
+# IDEA : FIX THE MIDDLE INDEX AND MULTIPLY THE TWO SIDE COUNTS
+#
+#   both outer elements have to equal 2 * nums[j], and the two choices are
+#   completely independent once j is pinned down. so sweeping j left to
+#   right while maintaining a counter of everything strictly left of j and a
+#   counter of everything strictly right of j turns the whole thing into one
+#   multiplication per position.
+#
+# time = O(n), space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def specialTriplets(self, nums):
+        MOD = 10 ** 9 + 7
+        n = len(nums)
+        left = Counter()
+        right = Counter(nums)
+        ans = 0
+        for j in range(n):
+            right[nums[j]] -= 1
+            target = nums[j] * 2
+            ans += left[target] * right[target]
+            left[nums[j]] += 1
+        return ans % MOD

--- a/leetcode_python/Hash_table/maximize-ysum-by-picking-a-triplet-of-distinct-xvalues.py
+++ b/leetcode_python/Hash_table/maximize-ysum-by-picking-a-triplet-of-distinct-xvalues.py
@@ -1,0 +1,61 @@
+"""
+
+3572. Maximize Y-Sum by Picking a Triplet of Distinct X-Values
+Medium
+
+You are given two integer arrays x and y, each of length n. You must choose three distinct indices i, j, and k such that:
+
+x[i] != x[j]
+x[j] != x[k]
+x[k] != x[i]
+
+Your goal is to maximize the value of y[i] + y[j] + y[k] under these conditions. Return the maximum possible sum that can be obtained by choosing such a triplet of indices.
+
+If no such triplet exists, return -1.
+
+
+Example 1:
+
+Input: x = [1,2,1,3,2], y = [5,3,4,6,2]
+Output: 14
+Explanation:
+Choose i = 0 (x[i] = 1, y[i] = 5), j = 1 (x[j] = 2, y[j] = 3), k = 3 (x[k] = 3, y[k] = 6).
+All three values chosen from x are distinct. 5 + 3 + 6 = 14 is the maximum we can obtain. Hence, the output is 14.
+
+Example 2:
+
+Input: x = [1,2,1,2], y = [4,5,6,7]
+Output: -1
+Explanation:
+There are only two distinct values in x. Hence, the output is -1.
+
+
+Constraints:
+
+n == x.length == y.length
+3 <= n <= 10^5
+1 <= x[i], y[i] <= 10^6
+
+"""
+
+# V0
+# IDEA : KEEP ONLY THE BEST Y PER DISTINCT X, THEN TAKE THE TOP THREE
+#
+#   the constraint only forbids reusing an x value, so for a given x value
+#   there is never a reason to pick anything but its largest y — swapping in
+#   the largest y keeps the triplet legal and can only raise the sum.
+#
+#   after that collapse the problem is "sum of the three largest numbers",
+#   and it is impossible exactly when fewer than three distinct x values exist.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def maxSumDistinctTriplet(self, x, y):
+        best = {}
+        for xi, yi in zip(x, y):
+            if xi not in best or best[xi] < yi:
+                best[xi] = yi
+        if len(best) < 3:
+            return -1
+        top = sorted(best.values(), reverse=True)[:3]
+        return sum(top)

--- a/leetcode_python/Math/check-divisibility-by-digit-sum-and-product.py
+++ b/leetcode_python/Math/check-divisibility-by-digit-sum-and-product.py
@@ -1,0 +1,58 @@
+"""
+
+3622. Check Divisibility by Digit Sum and Product
+Easy
+
+You are given a positive integer n. Determine whether n is divisible by the sum
+of the following two values:
+
+The digit sum of n (the sum of its digits).
+The digit product of n (the product of its digits).
+
+Return true if n is divisible by this sum; otherwise, return false.
+
+
+Example 1:
+
+Input: n = 99
+Output: true
+Explanation:
+Since 99 is divisible by the sum (9 + 9 = 18) plus product (9 * 9 = 81) of its
+digits (total 99), the output is true.
+
+Example 2:
+
+Input: n = 23
+Output: false
+Explanation:
+Since 23 is not divisible by the sum (2 + 3 = 5) plus product (2 * 3 = 6) of its
+digits (total 11), the output is false.
+
+
+Constraints:
+
+1 <= n <= 10^6
+
+"""
+
+# V0
+# IDEA : DIGIT SCAN
+#
+#   nothing subtle here: peel the decimal digits off with divmod, accumulate
+#   the sum and the product as we go, then test one divisibility.
+#
+#   the only value worth thinking about is the divisor s + p. n >= 1 so it
+#   has at least one digit, and its leading digit is non-zero, hence s >= 1
+#   and s + p >= 1 — the modulo can never divide by zero even when some digit
+#   is 0 and drags the product down to 0.
+#
+# time = O(log n), space = O(1)
+class Solution(object):
+    def checkDivisibility(self, n):
+        s, p = 0, 1
+        x = n
+        while x:
+            x, d = divmod(x, 10)
+            s += d
+            p *= d
+        return n % (s + p) == 0

--- a/leetcode_python/Math/count-number-of-trapezoids-i.py
+++ b/leetcode_python/Math/count-number-of-trapezoids-i.py
@@ -1,0 +1,80 @@
+"""
+
+3623. Count Number of Trapezoids I
+Medium
+
+You are given a 2D integer array points, where points[i] = [xi, yi] represents
+the coordinates of the ith point on the Cartesian plane.
+
+A horizontal trapezoid is a convex quadrilateral with at least one pair of
+horizontal sides (i.e. parallel to the x-axis). Two lines are parallel if and
+only if they have the same slope.
+
+Return the number of unique horizontal trapezoids that can be formed by
+choosing any four distinct points from points.
+
+Since the answer may be very large, return it modulo 10^9 + 7.
+
+
+Example 1:
+
+Input: points = [[1,0],[2,0],[3,0],[2,2],[3,2]]
+Output: 3
+Explanation:
+There are three distinct ways to pick four points that form a horizontal
+trapezoid:
+Using points [1,0], [2,0], [3,2], and [2,2].
+Using points [2,0], [3,0], [3,2], and [2,2].
+Using points [1,0], [3,0], [3,2], and [2,2].
+
+Example 2:
+
+Input: points = [[0,0],[1,0],[0,1],[2,1]]
+Output: 1
+Explanation:
+There is only one horizontal trapezoid that can be formed.
+
+
+Constraints:
+
+4 <= points.length <= 10^5
+-10^8 <= xi, yi <= 10^8
+All points are pairwise distinct.
+
+"""
+
+# V0
+# IDEA : COUNT HORIZONTAL SEGMENTS PER ROW, THEN PAIR ACROSS ROWS
+#
+#   a horizontal side is just two points sharing a y. so bucket the points by
+#   y: a row holding v points contributes C(v, 2) candidate horizontal sides.
+#
+#   now pick one side from row y1 and one from a different row y2. the four
+#   points are automatically distinct, and automatically in convex position —
+#   the horizontal line y = y1 meets the triangle of the other three points in
+#   a single point, so nothing can sit inside the others. hence every such
+#   pair really is a horizontal trapezoid, and the count is just the product
+#   of the two rows' side counts.
+#
+#   no double counting is possible: from the 4-point set the split back into
+#   the two sides is forced (2 points per row), and a quadrilateral cannot own
+#   two *different* pairs of horizontal sides — that would make all four sides
+#   parallel. so a single running prefix sum s of "sides seen so far" gives
+#   every cross-row pair exactly once.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def countTrapezoids(self, points):
+        MOD = 10 ** 9 + 7
+
+        cnt = {}
+        for _, y in points:
+            cnt[y] = cnt.get(y, 0) + 1
+
+        ans = 0
+        s = 0
+        for v in cnt.values():
+            t = v * (v - 1) // 2
+            ans = (ans + s * t) % MOD
+            s += t
+        return ans

--- a/leetcode_python/Math/count-number-of-trapezoids-ii.py
+++ b/leetcode_python/Math/count-number-of-trapezoids-ii.py
@@ -1,0 +1,120 @@
+"""
+
+3625. Count Number of Trapezoids II
+Hard
+
+You are given a 2D integer array points where points[i] = [xi, yi] represents
+the coordinates of the ith point on the Cartesian plane.
+
+Return the number of unique trapezoids that can be formed by choosing any four
+distinct points from points.
+
+A trapezoid is a convex quadrilateral with at least one pair of parallel sides.
+Two lines are parallel if and only if they have the same slope.
+
+
+Example 1:
+
+Input: points = [[-3,2],[3,0],[2,3],[3,2],[2,-3]]
+Output: 2
+Explanation:
+There are two distinct ways to pick four points that form a trapezoid:
+The points [-3,2], [2,3], [3,2], [2,-3] form one trapezoid.
+The points [2,3], [3,2], [3,0], [2,-3] form another trapezoid.
+
+Example 2:
+
+Input: points = [[0,0],[1,0],[0,1],[2,1]]
+Output: 1
+Explanation:
+There is only one trapezoid which can be formed.
+
+
+Constraints:
+
+4 <= points.length <= 500
+-1000 <= xi, yi <= 1000
+All points are pairwise distinct.
+
+"""
+
+# V0
+# IDEA : PAIR UP PARALLEL SEGMENTS, THEN UNDO THE PARALLELOGRAM DOUBLE COUNT
+#
+#   take any two segments that are parallel but lie on *different* lines.
+#   two points sit on each of two distinct parallel lines, so the four points
+#   are distinct and in convex position (a line meets the triangle of the
+#   other three in one point, so none can be interior). their hull is exactly
+#   a trapezoid whose parallel sides are those two segments. so every such
+#   segment pair yields one trapezoid, and conversely every trapezoid arises
+#   from a pair of its parallel sides.
+#
+#   the map is not quite a bijection. a convex quadrilateral has three ways to
+#   split its 4 vertices into two segments: the two pairs of opposite sides
+#   and the pair of diagonals. diagonals cross, so they are never parallel;
+#   therefore a quadrilateral is generated once if it has one pair of parallel
+#   sides, and twice if it has two — i.e. exactly when it is a parallelogram.
+#   subtract the parallelograms once and every trapezoid is counted once.
+#
+#   parallelograms are counted by the diagonal property: the diagonals bisect
+#   each other, so a parallelogram is exactly an unordered pair of segments
+#   sharing a midpoint and having different directions. (same midpoint plus
+#   same direction means the two segments are collinear — a degenerate flat
+#   figure, correctly excluded.) no 4-point set is hit twice here either: if
+#   A+B = C+D and A+C = B+D then B = C.
+#
+#   everything is kept in exact integers — direction reduced by gcd with a
+#   canonical sign, line id = dy*x - dx*y, midpoint id = (x1+x2, y1+y2) —
+#   so no float slope ever has to be compared for equality.
+#
+# time = O(n^2), space = O(n^2)
+class Solution(object):
+    def countTrapezoids(self, points):
+        def norm(dx, dy):
+            a, b = abs(dx), abs(dy)
+            while b:
+                a, b = b, a % b
+            g = a
+            dx //= g
+            dy //= g
+            if dx < 0 or (dx == 0 and dy < 0):
+                dx, dy = -dx, -dy
+            return dx, dy
+
+        n = len(points)
+
+        by_dir = {}   # direction -> {line id: how many segments on that line}
+        by_mid = {}   # midpoint  -> {direction: how many segments}
+
+        for i in range(n):
+            x1, y1 = points[i]
+            for j in range(i):
+                x2, y2 = points[j]
+                dx, dy = norm(x2 - x1, y2 - y1)
+
+                line = dy * x1 - dx * y1
+                d = by_dir.get((dx, dy))
+                if d is None:
+                    d = by_dir[(dx, dy)] = {}
+                d[line] = d.get(line, 0) + 1
+
+                mid = (x1 + x2, y1 + y2)
+                m = by_mid.get(mid)
+                if m is None:
+                    m = by_mid[mid] = {}
+                m[(dx, dy)] = m.get((dx, dy), 0) + 1
+
+        ans = 0
+        # same direction, different line -> a trapezoid
+        for d in by_dir.values():
+            s = 0
+            for t in d.values():
+                ans += s * t
+                s += t
+        # same midpoint, different direction -> a parallelogram, counted twice
+        for m in by_mid.values():
+            s = 0
+            for t in m.values():
+                ans -= s * t
+                s += t
+        return ans

--- a/leetcode_python/Math/count-the-number-of-computer-unlocking-permutations.py
+++ b/leetcode_python/Math/count-the-number-of-computer-unlocking-permutations.py
@@ -1,0 +1,78 @@
+"""
+
+3577. Count the Number of Computer Unlocking Permutations
+Medium
+
+You are given an array complexity of length n.
+
+There are n locked computers in a room with labels from 0 to n - 1, each with its own unique password. The password of the computer i has a complexity complexity[i].
+
+The password for the computer labeled 0 is already decrypted and serves as the root. All other computers must be unlocked using it or another previously unlocked computer, following this rule:
+
+You can decrypt the password for the computer j using the password for computer i, where i is any integer less than j with a lower complexity. (i.e. i < j and complexity[i] < complexity[j])
+
+To decrypt the password for computer j, you must have already unlocked a computer i such that i < j and complexity[i] < complexity[j].
+
+Find the number of permutations of [0, 1, 2, ..., (n - 1)] that represent a valid order in which the computers can be unlocked, starting from computer 0.
+
+Since the answer may be large, return it modulo 10^9 + 7.
+
+Note that the password for the computer with label 0 is decrypted, and not the computer with the first index.
+
+
+Example 1:
+
+Input: complexity = [1,2,3]
+Output: 2
+Explanation:
+The valid permutations are:
+[0, 1, 2]
+Unlock computer 0 first with root password.
+Unlock computer 1 with password of computer 0 since complexity[0] < complexity[1].
+Unlock computer 2 with password of computer 0 since complexity[0] < complexity[2].
+[0, 2, 1]
+Unlock computer 0 first with root password.
+Unlock computer 2 with password of computer 0 since complexity[0] < complexity[2].
+Unlock computer 1 with password of computer 0 since complexity[0] < complexity[1].
+
+Example 2:
+
+Input: complexity = [3,3,3,4,4,4]
+Output: 0
+Explanation:
+There are no valid permutations. Since computers 1 and 2 can not be unlocked.
+
+
+Constraints:
+
+2 <= complexity.length <= 10^5
+1 <= complexity[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : EITHER COMPUTER 0 UNLOCKS EVERYTHING, OR NOTHING WORKS
+#
+#   computer 0 is the only one that starts unlocked and it has the smallest
+#   index, so if complexity[0] is strictly below every other complexity then
+#   computer 0 alone is a legal parent for all the rest — the order of the
+#   remaining n-1 computers is then completely free, giving (n-1)!.
+#
+#   otherwise some computer j has complexity[j] <= complexity[0]; every
+#   candidate parent i < j must itself be unlocked first and must have an
+#   even smaller complexity, which cascades down to a computer that nothing
+#   can open. so the count is 0.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def countPermutations(self, complexity):
+        MOD = 10 ** 9 + 7
+        n = len(complexity)
+        root = complexity[0]
+        for i in range(1, n):
+            if complexity[i] <= root:
+                return 0
+        res = 1
+        for i in range(1, n):
+            res = res * i % MOD
+        return res

--- a/leetcode_python/Math/hexadecimal-and-hexatrigesimal-conversion.py
+++ b/leetcode_python/Math/hexadecimal-and-hexatrigesimal-conversion.py
@@ -1,0 +1,65 @@
+"""
+
+3602. Hexadecimal and Hexatrigesimal Conversion
+Easy
+
+You are given an integer n.
+
+Return the concatenation of the hexadecimal representation of n^2 and the hexatrigesimal representation of n^3.
+
+A hexadecimal number is defined as a base-16 numeral system that uses the digits 0 - 9 along with the uppercase letters A - F to represent values from 0 to 15.
+
+A hexatrigesimal number is defined as a base-36 numeral system that uses the digits 0 - 9 along with the uppercase letters A - Z to represent values from 0 to 35.
+
+
+Example 1:
+
+Input: n = 13
+Output: "A91P1"
+Explanation:
+n^2 = 13 * 13 = 169. In hexadecimal, 169 is A9.
+n^3 = 13 * 13 * 13 = 2197. In hexatrigesimal, 2197 is 1P1.
+Concatenating both gives us A9 + 1P1 = A91P1.
+
+Example 2:
+
+Input: n = 36
+Output: "5101000"
+Explanation:
+n^2 = 36 * 36 = 1296. In hexadecimal, 1296 is 510.
+n^3 = 36 * 36 * 36 = 46656. In hexatrigesimal, 46656 is 1000.
+Concatenating both gives us 510 + 1000 = 5101000.
+
+
+Constraints:
+
+1 <= n <= 1000
+
+"""
+
+# V0
+# IDEA : ONE GENERIC BASE-CONVERSION HELPER, CALLED TWICE
+#
+#   repeated divmod peels off the least significant digit first, so the
+#   digits come out reversed and get flipped at the end. both bases draw
+#   from the same "0-9 then A-Z" alphabet, base 16 just stops at F, so a
+#   single digit table serves both calls.
+#
+#   n >= 1 means neither power is ever zero, so the "0" special case cannot
+#   arise here — it is kept only for safety.
+#
+# time = O(log n), space = O(log n)
+class Solution(object):
+    def concatHex36(self, n):
+        DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+        def to_base(x, base):
+            if x == 0:
+                return "0"
+            out = []
+            while x:
+                x, r = divmod(x, base)
+                out.append(DIGITS[r])
+            return "".join(reversed(out))
+
+        return to_base(n * n, 16) + to_base(n * n * n, 36)

--- a/leetcode_python/Math/maximize-subarray-gcd-score.py
+++ b/leetcode_python/Math/maximize-subarray-gcd-score.py
@@ -1,0 +1,98 @@
+"""
+
+3574. Maximize Subarray GCD Score
+Hard
+
+You are given an array of positive integers nums and an integer k.
+
+You may perform at most k operations. In each operation, you can choose one element in the array and double its value. Each element can be doubled at most once.
+
+The score of a contiguous subarray is defined as the product of its length and the greatest common divisor (GCD) of all its elements.
+
+Your task is to return the maximum score that can be achieved by selecting a contiguous subarray from the modified array.
+
+Note:
+
+The greatest common divisor (GCD) of an array is the largest integer that evenly divides all the array elements.
+
+
+Example 1:
+
+Input: nums = [2,4], k = 1
+Output: 8
+Explanation:
+Double nums[0] to 4 using one operation. The modified array becomes [4, 4].
+The GCD of the subarray [4, 4] is 4, and the length is 2.
+Thus, the maximum possible score is 2 * 4 = 8.
+
+Example 2:
+
+Input: nums = [3,5,7], k = 2
+Output: 14
+Explanation:
+Double nums[2] to 14 using one operation. The modified array becomes [3, 5, 14].
+The GCD of the subarray [14] is 14, and the length is 1.
+Thus, the maximum possible score is 1 * 14 = 14.
+
+Example 3:
+
+Input: nums = [5,5,5], k = 1
+Output: 15
+Explanation:
+The subarray [5, 5, 5] has a GCD of 5, and its length is 3.
+Thus, the maximum possible score is 3 * 5 = 15.
+
+
+Constraints:
+
+1 <= n == nums.length <= 1500
+1 <= nums[i] <= 10^9
+1 <= k <= n
+
+"""
+
+# V0
+# IDEA : DOUBLING CAN ONLY LIFT THE GCD BY ONE FACTOR OF 2
+#
+#   write every element as (odd part) * 2^v. the gcd of a window is
+#   (gcd of odd parts) * 2^(min v). doubling an element bumps its v by one
+#   and leaves its odd part alone, so the gcd never gains a new odd factor —
+#   at best its power of two rises by exactly one, and only if *every*
+#   element sitting at the minimal v gets doubled.
+#
+#   so for each window we just need the gcd and how many elements attain the
+#   minimal 2-adic valuation; if that count fits in k, the doubled score is
+#   available too.
+#
+# time = O(n^2 * log(max)), space = O(n)
+from math import gcd
+
+
+class Solution(object):
+    def maxGCDScore(self, nums, k):
+        n = len(nums)
+        # 2-adic valuation of each element
+        val = [(v & -v).bit_length() - 1 for v in nums]
+
+        ans = 0
+        for i in range(n):
+            g = 0
+            lo = 64
+            cnt = 0
+            for j in range(i, n):
+                g = gcd(g, nums[j])
+                vj = val[j]
+                if vj < lo:
+                    lo = vj
+                    cnt = 1
+                elif vj == lo:
+                    cnt += 1
+                length = j - i + 1
+                s = length * g
+                if s > ans:
+                    ans = s
+                if cnt <= k:
+                    s = length * g * 2
+                    if s > ans:
+                        ans = s
+        return ans

--- a/leetcode_python/Math/minimum-cost-path-with-alternating-directions-i.py
+++ b/leetcode_python/Math/minimum-cost-path-with-alternating-directions-i.py
@@ -1,0 +1,76 @@
+"""
+
+3596. Minimum Cost Path with Alternating Directions I
+Medium
+
+You are given two integers m and n representing the number of rows and
+columns of a grid, respectively.
+
+The cost to enter cell (i, j) is defined as (i + 1) * (j + 1).
+
+The path will always begin by entering cell (0, 0) on move 1 and paying the
+entrance cost.
+
+At each step, you move to an adjacent cell, following an alternating
+pattern:
+
+On odd-numbered moves, you must move either right or down.
+On even-numbered moves, you must move either left or up.
+
+Return the minimum total cost required to reach (m - 1, n - 1). If it is
+impossible, return -1.
+
+
+Example 1:
+
+Input: m = 1, n = 1
+Output: 1
+Explanation:
+You start at cell (0, 0).
+The cost to enter (0, 0) is (0 + 1) * (0 + 1) = 1.
+Since you're at the destination, the total cost is 1.
+
+Example 2:
+
+Input: m = 2, n = 1
+Output: 3
+Explanation:
+You start at cell (0, 0) with cost (0 + 1) * (0 + 1) = 1.
+Move 1 (odd): You can move down to (1, 0) with cost (1 + 1) * (0 + 1) = 2.
+Thus, the total cost is 1 + 2 = 3.
+
+
+Constraints:
+
+1 <= m, n <= 10^6
+
+"""
+
+# V0
+# IDEA : PARITY INVARIANT ON (row + col) — ONLY THREE GRIDS ARE SOLVABLE
+#
+#   look at what a *pair* of consecutive moves does to the quantity
+#   (row + col). the odd move adds 1 to it (right or down), the even move
+#   subtracts 1 from it (left or up). so every completed odd/even pair
+#   leaves row + col exactly where it started.
+#
+#   we begin at (0, 0) with row + col = 0. therefore after an even number
+#   of moves row + col is still 0, which pins us back at (0, 0) since both
+#   coordinates are non-negative; after an odd number of moves row + col
+#   is exactly 1, i.e. we are at (0, 1) or (1, 0). no other cell in the
+#   grid is ever reachable, no matter how long we wander.
+#
+#   so the destination (m - 1, n - 1) is reachable only when
+#   (m - 1) + (n - 1) is 0 or 1 — the 1x1, 2x1 and 1x2 grids. in the 1x1
+#   case we pay just the entrance cost 1; in the other two we pay 1 for
+#   (0, 0) plus 2 for the single neighbour, and there is nothing to
+#   optimise because there is only one path.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def minCost(self, m, n):
+        if m == 1 and n == 1:
+            return 1
+        if (m == 2 and n == 1) or (m == 1 and n == 2):
+            return 3
+        return -1

--- a/leetcode_python/Math/number-of-integers-with-popcount-depth-equal-to-k-i.py
+++ b/leetcode_python/Math/number-of-integers-with-popcount-depth-equal-to-k-i.py
@@ -1,0 +1,126 @@
+"""
+
+3621. Number of Integers With Popcount-Depth Equal to K I
+Hard
+
+You are given two integers n and k.
+
+For any positive integer x, define the following sequence:
+
+p0 = x
+p(i+1) = popcount(pi) for all i >= 0, where popcount(y) is the number of set
+bits (1's) in the binary representation of y.
+
+This sequence will eventually reach the value 1.
+
+The popcount-depth of x is defined as the smallest integer d >= 0 such that
+pd = 1.
+
+For example, if x = 7 (binary representation "111"). Then, the sequence is:
+7 -> 3 -> 2 -> 1, so the popcount-depth of 7 is 3.
+
+Your task is to determine the number of integers in the range [1, n] whose
+popcount-depth is exactly equal to k.
+
+Return the number of such integers.
+
+
+Example 1:
+
+Input: n = 4, k = 1
+Output: 2
+Explanation:
+The following integers in the range [1, 4] have popcount-depth exactly equal
+to 1:
+
+x    Binary    Sequence
+2    "10"      2 -> 1
+4    "100"     4 -> 1
+
+Thus, the answer is 2.
+
+Example 2:
+
+Input: n = 7, k = 2
+Output: 3
+Explanation:
+The following integers in the range [1, 7] have popcount-depth exactly equal
+to 2:
+
+x    Binary    Sequence
+3    "11"      3 -> 2 -> 1
+5    "101"     5 -> 2 -> 1
+6    "110"     6 -> 2 -> 1
+
+Thus, the answer is 3.
+
+
+Constraints:
+
+1 <= n <= 10^15
+0 <= k <= 5
+
+"""
+
+# V0
+# IDEA : COLLAPSE THE DEPTH ONTO THE POPCOUNT, THEN COUNT BY POPCOUNT
+#
+#   the first step of the sequence throws away everything about x except how
+#   many bits it has: for x > 1, depth(x) = 1 + depth(popcount(x)). and
+#   popcount(x) <= 50 for n <= 10^15, so the depths of every value that can
+#   ever appear after step one are precomputable from a 50-entry table.
+#
+#   that turns the question into "how many x in [1, n] have popcount exactly
+#   c", summed over the handful of c whose own depth is k-1. x = 1 is the one
+#   value the recurrence does not cover — its depth is 0, not 1 — so it must
+#   be subtracted back out of the c = 1 bucket when k = 1.
+#
+#   counting x <= n with a given popcount is the standard "walk the bits of n
+#   from the top" argument: whenever n has a 1 at position i, the numbers that
+#   agree with n above i but put a 0 there are all strictly below n, and their
+#   low i bits are completely free — C(i, remaining) of them have the right
+#   popcount. after passing every set bit we have described every x < n
+#   exactly once, so only n itself is left to check.
+#
+# time = O((log n)^2), space = O((log n)^2)
+class Solution(object):
+    def popcountDepth(self, n, k):
+        if k == 0:
+            return 1
+
+        L = n.bit_length()
+
+        # binomials up to L
+        C = [[0] * (L + 1) for _ in range(L + 1)]
+        for i in range(L + 1):
+            C[i][0] = 1
+            for j in range(1, i + 1):
+                C[i][j] = C[i - 1][j - 1] + C[i - 1][j]
+
+        # depth of every reachable popcount value
+        depth = [0] * (L + 1)
+        for i in range(2, L + 1):
+            depth[i] = depth[bin(i).count('1')] + 1
+
+        def count_popcount(c):
+            # how many x in [1, n] have exactly c set bits
+            res = 0
+            used = 0
+            for i in range(L - 1, -1, -1):
+                if not (n >> i) & 1:
+                    continue
+                need = c - used
+                if 0 <= need <= i:
+                    res += C[i][need]
+                used += 1
+            if used == c:
+                res += 1
+            return res
+
+        ans = 0
+        for c in range(1, L + 1):
+            if depth[c] == k - 1:
+                ans += count_popcount(c)
+        if k == 1:
+            ans -= 1  # x = 1 has popcount 1 but depth 0, not 1
+        return ans

--- a/leetcode_python/Math/number-of-integers-with-popcount-depth-equal-to-k-ii.py
+++ b/leetcode_python/Math/number-of-integers-with-popcount-depth-equal-to-k-ii.py
@@ -1,0 +1,163 @@
+"""
+
+3624. Number of Integers With Popcount-Depth Equal to K II
+Hard
+
+You are given an integer array nums.
+
+For any positive integer x, define the following sequence:
+
+p0 = x
+p(i+1) = popcount(pi) for all i >= 0, where popcount(y) is the number of set
+bits (1's) in the binary representation of y.
+
+This sequence will eventually reach the value 1.
+
+The popcount-depth of x is defined as the smallest integer d >= 0 such that
+pd = 1.
+
+For example, if x = 7 (binary representation "111"). Then, the sequence is:
+7 -> 3 -> 2 -> 1, so the popcount-depth of 7 is 3.
+
+You are also given a 2D integer array queries, where each queries[i] is either:
+
+[1, l, r, k] - Determine the number of indices j such that l <= j <= r and the
+popcount-depth of nums[j] is equal to k.
+[2, idx, val] - Update nums[idx] to val.
+
+Return an integer array answer, where answer[i] is the number of indices for
+the ith query of type [1, l, r, k].
+
+
+Example 1:
+
+Input: nums = [2,4], queries = [[1,0,1,1],[2,1,1],[1,0,1,0]]
+Output: [2,1]
+Explanation:
+Query [1,0,1,1] on nums = [2,4] (binary [10, 100], depths [1, 1]) counts both
+indices 0 and 1, so the answer is 2.
+Query [2,1,1] updates nums to [2,1].
+Query [1,0,1,0] on nums = [2,1] (binary [10, 1], depths [1, 0]) counts only
+index 1, so the answer is 1.
+Thus, the final answer is [2, 1].
+
+Example 2:
+
+Input: nums = [3,5,6], queries = [[1,0,2,2],[2,1,4],[1,1,2,1],[1,0,1,0]]
+Output: [3,1,0]
+Explanation:
+Query [1,0,2,2] on nums = [3,5,6] (binary [11, 101, 110], depths [2, 2, 2])
+counts indices 0, 1 and 2, so the answer is 3.
+Query [2,1,4] updates nums to [3,4,6].
+Query [1,1,2,1] on nums = [3,4,6] (binary [11, 100, 110], depths [2, 1, 2])
+counts only index 1, so the answer is 1.
+Query [1,0,1,0] on nums = [3,4,6] counts nothing, so the answer is 0.
+Thus, the final answer is [3, 1, 0].
+
+Example 3:
+
+Input: nums = [1,2], queries = [[1,0,1,1],[2,0,3],[1,0,0,1],[1,0,0,2]]
+Output: [1,0,1]
+Explanation:
+Query [1,0,1,1] on nums = [1,2] (binary [1, 10], depths [0, 1]) counts only
+index 1, so the answer is 1.
+Query [2,0,3] updates nums to [3,2].
+Query [1,0,0,1] on nums = [3,2] (binary [11, 10], depths [2, 1]) counts
+nothing in [0, 0], so the answer is 0.
+Query [1,0,0,2] on nums = [3,2] counts index 0, so the answer is 1.
+Thus, the final answer is [1, 0, 1].
+
+
+Constraints:
+
+1 <= n == nums.length <= 10^5
+1 <= nums[i] <= 10^15
+1 <= queries.length <= 10^5
+queries[i].length == 3 or 4
+queries[i] == [1, l, r, k] or,
+queries[i] == [2, idx, val]
+0 <= l <= r <= n - 1
+0 <= k <= 5
+0 <= idx <= n - 1
+1 <= val <= 10^15
+
+"""
+
+# V0
+# IDEA : DEPTH IS TINY, SO KEEP ONE FENWICK TREE PER DEPTH
+#
+#   the key observation is how few distinct depths exist. values go up to
+#   10^15 < 2^50, so one popcount step already lands in [1, 50], and iterating
+#   from there collapses fast — no value in range has depth above 4. with only
+#   a handful of possible answers, "count depth == k on [l, r]" is really six
+#   independent 0/1 arrays, one per depth.
+#
+#   each of those arrays needs prefix sums that survive point updates, which
+#   is exactly a fenwick tree. an update moves a single index from its old
+#   depth's tree to its new one — two O(log n) touches — and a query is one
+#   prefix-sum difference in the tree for k. keeping k separate is what makes
+#   this work: a single tree could not answer "how many equal k" without
+#   rescanning.
+#
+#   depth itself is O(1) to evaluate: depth(1) = 0 and otherwise
+#   depth(x) = 1 + depth(popcount(x)), and popcount(x) <= 50 is precomputed.
+#
+# time = O((n + q) * log n), space = O(n)
+class Solution(object):
+    def popcountDepth(self, nums, queries):
+        MAX_BITS = 50          # 10^15 < 2^50
+        MAX_DEPTH = 5          # k is capped at 5 by the constraints
+
+        # depth of every value a popcount can produce
+        small = [0] * (MAX_BITS + 1)
+        for i in range(2, MAX_BITS + 1):
+            small[i] = small[bin(i).count('1')] + 1
+
+        def depth(x):
+            if x == 1:
+                return 0
+            return small[bin(x).count('1')] + 1
+
+        n = len(nums)
+
+        # trees[d] is a 1-indexed fenwick tree over the indices of nums
+        trees = [[0] * (n + 1) for _ in range(MAX_DEPTH + 1)]
+
+        def add(d, i, delta):
+            tree = trees[d]
+            i += 1
+            while i <= n:
+                tree[i] += delta
+                i += i & (-i)
+
+        def prefix(d, i):
+            # sum over indices [0, i]
+            tree = trees[d]
+            i += 1
+            s = 0
+            while i > 0:
+                s += tree[i]
+                i -= i & (-i)
+            return s
+
+        cur = [0] * n
+        for i, x in enumerate(nums):
+            cur[i] = depth(x)
+            add(cur[i], i, 1)
+
+        ans = []
+        for q in queries:
+            if q[0] == 1:
+                _, l, r, k = q
+                if k > MAX_DEPTH:
+                    ans.append(0)
+                else:
+                    ans.append(prefix(k, r) - (prefix(k, l - 1) if l else 0))
+            else:
+                _, idx, val = q
+                d = depth(val)
+                if d != cur[idx]:
+                    add(cur[idx], idx, -1)
+                    add(d, idx, 1)
+                    cur[idx] = d
+        return ans

--- a/leetcode_python/Math/split-array-by-prime-indices.py
+++ b/leetcode_python/Math/split-array-by-prime-indices.py
@@ -1,0 +1,77 @@
+"""
+
+3618. Split Array by Prime Indices
+Medium
+
+You are given an integer array nums.
+
+Split nums into two arrays A and B using the following rule:
+
+Elements at prime indices in nums must go into array A.
+All other elements must go into array B.
+
+Return the absolute difference between the sums of the two arrays:
+|sum(A) - sum(B)|.
+
+Note: An empty array has a sum of 0.
+
+
+Example 1:
+
+Input: nums = [2,3,4]
+Output: 1
+Explanation:
+The only prime index in the array is 2, so nums[2] = 4 is placed in array A.
+The remaining elements, nums[0] = 2 and nums[1] = 3 are placed in array B.
+sum(A) = 4, sum(B) = 2 + 3 = 5.
+The absolute difference is |4 - 5| = 1.
+
+Example 2:
+
+Input: nums = [-1,5,7,0]
+Output: 3
+Explanation:
+The prime indices in the array are 2 and 3, so nums[2] = 7 and nums[3] = 0 are
+placed in array A.
+The remaining elements, nums[0] = -1 and nums[1] = 5 are placed in array B.
+sum(A) = 7 + 0 = 7, sum(B) = -1 + 5 = 4.
+The absolute difference is |7 - 4| = 3.
+
+
+Constraints:
+
+1 <= nums.length <= 10^5
+-10^9 <= nums[i] <= 10^9
+
+"""
+
+# V0
+# IDEA : SIEVE OF ERATOSTHENES + SIGNED SUM IN ONE PASS
+#
+#   the split is decided purely by the index, never by the value, so the two
+#   arrays never actually need to be materialised. give every element a sign
+#   (+1 at a prime index, -1 elsewhere) and sum: that single number is
+#   sum(A) - sum(B), and the answer is its absolute value.
+#
+#   the only real work is deciding primality of every index below n, which a
+#   linear-memory sieve settles in O(n log log n) — far cheaper than testing
+#   each index on its own.
+#
+# time = O(n log log n), space = O(n)
+class Solution(object):
+    def splitArray(self, nums):
+        n = len(nums)
+
+        is_prime = [True] * max(n, 2)
+        is_prime[0] = is_prime[1] = False
+        i = 2
+        while i * i < n:
+            if is_prime[i]:
+                for j in range(i * i, n, i):
+                    is_prime[j] = False
+            i += 1
+
+        total = 0
+        for i in range(n):
+            total += nums[i] if is_prime[i] else -nums[i]
+        return abs(total)

--- a/leetcode_python/String/coupon-code-validator.py
+++ b/leetcode_python/String/coupon-code-validator.py
@@ -1,0 +1,101 @@
+"""
+
+3606. Coupon Code Validator
+Easy
+
+You are given three arrays of length n that describe the properties of n
+coupons: code, businessLine, and isActive. The ith coupon has:
+
+code[i]: a string representing the coupon identifier.
+businessLine[i]: a string denoting the business category of the coupon.
+isActive[i]: a boolean indicating whether the coupon is currently active.
+
+A coupon is considered valid if all of the following conditions hold:
+
+1. code[i] is non-empty and consists only of alphanumeric characters
+   (a-z, A-Z, 0-9) and underscores (_).
+2. businessLine[i] is one of the following four categories: "electronics",
+   "grocery", "pharmacy", "restaurant".
+3. isActive[i] is true.
+
+Return an array of the codes of all valid coupons, sorted first by their
+businessLine in the order: "electronics", "grocery", "pharmacy",
+"restaurant", and then by code in lexicographical (ascending) order within
+each category.
+
+
+Example 1:
+
+Input: code = ["SAVE20","","PHARMA5","SAVE@20"],
+       businessLine = ["restaurant","grocery","pharmacy","restaurant"],
+       isActive = [true,true,true,true]
+Output: ["PHARMA5","SAVE20"]
+Explanation:
+First coupon is valid.
+Second coupon has empty code (invalid).
+Third coupon is valid.
+Fourth coupon has special character @ (invalid).
+
+Example 2:
+
+Input: code = ["GROCERY15","ELECTRONICS_50","DISCOUNT10"],
+       businessLine = ["grocery","electronics","invalid"],
+       isActive = [false,true,true]
+Output: ["ELECTRONICS_50"]
+Explanation:
+First coupon is inactive (invalid).
+Second coupon is valid.
+Third coupon has invalid business line (invalid).
+
+
+Constraints:
+
+n == code.length == businessLine.length == isActive.length
+1 <= n <= 100
+0 <= code[i].length, businessLine[i].length <= 100
+code[i] and businessLine[i] consist of printable ASCII characters.
+isActive[i] is either true or false.
+
+"""
+
+# V0
+# IDEA : FILTER + SORT ON THE (CATEGORY, CODE) KEY
+#
+#   the three validity rules are independent of each other, so a single
+#   pass that ands them together is enough. the only rule with any teeth
+#   is the code check: "alphanumeric or underscore" must be tested per
+#   character, and the empty string has to be rejected explicitly because
+#   an all-pass over zero characters would otherwise accept it.
+#
+#   the ordering looks like it needs a hand-written rank for the four
+#   categories, but the required order — electronics, grocery, pharmacy,
+#   restaurant — is already the alphabetical order of those four words.
+#   so plain string comparison on businessLine reproduces it, and the
+#   tie-break on code is lexicographic too; one tuple key sorts both
+#   levels at once.
+#
+#   note the per-character test is spelled out against explicit ascii
+#   ranges rather than str.isalnum(), which would also accept unicode
+#   letters and digits outside a-z A-Z 0-9.
+#
+# time = O(n * L + n * log(n)), space = O(n)
+class Solution(object):
+    def validateCoupons(self, code, businessLine, isActive):
+        lines = ("electronics", "grocery", "pharmacy", "restaurant")
+
+        def ok_code(s):
+            if not s:
+                return False
+            for c in s:
+                if not (("a" <= c <= "z") or ("A" <= c <= "Z")
+                        or ("0" <= c <= "9") or c == "_"):
+                    return False
+            return True
+
+        valid = []
+        for i in range(len(code)):
+            if isActive[i] and businessLine[i] in lines and ok_code(code[i]):
+                valid.append((businessLine[i], code[i]))
+
+        valid.sort()
+        return [c for _, c in valid]

--- a/leetcode_python/String/find-the-shortest-superstring-ii.py
+++ b/leetcode_python/String/find-the-shortest-superstring-ii.py
@@ -1,0 +1,76 @@
+"""
+
+3571. Find the Shortest Superstring II
+Easy
+
+You are given two strings, s1 and s2. Return the shortest possible string
+that contains both s1 and s2 as substrings. If there are multiple valid
+answers, return any one of them.
+
+A substring is a contiguous sequence of characters within a string.
+
+
+Example 1:
+
+Input: s1 = "aba", s2 = "bab"
+Output: "abab"
+Explanation:
+"abab" is the shortest string that contains both "aba" and "bab" as
+substrings.
+
+Example 2:
+
+Input: s1 = "aa", s2 = "aaa"
+Output: "aaa"
+Explanation:
+"aa" is already contained within "aaa", so the shortest superstring is
+"aaa".
+
+
+Constraints:
+
+1 <= s1.length <= 100
+1 <= s2.length <= 100
+s1 and s2 consist of lowercase English letters only.
+
+"""
+
+# V0
+# IDEA : MAXIMUM PREFIX / SUFFIX OVERLAP
+#
+#   any string that contains both s1 and s2 pins down an occurrence of each,
+#   and those two occurrences either nest (one inside the other) or stick
+#   out on opposite ends. so the answer is always one of: the longer string
+#   alone, s1 followed by s2, or s2 followed by s1 — and in the last two
+#   cases the only freedom left is how far the two blocks are pushed into
+#   each other, i.e. how much of one's suffix equals the other's prefix.
+#
+#   fixing m = min(len) and normalising so s1 is the shorter one, an overlap
+#   of m - i characters (either orientation) yields a superstring of length
+#   n + i. so sweeping i upward from 0 and returning the first orientation
+#   that fits gives the minimum length directly — no need to compare the two
+#   orientations, they tie at equal i and either is accepted.
+#
+#   the nesting case is exactly "s1 is a substring of s2", checked first.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def shortestSuperstring(self, s1, s2):
+        # keep s1 as the shorter string; a superstring of the pair is
+        # symmetric in the two arguments
+        if len(s1) > len(s2):
+            s1, s2 = s2, s1
+
+        if s1 in s2:
+            return s2
+
+        m = len(s1)
+        for i in range(m):
+            # s1's suffix of length m - i is a prefix of s2
+            if s2.startswith(s1[i:]):
+                return s1[:i] + s2
+            # s1's prefix of length m - i is a suffix of s2
+            if s2.endswith(s1[:m - i]):
+                return s2 + s1[m - i:]
+
+        return s1 + s2

--- a/leetcode_python/String/generate-tag-for-video-caption.py
+++ b/leetcode_python/String/generate-tag-for-video-caption.py
@@ -1,0 +1,66 @@
+"""
+
+3582. Generate Tag for Video Caption
+Easy
+
+You are given a string caption representing the caption for a video.
+
+The following actions must be performed in order to generate a valid tag for the video:
+
+Combine all words in the string into a single camelCase string prefixed with '#'. A camelCase string is one where the first letter of all words except the first one is capitalized. All the characters in the first word must be in lower case.
+Remove all characters that are not an English letter, except the leading '#'.
+Truncate the result to a maximum of 100 characters.
+
+Return the tag after performing the actions on caption.
+
+
+Example 1:
+
+Input: caption = "Leetcode daily streak achieved"
+Output: "#leetcodeDailyStreakAchieved"
+Explanation:
+The first word is "leetcode" in lowercase, and the remaining words are capitalized: "Daily", "Streak" and "Achieved".
+
+Example 2:
+
+Input: caption = "can I Go There"
+Output: "#canIGoThere"
+Explanation:
+The first word is "can" in lowercase, and the remaining words are capitalized: "I", "Go" and "There".
+
+Example 3:
+
+Input: caption = "hhhh...hhhh"   (a single word of 101 'h' characters)
+Output: "#hhhh...hhhh"           ('#' followed by 99 'h' characters)
+Explanation:
+Since the first word has length 101, we need to truncate the last two
+letters from the word.
+
+
+Constraints:
+
+1 <= caption.length <= 150
+caption consists only of English letters and ' '.
+
+"""
+
+# V0
+# IDEA : SPLIT ON WHITESPACE, THEN RE-CASE EACH WORD BY ITS POSITION
+#
+#   str.split() with no argument already collapses runs of spaces and drops
+#   leading/trailing ones, so an empty word never reaches the join step.
+#   the first word is fully lowercased; every later word is
+#   "upper first char + lowercased rest".
+#
+#   the final slice enforces the 100 character cap *including* the '#'.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def generateTag(self, caption):
+        words = caption.split()
+        if not words:
+            return "#"
+        out = ["#", words[0].lower()]
+        for w in words[1:]:
+            out.append(w[0].upper() + w[1:].lower())
+        return "".join(out)[:100]

--- a/leetcode_python/String/longest-common-prefix-between-adjacent-strings-after-removals.py
+++ b/leetcode_python/String/longest-common-prefix-between-adjacent-strings-after-removals.py
@@ -1,0 +1,106 @@
+"""
+
+3598. Longest Common Prefix Between Adjacent Strings After Removals
+Medium
+
+You are given an array of strings words. For each index i in the range [0, words.length - 1], perform the following steps:
+
+Remove the element at index i from the words array.
+Compute the length of the longest common prefix among all adjacent pairs in the modified array.
+
+Return an array answer, where answer[i] denotes the length of the longest common prefix between the adjacent pairs after removing the element at index i. If the words array contains fewer than 2 strings after removing element i, or if no adjacent pair exists, then answer[i] should be 0.
+
+
+Example 1:
+
+Input: words = ["jump","run","run","jump","run"]
+Output: [3,0,0,3,3]
+Explanation:
+Removing index 0:
+words becomes ["run", "run", "jump", "run"]
+Longest adjacent pair prefix: "run" and "run" -> 3
+Removing index 1:
+words becomes ["jump", "run", "jump", "run"]
+Longest adjacent pair prefix: none -> 0
+Removing index 2:
+words becomes ["jump", "run", "jump", "run"]
+Longest adjacent pair prefix: none -> 0
+Removing index 3:
+words becomes ["jump", "run", "run", "run"]
+Longest adjacent pair prefix: "run" and "run" -> 3
+Removing index 4:
+words becomes ["jump", "run", "run", "jump"]
+Longest adjacent pair prefix: "run" and "run" -> 3
+
+Example 2:
+
+Input: words = ["dog","racer","car"]
+Output: [0,0,0]
+Explanation:
+Removing any index results in an answer of 0.
+
+
+Constraints:
+
+1 <= words.length <= 10^5
+1 <= words[i].length <= 10^4
+words[i] consists of lowercase English letters.
+The sum of words[i].length is smaller than or equal 10^5.
+
+"""
+
+# V0
+# IDEA : PREFIX / SUFFIX MAXIMA OVER THE ORIGINAL ADJACENT PAIRS
+#
+#   deleting index i destroys at most two of the original adjacent pairs
+#   (i-1,i) and (i,i+1) and creates exactly one brand new pair (i-1,i+1).
+#   every other pair survives untouched, so the answer is the max of
+#   - the best pair entirely left of i,
+#   - the best pair entirely right of i,
+#   - the freshly stitched pair.
+#
+#   precomputed running maxima of the pairwise lcp array make each query
+#   O(1) apart from the single stitched lcp.
+#
+# time = O(total length), space = O(n)
+class Solution(object):
+    def longestCommonPrefix(self, words):
+        n = len(words)
+        if n <= 2:
+            return [0] * n
+
+        def lcp(a, b):
+            m = min(len(a), len(b))
+            i = 0
+            while i < m and a[i] == b[i]:
+                i += 1
+            return i
+
+        pairs = [lcp(words[i], words[i + 1]) for i in range(n - 1)]
+        m = n - 1
+        pre = [0] * m           # pre[j] = max(pairs[0..j])
+        run = 0
+        for j in range(m):
+            if pairs[j] > run:
+                run = pairs[j]
+            pre[j] = run
+        suf = [0] * m           # suf[j] = max(pairs[j..m-1])
+        run = 0
+        for j in range(m - 1, -1, -1):
+            if pairs[j] > run:
+                run = pairs[j]
+            suf[j] = run
+
+        ans = [0] * n
+        for i in range(n):
+            best = 0
+            if i - 2 >= 0:
+                best = pre[i - 2]
+            if i + 1 <= m - 1 and suf[i + 1] > best:
+                best = suf[i + 1]
+            if 0 < i < n - 1:
+                v = lcp(words[i - 1], words[i + 1])
+                if v > best:
+                    best = v
+            ans[i] = best
+        return ans

--- a/leetcode_python/String/partition-string.py
+++ b/leetcode_python/String/partition-string.py
@@ -1,0 +1,85 @@
+"""
+
+3597. Partition String
+Medium
+
+Given a string s, partition it into unique segments according to the following procedure:
+
+Start building a segment beginning at index 0.
+Continue extending the current segment character by character until the current segment has not been seen before.
+Once the segment is unique, add it to your list of segments, mark it as seen, and begin a new segment from the next index.
+Repeat until you reach the end of s.
+
+Return an array of strings segments, where segments[i] is the ith segment created.
+
+
+Example 1:
+
+Input: s = "abbccccd"
+Output: ["a","b","bc","c","cc","d"]
+Explanation:
+
+Index | Segment After Adding | Segment Exists Before? | New Segment | Updated Seen Segments
+0     | "a"                  | No                     | ""          | ["a"]
+1     | "b"                  | No                     | ""          | ["a", "b"]
+2     | "b"                  | Yes                    | "b"         | ["a", "b"]
+3     | "bc"                 | No                     | ""          | ["a", "b", "bc"]
+4     | "c"                  | No                     | ""          | ["a", "b", "bc", "c"]
+5     | "c"                  | Yes                    | "c"         | ["a", "b", "bc", "c"]
+6     | "cc"                 | No                     | ""          | ["a", "b", "bc", "c", "cc"]
+7     | "d"                  | No                     | ""          | ["a", "b", "bc", "c", "cc", "d"]
+
+Hence, the final output is ["a", "b", "bc", "c", "cc", "d"].
+
+Example 2:
+
+Input: s = "aaaa"
+Output: ["a","aa"]
+Explanation:
+
+Index | Segment After Adding | Segment Exists Before? | New Segment | Updated Seen Segments
+0     | "a"                  | No                     | ""          | ["a"]
+1     | "a"                  | Yes                    | "a"         | ["a"]
+2     | "aa"                 | No                     | ""          | ["a", "aa"]
+3     | "a"                  | Yes                    | "a"         | ["a", "aa"]
+
+Hence, the final output is ["a", "aa"].
+
+
+Constraints:
+
+1 <= s.length <= 10^5
+s contains only lowercase English letters.
+
+"""
+
+# V0
+# IDEA : GREEDY SCAN WITH A SET OF ALREADY-EMITTED SEGMENTS
+#
+#   the procedure is fully deterministic — no choice is ever made — so a
+#   single left-to-right pass reproduces it exactly. a trailing run of
+#   characters that never becomes unique before the string ends simply
+#   produces no segment, which is why "aaaa" yields only two segments.
+#
+#   the k-th distinct segment of length L needs L <= O(sqrt(n)) in the worst
+#   case because all emitted segments are distinct, so the repeated slicing
+#   stays near linear overall.
+#
+# time = O(n * sqrt(n)) worst case, space = O(n)
+class Solution(object):
+    def partitionString(self, s):
+        n = len(s)
+        seen = set()
+        res = []
+        i = 0
+        while i < n:
+            j = i
+            while j < n:
+                seg = s[i:j + 1]
+                if seg not in seen:
+                    seen.add(seg)
+                    res.append(seg)
+                    break
+                j += 1
+            i = j + 1
+        return res

--- a/leetcode_python/Tree/find-weighted-median-node-in-tree.py
+++ b/leetcode_python/Tree/find-weighted-median-node-in-tree.py
@@ -1,0 +1,190 @@
+"""
+
+3585. Find Weighted Median Node in Tree
+Hard
+
+You are given an integer n and an undirected, weighted tree rooted at node 0
+with n nodes numbered from 0 to n - 1. This is represented by a 2D array edges
+of length n - 1, where edges[i] = [u_i, v_i, w_i] indicates an edge from node
+u_i to v_i with weight w_i.
+
+The weighted median node is defined as the first node x on the path from u_i
+to v_i such that the sum of edge weights from u_i to x is greater than or equal
+to half of the total path weight.
+
+You are given a 2D integer array queries. For each queries[j] = [u_j, v_j],
+determine the weighted median node along the path from u_j to v_j.
+
+Return an array ans, where ans[j] is the node index of the weighted median for
+queries[j].
+
+
+Example 1:
+
+Input: n = 2, edges = [[0,1,7]], queries = [[1,0],[0,1]]
+Output: [0,1]
+Explanation:
+
+Query [1, 0]: path 1 -> 0, edge weights [7], total path weight 7, half 3.5.
+Sum from 1 -> 0 = 7 >= 3.5, median is node 0. Answer 0.
+
+Query [0, 1]: path 0 -> 1, edge weights [7], total path weight 7, half 3.5.
+Sum from 0 -> 1 = 7 >= 3.5, median is node 1. Answer 1.
+
+Example 2:
+
+Input: n = 3, edges = [[0,1,2],[2,0,4]], queries = [[0,1],[2,0],[1,2]]
+Output: [1,0,2]
+Explanation:
+
+Query [0, 1]: path 0 -> 1, edge weights [2], total path weight 2, half 1.
+Sum from 0 -> 1 = 2 >= 1, median is node 1. Answer 1.
+
+Query [2, 0]: path 2 -> 0, edge weights [4], total path weight 4, half 2.
+Sum from 2 -> 0 = 4 >= 2, median is node 0. Answer 0.
+
+Query [1, 2]: path 1 -> 0 -> 2, edge weights [2, 4], total path weight 6,
+half 3. Sum from 1 -> 0 = 2 < 3. Sum from 1 -> 2 = 2 + 4 = 6 >= 3, median is
+node 2. Answer 2.
+
+Example 3:
+
+Input: n = 5, edges = [[0,1,2],[0,2,5],[1,3,1],[2,4,3]], queries = [[3,4],[1,2]]
+Output: [2,2]
+Explanation:
+
+Query [3, 4]: path 3 -> 1 -> 0 -> 2 -> 4, edge weights [1, 2, 5, 3], total
+path weight 11, half 5.5. Sum from 3 -> 1 = 1 < 5.5. Sum from 3 -> 0 =
+1 + 2 = 3 < 5.5. Sum from 3 -> 2 = 1 + 2 + 5 = 8 >= 5.5, median is node 2.
+Answer 2.
+
+Query [1, 2]: path 1 -> 0 -> 2, edge weights [2, 5], total path weight 7,
+half 3.5. Sum from 1 -> 0 = 2 < 3.5. Sum from 1 -> 2 = 2 + 5 = 7 >= 3.5,
+median is node 2. Answer 2.
+
+
+Constraints:
+
+2 <= n <= 10^5
+edges.length == n - 1
+edges[i] == [u_i, v_i, w_i]
+0 <= u_i, v_i < n
+1 <= w_i <= 10^9
+1 <= queries.length <= 10^5
+queries[j] == [u_j, v_j]
+0 <= u_j, v_j < n
+The input is generated such that edges represents a valid tree.
+
+"""
+
+# V0
+# IDEA : ROOT DISTANCES + LCA, THEN ONE BINARY-LIFTING JUMP PER QUERY
+#
+#   root the tree once and store dist[x], the weighted distance from node 0.
+#   with l = lca(u, v) the path splits into an upward leg of length
+#   A = dist[u] - dist[l] and a downward leg of length B = dist[v] - dist[l],
+#   and the total path weight is A + B. all the comparisons below are doubled
+#   so the "half" is exact integer arithmetic and never a float.
+#
+#   which leg holds the median is decided in O(1) by testing l itself: the
+#   prefix from u down to l measures A, so l qualifies exactly when
+#   2A >= A + B, i.e. when A >= B.
+#
+#   on the upward leg the prefix from u to an ancestor x is dist[u] - dist[x],
+#   so the test 2*(dist[u] - dist[x]) >= A + B rewrites to
+#   2*dist[x] <= 2*dist[l] + A - B. climbing from u the left side only shrinks,
+#   so the failing nodes form an unbroken run starting at u; binary lifting
+#   climbs to the last failing node and the answer is its parent. u itself
+#   always fails here (as long as u != v), which is what guarantees that parent
+#   exists.
+#
+#   on the downward leg the prefix from u to x is A + dist[x] - dist[l], and
+#   the test becomes 2*dist[x] >= 2*dist[l] + B - A. now deeper nodes are the
+#   ones that qualify, so climbing from v the qualifying nodes form an unbroken
+#   run; the answer is the highest one still strictly below l. v itself always
+#   qualifies, and l does not (that is exactly the A < B branch), so the climb
+#   is well defined.
+#
+# time = O((n + q) * log n), space = O(n * log n)
+class Solution(object):
+    def findMedian(self, n, edges, queries):
+        LOG = max(1, n.bit_length())
+
+        g = [[] for _ in range(n)]
+        for u, v, w in edges:
+            g[u].append((v, w))
+            g[v].append((u, w))
+
+        parent = [-1] * n
+        depth = [0] * n
+        dist = [0] * n
+        seen = [False] * n
+        seen[0] = True
+        stack = [0]
+        while stack:
+            x = stack.pop()
+            for y, w in g[x]:
+                if not seen[y]:
+                    seen[y] = True
+                    parent[y] = x
+                    depth[y] = depth[x] + 1
+                    dist[y] = dist[x] + w
+                    stack.append(y)
+
+        up = [parent]
+        for _ in range(1, LOG):
+            prev = up[-1]
+            cur = [-1] * n
+            for i in range(n):
+                p = prev[i]
+                if p != -1:
+                    cur[i] = prev[p]
+            up.append(cur)
+
+        def lca(a, b):
+            if depth[a] < depth[b]:
+                a, b = b, a
+            diff = depth[a] - depth[b]
+            k = 0
+            while diff:
+                if diff & 1:
+                    a = up[k][a]
+                diff >>= 1
+                k += 1
+            if a == b:
+                return a
+            for k in range(LOG - 1, -1, -1):
+                if up[k][a] != up[k][b]:
+                    a = up[k][a]
+                    b = up[k][b]
+            return parent[a]
+
+        ans = []
+        for u, v in queries:
+            if u == v:
+                ans.append(u)
+                continue
+
+            l = lca(u, v)
+            a = dist[u] - dist[l]
+            b = dist[v] - dist[l]
+
+            if a >= b:
+                # median sits on the u -> l leg; climb past every failing node
+                limit = 2 * dist[l] + a - b
+                cur = u
+                for k in range(LOG - 1, -1, -1):
+                    p = up[k][cur]
+                    if p != -1 and depth[p] >= depth[l] and 2 * dist[p] > limit:
+                        cur = p
+                ans.append(parent[cur])
+            else:
+                # median sits on the l -> v leg; climb while still qualifying
+                limit = 2 * dist[l] + b - a
+                cur = v
+                for k in range(LOG - 1, -1, -1):
+                    p = up[k][cur]
+                    if p != -1 and depth[p] > depth[l] and 2 * dist[p] >= limit:
+                        cur = p
+                ans.append(cur)
+        return ans

--- a/leetcode_python/slide_window/count-prime-gap-balanced-subarrays.py
+++ b/leetcode_python/slide_window/count-prime-gap-balanced-subarrays.py
@@ -1,0 +1,105 @@
+"""
+
+3589. Count Prime-Gap Balanced Subarrays
+Medium
+
+You are given an integer array nums and an integer k.
+
+Call a subarray prime-gap balanced if:
+
+It contains at least two prime numbers, and
+The difference between the maximum and minimum prime numbers in that subarray is less than or equal to k.
+
+Return the count of prime-gap balanced subarrays in nums.
+
+Note:
+
+A subarray is a contiguous non-empty sequence of elements within an array.
+A prime number is a natural number greater than 1 with only two factors, 1 and itself.
+
+
+Example 1:
+
+Input: nums = [1,2,3], k = 1
+Output: 2
+Explanation:
+Prime-gap balanced subarrays are:
+[2,3]: contains two primes (2 and 3), max - min = 3 - 2 = 1 <= k
+[1,2,3]: contains two primes (2 and 3), max - min = 3 - 2 = 1 <= k
+Thus, the answer is 2.
+
+Example 2:
+
+Input: nums = [2,3,5,7], k = 3
+Output: 4
+Explanation:
+Prime-gap balanced subarrays are:
+[2,3]: contains two primes (2 and 3), max - min = 3 - 2 = 1 <= k
+[2,3,5]: contains three primes (2, 3 and 5), max - min = 5 - 2 = 3 <= k
+[3,5]: contains two primes (3 and 5), max - min = 5 - 3 = 2 <= k
+[5,7]: contains two primes (5 and 7), max - min = 7 - 5 = 2 <= k
+Thus, the answer is 4.
+
+
+Constraints:
+
+1 <= nums.length <= 5 * 10^4
+1 <= nums[i] <= 5 * 10^4
+0 <= k <= 5 * 10^4
+
+"""
+
+# V0
+# IDEA : TWO OPPOSING BOUNDS ON THE LEFT ENDPOINT, FOR EACH RIGHT ENDPOINT
+#
+#   fix the right end r. shrinking the window from the left can only remove
+#   primes, so the "max prime - min prime <= k" condition holds for every
+#   left >= some threshold L (monotone, maintained by two monotonic deques).
+#   the "at least two primes" condition holds for every left <= the index of
+#   the second-to-last prime seen so far.
+#
+#   so the valid lefts are exactly the interval [L, second_last_prime_index]
+#   and the count is its size — no inner loop needed.
+#
+# time = O(n log log max + n), space = O(max)
+from collections import deque
+
+
+class Solution(object):
+    def primeSubarray(self, nums, k):
+        mx = max(nums)
+        sieve = bytearray([1]) * (mx + 1)
+        if mx >= 0:
+            sieve[0] = 0
+        if mx >= 1:
+            sieve[1] = 0
+        i = 2
+        while i * i <= mx:
+            if sieve[i]:
+                sieve[i * i::i] = bytearray(len(sieve[i * i::i]))
+            i += 1
+
+        maxq, minq = deque(), deque()
+        prime_idx = []
+        left = 0
+        ans = 0
+        for r, v in enumerate(nums):
+            if sieve[v]:
+                while maxq and nums[maxq[-1]] <= v:
+                    maxq.pop()
+                maxq.append(r)
+                while minq and nums[minq[-1]] >= v:
+                    minq.pop()
+                minq.append(r)
+                prime_idx.append(r)
+            while maxq and nums[maxq[0]] - nums[minq[0]] > k:
+                if maxq[0] == left:
+                    maxq.popleft()
+                if minq[0] == left:
+                    minq.popleft()
+                left += 1
+            if len(prime_idx) >= 2:
+                hi = prime_idx[-2]
+                if hi >= left:
+                    ans += hi - left + 1
+        return ans


### PR DESCRIPTION
Closes another slice of the coverage gap against kamyu104/LeetCode-Solutions, tracked in doc/lc-coverage-kamyu/. Every file follows the repo layout (leetcode_python/<Category>/<slug>.py) with the full problem statement, an IDEA block, and a stated time/space complexity. This closes 3563-3626 completely except for the SQL problems listed below.

Verification, before committing:
  - all 143 worked examples parsed out of the docstrings run green
  - all 56 were cross-checked against independent brute forces on randomised small inputs, roughly 150k cases in total. several were checked exhaustively rather than by sampling: 3622 over its entire constraint domain (n = 1..10^6), 3609 over 1.19M reachable start/target pairs, 3579 over every string pair of length <= 4 on a 3-letter alphabet, 3571 over every pair of length <= 4, 3596 over all 36 grids, 3602 over n = 1..1000, and 3610 over every (n <= 120, m) pair
  - the brute forces were written to be genuinely independent, not restatements of the solution: 3604 checked against Bellman-Ford rather than assuming Dijkstra applies, 3593 against a 2^n subset enumeration, 3592 against all 2^n denomination subsets, 3600 against every spanning tree x every upgrade subset, 3594 against a differently-formulated Dijkstra, and 3605 against a brute force allowing arbitrary replacement values, which independently confirms the "writing 1 is optimal" reduction the solution rests on
  - every solution with large constraints was timed at full input size; the slowest is 3569 at 0.80s, then 3600 at 0.58s and 3585 at 0.51s, with everything else under 0.4s
  - method signatures absent from the doocs statements (3603, 3605, 3609, 3615, 3621, 3624, 3585, 3594, 3595, 3569, 3575) were confirmed against kamyu104's published Python sources rather than guessed

Statement fixes made during verification, to files written earlier in this batch but not yet committed. No algorithmic bugs were found; these were all transcription defects in the docstrings, and the existing code already handled the restored examples correctly:
  - 3582 had a fabricated Example 3 in place of the real one, which was the only example exercising the 100-character truncation rule
  - 3587 was missing Example 2 and had Example 4's input altered from [4,5,6,8] to [2,4,6,8]
  - 3568, 3592, 3599 were each missing a worked example
  - wrong constraints corrected in 3576 (k <= 10^9, actually k <= n), 3578 and 3592 (10^8, actually 2 * 10^8), 3599
  - minor omissions restored in 3588, 3593, 3597

Not included from this number range:
  - SQL/database problems, out of scope for leetcode_python/: 3564, 3570, 3580, 3586, 3601, 3611, 3617, 3626
  - nothing was deferred; every non-SQL problem in 3563-3626 is covered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solutions for a broad set of array, string, graph, tree, grid, geometry, and mathematical challenges.
  * Added support for dynamic updates, connectivity and path analysis, partitioning, optimization, counting, and subsequence calculations.
  * Added string processing tools for transformations, validation, formatting, superstrings, and special operations.
  * Added grid and graph utilities for navigation, cleanup, component analysis, and network reliability.
  * Added comprehensive problem documentation and examples for several newly supported challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->