### PR TITLE
feat(java): add 166 Java LC solutions for 10 pattern categories

### DIFF
--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/BalancedKFactorDecomposition.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/BalancedKFactorDecomposition.java
@@ -1,0 +1,118 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/balanced-k-factor-decomposition/
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *  3669. Balanced K-Factor Decomposition
+ *  Medium
+ *
+ *  Given two integers n and k, split the number n into exactly k positive
+ *  integers such that the product of these integers is equal to n.
+ *
+ *  Return any one split in which the maximum difference between any two
+ *  numbers is minimized. You may return the result in any order.
+ *
+ *  Example 1:
+ *    Input: n = 100, k = 2
+ *    Output: [10,10]
+ *    Explanation: The split [10, 10] yields 10 * 10 = 100 and a max-min
+ *                 difference of 0, which is minimal.
+ *
+ *  Example 2:
+ *    Input: n = 44, k = 3
+ *    Output: [2,2,11]
+ *    Explanation: [1,1,44] -> diff 43, [1,2,22] -> diff 21,
+ *                 [1,4,11] -> diff 10, [2,2,11] -> diff 9 (minimal).
+ *
+ *  Constraints:
+ *    4 <= n <= 10^5
+ *    2 <= k <= 5
+ *    k is strictly less than the total number of positive divisors of n.
+ */
+public class BalancedKFactorDecomposition {
+
+    // V0
+    // IDEA: DFS OVER DIVISORS IN NON-DECREASING ORDER
+    //       a factorisation is a multiset, so forcing the factors out in
+    //       non-decreasing order kills all k! permutations of the same answer
+    //       and lets the spread be read off as (last - first) at the leaf.
+    //       at each level only divisors of what is left AND >= the previous
+    //       factor are viable; the extra prune d^(levels left) <= remaining
+    //       collapses the search to a handful of nodes for k <= 5.
+    /**
+     * time = O(d(n)^(k-1) * sqrt(n))  // tiny in practice
+     * space = O(k)
+     */
+    private int[] best;
+    private int bestSpread;
+
+    public int[] minDifference(int n, int k) {
+        this.best = null;
+        this.bestSpread = Integer.MAX_VALUE;
+        dfs(n, k, new ArrayList<>());
+        return best;
+    }
+
+    private void dfs(int rem, int left, List<Integer> cur) {
+        if (left == 1) {
+            if (cur.isEmpty() || rem >= cur.get(cur.size() - 1)) {
+                int first = cur.isEmpty() ? rem : cur.get(0);
+                int spread = rem - first;
+                if (spread < bestSpread) {
+                    bestSpread = spread;
+                    int[] out = new int[cur.size() + 1];
+                    for (int i = 0; i < cur.size(); i++) {
+                        out[i] = cur.get(i);
+                    }
+                    out[cur.size()] = rem;
+                    best = out;
+                }
+            }
+            return;
+        }
+
+        int lo = cur.isEmpty() ? 1 : cur.get(cur.size() - 1);
+        for (Integer d : divisorsAtLeast(rem, lo)) {
+            // prune: d is the SMALLEST remaining factor -> d^left <= rem
+            if (pow(d, left) > rem) {
+                break;
+            }
+            cur.add(d);
+            dfs(rem / d, left - 1, cur);
+            cur.remove(cur.size() - 1);
+        }
+    }
+
+    private List<Integer> divisorsAtLeast(int m, int lo) {
+        List<Integer> out = new ArrayList<>();
+        for (int i = 1; (long) i * i <= m; i++) {
+            if (m % i == 0) {
+                if (i >= lo) {
+                    out.add(i);
+                }
+                int j = m / i;
+                if (j != i && j >= lo) {
+                    out.add(j);
+                }
+            }
+        }
+        Collections.sort(out);
+        return out;
+    }
+
+    // d^e capped so it never overflows
+    private long pow(int d, int e) {
+        long r = 1;
+        for (int i = 0; i < e; i++) {
+            r *= d;
+            if (r > 1000000000L) {
+                return r;
+            }
+        }
+        return r;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/BraceExpansionII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/BraceExpansionII.java
@@ -1,0 +1,109 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/brace-expansion-ii/
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ *  1096. Brace Expansion II
+ *  Hard
+ *
+ *  Under the grammar given below, strings can represent a set of lowercase
+ *  words. Let R(expr) denote the set of words the expression represents.
+ *
+ *    - For every lowercase letter x, R(x) = {x}.
+ *    - For expressions e1, e2, ..., ek with k >= 2,
+ *      R({e1,e2,...}) = R(e1) union R(e2) union ...
+ *    - For expressions e1 and e2,
+ *      R(e1 + e2) = { a + b for (a, b) in R(e1) x R(e2) }.
+ *
+ *  Given an expression representing a set of words under the given grammar,
+ *  return the sorted list of words that the expression represents.
+ *
+ *  Example 1:
+ *    Input: expression = "{a,b}{c,{d,e}}"
+ *    Output: ["ac","ad","ae","bc","bd","be"]
+ *
+ *  Example 2:
+ *    Input: expression = "{{a,z},a{b,c},{ab,z}}"
+ *    Output: ["a","ab","ac","z"]
+ *    Explanation: Each distinct word is written only once in the answer.
+ *
+ *  Constraints:
+ *    1 <= expression.length <= 60
+ *    expression[i] consists of '{', '}', ',' or lowercase English letters.
+ *    The given expression represents a set of words based on the grammar.
+ */
+public class BraceExpansionII {
+
+    // V0
+    // IDEA: STACK PARSER (union list + concatenation product per nesting level)
+    //       per level we keep
+    //         cur   : set of words built by CONCATENATION so far
+    //         parts : list of sets already closed by a ',' (to be UNIONed)
+    //       '{'    -> push (parts, cur), start a fresh level
+    //       ','    -> flush cur into parts, restart cur = {""}
+    //       '}'    -> union the level, pop the parent, product it into parent cur
+    //       letter -> append the letter to every word in cur
+    /**
+     * time = O(L * W)
+     * space = O(W)
+     *   L = expression length, W = number of distinct words produced
+     */
+    public List<String> braceExpansionII(String expression) {
+        List<Set<String>> parts = new ArrayList<>();
+        Set<String> cur = new HashSet<>();
+        cur.add("");
+
+        Deque<List<Set<String>>> partsStack = new ArrayDeque<>();
+        Deque<Set<String>> curStack = new ArrayDeque<>();
+
+        for (char c : expression.toCharArray()) {
+            if (c == '{') {
+                partsStack.push(parts);
+                curStack.push(cur);
+                parts = new ArrayList<>();
+                cur = new HashSet<>();
+                cur.add("");
+            } else if (c == '}') {
+                parts.add(cur);
+                Set<String> grp = new HashSet<>();
+                for (Set<String> p : parts) {
+                    grp.addAll(p);
+                }
+                parts = partsStack.pop();
+                Set<String> parent = curStack.pop();
+                // NOTE !!! close the group -> product with the parent prefix
+                cur = new HashSet<>();
+                for (String a : parent) {
+                    for (String b : grp) {
+                        cur.add(a + b);
+                    }
+                }
+            } else if (c == ',') {
+                parts.add(cur);
+                cur = new HashSet<>();
+                cur.add("");
+            } else {
+                Set<String> next = new HashSet<>();
+                for (String a : cur) {
+                    next.add(a + c);
+                }
+                cur = next;
+            }
+        }
+
+        parts.add(cur);
+        Set<String> res = new TreeSet<>();
+        for (Set<String> p : parts) {
+            res.addAll(p);
+        }
+        return new ArrayList<>(res);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/ConstructTheLexicographicallyLargestValidSequence.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/ConstructTheLexicographicallyLargestValidSequence.java
@@ -1,0 +1,92 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/construct-the-lexicographically-largest-valid-sequence/
+
+/**
+ *  1718. Construct the Lexicographically Largest Valid Sequence
+ *  Medium
+ *
+ *  Given an integer n, find a sequence with elements in the range [1, n] that
+ *  satisfies all of the following:
+ *    - The integer 1 occurs once in the sequence.
+ *    - Each integer between 2 and n occurs twice in the sequence.
+ *    - For every integer i between 2 and n, the distance between the two
+ *      occurrences of i is exactly i.
+ *
+ *  The distance between a[i] and a[j] is |j - i|.
+ *  Return the lexicographically largest sequence. It is guaranteed that under
+ *  the given constraints there is always a solution.
+ *
+ *  Example 1:
+ *    Input: n = 3
+ *    Output: [3,1,2,3,2]
+ *    Explanation: [2,3,2,1,3] is also valid, but [3,1,2,3,2] is the
+ *                 lexicographically largest one.
+ *
+ *  Example 2:
+ *    Input: n = 5
+ *    Output: [5,3,1,4,3,5,2,4,2]
+ *
+ *  Constraints:
+ *    1 <= n <= 20
+ */
+public class ConstructTheLexicographicallyLargestValidSequence {
+
+    // V0
+    // IDEA: BACKTRACKING, TRY BIG VALUES FIRST (first success = the answer)
+    //       the sequence has length 2n - 1 (1 appears once, 2..n appear twice).
+    //       fill left to right; at the leftmost EMPTY slot i try n, n-1, ..., 1
+    //       in DESCENDING order. since we commit greedily to the biggest value
+    //       that can still be completed, the FIRST full assignment reached is
+    //       already the lexicographically largest one.
+    //       placing v at i also fixes its partner:
+    //         v >= 2 -> slot i + v must be free and inside the array
+    //         v == 1 -> occupies only slot i
+    //       NOTE: a slot may already be filled by an earlier value's partner,
+    //             then just skip ahead to i + 1.
+    /**
+     * time = O(n!) worst case (heavily pruned, n <= 20)
+     * space = O(n)
+     */
+    public int[] constructDistancedSequence(int n) {
+        int size = 2 * n - 1;
+        int[] res = new int[size];
+        boolean[] used = new boolean[n + 1];
+        dfs(0, size, n, res, used);
+        return res;
+    }
+
+    private boolean dfs(int i, int size, int n, int[] res, boolean[] used) {
+        if (i == size) {
+            return true;
+        }
+        if (res[i] != 0) {
+            return dfs(i + 1, size, n, res, used);
+        }
+        for (int v = n; v >= 1; v--) {
+            if (used[v]) {
+                continue;
+            }
+            if (v == 1) {
+                used[1] = true;
+                res[i] = 1;
+                if (dfs(i + 1, size, n, res, used)) {
+                    return true;
+                }
+                res[i] = 0;
+                used[1] = false;
+            } else if (i + v < size && res[i + v] == 0) {
+                used[v] = true;
+                res[i] = v;
+                res[i + v] = v;
+                if (dfs(i + 1, size, n, res, used)) {
+                    return true;
+                }
+                res[i] = 0;
+                res[i + v] = 0;
+                used[v] = false;
+            }
+        }
+        return false;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/FindACorrespondingNodeOfABinaryTreeInACloneOfThatTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/FindACorrespondingNodeOfABinaryTreeInACloneOfThatTree.java
@@ -1,0 +1,62 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/find-a-corresponding-node-of-a-binary-tree-in-a-clone-of-that-tree/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1379. Find a Corresponding Node of a Binary Tree in a Clone of That Tree
+ *  Easy
+ *
+ *  Given two binary trees original and cloned and given a reference to a node
+ *  target in the original tree.
+ *
+ *  The cloned tree is a copy of the original tree.
+ *
+ *  Return a reference to the same node in the cloned tree.
+ *  Note that you are not allowed to change any of the two trees or the target
+ *  node and the answer must be a reference to a node in the cloned tree.
+ *
+ *  Example 1:
+ *    Input: tree = [7,4,3,null,null,6,19], target = 3
+ *    Output: 3
+ *
+ *  Example 2:
+ *    Input: tree = [7], target = 7
+ *    Output: 7
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [1, 10^4].
+ *    The values of the nodes of the tree are unique.
+ *    target node is a node from the original tree and is not null.
+ *
+ *  Follow up: Could you solve the problem if repeated values on the tree are
+ *  allowed?
+ */
+public class FindACorrespondingNodeOfABinaryTreeInACloneOfThatTree {
+
+    // V0
+    // IDEA: WALK BOTH TREES IN LOCK STEP (DFS)
+    //       the two trees have the exact same shape, so whenever we stand on
+    //       `target` in `original`, the node we stand on in `cloned` is the
+    //       answer.
+    //       NOTE !!! we compare by IDENTITY (==), not by value -> this also
+    //                handles the follow up (duplicated values allowed)
+    /**
+     * time = O(n)
+     * space = O(h), h = tree height (recursion stack)
+     */
+    public final TreeNode getTargetCopy(final TreeNode original, final TreeNode cloned, final TreeNode target) {
+        if (original == null) {
+            return null;
+        }
+        if (original == target) {
+            return cloned;
+        }
+        TreeNode left = getTargetCopy(original.left, cloned.left, target);
+        if (left != null) {
+            return left;
+        }
+        return getTargetCopy(original.right, cloned.right, target);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/FindMinimumTimeToFinishAllJobs.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/FindMinimumTimeToFinishAllJobs.java
@@ -1,0 +1,96 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/find-minimum-time-to-finish-all-jobs/
+
+import java.util.Arrays;
+
+/**
+ *  1723. Find Minimum Time to Finish All Jobs
+ *  Hard
+ *
+ *  You are given an integer array jobs, where jobs[i] is the amount of time it
+ *  takes to complete the ith job.
+ *
+ *  There are k workers that you can assign jobs to. Each job should be assigned
+ *  to exactly one worker. The working time of a worker is the sum of the time it
+ *  takes to complete all jobs assigned to them. Your goal is to devise an
+ *  optimal assignment such that the maximum working time of any worker is
+ *  minimized.
+ *
+ *  Return the minimum possible maximum working time of any assignment.
+ *
+ *  Example 1:
+ *    Input: jobs = [3,2,3], k = 3
+ *    Output: 3
+ *    Explanation: By assigning each person one job, the maximum time is 3.
+ *
+ *  Example 2:
+ *    Input: jobs = [1,2,4,7,8], k = 2
+ *    Output: 11
+ *    Explanation: Worker 1: 1, 2, 8 (= 11), Worker 2: 4, 7 (= 11).
+ *
+ *  Constraints:
+ *    1 <= k <= jobs.length <= 12
+ *    1 <= jobs[i] <= 10^7
+ */
+public class FindMinimumTimeToFinishAllJobs {
+
+    // V0
+    // IDEA: BACKTRACKING WITH BRANCH-AND-BOUND PRUNING
+    //       assign jobs one by one to one of the k workers, tracking each
+    //       worker's load. three prunings turn the naive k^n search into
+    //       something that finishes instantly for n <= 12:
+    //       1) SORT jobs DESCENDING -> big jobs first, so bad branches blow
+    //          past the incumbent best near the root.
+    //       2) SYMMETRY BREAK -> after trying job i on an EMPTY worker, stop;
+    //          all remaining empty workers are interchangeable.
+    //       3) BOUND -> skip a worker whose load would reach the current best.
+    /**
+     * time = O(k^n) worst case, heavily pruned (n <= 12)
+     * space = O(n + k)
+     */
+    private int res;
+
+    public int minimumTimeRequired(int[] jobs, int k) {
+        int n = jobs.length;
+        Integer[] boxed = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            boxed[i] = jobs[i];
+        }
+        // descending
+        Arrays.sort(boxed, java.util.Collections.reverseOrder());
+        int[] sorted = new int[n];
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            sorted[i] = boxed[i];
+            total += sorted[i];
+        }
+
+        this.res = total;
+        dfs(0, sorted, new int[k]);
+        return this.res;
+    }
+
+    private void dfs(int i, int[] jobs, int[] load) {
+        if (i == jobs.length) {
+            int mx = 0;
+            for (int x : load) {
+                mx = Math.max(mx, x);
+            }
+            this.res = Math.min(this.res, mx);
+            return;
+        }
+        for (int j = 0; j < load.length; j++) {
+            if (load[j] + jobs[i] >= this.res) {
+                continue;
+            }
+            load[j] += jobs[i];
+            dfs(i + 1, jobs, load);
+            load[j] -= jobs[i];
+            // this worker was empty -> every later empty worker is a twin
+            if (load[j] == 0) {
+                break;
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/FindThePunishmentNumberOfAnInteger.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/FindThePunishmentNumberOfAnInteger.java
@@ -1,0 +1,77 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/find-the-punishment-number-of-an-integer/
+
+/**
+ *  2698. Find the Punishment Number of an Integer
+ *  Medium
+ *
+ *  Given a positive integer n, return the punishment number of n.
+ *
+ *  The punishment number of n is defined as the sum of the squares of all
+ *  integers i such that:
+ *    - 1 <= i <= n
+ *    - The decimal representation of i * i can be partitioned into contiguous
+ *      substrings such that the sum of the integer values of these substrings
+ *      equals i.
+ *
+ *  Example 1:
+ *    Input: n = 10
+ *    Output: 182
+ *    Explanation: 1 (1*1=1), 9 (81 -> 8+1), 10 (100 -> 10+0)
+ *                 -> 1 + 81 + 100 = 182
+ *
+ *  Example 2:
+ *    Input: n = 37
+ *    Output: 1478
+ *    Explanation: 1, 9, 10 and 36 (1296 -> 1+29+6)
+ *                 -> 1 + 81 + 100 + 1296 = 1478
+ *
+ *  Constraints:
+ *    1 <= n <= 1000
+ */
+public class FindThePunishmentNumberOfAnInteger {
+
+    // V0
+    // IDEA: BACKTRACKING OVER THE SPLIT POINTS OF str(i * i)
+    //       for each i walk the digits of i*i and try every possible length for
+    //       the next chunk, carrying `rest` = how much of i is still unmatched.
+    //         - consumed the whole string -> success iff rest == 0
+    //         - otherwise grow the chunk digit by digit (y = y*10 + d) and
+    //           recurse with rest - y
+    //       NOTE: PRUNING - once y > rest, that chunk and every longer one
+    //             (appending digits only grows y) can never fit -> break.
+    //       NOTE: chunks may be "0" / carry leading zeros ("100" -> 10 + 0),
+    //             which the running y = y*10 + d construction handles naturally.
+    /**
+     * time = O(n * 2^d), d = digits of n^2 (<= 7 for n <= 1000)
+     * space = O(d)
+     */
+    public int punishmentNumber(int n) {
+        int ans = 0;
+        for (int i = 1; i <= n; i++) {
+            int sq = i * i;
+            if (canSplit(String.valueOf(sq), 0, i)) {
+                ans += sq;
+            }
+        }
+        return ans;
+    }
+
+    private boolean canSplit(String s, int start, int rest) {
+        if (start == s.length()) {
+            return rest == 0;
+        }
+        int y = 0;
+        for (int j = start; j < s.length(); j++) {
+            y = y * 10 + (s.charAt(j) - '0');
+            if (y > rest) {
+                break; // pruning: a longer chunk is only bigger
+            }
+            if (canSplit(s, j + 1, rest - y)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/Finding3DigitEvenNumbers.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/Finding3DigitEvenNumbers.java
@@ -1,0 +1,75 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/finding-3-digit-even-numbers/
+
+/**
+ *  2094. Finding 3-Digit Even Numbers
+ *  Easy
+ *
+ *  You are given an integer array digits, where each element is a digit. The
+ *  array may contain duplicates.
+ *
+ *  You need to find all the unique integers that follow the given requirements:
+ *    - The integer consists of the concatenation of three elements from digits
+ *      in any arbitrary order.
+ *    - The integer does not have leading zeros.
+ *    - The integer is even.
+ *
+ *  Return a sorted array of the unique integers.
+ *
+ *  Example 1:
+ *    Input: digits = [2,1,3,0]
+ *    Output: [102,120,130,132,210,230,302,310,312,320]
+ *
+ *  Example 2:
+ *    Input: digits = [2,2,8,8,2]
+ *    Output: [222,228,282,288,822,828,882]
+ *    Explanation: The same digit can be used as many times as it appears.
+ *
+ *  Constraints:
+ *    3 <= digits.length <= 100
+ *    0 <= digits[i] <= 9
+ */
+public class Finding3DigitEvenNumbers {
+
+    // V0
+    // IDEA: ENUMERATE ALL 450 THREE-DIGIT EVEN NUMBERS, CHECK MULTISET SUPPLY
+    //       instead of permuting the input, walk the 450 even numbers in
+    //       [100, 999] and ask "does `digits` hold enough of each digit?".
+    //       that makes the rules trivial: starting at 100 kills leading zeros,
+    //       stepping by 2 keeps them even, and ascending enumeration yields a
+    //       sorted, unique list for free.
+    /**
+     * time = O(N + 450) -> O(N)
+     * space = O(1)
+     */
+    public int[] findEvenNumbers(int[] digits) {
+        int[] have = new int[10];
+        for (int d : digits) {
+            have[d]++;
+        }
+
+        int[] buf = new int[450];
+        int size = 0;
+        for (int x = 100; x < 1000; x += 2) {
+            int[] need = new int[10];
+            need[x / 100]++;
+            need[(x / 10) % 10]++;
+            need[x % 10]++;
+            boolean ok = true;
+            for (int d = 0; d < 10; d++) {
+                if (need[d] > have[d]) {
+                    ok = false;
+                    break;
+                }
+            }
+            if (ok) {
+                buf[size++] = x;
+            }
+        }
+
+        int[] res = new int[size];
+        System.arraycopy(buf, 0, res, 0, size);
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/GenerateBinaryStringsWithoutAdjacentZeros.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/GenerateBinaryStringsWithoutAdjacentZeros.java
@@ -1,0 +1,64 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/generate-binary-strings-without-adjacent-zeros/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  3211. Generate Binary Strings Without Adjacent Zeros
+ *  Medium
+ *
+ *  You are given a positive integer n.
+ *
+ *  A binary string x is valid if all substrings of x of length 2 contain at
+ *  least one "1".
+ *
+ *  Return all valid strings with length n, in any order.
+ *
+ *  Example 1:
+ *    Input: n = 3
+ *    Output: ["010","011","101","110","111"]
+ *
+ *  Example 2:
+ *    Input: n = 1
+ *    Output: ["0","1"]
+ *
+ *  Constraints:
+ *    1 <= n <= 18
+ */
+public class GenerateBinaryStringsWithoutAdjacentZeros {
+
+    // V0
+    // IDEA: BACKTRACK, REFUSING TO PLACE A '0' RIGHT AFTER A '0'
+    //       "every length-2 substring holds a 1" == "no two adjacent zeros",
+    //       so building left to right the only rule is: a '0' may follow
+    //       anything except another '0'.
+    //       the count of such strings is a Fibonacci number, so n = 18 yields
+    //       only a few thousand results.
+    /**
+     * time = O(n * F(n)), F(n) = number of valid strings (Fibonacci)
+     * space = O(n) recursion (excluding the output)
+     */
+    public List<String> validStrings(int n) {
+        List<String> res = new ArrayList<>();
+        build(0, n, new StringBuilder(), res);
+        return res;
+    }
+
+    private void build(int i, int n, StringBuilder cur, List<String> res) {
+        if (i == n) {
+            res.add(cur.toString());
+            return;
+        }
+        // '0' only when the previous char is not '0'
+        if (cur.length() == 0 || cur.charAt(cur.length() - 1) == '1') {
+            cur.append('0');
+            build(i + 1, n, cur, res);
+            cur.deleteCharAt(cur.length() - 1);
+        }
+        cur.append('1');
+        build(i + 1, n, cur, res);
+        cur.deleteCharAt(cur.length() - 1);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/LongestSubsequenceRepeatedKTimes.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/LongestSubsequenceRepeatedKTimes.java
@@ -1,0 +1,110 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/longest-subsequence-repeated-k-times/
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ *  2014. Longest Subsequence Repeated k Times
+ *  Hard
+ *
+ *  You are given a string s of length n, and an integer k. You are tasked to
+ *  find the longest subsequence repeated k times in string s.
+ *
+ *  A subsequence seq is repeated k times in s if seq * k is a subsequence of s,
+ *  where seq * k is seq concatenated k times.
+ *  For example, "bba" is repeated 2 times in "bababcba", because "bbabba" is a
+ *  subsequence of "bababcba".
+ *
+ *  Return the longest subsequence repeated k times in s. If multiple such
+ *  subsequences exist, return the lexicographically largest one. If there is no
+ *  such subsequence, return an empty string.
+ *
+ *  Example 1:
+ *    Input: s = "letsleetcode", k = 2
+ *    Output: "let"
+ *    Explanation: "let" and "ete" are both repeated 2 times; "let" is the
+ *                 lexicographically largest one.
+ *
+ *  Example 2:
+ *    Input: s = "bb", k = 2
+ *    Output: "b"
+ *
+ *  Example 3:
+ *    Input: s = "ab", k = 2
+ *    Output: ""
+ *
+ *  Constraints:
+ *    n == s.length
+ *    2 <= k <= 2000
+ *    2 <= n < min(2001, k * 8)
+ *    s consists of lowercase English letters.
+ */
+public class LongestSubsequenceRepeatedKTimes {
+
+    // V0
+    // IDEA: BFS OVER CANDIDATES (grow level by level, prune with a greedy check)
+    //       n < k * 8  =>  the answer is at most 7 characters long, and only
+    //       letters occurring at least k times can appear in it at all.
+    //       BFS from "" and extend every surviving candidate by each usable
+    //       letter; a candidate survives iff cand * k is a subsequence of s
+    //       (greedy scan). any prefix of a valid answer is itself valid, so
+    //       pruning is safe.
+    //       NOTE !!! visiting the letters in ASCENDING order with a FIFO queue
+    //                makes each BFS level come out in ascending lexicographic
+    //                order, so the LAST accepted candidate is the longest &
+    //                lexicographically largest one.
+    /**
+     * time = O(26^L * n) with L <= 7, but the k-repetition prune keeps it tiny
+     * space = O(number of surviving candidates)
+     */
+    public String longestSubsequenceRepeatedK(String s, int k) {
+        int[] cnt = new int[26];
+        for (char c : s.toCharArray()) {
+            cnt[c - 'a']++;
+        }
+        List<Character> letters = new ArrayList<>();
+        for (int i = 0; i < 26; i++) {
+            if (cnt[i] >= k) {
+                letters.add((char) ('a' + i));
+            }
+        }
+
+        String res = "";
+        Deque<String> q = new ArrayDeque<>();
+        q.add("");
+        while (!q.isEmpty()) {
+            String cur = q.poll();
+            for (Character c : letters) {
+                String nxt = cur + c;
+                if (repeatedK(s, nxt, k)) {
+                    res = nxt;
+                    q.add(nxt);
+                }
+            }
+        }
+        return res;
+    }
+
+    // is t * k a subsequence of s ?
+    private boolean repeatedK(String s, String t, int k) {
+        int need = k;
+        int i = 0;
+        for (int p = 0; p < s.length(); p++) {
+            if (s.charAt(p) == t.charAt(i)) {
+                i++;
+                if (i == t.length()) {
+                    i = 0;
+                    need--;
+                    if (need == 0) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/MaximizeGridHappiness.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/MaximizeGridHappiness.java
@@ -1,0 +1,131 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/maximize-grid-happiness/
+
+/**
+ *  1659. Maximize Grid Happiness
+ *  Hard
+ *
+ *  You are given four integers, m, n, introvertsCount, and extrovertsCount.
+ *  You have an m x n grid, and there are two types of people: introverts and
+ *  extroverts. There are introvertsCount introverts and extrovertsCount
+ *  extroverts. You should decide how many people you want to live in the grid
+ *  and assign each of them one grid cell. Note that you do not have to have all
+ *  the people living in the grid.
+ *
+ *  The happiness of each person is calculated as follows:
+ *    - Introverts start with 120 happiness and lose 30 happiness for each
+ *      neighbor (introvert or extrovert).
+ *    - Extroverts start with 40 happiness and gain 20 happiness for each
+ *      neighbor (introvert or extrovert).
+ *
+ *  Neighbors live in the directly adjacent cells north, east, south and west.
+ *  The grid happiness is the sum of each person's happiness. Return the maximum
+ *  possible grid happiness.
+ *
+ *  Example 1:
+ *    Input: m = 2, n = 3, introvertsCount = 1, extrovertsCount = 2
+ *    Output: 240
+ *    Explanation: introvert at (1,1) -> 120, extroverts at (1,3) and (2,3)
+ *                 -> 60 + 60. total = 240
+ *
+ *  Example 2:
+ *    Input: m = 3, n = 1, introvertsCount = 2, extrovertsCount = 1
+ *    Output: 260
+ *
+ *  Constraints:
+ *    1 <= m, n <= 5
+ *    0 <= introvertsCount, extrovertsCount <= min(m * n, 6)
+ */
+public class MaximizeGridHappiness {
+
+    // V0
+    // IDEA: PROFILE (BROKEN-PROFILE) DP + MEMO, cell by cell, base-3 mask
+    //       fill cells in row-major order. when placing cell `pos` we only need
+    //       the last n placed cells -> keep them as a base-3 number `mask`
+    //         digit 0   = cell pos-1 (the LEFT neighbour, if same row)
+    //         digit n-1 = cell pos-n (the UP   neighbour, if not first row)
+    //       digit value : 0 = empty, 1 = introvert, 2 = extrovert.
+    //       score the PAIR when the second member is placed, so each edge is
+    //       counted exactly once:
+    //         h[1][1] = -60, h[1][2] = h[2][1] = -10, h[2][2] = +40
+    //       plus the base 120 / 40 for the person just placed.
+    //       NOTE: people are optional -> "leave empty" (cur = 0) is always a
+    //             candidate.
+    //       NOTE: shifting the window drops the oldest digit
+    //             -> mask % 3^(n-1), then * 3 + cur.
+    /**
+     * time = O(m*n * 3^n * I * E * 3)
+     * space = O(m*n * 3^n * I * E)
+     */
+    private static final int[][] H = {
+            {0, 0, 0},
+            {0, -60, -10},
+            {0, -10, 40}
+    };
+    private static final int[] BASE = {0, 120, 40};
+
+    private int n;
+    private int total;
+    private int pw;
+    private int[][][][] memo;
+
+    public int getMaxGridHappiness(int m, int n, int introvertsCount, int extrovertsCount) {
+        this.n = n;
+        this.total = m * n;
+        this.pw = (int) Math.pow(3, n - 1);
+        int maskSize = this.pw * 3;
+        this.memo = new int[total + 1][maskSize][introvertsCount + 1][extrovertsCount + 1];
+        for (int a = 0; a <= total; a++) {
+            for (int b = 0; b < maskSize; b++) {
+                for (int c = 0; c <= introvertsCount; c++) {
+                    for (int d = 0; d <= extrovertsCount; d++) {
+                        this.memo[a][b][c][d] = -1;
+                    }
+                }
+            }
+        }
+        return dfs(0, 0, introvertsCount, extrovertsCount);
+    }
+
+    private int dfs(int pos, int mask, int ic, int ec) {
+        if (pos == total || (ic == 0 && ec == 0)) {
+            return 0;
+        }
+        if (memo[pos][mask][ic][ec] != -1) {
+            return memo[pos][mask][ic][ec];
+        }
+
+        int r = pos / n;
+        int c = pos % n;
+        int up = mask / pw;   // digit n-1 -> cell pos - n
+        int left = mask % 3;  // digit 0   -> cell pos - 1
+
+        int best = 0;
+        for (int cur = 0; cur <= 2; cur++) {
+            if (cur == 1 && ic == 0) {
+                continue;
+            }
+            if (cur == 2 && ec == 0) {
+                continue;
+            }
+            int gain = BASE[cur];
+            if (r > 0) {
+                gain += H[cur][up];
+            }
+            if (c > 0) {
+                gain += H[cur][left];
+            }
+            int nmask = (mask % pw) * 3 + cur;
+            int nic = (cur == 1) ? ic - 1 : ic;
+            int nec = (cur == 2) ? ec - 1 : ec;
+            int cand = gain + dfs(pos + 1, nmask, nic, nec);
+            if (cand > best) {
+                best = cand;
+            }
+        }
+
+        memo[pos][mask][ic][ec] = best;
+        return best;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/MaximumScoreWordsFormedByLetters.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/MaximumScoreWordsFormedByLetters.java
@@ -1,0 +1,112 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/maximum-score-words-formed-by-letters/
+
+/**
+ *  1255. Maximum Score Words Formed by Letters
+ *  Hard
+ *
+ *  Given a list of words, list of single letters (might be repeating) and score
+ *  of every character.
+ *
+ *  Return the maximum score of any valid set of words formed by using the given
+ *  letters (words[i] cannot be used two or more times).
+ *
+ *  It is not necessary to use all characters in letters and each letter can only
+ *  be used once. Score of letters 'a', 'b', 'c', ..., 'z' is given by score[0],
+ *  score[1], ..., score[25] respectively.
+ *
+ *  Example 1:
+ *    Input: words = ["dog","cat","dad","good"],
+ *           letters = ["a","a","c","d","d","d","g","o","o"],
+ *           score = [1,0,9,5,0,0,3,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0]
+ *    Output: 23
+ *    Explanation: a=1, c=9, d=5, g=3, o=2 -> "dad" (11) + "good" (12) = 23
+ *
+ *  Example 2:
+ *    Input: words = ["xxxz","ax","bx","cx"],
+ *           letters = ["z","a","b","c","x","x","x"],
+ *           score = [4,4,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,5,0,10]
+ *    Output: 27
+ *    Explanation: "ax" + "bx" + "cx" = 9 + 9 + 9 = 27
+ *
+ *  Constraints:
+ *    1 <= words.length <= 14
+ *    1 <= words[i].length <= 15
+ *    1 <= letters.length <= 100
+ *    letters[i].length == 1
+ *    score.length == 26
+ *    0 <= score[i] <= 10
+ *    words[i], letters[i] contains only lower case English letters.
+ */
+public class MaximumScoreWordsFormedByLetters {
+
+    // V0
+    // IDEA: BACKTRACKING (take / skip each word, undo the letter spend on return)
+    //       n <= 14, so exploring every subset of words is fine.
+    //       walk the words left to right holding a live letter budget:
+    //         - skip word i                                    -> recurse i + 1
+    //         - take word i, if every letter is still in stock -> pay the
+    //           letters, add its score, recurse i + 1, then REFUND the letters
+    //       NOTE: the refund (backtrack step) is what keeps the two branches
+    //             independent - without it the budget leaks across subsets.
+    //       NOTE: scoring a word is a pure function of its letters, so
+    //             precompute each word's letter counts + score once.
+    /**
+     * time = O(2^n * 26), space = O(n * 26)
+     *   n = words.length
+     */
+    private int res;
+    private int[] budget;
+    private int[][] need;
+    private int[] gain;
+
+    public int maxScoreWords(String[] words, char[] letters, int[] score) {
+        this.budget = new int[26];
+        for (char c : letters) {
+            this.budget[c - 'a']++;
+        }
+
+        int n = words.length;
+        this.need = new int[n][26];
+        this.gain = new int[n];
+        for (int i = 0; i < n; i++) {
+            for (char c : words[i].toCharArray()) {
+                this.need[i][c - 'a']++;
+                this.gain[i] += score[c - 'a'];
+            }
+        }
+
+        this.res = 0;
+        backtrack(0, 0, n);
+        return this.res;
+    }
+
+    private void backtrack(int i, int cur, int n) {
+        if (i == n) {
+            this.res = Math.max(this.res, cur);
+            return;
+        }
+
+        // skip words[i]
+        backtrack(i + 1, cur, n);
+
+        // take words[i] if affordable
+        boolean ok = true;
+        for (int c = 0; c < 26; c++) {
+            if (this.budget[c] < this.need[i][c]) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) {
+            for (int c = 0; c < 26; c++) {
+                this.budget[c] -= this.need[i][c];
+            }
+            backtrack(i + 1, cur + this.gain[i], n);
+            for (int c = 0; c < 26; c++) {
+                this.budget[c] += this.need[i][c];
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/MinimumTimeToBreakLocksI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/MinimumTimeToBreakLocksI.java
@@ -1,0 +1,87 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/minimum-time-to-break-locks-i/
+
+import java.util.List;
+
+/**
+ *  3376. Minimum Time to Break Locks I
+ *  Medium
+ *
+ *  Bob is stuck in a dungeon and must break n locks, each requiring some amount
+ *  of energy to break. The required energy for each lock is stored in an array
+ *  called strength where strength[i] indicates the energy needed to break the
+ *  ith lock.
+ *
+ *  To break a lock, Bob uses a sword with the following characteristics:
+ *    - The initial energy of the sword is 0.
+ *    - The initial factor X by which the energy increases is 1.
+ *    - Every minute, the energy of the sword increases by the current factor X.
+ *    - To break the ith lock, the energy must reach at least strength[i].
+ *    - After breaking a lock, the energy resets to 0, and the factor X increases
+ *      by a given value K.
+ *
+ *  Return the minimum time in minutes required for Bob to break all n locks.
+ *
+ *  Example 1:
+ *    Input: strength = [3,4,1], K = 1
+ *    Output: 4
+ *    Explanation: break lock 3 (X=1, 1 min), lock 2 (X=2, 2 min),
+ *                 lock 1 (X=3, 1 min) -> 4
+ *
+ *  Example 2:
+ *    Input: strength = [2,5,4], K = 2
+ *    Output: 5
+ *
+ *  Constraints:
+ *    n == strength.length
+ *    1 <= n <= 8
+ *    1 <= K <= 10
+ *    1 <= strength[i] <= 10^6
+ */
+public class MinimumTimeToBreakLocksI {
+
+    // V0
+    // IDEA: n <= 8, SO TRY EVERY ORDER - THE COST OF AN ORDER IS FORCED
+    //       the only decision is the SEQUENCE of locks. once that is fixed,
+    //       breaking the t-th lock (0-indexed) takes ceil(strength / X) minutes
+    //       with X = 1 + t*K, since waiting longer than necessary never helps
+    //       and the factor only changes on a break.
+    //       8! = 40320 orders, each scored in 8 steps; the running-total bound
+    //       prunes most of them away.
+    /**
+     * time = O(n! * n)
+     * space = O(n)
+     */
+    private int best;
+
+    public int findMinimumTime(List<Integer> strength, int K) {
+        int n = strength.size();
+        int[] s = new int[n];
+        for (int i = 0; i < n; i++) {
+            s[i] = strength.get(i);
+        }
+        this.best = Integer.MAX_VALUE;
+        dfs(s, new boolean[n], 0, 1, 0, K);
+        return this.best;
+    }
+
+    private void dfs(int[] s, boolean[] used, int done, int x, int total, int K) {
+        if (total >= this.best) {
+            return; // bound: this order can no longer win
+        }
+        if (done == s.length) {
+            this.best = total;
+            return;
+        }
+        for (int i = 0; i < s.length; i++) {
+            if (used[i]) {
+                continue;
+            }
+            used[i] = true;
+            // ceil(s[i] / x)
+            dfs(s, used, done + 1, x + K, total + (s[i] + x - 1) / x, K);
+            used[i] = false;
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/NumberOfValidMoveCombinationsOnChessboard.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/NumberOfValidMoveCombinationsOnChessboard.java
@@ -1,0 +1,185 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/number-of-valid-move-combinations-on-chessboard/
+
+/**
+ *  2056. Number of Valid Move Combinations On Chessboard
+ *  Hard
+ *
+ *  There is an 8 x 8 chessboard containing n pieces (rooks, queens, or bishops).
+ *  You are given a string array pieces of length n, where pieces[i] describes the
+ *  type (rook, queen, or bishop) of the ith piece. In addition, you are given a 2D
+ *  integer array positions also of length n, where positions[i] = [ri, ci]
+ *  indicates that the ith piece is currently at the 1-based coordinate (ri, ci) on
+ *  the chessboard.
+ *
+ *  When making a move for a piece, you choose a destination square that the piece
+ *  will travel toward and stop on.
+ *
+ *  A rook can only travel horizontally or vertically.
+ *  A queen can only travel horizontally, vertically, or diagonally.
+ *  A bishop can only travel diagonally.
+ *
+ *  You must make a move for every piece on the board simultaneously. A move
+ *  combination consists of all the moves performed on all the given pieces. Every
+ *  second, each piece will instantaneously travel one square towards their
+ *  destination if they are not already at it. All pieces start traveling at the 0th
+ *  second. A move combination is invalid if, at a given time, two or more pieces
+ *  occupy the same square.
+ *
+ *  Return the number of valid move combinations.
+ *
+ *  Notes:
+ *    No two pieces will start in the same square.
+ *    You may choose the square a piece is already on as its destination.
+ *    If two pieces are directly adjacent to each other, it is valid for them to
+ *    move past each other and swap positions in one second.
+ *
+ *  Example 1:
+ *    Input: pieces = ["rook"], positions = [[1,1]]
+ *    Output: 15
+ *
+ *  Example 2:
+ *    Input: pieces = ["queen"], positions = [[1,1]]
+ *    Output: 22
+ *
+ *  Example 3:
+ *    Input: pieces = ["bishop"], positions = [[4,3]]
+ *    Output: 12
+ *
+ *  Constraints:
+ *    n == pieces.length
+ *    n == positions.length
+ *    1 <= n <= 4
+ *    pieces only contains the strings "rook", "queen", and "bishop".
+ *    There will be at most one queen on the chessboard.
+ *    1 <= ri, ci <= 8
+ *    Each positions[i] is distinct.
+ */
+public class NumberOfValidMoveCombinationsOnChessboard {
+
+    private static final int[][] ROOK = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };
+    private static final int[][] BISHOP = { { 1, 1 }, { 1, -1 }, { -1, 1 }, { -1, -1 } };
+    private static final int[][] QUEEN = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 },
+            { 1, 1 }, { 1, -1 }, { -1, 1 }, { -1, -1 } };
+
+    private static final int M = 9; // 1-based board, index 1..8
+
+    private String[] pieces;
+    private int[][] positions;
+    private int n;
+    private int[][][] dist; // dist[i][x][y] = second at which piece i sits on (x, y), else -1
+    private int[][] end;    // end[i] = {x, y, t} : where piece i finally parks
+    private int res;
+
+    // V0
+    // IDEA: BACKTRACKING PIECE BY PIECE, RECORDING EACH PIECE'S TIMELINE
+    //       n <= 4 and every piece walks at most 7 squares in one of <= 8 directions,
+    //       so brute forcing (direction, stop-square) per piece is tiny.
+    //
+    //       when placing piece i we only need to check it against pieces 0..i-1:
+    //         - checkPass(x, y, t) : nobody earlier is on (x, y) at exactly second t,
+    //           and nobody earlier has already PARKED on (x, y) at a second <= t.
+    //         - checkStop(x, y, t) : to park here, every earlier piece must have left
+    //           (x, y) strictly before t.
+    //
+    //       passing THROUGH each other (swapping) is legal, which is why the collision
+    //       test compares equal timestamps rather than segments.
+    /**
+     * time = O((8 * 8)^n) with n <= 4
+     * space = O(n * 81)
+     */
+    public int countCombinations(String[] pieces, int[][] positions) {
+        this.pieces = pieces;
+        this.positions = positions;
+        this.n = pieces.length;
+        this.dist = new int[n][M][M];
+        this.end = new int[n][3];
+        this.res = 0;
+        for (int i = 0; i < n; i++) {
+            reset(i);
+        }
+        dfs(0);
+        return res;
+    }
+
+    private int[][] dirsOf(String p) {
+        char c = p.charAt(0);
+        if (c == 'r') {
+            return ROOK;
+        }
+        if (c == 'b') {
+            return BISHOP;
+        }
+        return QUEEN;
+    }
+
+    private void reset(int i) {
+        for (int a = 0; a < M; a++) {
+            for (int b = 0; b < M; b++) {
+                dist[i][a][b] = -1;
+            }
+        }
+    }
+
+    private boolean checkStop(int i, int x, int y, int t) {
+        for (int j = 0; j < i; j++) {
+            if (dist[j][x][y] >= t) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean checkPass(int i, int x, int y, int t) {
+        for (int j = 0; j < i; j++) {
+            if (dist[j][x][y] == t) {
+                return false;
+            }
+            if (end[j][0] == x && end[j][1] == y && end[j][2] <= t) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void dfs(int i) {
+        if (i == n) {
+            res++;
+            return;
+        }
+        int x = positions[i][0];
+        int y = positions[i][1];
+
+        // option 1 : stay put
+        reset(i);
+        dist[i][x][y] = 0;
+        end[i][0] = x;
+        end[i][1] = y;
+        end[i][2] = 0;
+        if (checkStop(i, x, y, 0)) {
+            dfs(i + 1);
+        }
+
+        // option 2 : walk along one direction and stop somewhere
+        for (int[] d : dirsOf(pieces[i])) {
+            reset(i);
+            dist[i][x][y] = 0;
+            int nx = x + d[0];
+            int ny = y + d[1];
+            int nt = 1;
+            while (nx >= 1 && nx < M && ny >= 1 && ny < M && checkPass(i, nx, ny, nt)) {
+                dist[i][nx][ny] = nt;
+                end[i][0] = nx;
+                end[i][1] = ny;
+                end[i][2] = nt;
+                if (checkStop(i, nx, ny, nt)) {
+                    dfs(i + 1);
+                }
+                nx += d[0];
+                ny += d[1];
+                nt++;
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/PermutationsIII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/PermutationsIII.java
@@ -1,0 +1,94 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/permutations-iii/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  3437. Permutations III
+ *  Medium
+ *
+ *  Given an integer n, an alternating permutation is a permutation of the first n
+ *  positive integers such that no two adjacent elements are both odd or both even.
+ *
+ *  Return all such alternating permutations sorted in lexicographical order.
+ *
+ *  Example 1:
+ *    Input: n = 4
+ *    Output: [[1,2,3,4],[1,4,3,2],[2,1,4,3],[2,3,4,1],
+ *             [3,2,1,4],[3,4,1,2],[4,1,2,3],[4,3,2,1]]
+ *
+ *  Example 2:
+ *    Input: n = 3
+ *    Output: [[1,2,3],[3,2,1]]
+ *
+ *  Constraints:
+ *    1 <= n <= 10
+ */
+public class PermutationsIII {
+
+    private int n;
+    private int[] cur;
+    private int size;
+    private boolean[] used;
+    private List<int[]> res;
+
+    // V0
+    // IDEA: BACKTRACKING THAT ONLY EVER OFFERS THE OPPOSITE PARITY
+    //       "no two adjacent elements share a parity" means the parities must
+    //       alternate, so once the first element is placed the parity of every later
+    //       slot is fixed. the search therefore never has to test the constraint
+    //       after the fact -- at each step it simply iterates over the unused numbers
+    //       of the required parity.
+    //
+    //       trying the candidates in increasing order makes the recursion emit
+    //       complete permutations in lexicographic order, so no final sort is needed.
+    /**
+     * time = O(n * number of alternating permutations)
+     * space = O(n)   // excluding the output
+     */
+    public int[][] permute(int n) {
+        this.n = n;
+        this.cur = new int[n];
+        this.size = 0;
+        this.used = new boolean[n + 1];
+        this.res = new ArrayList<>();
+        dfs();
+        int[][] out = new int[res.size()][];
+        for (int i = 0; i < res.size(); i++) {
+            out[i] = res.get(i);
+        }
+        return out;
+    }
+
+    private void dfs() {
+        if (size == n) {
+            int[] copy = new int[n];
+            System.arraycopy(cur, 0, copy, 0, n);
+            res.add(copy);
+            return;
+        }
+        if (size > 0) {
+            // the next value must have the OPPOSITE parity of the previous one
+            int lo = ((cur[size - 1] & 1) == 1) ? 2 : 1;
+            for (int v = lo; v <= n; v += 2) {
+                if (!used[v]) {
+                    used[v] = true;
+                    cur[size++] = v;
+                    dfs();
+                    size--;
+                    used[v] = false;
+                }
+            }
+        } else {
+            for (int v = 1; v <= n; v++) {
+                used[v] = true;
+                cur[size++] = v;
+                dfs();
+                size--;
+                used[v] = false;
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SequentialGridPathCover.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SequentialGridPathCover.java
@@ -1,0 +1,124 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/sequential-grid-path-cover/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  3565. Sequential Grid Path Cover
+ *  Medium
+ *
+ *  You are given a 2D array grid of size m x n, and an integer k. There are k cells
+ *  in grid containing the values from 1 to k exactly once, and the rest of the cells
+ *  have a value 0.
+ *
+ *  You can start at any cell, and move from a cell to its neighbors (up, down, left,
+ *  or right). You must find a path in grid which:
+ *    Visits each cell in grid exactly once.
+ *    Visits the cells with values from 1 to k in order.
+ *
+ *  Return a 2D array result of size (m * n) x 2, where result[i] = [xi, yi]
+ *  represents the ith cell visited in the path. If there are multiple such paths,
+ *  you may return any one of them. If no such path exists, return an empty array.
+ *
+ *  Example 1:
+ *    Input: grid = [[0,0,0],[0,1,2]], k = 2
+ *    Output: [[0,0],[1,0],[1,1],[1,2],[0,2],[0,1]]
+ *
+ *  Example 2:
+ *    Input: grid = [[1,0,4],[3,0,2]], k = 4
+ *    Output: []
+ *
+ *  Constraints:
+ *    1 <= m == grid.length <= 5
+ *    1 <= n == grid[i].length <= 5
+ *    1 <= k <= m * n
+ *    0 <= grid[i][j] <= k
+ *    grid contains all integers between 1 and k exactly once.
+ */
+public class SequentialGridPathCover {
+
+    private int[][] grid;
+    private int m;
+    private int n;
+    private int total;
+    private int seen; // bitmask over the <= 25 cells
+    private List<int[]> path;
+
+    private static final int[][] DIRS = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+
+    // V0
+    // IDEA: BACKTRACKING WITH THE "NEXT WANTED LABEL" AS PART OF THE STATE
+    //       the path is a hamiltonian path in the grid graph, so brute force search
+    //       is unavoidable; the ordering constraint is what makes it cheap. carry the
+    //       next label we still owe, v (starting at 1). a cell may be stepped on only
+    //       if it is blank or carries exactly v -- a cell holding a label larger than
+    //       v would jump the queue, and one holding a smaller label was already
+    //       consumed. that single test enforces "1..k in order" locally, so no global
+    //       check at the end is needed.
+    //
+    //       the start cell is likewise restricted to blank or 1, and since the walk
+    //       ends only when all m*n cells are on the path, covering every cell exactly
+    //       once is guaranteed by construction.
+    /**
+     * time = O(m * n * 3^(m * n)) worst case
+     * space = O(m * n)
+     */
+    public int[][] findPath(int[][] grid, int k) {
+        this.grid = grid;
+        this.m = grid.length;
+        this.n = grid[0].length;
+        this.total = m * n;
+        this.path = new ArrayList<>();
+
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                if (grid[i][j] == 0 || grid[i][j] == 1) {
+                    if (dfs(i, j, 1)) {
+                        int[][] out = new int[path.size()][];
+                        for (int t = 0; t < path.size(); t++) {
+                            out[t] = path.get(t);
+                        }
+                        return out;
+                    }
+                    path.clear();
+                    seen = 0;
+                }
+            }
+        }
+        return new int[0][0];
+    }
+
+    private boolean dfs(int i, int j, int v) {
+        path.add(new int[] { i, j });
+        if (path.size() == total) {
+            return true;
+        }
+
+        seen |= 1 << (i * n + j);
+        if (grid[i][j] == v) {
+            v++;
+        }
+
+        for (int[] d : DIRS) {
+            int x = i + d[0];
+            int y = j + d[1];
+            if (x < 0 || x >= m || y < 0 || y >= n) {
+                continue;
+            }
+            if ((seen & (1 << (x * n + y))) != 0) {
+                continue;
+            }
+            if (grid[x][y] == 0 || grid[x][y] == v) {
+                if (dfs(x, y, v)) {
+                    return true;
+                }
+            }
+        }
+
+        seen ^= 1 << (i * n + j);
+        path.remove(path.size() - 1);
+        return false;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SmallestGreaterMultipleMadeOfTwoDigits.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SmallestGreaterMultipleMadeOfTwoDigits.java
@@ -1,0 +1,87 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/smallest-greater-multiple-made-of-two-digits/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1999. Smallest Greater Multiple Made of Two Digits
+ *  Medium
+ *
+ *  Given three integers, k, digit1, and digit2, you want to find the smallest
+ *  integer that is:
+ *    Larger than k,
+ *    A multiple of k, and
+ *    Comprised of only the digits digit1 and/or digit2.
+ *
+ *  Return the smallest such integer. If no such integer exists or the integer
+ *  exceeds the limit of a signed 32-bit integer (2^31 - 1), return -1.
+ *
+ *  Example 1:
+ *    Input: k = 2, digit1 = 0, digit2 = 2
+ *    Output: 20
+ *
+ *  Example 2:
+ *    Input: k = 3, digit1 = 4, digit2 = 2
+ *    Output: 24
+ *
+ *  Example 3:
+ *    Input: k = 2, digit1 = 0, digit2 = 0
+ *    Output: -1
+ *
+ *  Constraints:
+ *    1 <= k <= 1000
+ *    0 <= digit1 <= 9
+ *    0 <= digit2 <= 9
+ */
+public class SmallestGreaterMultipleMadeOfTwoDigits {
+
+    // V0
+    // IDEA: BFS OVER THE DIGIT TREE (generates candidates in increasing order)
+    //       every candidate is built by repeatedly appending digit1 or digit2 to a
+    //       shorter candidate : x -> x*10 + d.
+    //
+    //       push the smaller digit first, so a FIFO queue emits candidates in
+    //       non-decreasing numeric order - the first one that is > k and divisible by
+    //       k is the answer, no sorting needed.
+    //
+    //       NOTE : with digit1 == digit2 push only one child, otherwise the queue
+    //              duplicates every value and blows up.
+    //       NOTE : the search is bounded - stop and return -1 as soon as the front of
+    //              the queue passes 2^31 - 1, since everything behind it is larger.
+    //       NOTE : use long for the arithmetic so appending a digit cannot overflow.
+    /**
+     * time = O(2^L), L <= 10 digits before the 2^31 cutoff
+     * space = O(2^L)
+     */
+    public int findInteger(int k, int digit1, int digit2) {
+        if (digit1 == 0 && digit2 == 0) {
+            return -1;
+        }
+        int lo = Math.min(digit1, digit2);
+        int hi = Math.max(digit1, digit2);
+        final long LIMIT = Integer.MAX_VALUE;
+
+        Deque<Long> q = new ArrayDeque<>();
+        q.add(0L);
+        while (!q.isEmpty()) {
+            long x = q.poll();
+            if (x > LIMIT) {
+                return -1;
+            }
+            if (x > k && x % k == 0) {
+                return (int) x;
+            }
+            // never append a leading zero (x == 0 means nothing built yet),
+            // otherwise 0 -> 0 loops forever
+            if (x > 0 || lo != 0) {
+                q.add(x * 10 + lo);
+            }
+            if (lo != hi && (x > 0 || hi != 0)) {
+                q.add(x * 10 + hi);
+            }
+        }
+        return -1;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SpecialPermutations.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SpecialPermutations.java
@@ -1,0 +1,96 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/special-permutations/
+
+/**
+ *  2741. Special Permutations
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array nums containing n distinct positive
+ *  integers. A permutation of nums is called special if:
+ *    For all indexes 0 <= i < n - 1, either nums[i] % nums[i+1] == 0 or
+ *    nums[i+1] % nums[i] == 0.
+ *
+ *  Return the total number of special permutations. As the answer could be large,
+ *  return it modulo 10^9 + 7.
+ *
+ *  Example 1:
+ *    Input: nums = [2,3,6]
+ *    Output: 2
+ *    Explanation: [3,6,2] and [2,6,3] are the two special permutations of nums.
+ *
+ *  Example 2:
+ *    Input: nums = [1,4,3]
+ *    Output: 2
+ *    Explanation: [3,1,4] and [4,1,3] are the two special permutations of nums.
+ *
+ *  Constraints:
+ *    2 <= nums.length <= 14
+ *    1 <= nums[i] <= 10^9
+ */
+public class SpecialPermutations {
+
+    // V0
+    // IDEA: BACKTRACKING COMPRESSED INTO BITMASK DP (STATE COMPRESSION)
+    //       Plain backtracking over all n! orders is 14! ~ 8.7e10 -- way too slow.
+    //       But the count of ways to FINISH a permutation only depends on:
+    //         (1) WHICH numbers are already used -> a 14-bit mask
+    //         (2) WHICH number was placed LAST   -> an index
+    //       The actual order of the used prefix is irrelevant, so memoizing on
+    //       (mask, last) collapses n! branches into n * 2^n states.
+    //
+    //       dp[mask][last] = number of ways to extend a prefix that used exactly the
+    //                        numbers in `mask` and ended with nums[last].
+    //       Base case : mask == full -> 1. Answer = sum over every start index.
+    //
+    //       NOTE : precompute the divisibility adjacency as bitmasks so the inner
+    //              loop is a single `ok[last] & ~mask` scan instead of n modulos.
+    /**
+     * time = O(n^2 * 2^n)
+     * space = O(n * 2^n)
+     */
+    public int specialPerm(int[] nums) {
+        final int MOD = 1_000_000_007;
+        int n = nums.length;
+        int full = (1 << n) - 1;
+
+        // ok[i] = bitmask of the j that may directly follow / precede i
+        int[] ok = new int[n];
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (i != j && (nums[i] % nums[j] == 0 || nums[j] % nums[i] == 0)) {
+                    ok[i] |= 1 << j;
+                }
+            }
+        }
+
+        // iterate masks descending so dp[bigger mask] is ready
+        int[][] dp = new int[1 << n][n];
+        for (int last = 0; last < n; last++) {
+            dp[full][last] = 1;
+        }
+
+        for (int mask = full - 1; mask > 0; mask--) {
+            int free = full ^ mask;
+            for (int last = 0; last < n; last++) {
+                if (((mask >> last) & 1) == 0) {
+                    continue;
+                }
+                int cand = ok[last] & free;
+                long total = 0;
+                while (cand != 0) {
+                    int j = Integer.numberOfTrailingZeros(cand);
+                    total += dp[mask | (1 << j)][j];
+                    cand &= cand - 1;
+                }
+                dp[mask][last] = (int) (total % MOD);
+            }
+        }
+
+        long res = 0;
+        for (int i = 0; i < n; i++) {
+            res += dp[1 << i][i];
+        }
+        return (int) (res % MOD);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SplitAStringIntoTheMaxNumberOfUniqueSubstrings.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SplitAStringIntoTheMaxNumberOfUniqueSubstrings.java
@@ -1,0 +1,79 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/split-a-string-into-the-max-number-of-unique-substrings/
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *  1593. Split a String Into the Max Number of Unique Substrings
+ *  Medium
+ *
+ *  Given a string s, return the maximum number of unique substrings that the given
+ *  string can be split into.
+ *
+ *  You can split string s into any list of non-empty substrings, where the
+ *  concatenation of the substrings forms the original string. However, you must
+ *  split the substrings such that all of them are unique.
+ *
+ *  A substring is a contiguous sequence of characters within a string.
+ *
+ *  Example 1:
+ *    Input: s = "ababccc"
+ *    Output: 5
+ *    Explanation: One way to split maximally is ['a', 'b', 'ab', 'c', 'cc'].
+ *
+ *  Example 2:
+ *    Input: s = "aba"
+ *    Output: 2
+ *    Explanation: One way to split maximally is ['a', 'ba'].
+ *
+ *  Constraints:
+ *    1 <= s.length <= 16
+ *    s contains only lower case English letters.
+ */
+public class SplitAStringIntoTheMaxNumberOfUniqueSubstrings {
+
+    private String s;
+    private int n;
+    private Set<String> used;
+    private int best;
+
+    // V0
+    // IDEA: BACKTRACKING (n <= 16, try every cut with a "used pieces" set)
+    //       at position i try every next cut j, and if s[i, j) has not been used yet
+    //       take it and recurse.
+    //       NOTE : prune with "current count + remaining characters <= best", since
+    //              every remaining char can add at most one more piece.
+    /**
+     * time = O(2^n * n)
+     * space = O(n^2)
+     */
+    public int maxUniqueSplit(String s) {
+        this.s = s;
+        this.n = s.length();
+        this.used = new HashSet<>();
+        this.best = 0;
+        dfs(0, 0);
+        return best;
+    }
+
+    private void dfs(int i, int cnt) {
+        if (cnt + (n - i) <= best) {
+            return;
+        }
+        if (i == n) {
+            best = cnt;
+            return;
+        }
+        for (int j = i + 1; j <= n; j++) {
+            String piece = s.substring(i, j);
+            if (used.contains(piece)) {
+                continue;
+            }
+            used.add(piece);
+            dfs(j, cnt + 1);
+            used.remove(piece);
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SplittingAStringIntoDescendingConsecutiveValues.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SplittingAStringIntoDescendingConsecutiveValues.java
@@ -1,0 +1,94 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/splitting-a-string-into-descending-consecutive-values/
+
+/**
+ *  1849. Splitting a String Into Descending Consecutive Values
+ *  Medium
+ *
+ *  You are given a string s that consists of only digits.
+ *
+ *  Check if we can split s into two or more non-empty substrings such that the
+ *  numerical values of the substrings are in descending order and the difference
+ *  between numerical values of every two adjacent substrings is equal to 1.
+ *
+ *  For example, the string s = "0090089" can be split into ["0090", "089"] with
+ *  numerical values [90,89]. The values are in descending order and adjacent values
+ *  differ by 1, so this way is valid.
+ *
+ *  Return true if it is possible to split s as described above, or false otherwise.
+ *
+ *  Example 1:
+ *    Input: s = "1234"
+ *    Output: false
+ *
+ *  Example 2:
+ *    Input: s = "050043"
+ *    Output: true
+ *    Explanation: s can be split into ["05", "004", "3"] -> [5,4,3].
+ *
+ *  Example 3:
+ *    Input: s = "9080701"
+ *    Output: false
+ *
+ *  Constraints:
+ *    1 <= s.length <= 20
+ *    s only consists of digits.
+ */
+public class SplittingAStringIntoDescendingConsecutiveValues {
+
+    private String s;
+    private int n;
+
+    // V0
+    // IDEA: BACKTRACKING -- only the FIRST piece really branches
+    //       dfs(i, prev) : can s[i:] be split so the next piece is prev - 1 and the
+    //       chain keeps descending by 1?
+    //         - i == len(s) -> the split closed cleanly -> true
+    //         - otherwise grow a candidate y digit by digit from position i and
+    //           recurse whenever y == prev - 1.
+    //
+    //       for the very first piece (prev = -1) every prefix is allowed, EXCEPT the
+    //       whole string -- the split must have at least two parts (the `n - 1` cap).
+    //
+    //       NOTE : leading zeros are fine ("004" == 4), so we just accumulate
+    //              y = y * 10 + digit without any special casing.
+    //       NOTE : once prev is fixed there is at most ONE valid next value, so the
+    //              search collapses to a linear walk after the first choice.
+    //       NOTE : 20 digits overflow int -> use long, and stop growing y once it
+    //              already exceeds prev (it can only get bigger).
+    /**
+     * time = O(n^2)
+     * space = O(n)
+     */
+    public boolean splitString(String s) {
+        this.s = s;
+        this.n = s.length();
+        return dfs(0, -1L);
+    }
+
+    private boolean dfs(int i, long prev) {
+        if (i == n) {
+            return true;
+        }
+        long y = 0;
+        int end = (prev < 0) ? n - 1 : n;
+        for (int j = i; j < end; j++) {
+            // guard : a piece that big can never be followed by (piece - 1)
+            // inside the remaining <= 20 characters, and it would overflow long
+            if (y > 100000000000000000L) {
+                break;
+            }
+            y = y * 10 + (s.charAt(j) - '0');
+            if (prev >= 0 && y >= prev) {
+                break; // y only grows from here -> prev - y == 1 impossible
+            }
+            if (prev < 0 || prev - y == 1) {
+                if (dfs(j + 1, y)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SumOfNumberAndItsReverse.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SumOfNumberAndItsReverse.java
@@ -1,0 +1,59 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/sum-of-number-and-its-reverse/
+
+/**
+ *  2443. Sum of Number and Its Reverse
+ *  Medium
+ *
+ *  Given a non-negative integer num, return true if num can be expressed as the sum
+ *  of any non-negative integer and its reverse, or false otherwise.
+ *
+ *  Example 1:
+ *    Input: num = 443
+ *    Output: true
+ *    Explanation: 172 + 271 = 443 so we return true.
+ *
+ *  Example 2:
+ *    Input: num = 63
+ *    Output: false
+ *
+ *  Example 3:
+ *    Input: num = 181
+ *    Output: true
+ *    Explanation: 140 + 041 = 181. Note that when a number is reversed, there may
+ *                 be leading zeros.
+ *
+ *  Constraints:
+ *    0 <= num <= 10^5
+ */
+public class SumOfNumberAndItsReverse {
+
+    // V0
+    // IDEA: ENUMERATION (the candidate k is bounded, so just scan it)
+    //       if num = k + reverse(k) then k <= num, and by symmetry one of
+    //       k / reverse(k) is >= num / 2, so scanning k in [num / 2, num] is enough.
+    //       NOTE : num <= 10^5, so this is ~5 * 10^4 cheap digit reversals.
+    //              reverse() drops leading zeros: 140 + reverse(140) = 140 + 41 = 181.
+    /**
+     * time = O(num * d), d = number of digits
+     * space = O(1)
+     */
+    public boolean sumOfNumberAndReverse(int num) {
+        for (int k = num / 2; k <= num; k++) {
+            if (k + reverse(k) == num) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int reverse(int x) {
+        int r = 0;
+        while (x > 0) {
+            r = r * 10 + x % 10;
+            x /= 10;
+        }
+        return r;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SynonymousSentences.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SynonymousSentences.java
@@ -1,0 +1,129 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/synonymous-sentences/
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  1258. Synonymous Sentences
+ *  Medium
+ *
+ *  You are given a list of equivalent string pairs synonyms where
+ *  synonyms[i] = [si, ti] indicates that si and ti are equivalent strings. You are
+ *  also given a sentence text.
+ *
+ *  Return all possible synonymous sentences sorted lexicographically.
+ *
+ *  Example 1:
+ *    Input: synonyms = [["happy","joy"],["sad","sorrow"],["joy","cheerful"]],
+ *           text = "I am happy today but was sad yesterday"
+ *    Output: ["I am cheerful today but was sad yesterday",
+ *             "I am cheerful today but was sorrow yesterday",
+ *             "I am happy today but was sad yesterday",
+ *             "I am happy today but was sorrow yesterday",
+ *             "I am joy today but was sad yesterday",
+ *             "I am joy today but was sorrow yesterday"]
+ *
+ *  Example 2:
+ *    Input: synonyms = [["happy","joy"],["cheerful","glad"]],
+ *           text = "I am happy today but was sad yesterday"
+ *    Output: ["I am happy today but was sad yesterday",
+ *             "I am joy today but was sad yesterday"]
+ *
+ *  Constraints:
+ *    0 <= synonyms.length <= 10
+ *    synonyms[i].length == 2
+ *    1 <= si.length, ti.length <= 10
+ *    si != ti
+ *    text consists of at most 10 words.
+ *    All the pairs of synonyms are unique.
+ *    The words of text are separated by single spaces.
+ */
+public class SynonymousSentences {
+
+    private Map<String, String> parent = new HashMap<>();
+    private Map<String, List<String>> group = new HashMap<>();
+    private String[] words;
+    private List<String> cur = new ArrayList<>();
+    private List<String> res = new ArrayList<>();
+
+    // V0
+    // IDEA: UNION FIND + BACKTRACK (DFS)
+    //       1) union all synonym pairs -> each group = a set of interchangeable words
+    //       2) DFS over the words of `text`, branching on every word of its group
+    //       words with no synonym are kept as they are (single branch).
+    /**
+     * time = O(m^w * w), m = max group size, w = number of words
+     * space = O(n + w), n = number of distinct synonym words
+     */
+    public List<String> generateSentences(List<List<String>> synonyms, String text) {
+        for (List<String> p : synonyms) {
+            union(p.get(0), p.get(1));
+        }
+        for (String w : parent.keySet()) {
+            String r = find(w);
+            if (!group.containsKey(r)) {
+                group.put(r, new ArrayList<String>());
+            }
+            group.get(r).add(w);
+        }
+        for (List<String> g : group.values()) {
+            Collections.sort(g);
+        }
+
+        this.words = text.split(" ");
+        dfs(0);
+        Collections.sort(res);
+        return res;
+    }
+
+    private String find(String x) {
+        if (!parent.containsKey(x)) {
+            parent.put(x, x);
+        }
+        while (!parent.get(x).equals(x)) {
+            parent.put(x, parent.get(parent.get(x)));
+            x = parent.get(x);
+        }
+        return x;
+    }
+
+    private void union(String a, String b) {
+        String ra = find(a);
+        String rb = find(b);
+        if (!ra.equals(rb)) {
+            parent.put(ra, rb);
+        }
+    }
+
+    private void dfs(int i) {
+        if (i == words.length) {
+            StringBuilder sb = new StringBuilder();
+            for (int k = 0; k < cur.size(); k++) {
+                if (k > 0) {
+                    sb.append(' ');
+                }
+                sb.append(cur.get(k));
+            }
+            res.add(sb.toString());
+            return;
+        }
+        String w = words[i];
+        if (!parent.containsKey(w)) {
+            // word has no synonym -> keep it as it is
+            cur.add(w);
+            dfs(i + 1);
+            cur.remove(cur.size() - 1);
+        } else {
+            for (String cand : group.get(find(w))) {
+                cur.add(cand);
+                dfs(i + 1);
+                cur.remove(cur.size() - 1);
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/TheKnightsTour.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/TheKnightsTour.java
@@ -1,0 +1,103 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/the-knights-tour/
+
+/**
+ *  2664. The Knight's Tour
+ *  Medium
+ *
+ *  Given two positive integers m and n which are the height and width of a
+ *  0-indexed 2D-array board, a pair of positive integers (r, c) which is the
+ *  starting position of the knight on the board.
+ *
+ *  Your task is to find an order of movements for the knight, in a manner that every
+ *  cell of the board gets visited exactly once (the starting cell is considered
+ *  visited and you shouldn't visit it again).
+ *
+ *  Return the array board in which the cells' values show the order of visiting the
+ *  cell starting from 0 (the initial place of the knight).
+ *
+ *  Note that a knight can move from cell (r1, c1) to cell (r2, c2) if
+ *  0 <= r2 <= m - 1 and 0 <= c2 <= n - 1 and min(|r1-r2|, |c1-c2|) = 1 and
+ *  max(|r1-r2|, |c1-c2|) = 2.
+ *
+ *  Example 1:
+ *    Input: m = 1, n = 1, r = 0, c = 0
+ *    Output: [[0]]
+ *
+ *  Example 2:
+ *    Input: m = 3, n = 4, r = 0, c = 0
+ *    Output: [[0,3,6,9],[11,8,1,4],[2,5,10,7]]
+ *
+ *  Constraints:
+ *    1 <= m, n <= 5
+ *    0 <= r <= m - 1
+ *    0 <= c <= n - 1
+ *    The inputs will be generated such that there exists at least one possible order
+ *    of movements with the given condition.
+ */
+public class TheKnightsTour {
+
+    private static final int[][] DIRS = { { -2, -1 }, { -1, 2 }, { 2, 1 }, { 1, -2 },
+            { -2, 1 }, { 1, 2 }, { 2, -1 }, { -1, -2 } };
+
+    private int m;
+    private int n;
+    private int last;
+    private int[][] g;
+    private boolean done;
+
+    // V0
+    // IDEA: BACKTRACKING (DFS) OVER THE 8 KNIGHT MOVES
+    //       the board is at most 5 x 5 = 25 cells, so a plain "try every move, undo
+    //       on failure" DFS is affordable -- the "visit each cell exactly once" rule
+    //       prunes almost all of the tree immediately.
+    //
+    //       g[i][j] holds the step number at which the knight lands on (i, j), or -1
+    //       when the cell is still unvisited. That single array doubles as the answer
+    //       AND as the visited marker -- no separate seen set needed.
+    //
+    //       NOTE : the `done` flag is what freezes the board. Without it the
+    //              unwinding would erase the very tour we just found.
+    //       NOTE : the termination test is on the STEP NUMBER (m*n - 1), which works
+    //              because step numbers are assigned consecutively.
+    //       NOTE : m*n == 1 is handled for free -> [[0]].
+    /**
+     * time = O(8^(m*n)) worst case (tiny in practice)
+     * space = O(m*n)
+     */
+    public int[][] tourOfKnight(int m, int n, int r, int c) {
+        this.m = m;
+        this.n = n;
+        this.last = m * n - 1;
+        this.g = new int[m][n];
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                g[i][j] = -1;
+            }
+        }
+        g[r][c] = 0;
+        this.done = false;
+        dfs(r, c);
+        return g;
+    }
+
+    private void dfs(int i, int j) {
+        if (g[i][j] == last) {
+            done = true;
+            return;
+        }
+        for (int[] d : DIRS) {
+            int x = i + d[0];
+            int y = j + d[1];
+            if (x >= 0 && x < m && y >= 0 && y < n && g[x][y] == -1) {
+                g[x][y] = g[i][j] + 1;
+                dfs(x, y);
+                if (done) {
+                    return;
+                }
+                g[x][y] = -1;
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/TilingARectangleWithTheFewestSquares.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/TilingARectangleWithTheFewestSquares.java
@@ -1,0 +1,113 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/tiling-a-rectangle-with-the-fewest-squares/
+
+/**
+ *  1240. Tiling a Rectangle with the Fewest Squares
+ *  Hard
+ *
+ *  Given a rectangle of size n x m, return the minimum number of integer-sided
+ *  squares that tile the rectangle.
+ *
+ *  Example 1:
+ *    Input: n = 2, m = 3
+ *    Output: 3
+ *    Explanation: 3 squares are necessary to cover the rectangle.
+ *                 2 (squares of 1x1) + 1 (square of 2x2)
+ *
+ *  Example 2:
+ *    Input: n = 5, m = 8
+ *    Output: 5
+ *
+ *  Example 3:
+ *    Input: n = 11, m = 13
+ *    Output: 6
+ *
+ *  Constraints:
+ *    1 <= n, m <= 13
+ */
+public class TilingARectangleWithTheFewestSquares {
+
+    private int n;
+    private int m;
+    private int[] filled; // filled[i] is a bitmask of row i ; bit j set = (i, j) covered
+    private int ans;
+
+    // V0
+    // IDEA: BACKTRACKING + BITMASK (fill the first empty cell, scan row by row)
+    //       - always work on the FIRST empty cell (i, j) in reading order
+    //       - the square we place must have its top-left corner exactly there
+    //       - enumerate the side length w, bounded by how far we can go down (r) and
+    //         right (c) before hitting a filled cell
+    //       - prune with `t + 1 >= ans` (can't beat the current best)
+    //
+    //       NOTE : we GROW the square from side 1 up to mx. going from side w-1 to
+    //              side w only needs the new bottom row + right column of the square
+    //              to be marked, so the marking is incremental (no re-marking), and
+    //              the whole mx x mx block is undone once at the end.
+    /**
+     * time = exponential (heavily pruned) ; n, m <= 13
+     * space = O(n + recursion depth)
+     */
+    public int tilingRectangle(int n, int m) {
+        this.n = n;
+        this.m = m;
+        this.filled = new int[n];
+        this.ans = n * m; // worst case: all 1x1 squares
+        dfs(0, 0, 0);
+        return ans;
+    }
+
+    private void dfs(int i, int j, int t) {
+        // end of row -> go to next row
+        if (j == m) {
+            i += 1;
+            j = 0;
+        }
+        // all rows done -> t is a complete tiling (better than ans by pruning)
+        if (i == n) {
+            ans = t;
+            return;
+        }
+        // already covered -> move right
+        if (((filled[i] >> j) & 1) == 1) {
+            dfs(i, j + 1, t);
+            return;
+        }
+        if (t + 1 >= ans) {
+            return;
+        }
+
+        // how far down / right is free from (i, j)
+        int r = 0;
+        int c = 0;
+        for (int k = i; k < n; k++) {
+            if (((filled[k] >> j) & 1) == 1) {
+                break;
+            }
+            r++;
+        }
+        for (int k = j; k < m; k++) {
+            if (((filled[i] >> k) & 1) == 1) {
+                break;
+            }
+            c++;
+        }
+        int mx = Math.min(r, c);
+
+        for (int w = 1; w <= mx; w++) {
+            for (int k = 0; k < w; k++) {
+                filled[i + w - 1] |= 1 << (j + k);
+                filled[i + k] |= 1 << (j + w - 1);
+            }
+            dfs(i, j + w, t + 1);
+        }
+
+        // undo : the whole mx x mx block was marked by the loop above
+        for (int x = i; x < i + mx; x++) {
+            for (int y = j; y < j + mx; y++) {
+                filled[x] ^= 1 << y;
+            }
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/VerbalArithmeticPuzzle.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/VerbalArithmeticPuzzle.java
@@ -1,0 +1,167 @@
+package LeetCodeJava.BackTrack;
+
+// https://leetcode.com/problems/verbal-arithmetic-puzzle/
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *  1307. Verbal Arithmetic Puzzle
+ *  Hard
+ *
+ *  Given an equation, represented by words on the left side and the result on the
+ *  right side.
+ *
+ *  You need to check if the equation is solvable under the following rules:
+ *    - Each character is decoded as one digit (0 - 9).
+ *    - No two characters can map to the same digit.
+ *    - Each words[i] and result are decoded as one number without leading zeros.
+ *    - Sum of numbers on the left side (words) will equal to the number on the right
+ *      side (result).
+ *
+ *  Return true if the equation is solvable, otherwise return false.
+ *
+ *  Example 1:
+ *    Input: words = ["SEND","MORE"], result = "MONEY"
+ *    Output: true
+ *    Explanation: 'S'->9, 'E'->5, 'N'->6, 'D'->7, 'M'->1, 'O'->0, 'R'->8, 'Y'->2
+ *                 so that 9567 + 1085 = 10652
+ *
+ *  Example 2:
+ *    Input: words = ["LEET","CODE"], result = "POINT"
+ *    Output: false
+ *
+ *  Constraints:
+ *    2 <= words.length <= 5
+ *    1 <= words[i].length, result.length <= 7
+ *    words[i], result contain only uppercase English letters.
+ *    The number of different characters used in the expression is at most 10.
+ */
+public class VerbalArithmeticPuzzle {
+
+    private int[] coefOf;      // coefficient per letter index
+    private boolean[] isLead;  // letter index may not be 0
+    private int lettersCnt;
+    private long[] posSuf;
+    private long[] negSuf;
+    private boolean[] usedDigit = new boolean[10];
+
+    // V0
+    // IDEA: COEFFICIENT BACKTRACKING
+    //       Turn the whole equation into a single linear form:
+    //           sum(coef[ch] * digit[ch]) == 0
+    //       where a letter in words[i] contributes +10^p and a letter in result
+    //       contributes -10^p. Then backtrack over the (at most 10) distinct letters,
+    //       assigning distinct digits.
+    //
+    //       Pruning : keep suffix bounds of the most positive / most negative
+    //       contribution still reachable; if even those cannot bring the running
+    //       total back to 0, cut the branch.
+    //
+    //       Letters with the biggest |coefficient| are assigned first so the bound
+    //       bites as early as possible.
+    /**
+     * time = O(10!) worst case, heavily pruned in practice
+     * space = O(1)   // at most 10 distinct letters
+     */
+    public boolean isSolvable(String[] words, String result) {
+        // a word longer than the result can never sum to the result
+        for (String w : words) {
+            if (w.length() > result.length()) {
+                return false;
+            }
+        }
+
+        Map<Character, Integer> coef = new HashMap<>();
+        Set<Character> leading = new HashSet<>();
+        for (String w : words) {
+            for (int i = 0; i < w.length(); i++) {
+                char ch = w.charAt(i);
+                int p = pow10(w.length() - 1 - i);
+                coef.put(ch, (coef.containsKey(ch) ? coef.get(ch) : 0) + p);
+            }
+            if (w.length() > 1) {
+                leading.add(w.charAt(0));
+            }
+        }
+        for (int i = 0; i < result.length(); i++) {
+            char ch = result.charAt(i);
+            int p = pow10(result.length() - 1 - i);
+            coef.put(ch, (coef.containsKey(ch) ? coef.get(ch) : 0) - p);
+        }
+        if (result.length() > 1) {
+            leading.add(result.charAt(0));
+        }
+
+        // biggest |coefficient| first -> the bound prunes earlier
+        List<Character> letters = new ArrayList<>(coef.keySet());
+        final Map<Character, Integer> cf = coef;
+        letters.sort(new Comparator<Character>() {
+            @Override
+            public int compare(Character a, Character b) {
+                return Math.abs(cf.get(b)) - Math.abs(cf.get(a));
+            }
+        });
+        int n = letters.size();
+        if (n > 10) {
+            return false;
+        }
+
+        this.lettersCnt = n;
+        this.coefOf = new int[n];
+        this.isLead = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            coefOf[i] = coef.get(letters.get(i));
+            isLead[i] = leading.contains(letters.get(i));
+        }
+
+        // suffix bounds : max / min contribution still reachable from index i on
+        this.posSuf = new long[n + 1];
+        this.negSuf = new long[n + 1];
+        for (int i = n - 1; i >= 0; i--) {
+            int c = coefOf[i];
+            posSuf[i] = posSuf[i + 1] + (c > 0 ? 9L * c : 0);
+            negSuf[i] = negSuf[i + 1] + (c < 0 ? 9L * c : 0);
+        }
+
+        Arrays.fill(usedDigit, false);
+        return backtrack(0, 0L);
+    }
+
+    private boolean backtrack(int i, long total) {
+        if (i == lettersCnt) {
+            return total == 0;
+        }
+        // even the most positive / most negative completion cannot reach 0
+        if (total + posSuf[i] < 0 || total + negSuf[i] > 0) {
+            return false;
+        }
+        int c = coefOf[i];
+        int start = isLead[i] ? 1 : 0;
+        for (int d = start; d < 10; d++) {
+            if (usedDigit[d]) {
+                continue;
+            }
+            usedDigit[d] = true;
+            if (backtrack(i + 1, total + (long) c * d)) {
+                return true;
+            }
+            usedDigit[d] = false;
+        }
+        return false;
+    }
+
+    private int pow10(int e) {
+        int r = 1;
+        for (int i = 0; i < e; i++) {
+            r *= 10;
+        }
+        return r;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ExtractKthCharacterFromTheRopeTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ExtractKthCharacterFromTheRopeTree.java
@@ -1,0 +1,112 @@
+package LeetCodeJava.BinarySearchTree;
+
+// https://leetcode.com/problems/extract-kth-character-from-the-rope-tree/
+
+/**
+ *  2689. Extract Kth Character From The Rope Tree
+ *  Easy
+ *
+ *  You are given the root of a binary tree and an integer k. Besides the left and
+ *  right children, every node of this tree has two other properties, a string
+ *  node.val containing only lowercase English letters (possibly empty) and a
+ *  non-negative integer node.len. There are two types of nodes in this tree:
+ *   - Leaf: no children, node.len = 0, and node.val is some non-empty string.
+ *   - Internal: at least one child (at most two), node.len > 0, node.val is empty.
+ *
+ *  The tree described above is called a Rope binary tree. We define S[node]
+ *  recursively as follows:
+ *   - If node is a leaf, S[node] = node.val
+ *   - Otherwise S[node] = concat(S[node.left], S[node.right]) and
+ *     S[node].length = node.len
+ *
+ *  Return the k-th character of the string S[root].
+ *
+ *  Example 1:
+ *    Input: root = [10,4,"abcpoe","g","rta"], k = 6
+ *    Output: "b"
+ *    Explanation: S[root] = concat(concat("g","rta"), "abcpoe") = "grtaabcpoe",
+ *                 so the 6th character is "b".
+ *
+ *  Example 2:
+ *    Input: root = [12,6,6,"abc","efg","hij","klm"], k = 3
+ *    Output: "c"
+ *    Explanation: S[root] = "abcefghijklm", so the 3rd character is "c".
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [1, 10^3]
+ *    node.val contains only lowercase English letters
+ *    0 <= node.val.length <= 50
+ *    0 <= node.len <= 10^4
+ *    for leaf nodes, node.len = 0 and node.val is non-empty
+ *    for internal nodes, node.len > 0 and node.val is empty
+ *    1 <= k <= S[root].length
+ */
+public class ExtractKthCharacterFromTheRopeTree {
+
+    // Definition for a rope tree node (problem specific shape).
+    public static class RopeTreeNode {
+        public int len;
+        public String val;
+        public RopeTreeNode left;
+        public RopeTreeNode right;
+
+        public RopeTreeNode() {
+            this.val = "";
+        }
+
+        public RopeTreeNode(String val) {
+            this.val = val;
+        }
+
+        public RopeTreeNode(int len) {
+            this.len = len;
+            this.val = "";
+        }
+
+        public RopeTreeNode(int len, RopeTreeNode left, RopeTreeNode right) {
+            this.len = len;
+            this.val = "";
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    // V0
+    // IDEA: BINARY-SEARCH STYLE DESCENT (NEVER BUILD THE WHOLE STRING)
+    //       every node already knows the length of the piece it produces:
+    //         - internal node -> node.len
+    //         - leaf node     -> node.val.length()   (its node.len is 0)
+    //       so from an internal node we decide where the k-th char lives by only
+    //       looking at the SIZE OF THE LEFT SUBTREE:
+    //         k <= size(left) -> go left, k unchanged
+    //         otherwise       -> go right with k -= size(left)
+    //       NOTE: k is 1-indexed, so the answer is node.val.charAt(k - 1).
+    //       NOTE: an internal node may have only ONE child - size(null) = 0 keeps
+    //             that case working with no special branch.
+    //       NOTE: written as a LOOP, so a degenerate chain-like tree can never
+    //             blow the stack.
+    /**
+     * time = O(H)     // H = tree height
+     * space = O(1)
+     */
+    public char getKthCharacter(RopeTreeNode root, int k) {
+        RopeTreeNode node = root;
+        while (node.len > 0) {          // internal -> keep descending
+            int leftSize = size(node.left);
+            if (k <= leftSize) {
+                node = node.left;
+            } else {
+                k -= leftSize;
+                node = node.right;
+            }
+        }
+        return node.val.charAt(k - 1);
+    }
+
+    private int size(RopeTreeNode node) {
+        if (node == null) {
+            return 0;
+        }
+        return node.len > 0 ? node.len : node.val.length();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/MaximumSumBSTInBinaryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/MaximumSumBSTInBinaryTree.java
@@ -1,0 +1,84 @@
+package LeetCodeJava.BinarySearchTree;
+
+// https://leetcode.com/problems/maximum-sum-bst-in-binary-tree/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1373. Maximum Sum BST in Binary Tree
+ *  Hard
+ *
+ *  Given a binary tree root, return the maximum sum of all keys of any sub-tree
+ *  which is also a Binary Search Tree (BST).
+ *
+ *  Assume a BST is defined as follows:
+ *   - The left subtree of a node contains only nodes with keys less than the
+ *     node's key.
+ *   - The right subtree of a node contains only nodes with keys greater than the
+ *     node's key.
+ *   - Both the left and right subtrees must also be binary search trees.
+ *
+ *  Example 1:
+ *    Input: root = [1,4,3,2,4,2,5,null,null,null,null,null,null,4,6]
+ *    Output: 20
+ *    Explanation: The maximum sum in a valid BST is obtained in the sub-tree
+ *                 rooted at the node with key 3.
+ *
+ *  Example 2:
+ *    Input: root = [-4,-2,-5]
+ *    Output: 0
+ *    Explanation: All values are negative, so return an empty BST.
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [1, 4 * 10^4].
+ *    -4 * 10^4 <= Node.val <= 4 * 10^4
+ */
+public class MaximumSumBSTInBinaryTree {
+
+    private int res;
+
+    // V0
+    // IDEA: POST-ORDER DFS RETURNING (isBst, subtreeMin, subtreeMax, subtreeSum)
+    //       a node roots a BST iff BOTH children root BSTs and
+    //         max(left subtree) < node.val < min(right subtree)
+    //       that check needs the extremes of each side, so every call returns the
+    //       4 values at once and the whole tree is validated in ONE bottom-up pass.
+    //       an EMPTY subtree returns (true, +INF, -INF, 0): those sentinels make
+    //       the comparison above trivially pass for a leaf.
+    //       NOTE: the answer starts at 0 because an EMPTY BST is allowed - an
+    //             all-negative tree therefore returns 0, not its largest node.
+    //       NOTE: once a subtree fails, only the false flag matters upward.
+    /**
+     * time = O(N)
+     * space = O(H)     // H = tree height
+     */
+    public int maxSumBST(TreeNode root) {
+        this.res = 0;
+        dfs(root);
+        return res;
+    }
+
+    // returns {isBst (1/0), minVal, maxVal, sum}
+    private long[] dfs(TreeNode node) {
+        if (node == null) {
+            return new long[]{1, Long.MAX_VALUE, Long.MIN_VALUE, 0};
+        }
+
+        long[] l = dfs(node.left);
+        long[] r = dfs(node.right);
+
+        if (l[0] == 1 && r[0] == 1 && l[2] < node.val && node.val < r[1]) {
+            long total = l[3] + r[3] + node.val;
+            if (total > res) {
+                res = (int) total;
+            }
+            return new long[]{
+                    1,
+                    Math.min(l[1], node.val),
+                    Math.max(r[2], node.val),
+                    total
+            };
+        }
+        return new long[]{0, 0, 0, 0};
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/MergeBSTsToCreateSingleBST.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/MergeBSTsToCreateSingleBST.java
@@ -1,0 +1,146 @@
+package LeetCodeJava.BinarySearchTree;
+
+// https://leetcode.com/problems/merge-bsts-to-create-single-bst/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1932. Merge BSTs to Create Single BST
+ *  Hard
+ *
+ *  You are given n BST (binary search tree) root nodes for n separate BSTs stored
+ *  in an array trees (0-indexed). Each BST in trees has at most 3 nodes, and no
+ *  two roots have the same value. In one operation, you can:
+ *   - Select two distinct indices i and j such that the value stored at one of the
+ *     leaves of trees[i] is equal to the root value of trees[j].
+ *   - Replace the leaf node in trees[i] with trees[j].
+ *   - Remove trees[j] from trees.
+ *
+ *  Return the root of the resulting BST if it is possible to form a valid BST after
+ *  performing n - 1 operations, or null if it is impossible to create a valid BST.
+ *
+ *  Example 1:
+ *    Input: trees = [[2,1],[3,2,5],[5,4]]
+ *    Output: [3,2,5,1,null,4]
+ *
+ *  Example 2:
+ *    Input: trees = [[5,3,8],[3,2,6]]
+ *    Output: []
+ *    Explanation: the only possible merge does not yield a valid BST.
+ *
+ *  Example 3:
+ *    Input: trees = [[5,4],[3]]
+ *    Output: []
+ *    Explanation: it is impossible to perform any operation.
+ *
+ *  Constraints:
+ *    n == trees.length
+ *    1 <= n <= 5 * 10^4
+ *    The number of nodes in each tree is in the range [1, 3].
+ *    Each node in the input may have children but no grandchildren.
+ *    No two roots of trees have the same value.
+ *    All the trees in the input are valid BSTs.
+ *    1 <= TreeNode.val <= 5 * 10^4
+ */
+public class MergeBSTsToCreateSingleBST {
+
+    // V0
+    // IDEA: FIND THE UNIQUE OVERALL ROOT, THEN SPLICE + VALIDATE IN ONE DFS
+    //       count how many times every value appears over ALL nodes (roots and
+    //       leaves). the final root must be a tree root whose value is used exactly
+    //       once - if it also appeared as some leaf, that tree would have to
+    //       swallow it, so it could not be the top. there is at most one such
+    //       candidate.
+    //       then walk down from that candidate carrying (lo, hi) BST bounds.
+    //       whenever we stand on a LEAF whose value is the root of a still unused
+    //       tree, graft that tree in place (copy its two children onto the leaf)
+    //       and re-examine the node.
+    //       the merge is valid iff every visited node respects its bounds AND all
+    //       n trees got consumed exactly once.
+    //       NOTE: the merged chain can be 5*10^4 deep -> the DFS must be ITERATIVE.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public TreeNode canMerge(List<TreeNode> trees) {
+        Map<Integer, Integer> cnt = new HashMap<>();
+        Map<Integer, TreeNode> byRoot = new HashMap<>();
+
+        for (int i = 0; i < trees.size(); i++) {
+            TreeNode t = trees.get(i);
+            byRoot.put(t.val, t);
+            bump(cnt, t.val);
+            if (t.left != null) {
+                bump(cnt, t.left.val);
+            }
+            if (t.right != null) {
+                bump(cnt, t.right.val);
+            }
+        }
+
+        TreeNode root = null;
+        for (int i = 0; i < trees.size(); i++) {
+            TreeNode t = trees.get(i);
+            if (cnt.get(t.val) == 1) {
+                root = t;
+                break;
+            }
+        }
+        if (root == null) {
+            return null;
+        }
+
+        byRoot.remove(root.val);
+        int used = 1;
+
+        Deque<TreeNode> nodeStack = new ArrayDeque<>();
+        Deque<long[]> boundStack = new ArrayDeque<>();
+        nodeStack.push(root);
+        boundStack.push(new long[]{Long.MIN_VALUE, Long.MAX_VALUE});
+
+        while (!nodeStack.isEmpty()) {
+            TreeNode node = nodeStack.pop();
+            long[] bound = boundStack.pop();
+            long lo = bound[0];
+            long hi = bound[1];
+
+            if (!(lo < node.val && node.val < hi)) {
+                return null;
+            }
+
+            if (node.left == null && node.right == null) {
+                TreeNode sub = byRoot.remove(node.val);
+                if (sub != null) {
+                    node.left = sub.left;
+                    node.right = sub.right;
+                    used++;
+                    // re-examine the node, now that it has children
+                    nodeStack.push(node);
+                    boundStack.push(new long[]{lo, hi});
+                }
+                continue;
+            }
+            if (node.left != null) {
+                nodeStack.push(node.left);
+                boundStack.push(new long[]{lo, node.val});
+            }
+            if (node.right != null) {
+                nodeStack.push(node.right);
+                boundStack.push(new long[]{node.val, hi});
+            }
+        }
+
+        return used == trees.size() ? root : null;
+    }
+
+    private void bump(Map<Integer, Integer> cnt, int key) {
+        Integer cur = cnt.get(key);
+        cnt.put(key, cur == null ? 1 : cur + 1);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/MinimumAbsoluteDifferenceBetweenElementsWithConstraint.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/MinimumAbsoluteDifferenceBetweenElementsWithConstraint.java
@@ -1,0 +1,92 @@
+package LeetCodeJava.BinarySearchTree;
+
+// https://leetcode.com/problems/minimum-absolute-difference-between-elements-with-constraint/
+
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ *  2817. Minimum Absolute Difference Between Elements With Constraint
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array nums and an integer x.
+ *
+ *  Find the minimum absolute difference between two elements in the array that are
+ *  at least x indices apart.
+ *
+ *  In other words, find two indices i and j such that abs(i - j) >= x and
+ *  abs(nums[i] - nums[j]) is minimized.
+ *
+ *  Return an integer denoting the minimum absolute difference between two elements
+ *  that are at least x indices apart.
+ *
+ *  Example 1:
+ *    Input: nums = [4,3,2,4], x = 2
+ *    Output: 0
+ *    Explanation: We can select nums[0] = 4 and nums[3] = 4. They are at least 2
+ *                 indices apart and their absolute difference is 0.
+ *
+ *  Example 2:
+ *    Input: nums = [5,3,2,10,15], x = 1
+ *    Output: 1
+ *    Explanation: We can select nums[1] = 3 and nums[2] = 2.
+ *
+ *  Example 3:
+ *    Input: nums = [1,2,3,4], x = 3
+ *    Output: 3
+ *    Explanation: We can select nums[0] = 1 and nums[3] = 4.
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^9
+ *    0 <= x < nums.length
+ */
+public class MinimumAbsoluteDifferenceBetweenElementsWithConstraint {
+
+    // V0
+    // IDEA: SLIDING "ORDERED SET" OF ELIGIBLE PARTNERS (BST PREDECESSOR /
+    //       SUCCESSOR QUERIES VIA TreeSet)
+    //       sweep j = x, x+1, ... and just BEFORE handling j insert nums[j - x]
+    //       into an ordered set S. by construction S then holds exactly the values
+    //       whose index is <= j - x, i.e. every partner that is >= x indices away
+    //       from j (pairs with i > j are covered symmetrically when the roles swap,
+    //       so one forward sweep is enough).
+    //       the best partner for nums[j] inside S is its PREDECESSOR (largest value
+    //       <= nums[j], TreeSet.floor) or its SUCCESSOR (smallest value >= nums[j],
+    //       TreeSet.ceiling) - any value further away is strictly worse. two
+    //       ordered-set queries per step, O(log N) each.
+    //       NOTE: x == 0 is legal and means "any two indices, including i == j", so
+    //             the sweep must insert nums[j] itself before querying j -> the
+    //             answer is then 0. starting at j = x with insert-then-query order
+    //             gets this right automatically.
+    //       NOTE: a TreeSet drops duplicates, which is harmless here - a repeated
+    //             value only ever yields difference 0, which the first copy in the
+    //             set already reports.
+    /**
+     * time = O(N * log N)
+     * space = O(N)
+     */
+    public int minAbsoluteDifference(List<Integer> nums, int x) {
+        int n = nums.size();
+        TreeSet<Integer> seen = new TreeSet<>();
+        int res = Integer.MAX_VALUE;
+
+        for (int j = x; j < n; j++) {
+            seen.add(nums.get(j - x));
+
+            int cur = nums.get(j);
+            Integer pred = seen.floor(cur);
+            if (pred != null && cur - pred < res) {
+                res = cur - pred;
+            }
+            Integer succ = seen.ceiling(cur);
+            if (succ != null && succ - cur < res) {
+                res = succ - cur;
+            }
+            if (res == 0) {
+                return 0;
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/NumberOfPairsSatisfyingInequality.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/NumberOfPairsSatisfyingInequality.java
@@ -1,0 +1,89 @@
+package LeetCodeJava.BinarySearchTree;
+
+// https://leetcode.com/problems/number-of-pairs-satisfying-inequality/
+
+/**
+ *  2426. Number of Pairs Satisfying Inequality
+ *  Hard
+ *
+ *  You are given two 0-indexed integer arrays nums1 and nums2, each of size n, and
+ *  an integer diff. Find the number of pairs (i, j) such that:
+ *   - 0 <= i < j <= n - 1 and
+ *   - nums1[i] - nums1[j] <= nums2[i] - nums2[j] + diff.
+ *
+ *  Return the number of pairs that satisfy the conditions.
+ *
+ *  Example 1:
+ *    Input: nums1 = [3,2,5], nums2 = [2,2,1], diff = 1
+ *    Output: 3
+ *    Explanation: the 3 valid pairs are (0,1), (0,2) and (1,2).
+ *
+ *  Example 2:
+ *    Input: nums1 = [3,-1], nums2 = [-2,2], diff = -1
+ *    Output: 0
+ *    Explanation: no pair satisfies the condition.
+ *
+ *  Constraints:
+ *    n == nums1.length == nums2.length
+ *    2 <= n <= 10^5
+ *    -10^4 <= nums1[i], nums2[i] <= 10^4
+ *    -10^4 <= diff <= 10^4
+ */
+public class NumberOfPairsSatisfyingInequality {
+
+    private static final int OFFSET = 20000;
+    private static final int SIZE = 40002;    // values -20000 .. 20000, 1-indexed
+
+    private int[] tree;
+
+    // V0
+    // IDEA: REARRANGE INTO ONE ARRAY, THEN COUNT WITH A FENWICK (BIT) TREE
+    //       move each index's terms to its own side:
+    //         nums1[i] - nums1[j] <= nums2[i] - nums2[j] + diff
+    //         (nums1[i] - nums2[i]) <= (nums1[j] - nums2[j]) + diff
+    //       so with a[k] = nums1[k] - nums2[k] the condition is simply
+    //         a[i] <= a[j] + diff        for i < j
+    //       sweep j left to right and for each j ask "how many earlier a[i] are
+    //       <= a[j] + diff?" - a prefix count over the VALUE axis, which a Fenwick
+    //       tree answers in O(log V).
+    //       values live in [-2*10^4, 2*10^4], so a fixed offset maps them onto
+    //       1-indexed tree positions.
+    /**
+     * time = O(N * log V)
+     * space = O(V)
+     */
+    public long numberOfPairs(int[] nums1, int[] nums2, int diff) {
+        this.tree = new int[SIZE + 1];
+        long res = 0;
+
+        for (int k = 0; k < nums1.length; k++) {
+            int a = nums1[k] - nums2[k];
+            int bound = a + diff + OFFSET + 1;   // 1-indexed position of a + diff
+            if (bound >= 1) {
+                res += query(bound);
+            }
+            add(a + OFFSET + 1);
+        }
+        return res;
+    }
+
+    private void add(int pos) {
+        while (pos <= SIZE) {
+            tree[pos] += 1;
+            pos += pos & -pos;
+        }
+    }
+
+    // how many stored values sit at index <= pos
+    private int query(int pos) {
+        int total = 0;
+        if (pos > SIZE) {
+            pos = SIZE;
+        }
+        while (pos > 0) {
+            total += tree[pos];
+            pos -= pos & -pos;
+        }
+        return total;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/RangeXORQueriesWithSubarrayReversals.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/RangeXORQueriesWithSubarrayReversals.java
@@ -1,0 +1,243 @@
+package LeetCodeJava.BinarySearchTree;
+
+// https://leetcode.com/problems/range-xor-queries-with-subarray-reversals/
+
+import java.util.Random;
+
+/**
+ *  3526. Range XOR Queries with Subarray Reversals
+ *  Hard
+ *
+ *  You are given an integer array nums of length n and a 2D integer array queries
+ *  of length q, where each query is one of the following three types:
+ *   - Update: queries[i] = [1, index, value] -> set nums[index] = value.
+ *   - Range XOR Query: queries[i] = [2, left, right] -> compute the bitwise XOR of
+ *     all elements in the subarray nums[left...right], and record this result.
+ *   - Reverse Subarray: queries[i] = [3, left, right] -> reverse the subarray
+ *     nums[left...right] in place.
+ *
+ *  Return an array of the results of all range XOR queries in the order they were
+ *  encountered.
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,3,4,5], queries = [[2,1,3],[1,2,10],[3,0,4],[2,0,4]]
+ *    Output: [5,8]
+ *    Explanation:
+ *      [2,1,3] -> XOR of [2,3,4] = 5
+ *      [1,2,10] -> nums becomes [1,2,10,4,5]
+ *      [3,0,4] -> nums becomes [5,4,10,2,1]
+ *      [2,0,4] -> XOR of [5,4,10,2,1] = 8
+ *
+ *  Example 2:
+ *    Input: nums = [7,8,9], queries = [[1,0,3],[2,0,2],[3,1,2]]
+ *    Output: [2]
+ *    Explanation:
+ *      [1,0,3] -> nums becomes [3,8,9]
+ *      [2,0,2] -> XOR of [3,8,9] = 2
+ *      [3,1,2] -> nums becomes [3,9,8]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    0 <= nums[i] <= 10^9
+ *    1 <= queries.length <= 10^5
+ *    queries[i].length == 3
+ *    queries[i][0] is 1, 2 or 3
+ *    if queries[i][0] == 1 : 0 <= index < nums.length, 0 <= value <= 10^9
+ *    otherwise             : 0 <= left <= right < nums.length
+ */
+public class RangeXORQueriesWithSubarrayReversals {
+
+    // node of an IMPLICIT treap (keyed by subtree size, not by value)
+    public static class TreapNode {
+        public int val;
+        public int pri;
+        public int size;
+        public int xor;
+        public boolean rev;
+        public TreapNode left;
+        public TreapNode right;
+
+        public TreapNode(int val, int pri) {
+            this.val = val;
+            this.pri = pri;
+            this.size = 1;
+            this.xor = val;
+        }
+    }
+
+    private final Random rnd = new Random(20130831L);
+    private int[] src;
+
+    // split results (kept in fields to avoid allocating a pair per recursion step)
+    private TreapNode splitA;
+    private TreapNode splitB;
+
+    // V0
+    // IDEA: IMPLICIT TREAP (BALANCED BST KEYED BY POSITION) + LAZY REVERSE FLAG
+    //       a Fenwick / segment tree cannot survive query type 3: reversing a range
+    //       PERMUTES positions and every later query addresses the NEW positions,
+    //       so the sequence itself must be reorderable. the structure that supports
+    //       "cut a positional range out and paste it back" is a balanced BST keyed
+    //       by subtree SIZE rather than by value - an implicit treap.
+    //       split(t, i) peels off the first i elements and merge(a, b) concatenates
+    //       two sequences; with those two primitives all three query types are the
+    //       same three lines - split out [left, right], act on the middle piece,
+    //       merge everything back.
+    //       the reversal is never performed for real (that would cost O(size)): the
+    //       middle piece only gets a `rev` flag, and push() swaps a node's children
+    //       and hands the flag down the moment that node is first visited. XOR is
+    //       order independent, so a pending flag never invalidates a stored
+    //       aggregate - that is exactly what makes lazy reversal cheap here.
+    //       the tree is built once, bottom-up and balanced, with the random
+    //       priorities sifted into heap order, which keeps the expected depth at
+    //       O(log N) for all later operations.
+    /**
+     * time = O(N + Q * log N)   // expected
+     * space = O(N)
+     */
+    public int[] getResults(int[] nums, int[][] queries) {
+        this.src = nums;
+        TreapNode root = build(0, nums.length);
+
+        int outCnt = 0;
+        for (int i = 0; i < queries.length; i++) {
+            if (queries[i][0] == 2) {
+                outCnt++;
+            }
+        }
+        int[] res = new int[outCnt];
+        int p = 0;
+
+        for (int i = 0; i < queries.length; i++) {
+            int kind = queries[i][0];
+            if (kind == 1) {
+                split(root, queries[i][1]);
+                TreapNode a = splitA;
+                split(splitB, 1);
+                TreapNode mid = splitA;
+                TreapNode b = splitB;
+                mid.val = queries[i][2];
+                mid.xor = queries[i][2];
+                root = merge(merge(a, mid), b);
+            } else {
+                int lo = queries[i][1];
+                int hi = queries[i][2];
+                split(root, lo);
+                TreapNode a = splitA;
+                split(splitB, hi - lo + 1);
+                TreapNode mid = splitA;
+                TreapNode b = splitB;
+                if (kind == 2) {
+                    res[p++] = mid.xor;
+                } else {
+                    mid.rev = !mid.rev;
+                }
+                root = merge(merge(a, mid), b);
+            }
+        }
+        return res;
+    }
+
+    // build a balanced treap over src[lo, hi), then sift the priority into heap order
+    private TreapNode build(int lo, int hi) {
+        if (lo >= hi) {
+            return null;
+        }
+        int mid = (lo + hi) >>> 1;
+        TreapNode t = new TreapNode(src[mid], rnd.nextInt());
+        t.left = build(lo, mid);
+        t.right = build(mid + 1, hi);
+
+        TreapNode cur = t;
+        while (true) {
+            TreapNode top = cur;
+            if (cur.left != null && cur.left.pri > top.pri) {
+                top = cur.left;
+            }
+            if (cur.right != null && cur.right.pri > top.pri) {
+                top = cur.right;
+            }
+            if (top == cur) {
+                break;
+            }
+            int tmp = cur.pri;
+            cur.pri = top.pri;
+            top.pri = tmp;
+            cur = top;
+        }
+
+        pull(t);
+        return t;
+    }
+
+    private int size(TreapNode t) {
+        return t == null ? 0 : t.size;
+    }
+
+    private int xor(TreapNode t) {
+        return t == null ? 0 : t.xor;
+    }
+
+    private void pull(TreapNode t) {
+        t.size = 1 + size(t.left) + size(t.right);
+        t.xor = t.val ^ xor(t.left) ^ xor(t.right);
+    }
+
+    // NOTE !!! apply a pending reversal before ever looking at t's children
+    private void push(TreapNode t) {
+        if (!t.rev) {
+            return;
+        }
+        t.rev = false;
+        TreapNode tmp = t.left;
+        t.left = t.right;
+        t.right = tmp;
+        if (t.left != null) {
+            t.left.rev = !t.left.rev;
+        }
+        if (t.right != null) {
+            t.right.rev = !t.right.rev;
+        }
+    }
+
+    private TreapNode merge(TreapNode a, TreapNode b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        if (a.pri > b.pri) {
+            push(a);
+            a.right = merge(a.right, b);
+            pull(a);
+            return a;
+        }
+        push(b);
+        b.left = merge(a, b.left);
+        pull(b);
+        return b;
+    }
+
+    // the first `cnt` elements land in splitA, the rest in splitB
+    private void split(TreapNode t, int cnt) {
+        if (t == null) {
+            splitA = null;
+            splitB = null;
+            return;
+        }
+        push(t);
+        int ls = size(t.left);
+        if (cnt <= ls) {
+            split(t.left, cnt);
+            t.left = splitB;      // NOTE !!! read the inner result right away
+            pull(t);
+            splitB = t;           // splitA still holds the inner left part
+        } else {
+            split(t.right, cnt - ls - 1);
+            t.right = splitA;
+            pull(t);
+            splitA = t;           // splitB still holds the inner right part
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/HashTable/BeforeAndAfterPuzzle.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/HashTable/BeforeAndAfterPuzzle.java
@@ -1,0 +1,100 @@
+package LeetCodeJava.HashTable;
+
+// https://leetcode.com/problems/before-and-after-puzzle/
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ *  1181. Before and After Puzzle
+ *  Medium
+ *
+ *  Given a list of phrases, generate a list of Before and After puzzles.
+ *
+ *  A phrase is a string that consists of lowercase English letters and spaces only.
+ *  No space appears in the start or the end of a phrase. There are no consecutive
+ *  spaces in a phrase.
+ *
+ *  Before and After puzzles are phrases that are formed by merging two phrases where
+ *  the last word of the first phrase is the same as the first word of the second
+ *  phrase. Note that only the last word of the first phrase and the first word of the
+ *  second phrase are merged in this process.
+ *
+ *  Return the Before and After puzzles that can be formed by every two phrases
+ *  phrases[i] and phrases[j] where i != j. Note that the order of matching two
+ *  phrases matters, we want to consider both orders.
+ *
+ *  You should return a list of distinct strings sorted lexicographically, after
+ *  removing all duplicate phrases in the generated Before and After puzzles.
+ *
+ *  Example 1:
+ *    Input: phrases = ["writing code","code rocks"]
+ *    Output: ["writing code rocks"]
+ *
+ *  Example 2:
+ *    Input: phrases = ["a","b","a"]
+ *    Output: ["a"]
+ *
+ *  Example 3:
+ *    Input: phrases = ["ab ba","ba ab","ab ba"]
+ *    Output: ["ab ba ab","ba ab ba"]
+ *
+ *  Constraints:
+ *    1 <= phrases.length <= 100
+ *    1 <= phrases[i].length <= 100
+ */
+public class BeforeAndAfterPuzzle {
+
+    // V0
+    // IDEA: HASH TABLE (index phrases by their FIRST word) + SORTED SET dedup
+    //       for each phrase, only look at the phrases whose first word equals
+    //       this phrase's LAST word -> no need to try all ordered pairs blindly.
+    //       NOTE !!! i != j is on the INDEX, so two IDENTICAL phrases sitting at
+    //                different indexes are still a legal pair (see example 2).
+    //       TreeSet gives dedup + lexicographic order in one shot.
+    /**
+     * time = O(N^2 * L)   // N = #phrases, L = phrase length
+     * space = O(N * L)
+     */
+    public List<String> beforeAndAfterPuzzles(String[] phrases) {
+        int n = phrases.length;
+        String[][] words = new String[n][];
+        for (int i = 0; i < n; i++) {
+            words[i] = phrases[i].split(" ");
+        }
+
+        Map<String, List<Integer>> byFirst = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            String first = words[i][0];
+            if (!byFirst.containsKey(first)) {
+                byFirst.put(first, new ArrayList<Integer>());
+            }
+            byFirst.get(first).add(i);
+        }
+
+        TreeSet<String> res = new TreeSet<>();
+        for (int i = 0; i < n; i++) {
+            String last = words[i][words[i].length - 1];
+            List<Integer> cands = byFirst.get(last);
+            if (cands == null) {
+                continue;
+            }
+            for (Integer j : cands) {
+                if (i == j) {
+                    continue;
+                }
+                StringBuilder sb = new StringBuilder(phrases[i]);
+                // skip words[j][0] : it is the merged word
+                for (int k = 1; k < words[j].length; k++) {
+                    sb.append(" ").append(words[j][k]);
+                }
+                res.add(sb.toString());
+            }
+        }
+
+        return new ArrayList<>(res);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/ApplyOperationsToMaximizeScore.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/ApplyOperationsToMaximizeScore.java
@@ -1,0 +1,151 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/apply-operations-to-maximize-score/
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ *  2818. Apply Operations to Maximize Score
+ *  Hard
+ *
+ *  You are given an array nums of n positive integers and an integer k.
+ *
+ *  Initially, you start with a score of 1. You have to maximize your score by
+ *  applying the following operation at most k times:
+ *
+ *    - Choose any non-empty subarray nums[l, ..., r] that you haven't chosen previously.
+ *    - Choose an element x of nums[l, ..., r] with the highest prime score. If multiple
+ *      such elements exist, choose the one with the smallest index.
+ *    - Multiply your score by x.
+ *
+ *  The prime score of an integer x is equal to the number of distinct prime factors
+ *  of x. For example, the prime score of 300 is 3 since 300 = 2 * 2 * 3 * 5 * 5.
+ *
+ *  Return the maximum possible score after applying at most k operations.
+ *  Since the answer may be large, return it modulo 10^9 + 7.
+ *
+ *  Example 1:
+ *    Input: nums = [8,3,9,3,8], k = 2
+ *    Output: 81
+ *    Explanation: pick nums[2..2] (score 9), then nums[2..3] (nums[2] wins the tie),
+ *                 so the score is 9 * 9 = 81.
+ *
+ *  Example 2:
+ *    Input: nums = [19,12,14,6,10,18], k = 3
+ *    Output: 4788
+ *
+ *  Constraints:
+ *    1 <= nums.length == n <= 10^5
+ *    1 <= nums[i] <= 10^5
+ *    1 <= k <= min(n * (n + 1) / 2, 10^9)
+ */
+public class ApplyOperationsToMaximizeScore {
+
+    private static final long MOD = 1_000_000_007L;
+
+    // V0
+    // IDEA: SIEVE FOR PRIME SCORES + MONOTONIC STACK "DOMINANCE RANGE" + GREEDY
+    //
+    //   1) a sieve over 1..max(nums) counts DISTINCT prime factors of every value
+    //      at once, far cheaper than factoring each number separately.
+    //
+    //   2) index i is the chosen element of nums[l..r] exactly when it beats
+    //      everything else under (prime score, then smallest index):
+    //        every j in [l, i-1] has score[j] <  score[i]
+    //        every j in [i+1, r] has score[j] <= score[i]
+    //      NOTE the asymmetry - that IS the "smallest index wins ties" rule, and
+    //      getting it wrong double counts subarrays. Two monotonic stacks give
+    //        left[i]  = last index on the left with score >= score[i]
+    //        right[i] = first index on the right with score >  score[i]
+    //      so cnt[i] = (i - left[i]) * (right[i] - i), and sum(cnt) = n(n+1)/2.
+    //
+    //   3) every operation costs one distinct subarray, so spend the k operations
+    //      on the LARGEST values first: take min(cnt[i], k) copies of nums[i].
+    //      Use fast modular exponentiation - k can reach 10^9.
+    /**
+     * time = O(V log log V + n log n)   // V = max(nums) <= 10^5
+     * space = O(V + n)
+     */
+    public int maximumScore(int[] nums, int k) {
+        int n = nums.length;
+        int top = 0;
+        for (int v : nums) {
+            top = Math.max(top, v);
+        }
+
+        // --- step 1 : distinct prime factor count for every value <= top ---
+        int[] omega = new int[top + 1];
+        for (int p = 2; p <= top; p++) {
+            if (omega[p] == 0) {                 // p untouched so far -> prime
+                for (int mult = p; mult <= top; mult += p) {
+                    omega[mult]++;
+                }
+            }
+        }
+        int[] score = new int[n];
+        for (int i = 0; i < n; i++) {
+            score[i] = omega[nums[i]];
+        }
+
+        // --- step 2 : dominance range of each index via monotonic stacks ---
+        int[] left = new int[n];
+        int[] right = new int[n];
+        int[] stack = new int[n];
+        int sp = 0;
+
+        for (int i = 0; i < n; i++) {            // last j < i with score[j] >= score[i]
+            while (sp > 0 && score[stack[sp - 1]] < score[i]) {
+                sp--;
+            }
+            left[i] = (sp > 0) ? stack[sp - 1] : -1;
+            stack[sp++] = i;
+        }
+
+        sp = 0;
+        for (int i = n - 1; i >= 0; i--) {       // first j > i with score[j] > score[i]
+            while (sp > 0 && score[stack[sp - 1]] <= score[i]) {
+                sp--;
+            }
+            right[i] = (sp > 0) ? stack[sp - 1] : n;
+            stack[sp++] = i;
+        }
+
+        // --- step 3 : greedily spend k operations on the largest values ---
+        Integer[] order = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            order[i] = i;
+        }
+        final int[] ref = nums;
+        Arrays.sort(order, new Comparator<Integer>() {
+            @Override
+            public int compare(Integer a, Integer b) {
+                return ref[b] - ref[a];          // value descending
+            }
+        });
+
+        long remain = k;
+        long ans = 1L;
+        for (int idx = 0; idx < n && remain > 0; idx++) {
+            int i = order[idx];
+            long cnt = (long) (i - left[i]) * (long) (right[i] - i);
+            long take = Math.min(cnt, remain);
+            ans = ans * modPow(nums[i], take) % MOD;
+            remain -= take;
+        }
+        return (int) ans;
+    }
+
+    private long modPow(long base, long exp) {
+        long res = 1L;
+        base %= MOD;
+        while (exp > 0) {
+            if ((exp & 1L) == 1L) {
+                res = res * base % MOD;
+            }
+            base = base * base % MOD;
+            exp >>= 1;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/CountTheNumberOfKBigIndices.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/CountTheNumberOfKBigIndices.java
@@ -1,0 +1,88 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/count-the-number-of-k-big-indices/
+
+import java.util.PriorityQueue;
+
+/**
+ *  2519. Count the Number of K-Big Indices
+ *  Hard
+ *
+ *  You are given a 0-indexed integer array nums and a positive integer k.
+ *
+ *  We call an index i k-big if the following conditions are satisfied:
+ *    - There exist at least k different indices idx1 such that idx1 < i and nums[idx1] < nums[i].
+ *    - There exist at least k different indices idx2 such that idx2 > i and nums[idx2] < nums[i].
+ *
+ *  Return the number of k-big indices.
+ *
+ *  Example 1:
+ *    Input: nums = [2,3,6,5,2,3], k = 2
+ *    Output: 2
+ *    Explanation: the 2-big indices are i = 2 and i = 3.
+ *
+ *  Example 2:
+ *    Input: nums = [1,1,1], k = 3
+ *    Output: 0
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i], k <= nums.length
+ */
+public class CountTheNumberOfKBigIndices {
+
+    // V0
+    // IDEA: TWO SIZE-K MAX HEAPS (keep only the k smallest values on each side)
+    //
+    //   "at least k earlier elements are smaller than nums[i]" is the same as
+    //   "the k-th smallest value among nums[0..i-1] is < nums[i]", so the whole
+    //   prefix is not needed - only its k smallest values.
+    //
+    //   Keep a MAX-heap capped at size k of the k smallest values seen so far;
+    //   its root is exactly the k-th smallest, so the test is root < nums[i]
+    //   (with size == k required, else fewer than k candidates exist at all).
+    //
+    //   Do one left-to-right pass and one right-to-left pass; an index is k-big
+    //   iff both passes flagged it.
+    //
+    //   NOTE: the strict `<` matters (equal values do NOT count), and the current
+    //         value is pushed only AFTER being tested so it never counts itself.
+    /**
+     * time = O(n log k)
+     * space = O(n)
+     */
+    public int kBigIndices(int[] nums, int k) {
+        int n = nums.length;
+        boolean[] left = scan(nums, k, true);
+        boolean[] right = scan(nums, k, false);
+
+        int res = 0;
+        for (int i = 0; i < n; i++) {
+            if (left[i] && right[i]) {
+                res++;
+            }
+        }
+        return res;
+    }
+
+    /** forward = true scans left-to-right, otherwise right-to-left. */
+    private boolean[] scan(int[] nums, int k, boolean forward) {
+        int n = nums.length;
+        boolean[] flag = new boolean[n];
+        // max-heap of the k smallest values seen so far
+        PriorityQueue<Integer> heap = new PriorityQueue<>(java.util.Collections.reverseOrder());
+
+        for (int step = 0; step < n; step++) {
+            int i = forward ? step : (n - 1 - step);
+            int v = nums[i];
+            if (heap.size() == k && heap.peek() < v) {
+                flag[i] = true;
+            }
+            heap.add(v);
+            if (heap.size() > k) {
+                heap.poll();
+            }
+        }
+        return flag;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/DigitOperationsToMakeTwoIntegersEqual.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/DigitOperationsToMakeTwoIntegersEqual.java
@@ -1,0 +1,136 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/digit-operations-to-make-two-integers-equal/
+
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+/**
+ *  3377. Digit Operations to Make Two Integers Equal
+ *  Medium
+ *
+ *  You are given two integers n and m that consist of the same number of digits.
+ *
+ *  You can perform the following operations any number of times:
+ *    - Choose any digit from n that is not 9 and increase it by 1.
+ *    - Choose any digit from n that is not 0 and decrease it by 1.
+ *
+ *  The integer n must not be a prime number at any point, including its original
+ *  value and after each operation.
+ *
+ *  The cost of a transformation is the sum of all values that n takes throughout
+ *  the operations performed.
+ *
+ *  Return the minimum cost to transform n into m. If it is impossible, return -1.
+ *
+ *  Example 1:
+ *    Input: n = 10, m = 12
+ *    Output: 85
+ *    Explanation: 10 -> 20 -> 21 -> 22 -> 12, and 10+20+21+22+12 = 85.
+ *
+ *  Example 2:
+ *    Input: n = 4, m = 8
+ *    Output: -1
+ *
+ *  Example 3:
+ *    Input: n = 6, m = 2
+ *    Output: -1
+ *    Explanation: 2 is already a prime, so n can never equal m.
+ *
+ *  Constraints:
+ *    1 <= n, m < 10^4
+ *    n and m consist of the same number of digits.
+ */
+public class DigitOperationsToMakeTwoIntegersEqual {
+
+    // V0
+    // IDEA: DIJKSTRA OVER THE NUMBERS, WHERE ENTERING A STATE COSTS ITS VALUE
+    //
+    //   every operation keeps the digit count, so the states are just the
+    //   integers of that width (at most 9000 of them), with an edge between two
+    //   numbers differing by +/-1 in a single digit.
+    //
+    //   the cost is the SUM of the values visited, i.e. ARRIVING at a node costs
+    //   that node's value - a shortest-path problem with node weights, which
+    //   Dijkstra handles directly once seeded with n's own value.
+    //
+    //   primes are forbidden everywhere, endpoints included, so a sieve marks
+    //   them up front and they are simply never entered.
+    /**
+     * time = O(S * D * 10 * log S)   // S = #states <= 9000, D = #digits <= 4
+     * space = O(S)
+     */
+    public int minOperations(int n, int m) {
+        int digits = String.valueOf(n).length();
+        int hi = (int) Math.pow(10, digits) - 1;
+
+        boolean[] isPrime = new boolean[hi + 1];
+        Arrays.fill(isPrime, true);
+        isPrime[0] = false;
+        if (hi >= 1) {
+            isPrime[1] = false;
+        }
+        for (int p = 2; (long) p * p <= hi; p++) {
+            if (isPrime[p]) {
+                for (int v = p * p; v <= hi; v += p) {
+                    isPrime[v] = false;
+                }
+            }
+        }
+
+        if (isPrime[n] || isPrime[m]) {
+            return -1;
+        }
+
+        long[] dist = new long[hi + 1];
+        Arrays.fill(dist, Long.MAX_VALUE);
+        dist[n] = n;
+
+        // {cost, value}
+        PriorityQueue<long[]> pq = new PriorityQueue<>(new java.util.Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                return Long.compare(a[0], b[0]);
+            }
+        });
+        pq.add(new long[]{n, n});
+
+        while (!pq.isEmpty()) {
+            long[] cur = pq.poll();
+            long d = cur[0];
+            int node = (int) cur[1];
+            if (d > dist[node]) {
+                continue;
+            }
+            if (node == m) {
+                return (int) d;
+            }
+            char[] s = String.valueOf(node).toCharArray();
+            for (int i = 0; i < s.length; i++) {
+                char old = s[i];
+                int c = old - '0';
+                for (int delta = -1; delta <= 1; delta += 2) {
+                    int nd = c + delta;
+                    if (nd < 0 || nd > 9) {
+                        continue;
+                    }
+                    if (i == 0 && nd == 0 && digits > 1) {
+                        continue;                      // no leading zero
+                    }
+                    s[i] = (char) ('0' + nd);
+                    int nxt = Integer.parseInt(new String(s));
+                    s[i] = old;
+                    if (isPrime[nxt]) {
+                        continue;                      // primes are off limits
+                    }
+                    long cand = d + nxt;
+                    if (cand < dist[nxt]) {
+                        dist[nxt] = cand;
+                        pq.add(new long[]{cand, nxt});
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/DivideAnArrayIntoSubarraysWithMinimumCostII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/DivideAnArrayIntoSubarraysWithMinimumCostII.java
@@ -1,0 +1,132 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/divide-an-array-into-subarrays-with-minimum-cost-ii/
+
+import java.util.Comparator;
+import java.util.TreeSet;
+
+/**
+ *  3013. Divide an Array Into Subarrays With Minimum Cost II
+ *  Hard
+ *
+ *  You are given a 0-indexed array of integers nums of length n, and two positive
+ *  integers k and dist.
+ *
+ *  The cost of an array is the value of its first element. For example, the cost of
+ *  [1,2,3] is 1 while the cost of [3,4,1] is 3.
+ *
+ *  You need to divide nums into k disjoint contiguous subarrays, such that the
+ *  difference between the starting index of the second subarray and the starting
+ *  index of the kth subarray is less than or equal to dist. In other words, if you
+ *  split nums into nums[0..(i1-1)], nums[i1..(i2-1)], ..., nums[ik-1..(n-1)], then
+ *  ik-1 - i1 <= dist.
+ *
+ *  Return the minimum possible sum of the cost of these subarrays.
+ *
+ *  Example 1:
+ *    Input: nums = [1,3,2,6,4,2], k = 3, dist = 3
+ *    Output: 5
+ *    Explanation: [1,3], [2], [6,4,2] -> 1 + 2 + 2 = 5.
+ *
+ *  Example 2:
+ *    Input: nums = [10,1,2,2,2,1], k = 4, dist = 3
+ *    Output: 15
+ *    Explanation: [10], [1], [2], [2,2,1] -> 10 + 1 + 2 + 2 = 15.
+ *
+ *  Constraints:
+ *    3 <= n <= 10^5
+ *    1 <= nums[i] <= 10^9
+ *    3 <= k <= n
+ *    k - 2 <= dist <= n - 2
+ */
+public class DivideAnArrayIntoSubarraysWithMinimumCostII {
+
+    // V0
+    // IDEA: SLIDING WINDOW OF WIDTH dist+1, KEEPING THE k-1 SMALLEST STARTS
+    //
+    //   nums[0] is always paid. The other k-1 subarray starts are distinct indices
+    //   in 1..n-1 whose spread is at most dist, i.e. they all fit inside some
+    //   window of dist+1 consecutive indices, so
+    //
+    //       answer = nums[0] + min over windows of (sum of the k-1 smallest)
+    //
+    //   Any window works: if the chosen starts sit inside [l, l+dist], the window
+    //   anchored at their own minimum contains them too.
+    //
+    //   Maintaining "sum of the k-1 smallest" under insert AND delete is the real
+    //   work. Two ordered sets straddle the cut, keyed by (value, index) so that
+    //   duplicates stay distinct and an exact element can be deleted in O(log n):
+    //       small : the k-1 smallest, with running sum
+    //       large : everything else
+    //   After every insert/delete, refill/trim `small` to k-1 elements and then
+    //   swap while its max exceeds `large`'s min.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public long minimumCost(int[] nums, int k, int dist) {
+        int n = nums.length;
+        final int need = k - 1;
+
+        Comparator<long[]> byValueThenIndex = new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                if (a[0] != b[0]) {
+                    return Long.compare(a[0], b[0]);
+                }
+                return Long.compare(a[1], b[1]);
+            }
+        };
+        TreeSet<long[]> small = new TreeSet<>(byValueThenIndex);
+        TreeSet<long[]> large = new TreeSet<>(byValueThenIndex);
+        long sumSmall = 0L;
+
+        long res = Long.MAX_VALUE;
+        for (int r = 1; r < n; r++) {
+            // ---- insert index r ----
+            large.add(new long[]{nums[r], r});
+            sumSmall = rebalance(small, large, sumSmall, need);
+
+            // ---- drop the index that just fell out of [r - dist, r] ----
+            int l = Math.max(1, r - dist);
+            int gone = l - 1;
+            if (gone >= 1) {
+                long[] e = new long[]{nums[gone], gone};
+                if (small.remove(e)) {
+                    sumSmall -= nums[gone];
+                } else {
+                    large.remove(e);
+                }
+                sumSmall = rebalance(small, large, sumSmall, need);
+            }
+
+            if (small.size() == need) {
+                res = Math.min(res, sumSmall);
+            }
+        }
+        return nums[0] + res;
+    }
+
+    /** keeps `small` at exactly `need` elements and every member <= every member of `large`. */
+    private long rebalance(TreeSet<long[]> small, TreeSet<long[]> large, long sumSmall, int need) {
+        while (small.size() < need && !large.isEmpty()) {
+            long[] e = large.pollFirst();
+            small.add(e);
+            sumSmall += e[0];
+        }
+        while (small.size() > need) {
+            long[] e = small.pollLast();
+            sumSmall -= e[0];
+            large.add(e);
+        }
+        while (!small.isEmpty() && !large.isEmpty()
+                && small.last()[0] > large.first()[0]) {
+            long[] a = small.pollLast();
+            long[] b = large.pollFirst();
+            sumSmall += b[0] - a[0];
+            large.add(a);
+            small.add(b);
+        }
+        return sumSmall;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FinalArrayStateAfterKMultiplicationOperationsI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FinalArrayStateAfterKMultiplicationOperationsI.java
@@ -1,0 +1,79 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/final-array-state-after-k-multiplication-operations-i/
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ *  3264. Final Array State After K Multiplication Operations I
+ *  Easy
+ *
+ *  You are given an integer array nums, an integer k, and an integer multiplier.
+ *
+ *  You need to perform k operations on nums. In each operation:
+ *    - Find the minimum value x in nums. If there are multiple occurrences of the
+ *      minimum value, select the one that appears first.
+ *    - Replace the selected minimum value x with x * multiplier.
+ *
+ *  Return an integer array denoting the final state of nums after performing all
+ *  k operations.
+ *
+ *  Example 1:
+ *    Input: nums = [2,1,3,5,6], k = 5, multiplier = 2
+ *    Output: [8,4,6,5,6]
+ *
+ *  Example 2:
+ *    Input: nums = [1,2], k = 3, multiplier = 4
+ *    Output: [16,8]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 100
+ *    1 <= nums[i] <= 100
+ *    1 <= k <= 10
+ *    1 <= multiplier <= 5
+ */
+public class FinalArrayStateAfterKMultiplicationOperationsI {
+
+    // V0
+    // IDEA: MIN-HEAP KEYED BY (VALUE, INDEX) - THE TIE-BREAK IS THE INDEX
+    //
+    //   "the first occurrence of the minimum" is exactly the ordering
+    //   (value, index), so one heap reproduces the rule directly: each operation
+    //   pops that pair, multiplies it, and pushes it back. The array is then
+    //   rebuilt from the heap contents.
+    //
+    //   k is only 10 here; the sequel (LC 3266) pushes k to 10^9 and needs the
+    //   bulk-multiplication shortcut.
+    /**
+     * time = O((n + k) log n)
+     * space = O(n)
+     */
+    public int[] getFinalState(int[] nums, int k, int multiplier) {
+        int n = nums.length;
+        // {value, index}
+        PriorityQueue<long[]> heap = new PriorityQueue<>(new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                if (a[0] != b[0]) {
+                    return Long.compare(a[0], b[0]);
+                }
+                return Long.compare(a[1], b[1]);
+            }
+        });
+        for (int i = 0; i < n; i++) {
+            heap.add(new long[]{nums[i], i});
+        }
+
+        for (int step = 0; step < k; step++) {
+            long[] cur = heap.poll();
+            heap.add(new long[]{cur[0] * multiplier, cur[1]});
+        }
+
+        int[] res = new int[n];
+        for (long[] e : heap) {
+            res[(int) e[1]] = (int) e[0];
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FinalArrayStateAfterKMultiplicationOperationsII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FinalArrayStateAfterKMultiplicationOperationsII.java
@@ -1,0 +1,120 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/final-array-state-after-k-multiplication-operations-ii/
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ *  3266. Final Array State After K Multiplication Operations II
+ *  Hard
+ *
+ *  You are given an integer array nums, an integer k, and an integer multiplier.
+ *
+ *  You need to perform k operations on nums. In each operation:
+ *    - Find the minimum value x in nums. If there are multiple occurrences of the
+ *      minimum value, select the one that appears first.
+ *    - Replace the selected minimum value x with x * multiplier.
+ *
+ *  After the k operations, apply modulo 10^9 + 7 to every value in nums, and return
+ *  the resulting array.
+ *
+ *  Example 1:
+ *    Input: nums = [2,1,3,5,6], k = 5, multiplier = 2
+ *    Output: [8,4,6,5,6]
+ *
+ *  Example 2:
+ *    Input: nums = [100000,2000], k = 2, multiplier = 1000000
+ *    Output: [999999307,999999993]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^4
+ *    1 <= nums[i] <= 10^9
+ *    1 <= k <= 10^9
+ *    1 <= multiplier <= 10^6
+ */
+public class FinalArrayStateAfterKMultiplicationOperationsII {
+
+    private static final long MOD = 1_000_000_007L;
+
+    // V0
+    // IDEA: SIMULATE UNTIL THE VALUES LEVEL OFF, THEN FINISH IN BULK
+    //
+    //   while some element is still below the ORIGINAL maximum the heap must be
+    //   walked one step at a time - but that phase is short: multiplier >= 2 at
+    //   least doubles an element each time, so after about n * log2(max) steps
+    //   every value has caught up with the maximum.
+    //
+    //   from there the heap is "flat" - one full sweep multiplies everybody once -
+    //   so the remaining r operations split evenly: each element gets r / n more
+    //   multiplications, and the first r % n in the current heap order get one
+    //   extra.
+    //
+    //   multiplier == 1 changes nothing, so it is answered immediately. The values
+    //   explode past 64 bits, hence modular exponentiation in the bulk phase.
+    /**
+     * time = O(n log(max) log n + n log n)
+     * space = O(n)
+     */
+    public int[] getFinalState(int[] nums, int k, int multiplier) {
+        int n = nums.length;
+        int[] res = new int[n];
+
+        if (multiplier == 1) {
+            for (int i = 0; i < n; i++) {
+                res[i] = (int) (nums[i] % MOD);
+            }
+            return res;
+        }
+
+        Comparator<long[]> byValueThenIndex = new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                if (a[0] != b[0]) {
+                    return Long.compare(a[0], b[0]);
+                }
+                return Long.compare(a[1], b[1]);
+            }
+        };
+        PriorityQueue<long[]> heap = new PriorityQueue<>(byValueThenIndex);
+        long limit = 0L;
+        for (int i = 0; i < n; i++) {
+            heap.add(new long[]{nums[i], i});
+            limit = Math.max(limit, nums[i]);
+        }
+
+        // phase 1 : real simulation until every value reaches the initial max
+        long remain = k;
+        while (remain > 0 && heap.peek()[0] < limit) {
+            long[] cur = heap.poll();
+            heap.add(new long[]{cur[0] * multiplier, cur[1]});
+            remain--;
+        }
+
+        // phase 2 : the heap order is now stable, so spread out what is left
+        long[][] rest = heap.toArray(new long[0][]);
+        Arrays.sort(rest, byValueThenIndex);
+        long base = remain / n;
+        long extra = remain % n;
+        for (int t = 0; t < n; t++) {
+            long times = base + (t < extra ? 1 : 0);
+            long v = rest[t][0] % MOD;
+            res[(int) rest[t][1]] = (int) (v * modPow(multiplier, times) % MOD);
+        }
+        return res;
+    }
+
+    private long modPow(long b, long exp) {
+        long r = 1L;
+        b %= MOD;
+        while (exp > 0) {
+            if ((exp & 1L) == 1L) {
+                r = r * b % MOD;
+            }
+            b = b * b % MOD;
+            exp >>= 1;
+        }
+        return r;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FindMinimumTimeToReachLastRoomI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FindMinimumTimeToReachLastRoomI.java
@@ -1,0 +1,100 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/find-minimum-time-to-reach-last-room-i/
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ *  3341. Find Minimum Time to Reach Last Room I
+ *  Medium
+ *
+ *  There is a dungeon with n x m rooms arranged as a grid.
+ *
+ *  You are given a 2D array moveTime of size n x m, where moveTime[i][j] represents
+ *  the minimum time in seconds when you can start moving to that room. You start
+ *  from the room (0, 0) at time t = 0 and can move to an adjacent room. Moving
+ *  between adjacent rooms takes exactly one second.
+ *
+ *  Return the minimum time to reach the room (n - 1, m - 1).
+ *  Two rooms are adjacent if they share a common wall, horizontally or vertically.
+ *
+ *  Example 1:
+ *    Input: moveTime = [[0,4],[4,4]]
+ *    Output: 6
+ *    Explanation: wait until t == 4, step to (1,0) at t == 5, then to (1,1) at t == 6.
+ *
+ *  Example 2:
+ *    Input: moveTime = [[0,0,0],[0,0,0]]
+ *    Output: 3
+ *
+ *  Constraints:
+ *    2 <= n == moveTime.length <= 50
+ *    2 <= m == moveTime[i].length <= 50
+ *    0 <= moveTime[i][j] <= 10^9
+ */
+public class FindMinimumTimeToReachLastRoomI {
+
+    private static final int[][] DIRS = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+    // V0
+    // IDEA: DIJKSTRA WHERE THE EDGE COST DEPENDS ON THE ARRIVAL TIME
+    //
+    //   the earliest one can ENTER a room is max(now, moveTime[room]) - waiting is
+    //   free - and the move itself costs one more second:
+    //
+    //       arrival = max(current time, moveTime[x][y]) + 1
+    //
+    //   that value never decreases along a path, so the usual Dijkstra argument
+    //   holds: the first time a room is popped from the priority queue its time is
+    //   final.
+    /**
+     * time = O(n * m * log(n * m))
+     * space = O(n * m)
+     */
+    public int minTimeToReach(int[][] moveTime) {
+        int n = moveTime.length;
+        int m = moveTime[0].length;
+
+        long[][] best = new long[n][m];
+        for (int i = 0; i < n; i++) {
+            java.util.Arrays.fill(best[i], Long.MAX_VALUE);
+        }
+        best[0][0] = 0L;
+
+        // {time, row, col}
+        PriorityQueue<long[]> pq = new PriorityQueue<>(new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                return Long.compare(a[0], b[0]);
+            }
+        });
+        pq.add(new long[]{0L, 0L, 0L});
+
+        while (!pq.isEmpty()) {
+            long[] cur = pq.poll();
+            long t = cur[0];
+            int i = (int) cur[1];
+            int j = (int) cur[2];
+            if (t > best[i][j]) {
+                continue;
+            }
+            if (i == n - 1 && j == m - 1) {
+                return (int) t;
+            }
+            for (int[] d : DIRS) {
+                int x = i + d[0];
+                int y = j + d[1];
+                if (x < 0 || x >= n || y < 0 || y >= m) {
+                    continue;
+                }
+                long nt = Math.max(t, moveTime[x][y]) + 1;
+                if (nt < best[x][y]) {
+                    best[x][y] = nt;
+                    pq.add(new long[]{nt, x, y});
+                }
+            }
+        }
+        return (int) best[n - 1][m - 1];
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FindMinimumTimeToReachLastRoomII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FindMinimumTimeToReachLastRoomII.java
@@ -1,0 +1,103 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/find-minimum-time-to-reach-last-room-ii/
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ *  3342. Find Minimum Time to Reach Last Room II
+ *  Medium
+ *
+ *  There is a dungeon with n x m rooms arranged as a grid.
+ *
+ *  You are given a 2D array moveTime of size n x m, where moveTime[i][j] represents
+ *  the minimum time in seconds when you can start moving to that room. You start
+ *  from the room (0, 0) at time t = 0 and can move to an adjacent room. Moving
+ *  between adjacent rooms takes one second for one move and two seconds for the
+ *  next, alternating between the two.
+ *
+ *  Return the minimum time to reach the room (n - 1, m - 1).
+ *
+ *  Example 1:
+ *    Input: moveTime = [[0,4],[4,4]]
+ *    Output: 7
+ *    Explanation: at t == 4 move to (1,0) in one second, then to (1,1) in two.
+ *
+ *  Example 2:
+ *    Input: moveTime = [[0,0,0,0],[0,0,0,0]]
+ *    Output: 6
+ *
+ *  Constraints:
+ *    2 <= n == moveTime.length <= 750
+ *    2 <= m == moveTime[i].length <= 750
+ *    0 <= moveTime[i][j] <= 10^9
+ */
+public class FindMinimumTimeToReachLastRoomII {
+
+    private static final int[][] DIRS = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+    // V0
+    // IDEA: SAME DIJKSTRA AS LC 3341, BUT THE STEP COST FOLLOWS THE BOARD PARITY
+    //
+    //   each move flips the parity of i + j, so after k moves the walker always
+    //   stands on a cell with (i + j) % 2 == k % 2. The costs alternate
+    //   1, 2, 1, 2, ... starting at 1, which means the move LEAVING a cell costs
+    //
+    //       1 when (i + j) is even, 2 when it is odd
+    //
+    //   - no extra state dimension is needed, the parity is baked into the cell.
+    //   The rest is LC 3341: a room cannot be entered before its moveTime, so
+    //   arrival = max(now, moveTime[x][y]) + cost.
+    /**
+     * time = O(n * m * log(n * m))
+     * space = O(n * m)
+     */
+    public int minTimeToReach(int[][] moveTime) {
+        int n = moveTime.length;
+        int m = moveTime[0].length;
+
+        long[][] best = new long[n][m];
+        for (int i = 0; i < n; i++) {
+            Arrays.fill(best[i], Long.MAX_VALUE);
+        }
+        best[0][0] = 0L;
+
+        // {time, row, col}
+        PriorityQueue<long[]> pq = new PriorityQueue<>(new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                return Long.compare(a[0], b[0]);
+            }
+        });
+        pq.add(new long[]{0L, 0L, 0L});
+
+        while (!pq.isEmpty()) {
+            long[] cur = pq.poll();
+            long t = cur[0];
+            int i = (int) cur[1];
+            int j = (int) cur[2];
+            if (t > best[i][j]) {
+                continue;
+            }
+            if (i == n - 1 && j == m - 1) {
+                return (int) t;
+            }
+            int cost = ((i + j) % 2 == 0) ? 1 : 2;
+            for (int[] d : DIRS) {
+                int x = i + d[0];
+                int y = j + d[1];
+                if (x < 0 || x >= n || y < 0 || y >= m) {
+                    continue;
+                }
+                long nt = Math.max(t, moveTime[x][y]) + cost;
+                if (nt < best[x][y]) {
+                    best[x][y] = nt;
+                    pq.add(new long[]{nt, x, y});
+                }
+            }
+        }
+        return (int) best[n - 1][m - 1];
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FindServersThatHandledMostNumberOfRequests.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FindServersThatHandledMostNumberOfRequests.java
@@ -1,0 +1,154 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/find-servers-that-handled-most-number-of-requests/
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/**
+ *  1606. Find Servers That Handled Most Number of Requests
+ *  Hard
+ *
+ *  You have k servers numbered from 0 to k-1 that handle multiple requests
+ *  simultaneously. Each server has infinite computational capacity but cannot handle
+ *  more than one request at a time. Requests are assigned like this:
+ *    - The ith (0-indexed) request arrives.
+ *    - If all servers are busy, the request is dropped.
+ *    - If the (i % k)th server is available, assign the request to that server.
+ *    - Otherwise assign it to the next available server, wrapping around to 0.
+ *
+ *  You are given a strictly increasing array arrival, where arrival[i] is the arrival
+ *  time of the ith request, and load, where load[i] is how long it takes to complete.
+ *  A server is busiest if it handled the most requests. Return the IDs of the
+ *  busiest server(s), in any order.
+ *
+ *  Example 1:
+ *    Input: k = 3, arrival = [1,2,3,4,5], load = [5,2,3,3,3]
+ *    Output: [1]
+ *    Explanation: server 1 handled two requests, servers 0 and 2 one each.
+ *
+ *  Example 2:
+ *    Input: k = 3, arrival = [1,2,3], load = [10,12,11]
+ *    Output: [0,1,2]
+ *
+ *  Constraints:
+ *    1 <= k <= 10^5
+ *    1 <= arrival.length == load.length <= 10^5
+ *    1 <= arrival[i], load[i] <= 10^9
+ *    arrival is strictly increasing.
+ */
+public class FindServersThatHandledMostNumberOfRequests {
+
+    private int k;
+    private int[] tree;      // BIT over free servers, 1-indexed
+    private int power;       // largest power of two <= k
+
+    // V0
+    // IDEA: MIN-HEAP OF BUSY SERVERS (by finish time) + BIT OVER THE FREE ONES
+    //
+    //   two structures:
+    //     busy : min-heap of (endTime, server) so every server that finished before
+    //            the current arrival can be released; each server is popped at most
+    //            once per request -> amortised O(log k).
+    //     BIT  : marks free servers with 1, answering "first free server at index
+    //            >= p, wrapping to 0" in O(log k):
+    //              c = #free in [0, p-1]
+    //              if freeTotal > c -> take the (c+1)-th free server
+    //              else             -> wrap and take the 1st free server
+    //            the t-th free server is located by binary lifting on the tree.
+    //
+    //   NOTE: a linear scan from i % k is O(k) per request and TLEs at
+    //         k = arrival.length = 10^5.
+    /**
+     * time = O((n + k) log k)
+     * space = O(k)
+     */
+    public List<Integer> busiestServers(int k, int[] arrival, int[] load) {
+        this.k = k;
+        this.tree = new int[k + 1];
+        this.power = 1;
+        while (this.power * 2 <= k) {
+            this.power *= 2;
+        }
+
+        for (int s = 1; s <= k; s++) {         // every server starts free
+            add(s, 1);
+        }
+        int free = k;
+
+        // {endTime, server}
+        PriorityQueue<long[]> busy = new PriorityQueue<>(new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                return Long.compare(a[0], b[0]);
+            }
+        });
+        int[] cnt = new int[k];
+
+        for (int i = 0; i < arrival.length; i++) {
+            long start = arrival[i];
+            while (!busy.isEmpty() && busy.peek()[0] <= start) {
+                int s = (int) busy.poll()[1];
+                add(s + 1, 1);
+                free++;
+            }
+            if (free == 0) {
+                continue;                      // dropped
+            }
+
+            int p = i % k;
+            int c = pref(p);                   // free servers among ids 0..p-1
+            int rank = (free > c) ? c + 1 : 1;
+            int idx = kth(rank);
+            int server = idx - 1;
+
+            add(idx, -1);
+            free--;
+            cnt[server]++;
+            busy.add(new long[]{start + load[i], server});
+        }
+
+        int best = 0;
+        for (int c : cnt) {
+            best = Math.max(best, c);
+        }
+        List<Integer> res = new ArrayList<>();
+        for (int s = 0; s < k; s++) {
+            if (cnt[s] == best) {
+                res.add(s);
+            }
+        }
+        return res;
+    }
+
+    private void add(int i, int v) {            // i is 1-indexed
+        while (i <= k) {
+            tree[i] += v;
+            i += i & (-i);
+        }
+    }
+
+    private int pref(int i) {                   // sum of 1..i
+        int s = 0;
+        while (i > 0) {
+            s += tree[i];
+            i -= i & (-i);
+        }
+        return s;
+    }
+
+    private int kth(int t) {                    // smallest idx with pref(idx) >= t
+        int pos = 0;
+        int bit = power;
+        while (bit > 0) {
+            if (pos + bit <= k && tree[pos + bit] < t) {
+                pos += bit;
+                t -= tree[pos];
+            }
+            bit >>= 1;
+        }
+        return pos + 1;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FindTheKSumOfAnArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FindTheKSumOfAnArray.java
@@ -1,0 +1,96 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/find-the-k-sum-of-an-array/
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ *  2386. Find the K-Sum of an Array
+ *  Hard
+ *
+ *  You are given an integer array nums and a positive integer k. You can choose any
+ *  subsequence of the array and sum all of its elements together.
+ *
+ *  We define the K-Sum of the array as the kth largest subsequence sum that can be
+ *  obtained (not necessarily distinct). Return the K-Sum of the array.
+ *
+ *  Note that the empty subsequence is considered to have a sum of 0.
+ *
+ *  Example 1:
+ *    Input: nums = [2,4,-2], k = 5
+ *    Output: 2
+ *    Explanation: the sums in decreasing order are 6, 4, 4, 2, 2, 0, 0, -2, so the
+ *                 5th largest is 2.
+ *
+ *  Example 2:
+ *    Input: nums = [1,-2,3,4,-10,12], k = 16
+ *    Output: 10
+ *
+ *  Constraints:
+ *    n == nums.length
+ *    1 <= n <= 10^5
+ *    -10^9 <= nums[i] <= 10^9
+ *    1 <= k <= min(2000, 2^n)
+ */
+public class FindTheKSumOfAnArray {
+
+    // V0
+    // IDEA: REDUCE TO "k SMALLEST SUBSET SUMS OF THE ABSOLUTE VALUES"
+    //
+    //   the largest possible sum takes every positive element:
+    //       total = sum(x for x in nums if x > 0)
+    //   every other subsequence sum is total minus some non-negative "loss":
+    //   dropping a positive x costs x, adding a negative x costs |x|. So the losses
+    //   are exactly the subset sums of a = sorted(|nums|), and
+    //
+    //       k-th LARGEST subsequence sum = total - (k-th SMALLEST subset sum of a)
+    //
+    //   Those are enumerated in order with a min-heap over (loss, next index),
+    //   expanding each popped state two ways:
+    //       include a[i]                 -> (loss + a[i],            i + 1)
+    //       swap a[i-1] out for a[i]     -> (loss + a[i] - a[i-1],   i + 1)
+    //   which reaches every subset exactly once in non-decreasing loss order.
+    //   Only k pops are needed, and k <= 2000.
+    /**
+     * time = O(n log n + k log k)
+     * space = O(n + k)
+     */
+    public long kSum(int[] nums, int k) {
+        int n = nums.length;
+        long total = 0L;
+        long[] a = new long[n];
+        for (int i = 0; i < n; i++) {
+            if (nums[i] > 0) {
+                total += nums[i];
+            }
+            a[i] = Math.abs((long) nums[i]);
+        }
+        Arrays.sort(a);
+
+        // {loss so far, next index to consider}
+        PriorityQueue<long[]> heap = new PriorityQueue<>(new Comparator<long[]>() {
+            @Override
+            public int compare(long[] x, long[] y) {
+                return Long.compare(x[0], y[0]);
+            }
+        });
+        heap.add(new long[]{0L, 0L});
+
+        long res = total;
+        for (int step = 0; step < k; step++) {
+            long[] cur = heap.poll();
+            long loss = cur[0];
+            int i = (int) cur[1];
+            res = total - loss;
+            if (i < n) {
+                heap.add(new long[]{loss + a[i], i + 1});
+                if (i > 0) {
+                    heap.add(new long[]{loss + a[i] - a[i - 1], i + 1});
+                }
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FindTheKthSmallestSumOfAMatrixWithSortedRows.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FindTheKthSmallestSumOfAMatrixWithSortedRows.java
@@ -1,0 +1,119 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/find-the-kth-smallest-sum-of-a-matrix-with-sorted-rows/
+
+import java.util.Arrays;
+
+/**
+ *  1439. Find the Kth Smallest Sum of a Matrix With Sorted Rows
+ *  Hard
+ *
+ *  You are given an m x n matrix mat that has its rows sorted in non-decreasing
+ *  order and an integer k.
+ *
+ *  You are allowed to choose exactly one element from each row to form an array.
+ *  Return the kth smallest array sum among all possible arrays.
+ *
+ *  Example 1:
+ *    Input: mat = [[1,3,11],[2,4,6]], k = 5
+ *    Output: 7
+ *    Explanation: the first 5 smallest sums come from [1,2], [1,4], [3,2], [3,4],
+ *                 [1,6], so the 5th is 7.
+ *
+ *  Example 2:
+ *    Input: mat = [[1,10,10],[1,4,5],[2,3,6]], k = 7
+ *    Output: 9
+ *
+ *  Constraints:
+ *    m == mat.length
+ *    n == mat[i].length
+ *    1 <= m, n <= 40
+ *    1 <= mat[i][j] <= 5000
+ *    1 <= k <= min(200, n^m)
+ *    mat[i] is a non-decreasing array.
+ */
+public class FindTheKthSmallestSumOfAMatrixWithSortedRows {
+
+    // V0
+    // IDEA: FOLD THE ROWS ONE AT A TIME, KEEPING ONLY THE k SMALLEST SUMS
+    //
+    //   pre = the k smallest sums using the rows seen so far, then
+    //   pre = k smallest of { a + b : a in pre, b in row }.
+    //   Since each row is sorted, only its first k entries can ever matter, so the
+    //   candidate set stays at k * k per step. The answer is the last (k-th) entry.
+    /**
+     * time = O(m * k * n log(k * n))
+     * space = O(k * n)
+     */
+    public int kthSmallest(int[][] mat, int k) {
+        int[] pre = new int[]{0};
+        for (int[] row : mat) {
+            int width = Math.min(k, row.length);
+            int[] cur = new int[pre.length * width];
+            int t = 0;
+            for (int a : pre) {
+                for (int c = 0; c < width; c++) {
+                    cur[t++] = a + row[c];
+                }
+            }
+            Arrays.sort(cur);
+            pre = Arrays.copyOf(cur, Math.min(k, cur.length));
+        }
+        return pre[pre.length - 1];
+    }
+
+    // V1
+    // IDEA: MIN-HEAP / BEST-FIRST SEARCH OVER THE COLUMN-INDEX TUPLES
+    //       start from column 0 of every row (the smallest sum), pop the smallest
+    //       sum and push its m "advance one row by one column" neighbours; the k-th
+    //       pop is the answer. A visited set keeps each tuple from being pushed
+    //       twice. Distinct trick from V0: it never materialises k*k candidates.
+    /**
+     * time = O(k * m log(k * m))
+     * space = O(k * m)
+     */
+    public int kthSmallestHeap(int[][] mat, int k) {
+        int m = mat.length;
+        int n = mat[0].length;
+
+        int[] start = new int[m];
+        int base = 0;
+        for (int[] row : mat) {
+            base += row[0];
+        }
+
+        // {sum, col index of row 0, col index of row 1, ...}
+        java.util.PriorityQueue<int[]> heap = new java.util.PriorityQueue<>(
+                new java.util.Comparator<int[]>() {
+                    @Override
+                    public int compare(int[] a, int[] b) {
+                        return Integer.compare(a[0], b[0]);
+                    }
+                });
+        int[] first = new int[m + 1];
+        first[0] = base;
+        System.arraycopy(start, 0, first, 1, m);
+        heap.add(first);
+
+        java.util.Set<String> seen = new java.util.HashSet<>();
+        seen.add(Arrays.toString(start));
+
+        for (int step = 0; step < k - 1; step++) {
+            int[] cur = heap.poll();
+            for (int i = 0; i < m; i++) {
+                int col = cur[i + 1];
+                if (col + 1 >= n) {
+                    continue;
+                }
+                int[] nxt = cur.clone();
+                nxt[i + 1] = col + 1;
+                nxt[0] = cur[0] - mat[i][col] + mat[i][col + 1];
+                String key = Arrays.toString(Arrays.copyOfRange(nxt, 1, m + 1));
+                if (seen.add(key)) {
+                    heap.add(nxt);
+                }
+            }
+        }
+        return heap.peek()[0];
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/FindXSumOfAllKLongSubarraysII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/FindXSumOfAllKLongSubarraysII.java
@@ -1,0 +1,153 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/find-x-sum-of-all-k-long-subarrays-ii/
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ *  3321. Find X-Sum of All K-Long Subarrays II
+ *  Hard
+ *
+ *  You are given an array nums of n integers and two integers k and x.
+ *
+ *  The x-sum of an array is calculated by the following procedure:
+ *    - Count the occurrences of all elements in the array.
+ *    - Keep only the occurrences of the top x most frequent elements. If two elements
+ *      have the same number of occurrences, the element with the bigger value is
+ *      considered more frequent.
+ *    - Calculate the sum of the resulting array.
+ *  If an array has fewer than x distinct elements, its x-sum is the sum of the array.
+ *
+ *  Return an integer array answer of length n - k + 1 where answer[i] is the x-sum of
+ *  the subarray nums[i..i + k - 1].
+ *
+ *  Example 1:
+ *    Input: nums = [1,1,2,2,3,4,2,3], k = 6, x = 2
+ *    Output: [6,10,12]
+ *    Explanation: for [1,1,2,2,3,4] only 1 and 2 are kept -> 1+1+2+2 = 6, etc.
+ *
+ *  Example 2:
+ *    Input: nums = [3,8,7,8,7,5], k = 2, x = 2
+ *    Output: [11,15,15,15,12]
+ *    Explanation: k == x, so every answer is just the window sum.
+ *
+ *  Constraints:
+ *    nums.length == n
+ *    1 <= n <= 10^5
+ *    1 <= nums[i] <= 10^9
+ *    1 <= x <= k <= nums.length
+ */
+public class FindXSumOfAllKLongSubarraysII {
+
+    // V0
+    // IDEA: TWO ORDERED SETS STRADDLING THE "TOP x" CUT
+    //
+    //   sliding the window changes exactly two counts, so the x-sum is MAINTAINED
+    //   rather than recomputed. The ranking key is (count, value) - more
+    //   occurrences first, bigger value breaking ties - so keep
+    //       top  : the x best (count, value) pairs, with their weighted sum
+    //       rest : everybody else
+    //   as two TreeSets on that key. `top.first()` is the weakest member (the one
+    //   that can be evicted) and `rest.last()` is the strongest challenger.
+    //
+    //   A TreeSet keyed by (count, value) allows the EXACT old entry of a value to
+    //   be deleted in O(log n) when its count changes - which is why no lazy
+    //   deletion / staleness bookkeeping is needed here. After each count change the
+    //   sets are rebalanced so `top` holds exactly min(x, distinct) values and no
+    //   member of `rest` outranks a member of `top`.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public long[] findXSum(int[] nums, int k, int x) {
+        int n = nums.length;
+        Map<Integer, Integer> cnt = new HashMap<>();
+
+        Comparator<long[]> byCountThenValue = new Comparator<long[]>() {
+            @Override
+            public int compare(long[] a, long[] b) {
+                if (a[0] != b[0]) {
+                    return Long.compare(a[0], b[0]);
+                }
+                return Long.compare(a[1], b[1]);
+            }
+        };
+        TreeSet<long[]> top = new TreeSet<>(byCountThenValue);   // the x best
+        TreeSet<long[]> rest = new TreeSet<>(byCountThenValue);  // everybody else
+
+        long[] res = new long[n - k + 1];
+        long[] sumTop = new long[]{0L};
+
+        for (int i = 0; i < n; i++) {
+            change(nums[i], 1, cnt, top, rest, sumTop, x);
+            if (i >= k) {
+                change(nums[i - k], -1, cnt, top, rest, sumTop, x);
+            }
+            if (i >= k - 1) {
+                res[i - k + 1] = sumTop[0];
+            }
+        }
+        return res;
+    }
+
+    /** applies cnt[v] += delta, keeping `top` / `rest` / sumTop consistent. */
+    private void change(int v, int delta, Map<Integer, Integer> cnt,
+                        TreeSet<long[]> top, TreeSet<long[]> rest,
+                        long[] sumTop, int x) {
+        int old = cnt.containsKey(v) ? cnt.get(v) : 0;
+        if (old > 0) {
+            long[] e = new long[]{old, v};
+            if (top.remove(e)) {
+                sumTop[0] -= (long) v * old;
+            } else {
+                rest.remove(e);
+            }
+        }
+        int now = old + delta;
+        if (now > 0) {
+            cnt.put(v, now);
+            rest.add(new long[]{now, v});
+        } else {
+            cnt.remove(v);
+        }
+        rebalance(top, rest, sumTop, x);
+    }
+
+    private void rebalance(TreeSet<long[]> top, TreeSet<long[]> rest,
+                           long[] sumTop, int x) {
+        while (true) {
+            if (top.size() < x && !rest.isEmpty()) {
+                long[] e = rest.pollLast();               // strongest challenger
+                top.add(e);
+                sumTop[0] += e[0] * e[1];
+                continue;
+            }
+            if (top.size() > x) {
+                long[] e = top.pollFirst();               // weakest member
+                sumTop[0] -= e[0] * e[1];
+                rest.add(e);
+                continue;
+            }
+            if (!top.isEmpty() && !rest.isEmpty()
+                    && compareKey(rest.last(), top.first()) > 0) {
+                long[] out = top.pollFirst();
+                long[] in = rest.pollLast();
+                sumTop[0] += in[0] * in[1] - out[0] * out[1];
+                rest.add(out);
+                top.add(in);
+                continue;
+            }
+            break;
+        }
+    }
+
+    private int compareKey(long[] a, long[] b) {
+        if (a[0] != b[0]) {
+            return Long.compare(a[0], b[0]);
+        }
+        return Long.compare(a[1], b[1]);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/KthNearestObstacleQueries.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/KthNearestObstacleQueries.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/k-th-nearest-obstacle-queries/
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  3275. K-th Nearest Obstacle Queries
+ *  Medium
+ *
+ *  There is an infinite 2D plane. You are given a positive integer k and a 2D array
+ *  queries, where queries[i] = [x, y] builds an obstacle at coordinate (x, y). It is
+ *  guaranteed that there is no obstacle at this coordinate when the query is made.
+ *
+ *  After each query, find the distance of the kth nearest obstacle from the origin.
+ *  Return an integer array results where results[i] is that distance after query i,
+ *  or -1 if there are fewer than k obstacles. Initially there are no obstacles.
+ *
+ *  The distance of an obstacle at (x, y) from the origin is |x| + |y|.
+ *
+ *  Example 1:
+ *    Input: k = 2, queries = [[1,2],[3,4],[2,3],[-3,0]]
+ *    Output: [-1,7,5,3]
+ *    Explanation: the distances build up as {3}, {3,7}, {3,5,7}, {3,3,5,7}.
+ *
+ *  Example 2:
+ *    Input: k = 1, queries = [[5,5],[4,4],[3,3]]
+ *    Output: [10,8,6]
+ *
+ *  Constraints:
+ *    1 <= queries.length <= 2 * 10^5
+ *    All queries[i] are unique.
+ *    -10^9 <= queries[i][0], queries[i][1] <= 10^9
+ *    0 <= k <= 10^5
+ */
+public class KthNearestObstacleQueries {
+
+    // V0
+    // IDEA: A BOUNDED MAX-HEAP HOLDING THE k CLOSEST DISTANCES
+    //
+    //   only the k-th smallest distance is ever asked for, so keeping the k smallest
+    //   distances is enough - and a MAX-heap of exactly those has the answer sitting
+    //   on top. Push each new distance, then pop whenever the heap exceeds k, which
+    //   discards the largest of the k+1. Before the heap fills up there are fewer
+    //   than k obstacles, hence -1.
+    /**
+     * time = O(q log k)
+     * space = O(k)
+     */
+    public int[] resultsArray(int[][] queries, int k) {
+        PriorityQueue<Integer> heap = new PriorityQueue<>(Collections.reverseOrder());
+        int[] res = new int[queries.length];
+
+        for (int i = 0; i < queries.length; i++) {
+            int d = Math.abs(queries[i][0]) + Math.abs(queries[i][1]);
+            heap.add(d);
+            if (heap.size() > k) {
+                heap.poll();
+            }
+            res[i] = (k > 0 && heap.size() == k) ? heap.peek() : -1;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MarkElementsOnArrayByPerformingQueries.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MarkElementsOnArrayByPerformingQueries.java
@@ -1,0 +1,95 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/mark-elements-on-array-by-performing-queries/
+
+import java.util.PriorityQueue;
+
+/**
+ *  3080. Mark Elements on Array by Performing Queries
+ *  Medium
+ *
+ *  You are given a 0-indexed array nums of size n consisting of positive integers.
+ *
+ *  You are also given a 2D array queries of size m where queries[i] = [index_i, k_i].
+ *
+ *  Initially all elements of the array are unmarked.
+ *
+ *  You need to apply m queries on the array in order, where on the ith query you do
+ *  the following:
+ *
+ *   - Mark the element at index index_i if it is not already marked.
+ *   - Then mark k_i unmarked elements in the array with the smallest values. If
+ *     multiple such elements exist, mark the ones with the smallest indices. And if
+ *     less than k_i unmarked elements exist, then mark all of them.
+ *
+ *  Return an array answer of size m where answer[i] is the sum of unmarked elements
+ *  in the array after the ith query.
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,2,1,2,3,1], queries = [[1,2],[3,3],[4,2]]
+ *    Output: [8,3,0]
+ *
+ *  Example 2:
+ *    Input: nums = [1,4,2,3], queries = [[0,1]]
+ *    Output: [7]
+ *
+ *  Constraints:
+ *    n == nums.length
+ *    m == queries.length
+ *    1 <= m <= n <= 10^5
+ *    1 <= nums[i] <= 10^5
+ *    queries[i].length == 2
+ *    0 <= index_i, k_i <= n - 1
+ */
+public class MarkElementsOnArrayByPerformingQueries {
+
+    // V0
+    // IDEA: MIN-HEAP ON (VALUE, INDEX) + LAZY DELETION
+    //       "smallest value, then smallest index" is exactly the (value, index)
+    //       ordering, so ONE heap over all elements serves every query.
+    //       an element can also be marked directly by index, leaving a stale
+    //       heap entry -> keep a `marked` flag and discard stale tops.
+    //       a running `total` makes each answer an O(1) read.
+    /**
+     * time = O((n + sum(k)) log n)
+     * space = O(n)
+     */
+    public long[] unmarkedSumArray(int[] nums, int[][] queries) {
+        int n = nums.length;
+        PriorityQueue<int[]> pq = new PriorityQueue<>((a, b) ->
+                a[0] != b[0] ? Integer.compare(a[0], b[0]) : Integer.compare(a[1], b[1]));
+
+        long total = 0L;
+        for (int i = 0; i < n; i++) {
+            pq.add(new int[]{nums[i], i});
+            total += nums[i];
+        }
+
+        boolean[] marked = new boolean[n];
+        long[] res = new long[queries.length];
+
+        for (int q = 0; q < queries.length; q++) {
+            int idx = queries[q][0];
+            int k = queries[q][1];
+
+            if (!marked[idx]) {
+                marked[idx] = true;
+                total -= nums[idx];
+            }
+
+            while (k > 0 && !pq.isEmpty()) {
+                int[] cur = pq.poll();
+                if (marked[cur[1]]) {
+                    continue; // stale entry, already handled
+                }
+                marked[cur[1]] = true;
+                total -= cur[0];
+                k--;
+            }
+
+            res[q] = total;
+        }
+
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MaximalScoreAfterApplyingKOperations.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MaximalScoreAfterApplyingKOperations.java
@@ -1,0 +1,62 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/maximal-score-after-applying-k-operations/
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  2530. Maximal Score After Applying K Operations
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array nums and an integer k. You have a
+ *  starting score of 0.
+ *
+ *  In one operation:
+ *    1. choose an index i such that 0 <= i < nums.length,
+ *    2. increase your score by nums[i], and
+ *    3. replace nums[i] with ceil(nums[i] / 3).
+ *
+ *  Return the maximum possible score you can attain after applying exactly k
+ *  operations.
+ *
+ *  Example 1:
+ *    Input: nums = [10,10,10,10,10], k = 5
+ *    Output: 50
+ *
+ *  Example 2:
+ *    Input: nums = [1,10,3,3,3], k = 3
+ *    Output: 17
+ *    Explanation: pick 10 -> 4 -> then 3. score = 10 + 4 + 3 = 17.
+ *
+ *  Constraints:
+ *    1 <= nums.length, k <= 10^5
+ *    1 <= nums[i] <= 10^9
+ */
+public class MaximalScoreAfterApplyingKOperations {
+
+    // V0
+    // IDEA: GREEDY + MAX HEAP
+    //       every operation is independent : taking the current maximum can never
+    //       hurt, since the value left behind (ceil(v/3)) is monotonic in v.
+    //       NOTE: ceil(v/3) with INTEGER math -> (v + 2) / 3 (float division would
+    //             lose precision for v up to 10^9).
+    /**
+     * time = O(n + k log n)
+     * space = O(n)
+     */
+    public long maxKelements(int[] nums, int k) {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int x : nums) {
+            pq.add(x);
+        }
+
+        long score = 0L;
+        for (int i = 0; i < k; i++) {
+            int v = pq.poll();
+            score += v;
+            pq.add((v + 2) / 3); // ceil(v / 3)
+        }
+        return score;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MaximizeSumOfAtMostKDistinctElements.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MaximizeSumOfAtMostKDistinctElements.java
@@ -1,0 +1,64 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/maximize-sum-of-at-most-k-distinct-elements/
+
+import java.util.Arrays;
+
+/**
+ *  3684. Maximize Sum of At Most K Distinct Elements
+ *  Easy
+ *
+ *  You are given a positive integer array nums and an integer k.
+ *
+ *  Choose at most k elements from nums so that their sum is maximized.
+ *  However, the chosen numbers must be distinct.
+ *
+ *  Return an array containing the chosen numbers in strictly descending order.
+ *
+ *  Example 1:
+ *    Input: nums = [84,93,100,77,90], k = 3
+ *    Output: [100,93,90]
+ *
+ *  Example 2:
+ *    Input: nums = [84,93,100,77,93], k = 3
+ *    Output: [100,93,84]
+ *    Explanation: we cannot pick 93 twice, the chosen numbers must be distinct.
+ *
+ *  Example 3:
+ *    Input: nums = [1,1,1,2,2,2], k = 6
+ *    Output: [2,1]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 100
+ *    1 <= nums[i] <= 10^9
+ *    1 <= k <= nums.length
+ */
+public class MaximizeSumOfAtMostKDistinctElements {
+
+    // V0
+    // IDEA: DEDUPE, THEN GREEDILY TAKE THE k LARGEST DISTINCT VALUES
+    //       "distinct" makes duplicates worthless, so the universe of choices is
+    //       set(nums). all values are positive -> adding any unused value strictly
+    //       increases the sum, so take the largest min(k, #distinct) of them.
+    //       sorting descending already gives the required output order.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int[] maxKDistinct(int[] nums, int k) {
+        int[] sorted = nums.clone();
+        Arrays.sort(sorted); // ascending
+
+        int[] res = new int[Math.min(k, sorted.length)];
+        int cnt = 0;
+        for (int i = sorted.length - 1; i >= 0 && cnt < k; i--) {
+            // skip duplicates (scanning from the largest downwards)
+            if (i < sorted.length - 1 && sorted[i] == sorted[i + 1]) {
+                continue;
+            }
+            res[cnt++] = sorted[i];
+        }
+
+        return cnt == res.length ? res : Arrays.copyOf(res, cnt);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MaximumAveragePassRatio.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MaximumAveragePassRatio.java
@@ -1,0 +1,78 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/maximum-average-pass-ratio/
+
+import java.util.PriorityQueue;
+
+/**
+ *  1792. Maximum Average Pass Ratio
+ *  Medium
+ *
+ *  There is a school that has classes of students and each class will be having a
+ *  final exam. You are given a 2D integer array classes, where
+ *  classes[i] = [pass_i, total_i]. In the ith class there are total_i students but
+ *  only pass_i of them will pass the exam.
+ *
+ *  You are also given an integer extraStudents. There are another extraStudents
+ *  brilliant students that are guaranteed to pass the exam of any class they are
+ *  assigned to. You want to assign each of the extraStudents students to a class in
+ *  a way that maximizes the average pass ratio across all the classes.
+ *
+ *  Return the maximum possible average pass ratio after assigning the extraStudents
+ *  students. Answers within 10^-5 of the actual answer will be accepted.
+ *
+ *  Example 1:
+ *    Input: classes = [[1,2],[3,5],[2,2]], extraStudents = 2
+ *    Output: 0.78333
+ *    Explanation: assign both extra students to the first class ->
+ *                 (3/4 + 3/5 + 2/2) / 3 = 0.78333
+ *
+ *  Example 2:
+ *    Input: classes = [[2,4],[3,9],[4,5],[2,10]], extraStudents = 4
+ *    Output: 0.53485
+ *
+ *  Constraints:
+ *    1 <= classes.length <= 10^5
+ *    classes[i].length == 2
+ *    1 <= pass_i <= total_i <= 10^5
+ *    1 <= extraStudents <= 10^5
+ */
+public class MaximumAveragePassRatio {
+
+    // V0
+    // IDEA: MAX HEAP ON THE MARGINAL GAIN
+    //       putting one extra student into class (a, b) raises its ratio by
+    //           gain = (a+1)/(b+1) - a/b
+    //       this gain STRICTLY DECREASES as the class grows, so handing each
+    //       student to the class with the currently largest gain is optimal
+    //       (exchange argument on the per-class decreasing gain sequence).
+    /**
+     * time = O((n + k) log n)
+     * space = O(n)
+     */
+    public double maxAverageRatio(int[][] classes, int extraStudents) {
+        // heap of {gain, pass, total}, largest gain first
+        PriorityQueue<double[]> pq = new PriorityQueue<>((x, y) -> Double.compare(y[0], x[0]));
+        for (int[] c : classes) {
+            pq.add(new double[]{gain(c[0], c[1]), c[0], c[1]});
+        }
+
+        for (int i = 0; i < extraStudents; i++) {
+            double[] cur = pq.poll();
+            double a = cur[1] + 1;
+            double b = cur[2] + 1;
+            pq.add(new double[]{gain(a, b), a, b});
+        }
+
+        double sum = 0.0;
+        while (!pq.isEmpty()) {
+            double[] cur = pq.poll();
+            sum += cur[1] / cur[2];
+        }
+        return sum / classes.length;
+    }
+
+    private double gain(double a, double b) {
+        return (a + 1) / (b + 1) - a / b;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumDifferenceInSumsAfterRemovalOfElements.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumDifferenceInSumsAfterRemovalOfElements.java
@@ -1,0 +1,92 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/minimum-difference-in-sums-after-removal-of-elements/
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  2163. Minimum Difference in Sums After Removal of Elements
+ *  Hard
+ *
+ *  You are given a 0-indexed integer array nums consisting of 3 * n elements.
+ *
+ *  You are allowed to remove any subsequence of elements of size exactly n from
+ *  nums. The remaining 2 * n elements will be divided into two equal parts:
+ *   - the first n elements belong to the first part, sum = sumFirst
+ *   - the next n elements belong to the second part, sum = sumSecond
+ *
+ *  Return the minimum possible value of sumFirst - sumSecond.
+ *
+ *  Example 1:
+ *    Input: nums = [3,1,2]
+ *    Output: -1
+ *    Explanation: n = 1. removing nums[0] leaves [1,2] -> 1 - 2 = -1, the minimum.
+ *
+ *  Example 2:
+ *    Input: nums = [7,9,5,8,1,3]
+ *    Output: 1
+ *    Explanation: n = 2. removing 9 and 1 leaves [7,5,8,3] -> (7+5) - (8+3) = 1.
+ *
+ *  Constraints:
+ *    nums.length == 3 * n
+ *    1 <= n <= 10^5
+ *    1 <= nums[i] <= 10^5
+ */
+public class MinimumDifferenceInSumsAfterRemovalOfElements {
+
+    // V0
+    // IDEA: SPLIT POINT + TWO HEAPS (minimise the left sum, maximise the right)
+    //       the kept elements keep their original order, so there is a cut index i:
+    //       the first part comes from nums[0..i-1], the second from nums[i..],
+    //       with i ranging over [n, 2n].
+    //         left[i]  = SMALLEST sum of n elements from nums[0..i-1]
+    //                    -> sweep forward keeping the n smallest in a MAX-heap
+    //         right[i] = LARGEST sum of n elements from nums[i..]
+    //                    -> mirror sweep with a MIN-heap
+    //       answer = min over i of (left[i] - right[i]).
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public long minimumDifference(int[] nums) {
+        int total = nums.length;
+        int n = total / 3;
+
+        // left[i] : min sum of n elements among nums[0..i-1], for i in [n, 2n]
+        long[] left = new long[total + 1];
+        PriorityQueue<Integer> maxHeap = new PriorityQueue<>(Collections.reverseOrder());
+        long cur = 0L;
+        for (int i = 0; i < 2 * n; i++) {
+            maxHeap.add(nums[i]);
+            cur += nums[i];
+            if (maxHeap.size() > n) {
+                cur -= maxHeap.poll(); // drop the largest kept so far
+            }
+            if (i + 1 >= n) {
+                left[i + 1] = cur;
+            }
+        }
+
+        // right[i] : max sum of n elements among nums[i..], for i in [n, 2n]
+        long[] right = new long[total + 1];
+        PriorityQueue<Integer> minHeap = new PriorityQueue<>();
+        cur = 0L;
+        for (int i = total - 1; i >= n; i--) {
+            minHeap.add(nums[i]);
+            cur += nums[i];
+            if (minHeap.size() > n) {
+                cur -= minHeap.poll(); // drop the smallest kept so far
+            }
+            if (total - i >= n) {
+                right[i] = cur;
+            }
+        }
+
+        long res = Long.MAX_VALUE;
+        for (int i = n; i <= 2 * n; i++) {
+            res = Math.min(res, left[i] - right[i]);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumOperationsToExceedThresholdValueII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumOperationsToExceedThresholdValueII.java
@@ -1,0 +1,68 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/minimum-operations-to-exceed-threshold-value-ii/
+
+import java.util.PriorityQueue;
+
+/**
+ *  3066. Minimum Operations to Exceed Threshold Value II
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array nums, and an integer k.
+ *
+ *  In one operation, you will:
+ *   - Take the two smallest integers x and y in nums.
+ *   - Remove x and y from nums.
+ *   - Add min(x, y) * 2 + max(x, y) anywhere in the array.
+ *
+ *  Note that you can only apply the operation if nums contains at least two
+ *  elements.
+ *
+ *  Return the minimum number of operations needed so that all elements of the array
+ *  are greater than or equal to k.
+ *
+ *  Example 1:
+ *    Input: nums = [2,11,10,1,3], k = 10
+ *    Output: 2
+ *    Explanation: remove 1 and 2 -> add 1*2+2 = 4 -> [4,11,10,3];
+ *                 remove 3 and 4 -> add 3*2+4 = 10 -> [10,11,10]. all >= 10.
+ *
+ *  Example 2:
+ *    Input: nums = [1,1,2,4,9], k = 20
+ *    Output: 4
+ *
+ *  Constraints:
+ *    2 <= nums.length <= 2 * 10^5
+ *    1 <= nums[i] <= 10^9
+ *    1 <= k <= 10^9
+ *    The input is generated such that an answer always exists.
+ */
+public class MinimumOperationsToExceedThresholdValueII {
+
+    // V0
+    // IDEA: MIN-HEAP — THE OPERATION IS FORCED, SO JUST SIMULATE IT
+    //       there is no choice: the two smallest are always consumed, and the
+    //       replacement 2*min + max is strictly larger than both, so the array's
+    //       minimum only ever rises. the stopping test is therefore just
+    //       "is the heap top >= k".
+    //       NOTE: use long — 2 * 10^9 + 10^9 overflows int.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int minOperations(int[] nums, int k) {
+        PriorityQueue<Long> pq = new PriorityQueue<>();
+        for (int x : nums) {
+            pq.add((long) x);
+        }
+
+        int res = 0;
+        while (pq.size() >= 2 && pq.peek() < k) {
+            long x = pq.poll(); // the smaller
+            long y = pq.poll();
+            pq.add(x * 2 + y);
+            res++;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumOperationsToHalveArraySum.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumOperationsToHalveArraySum.java
@@ -1,0 +1,66 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/minimum-operations-to-halve-array-sum/
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  2208. Minimum Operations to Halve Array Sum
+ *  Medium
+ *
+ *  You are given an array nums of positive integers. In one operation, you can
+ *  choose any number from nums and reduce it to exactly half the number. (Note that
+ *  you may choose this reduced number in future operations.)
+ *
+ *  Return the minimum number of operations to reduce the sum of nums by at least
+ *  half.
+ *
+ *  Example 1:
+ *    Input: nums = [5,19,8,1]
+ *    Output: 3
+ *    Explanation: sum = 33. 19 -> 9.5 -> 4.75, then 8 -> 4, leaving
+ *                 [5, 4.75, 4, 1] with sum 14.75; 33 - 14.75 = 18.25 >= 33/2.
+ *
+ *  Example 2:
+ *    Input: nums = [3,8,20]
+ *    Output: 3
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^7
+ */
+public class MinimumOperationsToHalveArraySum {
+
+    // V0
+    // IDEA: ALWAYS HALVE THE CURRENT LARGEST — MAX-HEAP
+    //       halving x removes exactly x/2 from the sum, so the biggest available
+    //       number always yields the biggest saving; the choice only depends on the
+    //       current multiset, so the greedy stays optimal step after step.
+    //       NOTE: halves are kept as doubles (values <= 10^7, so no precision
+    //             trouble within the ~O(n log n) steps needed).
+    /**
+     * time = O((n + ops) log n)
+     * space = O(n)
+     */
+    public int halveArray(int[] nums) {
+        double total = 0.0;
+        PriorityQueue<Double> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int x : nums) {
+            total += x;
+            pq.add((double) x);
+        }
+
+        double target = total / 2;
+        double removed = 0.0;
+        int ops = 0;
+        while (removed < target) {
+            double x = pq.poll();
+            double half = x / 2;
+            removed += half;
+            pq.add(half);
+            ops++;
+        }
+        return ops;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/RemoveStonesToMinimizeTheTotal.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/RemoveStonesToMinimizeTheTotal.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/remove-stones-to-minimize-the-total/
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  1962. Remove Stones to Minimize the Total
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array piles, where piles[i] represents the
+ *  number of stones in the ith pile, and an integer k. You should apply the
+ *  following operation exactly k times:
+ *
+ *   - Choose any piles[i] and remove floor(piles[i] / 2) stones from it.
+ *
+ *  Notice that you can apply the operation on the same pile more than once.
+ *
+ *  Return the minimum possible total number of stones remaining after applying the
+ *  k operations.
+ *
+ *  Example 1:
+ *    Input: piles = [5,4,9], k = 2
+ *    Output: 12
+ *    Explanation: [5,4,9] -> [5,4,5] -> [3,4,5], total = 12.
+ *
+ *  Example 2:
+ *    Input: piles = [4,3,6,7], k = 3
+ *    Output: 12
+ *
+ *  Constraints:
+ *    1 <= piles.length <= 10^5
+ *    1 <= piles[i] <= 10^4
+ *    1 <= k <= 10^5
+ */
+public class RemoveStonesToMinimizeTheTotal {
+
+    // V0
+    // IDEA: GREEDY + MAX HEAP
+    //       one operation on a pile of size x removes floor(x/2), which is monotone
+    //       in x -> always hit the CURRENT largest pile. (exchange argument: if an
+    //       optimal plan halves a smaller pile while a larger one is available,
+    //       swapping the targets never removes fewer stones.)
+    //       after halving, the pile keeps x - x/2 = ceil(x/2) stones.
+    /**
+     * time = O(n + k log n)
+     * space = O(n)
+     */
+    public int minStoneSum(int[] piles, int k) {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        int total = 0;
+        for (int x : piles) {
+            pq.add(x);
+            total += x;
+        }
+
+        for (int i = 0; i < k; i++) {
+            int x = pq.poll();
+            total -= x / 2;
+            pq.add(x - x / 2);
+        }
+        return total;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/TakeGiftsFromTheRichestPile.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/TakeGiftsFromTheRichestPile.java
@@ -1,0 +1,77 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/take-gifts-from-the-richest-pile/
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  2558. Take Gifts From the Richest Pile
+ *  Easy
+ *
+ *  You are given an integer array gifts denoting the number of gifts in various
+ *  piles. Every second, you do the following:
+ *
+ *   - Choose the pile with the maximum number of gifts.
+ *   - If there is more than one such pile, choose any.
+ *   - Reduce the number of gifts in the pile to the floor of the square root of the
+ *     original number of gifts in the pile.
+ *
+ *  Return the number of gifts remaining after k seconds.
+ *
+ *  Example 1:
+ *    Input: gifts = [25,64,9,4,100], k = 4
+ *    Output: 29
+ *    Explanation: 100 -> 10, 64 -> 8, 25 -> 5, 10 -> 3, leaving [5,8,9,4,3] = 29.
+ *
+ *  Example 2:
+ *    Input: gifts = [1,1,1,1], k = 4
+ *    Output: 4
+ *
+ *  Constraints:
+ *    1 <= gifts.length <= 10^3
+ *    1 <= gifts[i] <= 10^9
+ *    1 <= k <= 10^3
+ */
+public class TakeGiftsFromTheRichestPile {
+
+    // V0
+    // IDEA: MAX HEAP (SIMULATION)
+    //       k times : pop the biggest pile, push back floor(sqrt(x)).
+    //       NOTE: (int) Math.sqrt(x) can be off by one around perfect squares for
+    //             x up to 10^9, so the result is corrected explicitly.
+    //       NOTE: a pile of 1 stays 1 forever, so running all k rounds is safe.
+    /**
+     * time = O(n + k log n)
+     * space = O(n)
+     */
+    public long pickGifts(int[] gifts, int k) {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int x : gifts) {
+            pq.add(x);
+        }
+
+        for (int i = 0; i < k; i++) {
+            int top = pq.poll();
+            pq.add(isqrt(top));
+        }
+
+        long res = 0L;
+        while (!pq.isEmpty()) {
+            res += pq.poll();
+        }
+        return res;
+    }
+
+    // exact integer floor(sqrt(x)) for x >= 0
+    private int isqrt(int x) {
+        int r = (int) Math.sqrt((double) x);
+        while ((long) r * r > x) {
+            r--;
+        }
+        while ((long) (r + 1) * (r + 1) <= x) {
+            r++;
+        }
+        return r;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/TotalCostToHireKWorkers.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/TotalCostToHireKWorkers.java
@@ -1,0 +1,87 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/total-cost-to-hire-k-workers/
+
+import java.util.PriorityQueue;
+
+/**
+ *  2462. Total Cost to Hire K Workers
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array costs where costs[i] is the cost of
+ *  hiring the ith worker.
+ *
+ *  You are also given two integers k and candidates. We want to hire exactly k
+ *  workers according to the following rules:
+ *
+ *   - You will run k sessions and hire exactly one worker in each session.
+ *   - In each hiring session, choose the worker with the lowest cost from either the
+ *     first candidates workers or the last candidates workers. Break the tie by the
+ *     smallest index.
+ *   - If there are fewer than candidates workers remaining, choose the worker with
+ *     the lowest cost among them (tie broken by smallest index).
+ *   - A worker can only be chosen once.
+ *
+ *  Return the total cost to hire exactly k workers.
+ *
+ *  Example 1:
+ *    Input: costs = [17,12,10,2,7,2,11,20,8], k = 3, candidates = 4
+ *    Output: 11
+ *    Explanation: hire 2 (index 3), then 2 (index 5), then 7 -> 2 + 2 + 7 = 11.
+ *
+ *  Example 2:
+ *    Input: costs = [1,2,4,1], k = 3, candidates = 3
+ *    Output: 4
+ *
+ *  Constraints:
+ *    1 <= costs.length <= 10^5
+ *    1 <= costs[i] <= 10^5
+ *    1 <= k, candidates <= costs.length
+ */
+public class TotalCostToHireKWorkers {
+
+    // V0
+    // IDEA: TWO MIN-HEAPS (ONE PER END) REFILLED FROM THE SHRINKING MIDDLE
+    //       the candidate pool is always "the first `candidates` remaining" plus
+    //       "the last `candidates` remaining", so keep a heap per side and two
+    //       pointers marking the untouched middle.
+    //       each round takes the cheaper of the two tops; TIES GO TO THE HEAD heap,
+    //       which reproduces the "smallest index" rule.
+    //       after a pop that side is topped up from the middle — since the pointers
+    //       never cross, a worker sitting in BOTH windows is counted only once.
+    /**
+     * time = O((k + candidates) log candidates)
+     * space = O(candidates)
+     */
+    public long totalCost(int[] costs, int k, int candidates) {
+        int n = costs.length;
+        int left = 0;
+        int right = n - 1;
+
+        PriorityQueue<Integer> head = new PriorityQueue<>();
+        while (left <= right && head.size() < candidates) {
+            head.add(costs[left++]);
+        }
+
+        PriorityQueue<Integer> tail = new PriorityQueue<>();
+        while (left <= right && tail.size() < candidates) {
+            tail.add(costs[right--]);
+        }
+
+        long total = 0L;
+        for (int i = 0; i < k; i++) {
+            if (!tail.isEmpty() && (head.isEmpty() || tail.peek() < head.peek())) {
+                total += tail.poll();
+                if (left <= right) {
+                    tail.add(costs[right--]);
+                }
+            } else {
+                total += head.poll();
+                if (left <= right) {
+                    head.add(costs[left++]);
+                }
+            }
+        }
+        return total;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/TwoBestNonOverlappingEvents.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/TwoBestNonOverlappingEvents.java
@@ -1,0 +1,90 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/two-best-non-overlapping-events/
+
+import java.util.Arrays;
+
+/**
+ *  2054. Two Best Non-Overlapping Events
+ *  Medium
+ *
+ *  You are given a 0-indexed 2D integer array of events where
+ *  events[i] = [startTime_i, endTime_i, value_i]. The ith event starts at
+ *  startTime_i and ends at endTime_i, and if you attend this event you receive a
+ *  value of value_i. You can choose at most two non-overlapping events to attend
+ *  such that the sum of their values is maximized.
+ *
+ *  Return this maximum sum.
+ *
+ *  Note that the start time and end time are inclusive: if you attend an event with
+ *  end time t, the next event must start at or after t + 1.
+ *
+ *  Example 1:
+ *    Input: events = [[1,3,2],[4,5,2],[2,4,3]]
+ *    Output: 4
+ *
+ *  Example 2:
+ *    Input: events = [[1,3,2],[4,5,2],[1,5,5]]
+ *    Output: 5
+ *
+ *  Example 3:
+ *    Input: events = [[1,5,3],[1,5,1],[6,6,5]]
+ *    Output: 8
+ *
+ *  Constraints:
+ *    2 <= events.length <= 10^5
+ *    events[i].length == 3
+ *    1 <= startTime_i <= endTime_i <= 10^9
+ *    1 <= value_i <= 10^6
+ */
+public class TwoBestNonOverlappingEvents {
+
+    // V0
+    // IDEA: SORT BY START + SUFFIX MAX + BINARY SEARCH
+    //       sort events by start time and build suf[i] = max value among i..n-1.
+    //       for an event (s, e, v) taken as the FIRST one, any legal partner must
+    //       start at >= e + 1; sorted by start, those form the suffix beginning at
+    //       the first index whose start > e (upper bound / bisect_right).
+    //       candidate = v + suf[idx]; taking a single event is covered because suf
+    //       contributes 0 past the end.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int maxTwoEvents(int[][] events) {
+        int n = events.length;
+        Arrays.sort(events, (a, b) -> Integer.compare(a[0], b[0]));
+
+        int[] starts = new int[n];
+        for (int i = 0; i < n; i++) {
+            starts[i] = events[i][0];
+        }
+
+        int[] suf = new int[n + 1];
+        for (int i = n - 1; i >= 0; i--) {
+            suf[i] = Math.max(suf[i + 1], events[i][2]);
+        }
+
+        int res = 0;
+        for (int[] ev : events) {
+            int idx = upperBound(starts, ev[1]); // first index with start > end
+            res = Math.max(res, ev[2] + suf[idx]);
+        }
+        return res;
+    }
+
+    // first index i with arr[i] > target (arr sorted ascending)
+    private int upperBound(int[] arr, int target) {
+        int lo = 0;
+        int hi = arr.length;
+        while (lo < hi) {
+            int mid = lo + (hi - lo) / 2;
+            if (arr[mid] <= target) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Heap/ZeroArrayTransformationIII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Heap/ZeroArrayTransformationIII.java
@@ -1,0 +1,97 @@
+package LeetCodeJava.Heap;
+
+// https://leetcode.com/problems/zero-array-transformation-iii/
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ *  3362. Zero Array Transformation III
+ *  Medium
+ *
+ *  You are given an integer array nums of length n and a 2D array queries where
+ *  queries[i] = [l_i, r_i].
+ *
+ *  Each queries[i] represents the following action on nums:
+ *   - Decrement the value at each index in the range [l_i, r_i] in nums by at most 1.
+ *     The amount by which the value is decremented can be chosen independently for
+ *     each index.
+ *
+ *  A Zero Array is an array with all its elements equal to 0.
+ *
+ *  Return the maximum number of elements that can be removed from queries, such
+ *  that nums can still be converted to a zero array using the remaining queries.
+ *  If it is not possible to convert nums to a zero array, return -1.
+ *
+ *  Example 1:
+ *    Input: nums = [2,0,2], queries = [[0,2],[0,2],[1,1]]
+ *    Output: 1
+ *
+ *  Example 2:
+ *    Input: nums = [1,1,1,1], queries = [[1,3],[0,2],[1,3],[1,2]]
+ *    Output: 2
+ *
+ *  Example 3:
+ *    Input: nums = [1,2,3,4], queries = [[0,3]]
+ *    Output: -1
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    0 <= nums[i] <= 10^5
+ *    1 <= queries.length <= 10^5
+ *    queries[i].length == 2
+ *    0 <= l_i <= r_i < nums.length
+ */
+public class ZeroArrayTransformationIII {
+
+    // V0
+    // IDEA: LEFT-TO-RIGHT SWEEP, ALWAYS SPENDING THE QUERY THAT REACHES FURTHEST
+    //       maximising removals == minimising how many queries are KEPT.
+    //       sweeping index by index, whatever demand is still unmet at i must be
+    //       paid by a query starting at or before i — and among those the one with
+    //       the LARGEST right end is never worse, since it covers everything a
+    //       shorter one could.
+    //       so hold the available queries in a max-heap keyed by right end, adding
+    //       those that start at i, and pull until the running coverage meets nums[i].
+    //       a difference array remembers where each chosen query's coverage expires.
+    //       if the heap runs dry (or its best already ended before i) -> -1.
+    /**
+     * time = O((n + q) log q)
+     * space = O(n + q)
+     */
+    public int maxRemoval(int[] nums, int[][] queries) {
+        int n = nums.length;
+
+        // sort queries by start so they can be fed to the heap with one pointer
+        int[][] qs = queries.clone();
+        Arrays.sort(qs, (a, b) -> Integer.compare(a[0], b[0]));
+
+        PriorityQueue<Integer> available = new PriorityQueue<>(Collections.reverseOrder());
+        int[] expire = new int[n + 1]; // difference array of chosen coverage
+        int cover = 0;
+        int used = 0;
+        int p = 0;
+
+        for (int i = 0; i < n; i++) {
+            cover += expire[i];
+
+            while (p < qs.length && qs[p][0] == i) {
+                available.add(qs[p][1]);
+                p++;
+            }
+
+            while (cover < nums[i]) {
+                if (available.isEmpty() || available.peek() < i) {
+                    return -1;
+                }
+                int r = available.poll();
+                used++;
+                cover++;
+                expire[r + 1] -= 1;
+            }
+        }
+
+        return queries.length - used;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/AddTwoPolynomialsRepresentedAsLinkedLists.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/AddTwoPolynomialsRepresentedAsLinkedLists.java
@@ -1,0 +1,124 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/add-two-polynomials-represented-as-linked-lists/
+
+/**
+ *  1634. Add Two Polynomials Represented as Linked Lists
+ *  Medium
+ *
+ *  A polynomial linked list is a special type of linked list where every node
+ *  represents a term in a polynomial expression.
+ *
+ *  Each node has three attributes:
+ *   - coefficient: an integer representing the number multiplier of the term.
+ *                  The coefficient of the term 9x^4 is 9.
+ *   - power: an integer representing the exponent. The power of the term 9x^4 is 4.
+ *   - next: a pointer to the next node in the list, or null if it is the last node.
+ *
+ *  For example, the polynomial 5x^3 + 4x - 7 is represented by the polynomial
+ *  linked list [[5,3],[4,1],[-7,0]].
+ *
+ *  The polynomial linked list must be in its standard form: the polynomial must be
+ *  in strictly descending order by its power value. Also, terms with a coefficient
+ *  of 0 are omitted.
+ *
+ *  Given two polynomial linked list heads, poly1 and poly2, add the polynomials
+ *  together and return the head of the sum of the polynomials.
+ *
+ *  Example 1:
+ *    Input: poly1 = [[1,1]], poly2 = [[1,0]]
+ *    Output: [[1,1],[1,0]]
+ *    Explanation: poly1 = x. poly2 = 1. The sum is x + 1.
+ *
+ *  Example 2:
+ *    Input: poly1 = [[2,2],[4,1],[3,0]], poly2 = [[3,2],[-4,1],[-1,0]]
+ *    Output: [[5,2],[2,0]]
+ *    Explanation: poly1 = 2x^2 + 4x + 3. poly2 = 3x^2 - 4x - 1.
+ *                 The sum is 5x^2 + 2. Notice that we omit the "0x" term.
+ *
+ *  Example 3:
+ *    Input: poly1 = [[1,2]], poly2 = [[-1,2]]
+ *    Output: []
+ *    Explanation: The sum is 0. We return an empty list.
+ *
+ *  Constraints:
+ *    0 <= n <= 10^4
+ *    -10^9 <= PolyNode.coefficient <= 10^9
+ *    PolyNode.coefficient != 0
+ *    0 <= PolyNode.power <= 10^9
+ *    PolyNode.power > PolyNode.next.power
+ */
+public class AddTwoPolynomialsRepresentedAsLinkedLists {
+
+    // Definition for polynomial singly-linked list.
+    public static class PolyNode {
+        public int coefficient;
+        public int power;
+        public PolyNode next;
+
+        public PolyNode() {
+            this.coefficient = 0;
+            this.power = 0;
+            this.next = null;
+        }
+
+        public PolyNode(int x, int y) {
+            this.coefficient = x;
+            this.power = y;
+            this.next = null;
+        }
+
+        public PolyNode(int x, int y, PolyNode next) {
+            this.coefficient = x;
+            this.power = y;
+            this.next = next;
+        }
+    }
+
+    // V0
+    // IDEA: MERGE TWO SORTED LISTS (both strictly descending by power)
+    //       - poly1.power > poly2.power -> take poly1's term
+    //       - poly1.power < poly2.power -> take poly2's term
+    //       - equal powers              -> emit the SUM of coefficients, advance both
+    //       NOTE: a summed coefficient of 0 must be DROPPED (standard form omits
+    //             zero terms) -> that is the whole trick of example 3.
+    //       NOTE: build onto a dummy head so the empty-result case is free.
+    /**
+     * time = O(M + N)
+     * space = O(1)   // ignoring the output list
+     */
+    public PolyNode addPoly(PolyNode poly1, PolyNode poly2) {
+        PolyNode dummy = new PolyNode();
+        PolyNode cur = dummy;
+
+        while (poly1 != null && poly2 != null) {
+            if (poly1.power > poly2.power) {
+                cur.next = new PolyNode(poly1.coefficient, poly1.power);
+                cur = cur.next;
+                poly1 = poly1.next;
+            } else if (poly1.power < poly2.power) {
+                cur.next = new PolyNode(poly2.coefficient, poly2.power);
+                cur = cur.next;
+                poly2 = poly2.next;
+            } else {
+                // NOTE !!! coefficients can reach 2 * 10^9 -> use long, then narrow
+                long c = (long) poly1.coefficient + (long) poly2.coefficient;
+                if (c != 0) {
+                    cur.next = new PolyNode((int) c, poly1.power);
+                    cur = cur.next;
+                }
+                poly1 = poly1.next;
+                poly2 = poly2.next;
+            }
+        }
+
+        PolyNode rest = (poly1 != null) ? poly1 : poly2;
+        while (rest != null) {
+            cur.next = new PolyNode(rest.coefficient, rest.power);
+            cur = cur.next;
+            rest = rest.next;
+        }
+
+        return dummy.next;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ConvertBinaryNumberInALinkedListToInteger.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ConvertBinaryNumberInALinkedListToInteger.java
@@ -1,0 +1,53 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/convert-binary-number-in-a-linked-list-to-integer/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  1290. Convert Binary Number in a Linked List to Integer
+ *  Easy
+ *
+ *  Given head which is a reference node to a singly-linked list.
+ *  The value of each node in the linked list is either 0 or 1.
+ *  The linked list holds the binary representation of a number.
+ *
+ *  Return the decimal value of the number in the linked list.
+ *
+ *  The most significant bit is at the head of the linked list.
+ *
+ *  Example 1:
+ *    Input: head = [1,0,1]
+ *    Output: 5
+ *    Explanation: (101) in base 2 = (5) in base 10
+ *
+ *  Example 2:
+ *    Input: head = [0]
+ *    Output: 0
+ *
+ *  Constraints:
+ *    The Linked List is not empty.
+ *    Number of nodes will not exceed 30.
+ *    Each node's value is either 0 or 1.
+ */
+public class ConvertBinaryNumberInALinkedListToInteger {
+
+    // V0
+    // IDEA: LINKED LIST traversal + BIT SHIFT (HORNER'S RULE)
+    //       head holds the MOST significant bit, so we can accumulate left to
+    //       right in a single pass:  res = res * 2 + node.val
+    //       (equivalently res = (res << 1) | node.val)
+    //       -> no need to collect the bits first / know the length up front.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int getDecimalValue(ListNode head) {
+        int res = 0;
+        while (head != null) {
+            res = (res << 1) | head.val;
+            head = head.next;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ConvertDoublyLinkedListToArrayI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ConvertDoublyLinkedListToArrayI.java
@@ -1,0 +1,72 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/convert-doubly-linked-list-to-array-i/
+
+/**
+ *  3263. Convert Doubly Linked List to Array I
+ *  Easy
+ *  (premium)
+ *
+ *  You are given the head of a doubly linked list, which contains nodes that have
+ *  a next pointer and a previous pointer.
+ *
+ *  Return an integer array which contains the elements of the linked list in order.
+ *
+ *  Example 1:
+ *    Input: head = [1,2,3,4,3,2,1]
+ *    Output: [1,2,3,4,3,2,1]
+ *
+ *  Example 2:
+ *    Input: head = [2,2,2,2,2]
+ *    Output: [2,2,2,2,2]
+ *
+ *  Constraints:
+ *    The number of nodes in the given list is in the range [1, 50].
+ *    1 <= Node.val <= 50
+ */
+public class ConvertDoublyLinkedListToArrayI {
+
+    // Definition for a doubly linked list Node.
+    public static class Node {
+        public int val;
+        public Node prev;
+        public Node next;
+
+        public Node() {}
+
+        public Node(int val) {
+            this.val = val;
+        }
+
+        public Node(int val, Node prev, Node next) {
+            this.val = val;
+            this.prev = prev;
+            this.next = next;
+        }
+    }
+
+    // V0
+    // IDEA: WALK FORWARD FROM THE HEAD - THE prev POINTERS ARE NOT NEEDED
+    //       the traversal already starts at the head, so the doubly linked
+    //       structure adds nothing here. (the sequel LC 3294 hands over an
+    //       ARBITRARY node, and that is where prev earns its keep.)
+    //       one pass to count the nodes so we can size the int[] exactly,
+    //       a second pass to fill it.
+    /**
+     * time = O(N)
+     * space = O(N)   // the output array
+     */
+    public int[] toArray(Node head) {
+        int n = 0;
+        for (Node node = head; node != null; node = node.next) {
+            n++;
+        }
+
+        int[] res = new int[n];
+        int i = 0;
+        for (Node node = head; node != null; node = node.next) {
+            res[i++] = node.val;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ConvertDoublyLinkedListToArrayII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ConvertDoublyLinkedListToArrayII.java
@@ -1,0 +1,80 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/convert-doubly-linked-list-to-array-ii/
+
+/**
+ *  3294. Convert Doubly Linked List to Array II
+ *  Medium
+ *  (premium)
+ *
+ *  You are given an arbitrary node from a doubly linked list, which contains nodes
+ *  that have a next pointer and a previous pointer.
+ *
+ *  Return an integer array which contains the elements of the linked list in order.
+ *
+ *  Example 1:
+ *    Input: head = [1,2,3,4,5], node = 5
+ *    Output: [1,2,3,4,5]
+ *
+ *  Example 2:
+ *    Input: head = [4,5,6,7,8], node = 8
+ *    Output: [4,5,6,7,8]
+ *
+ *  Constraints:
+ *    The number of nodes in the given list is in the range [1, 500].
+ *    1 <= Node.val <= 1000
+ *    All nodes have unique Node.val.
+ */
+public class ConvertDoublyLinkedListToArrayII {
+
+    // Definition for a doubly linked list Node.
+    public static class Node {
+        public int val;
+        public Node prev;
+        public Node next;
+
+        public Node() {}
+
+        public Node(int val) {
+            this.val = val;
+        }
+
+        public Node(int val, Node prev, Node next) {
+            this.val = val;
+            this.prev = prev;
+            this.next = next;
+        }
+    }
+
+    // V0
+    // IDEA: WALK BACK TO THE HEAD FIRST - THAT IS WHAT prev IS FOR
+    //       unlike LC 3263 the given node can sit ANYWHERE in the list, so the
+    //       traversal has 2 phases:
+    //         1) follow prev until it runs out -> that node is the real head
+    //         2) follow next from there, collecting the values
+    //       each node is touched at most twice -> still linear.
+    /**
+     * time = O(N)
+     * space = O(N)   // the output array
+     */
+    public int[] toArray(Node node) {
+        // phase 1 : rewind to the head
+        Node head = node;
+        while (head.prev != null) {
+            head = head.prev;
+        }
+
+        // phase 2 : count, then collect
+        int n = 0;
+        for (Node cur = head; cur != null; cur = cur.next) {
+            n++;
+        }
+
+        int[] res = new int[n];
+        int i = 0;
+        for (Node cur = head; cur != null; cur = cur.next) {
+            res[i++] = cur.val;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DeleteNNodesAfterMNodesOfALinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DeleteNNodesAfterMNodesOfALinkedList.java
@@ -1,0 +1,85 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/delete-n-nodes-after-m-nodes-of-a-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  1474. Delete N Nodes After M Nodes of a Linked List
+ *  Easy
+ *
+ *  You are given the head of a linked list and two integers m and n.
+ *
+ *  Traverse the linked list and remove some nodes in the following way:
+ *   - Start with the head as the current node.
+ *   - Keep the first m nodes starting with the current node.
+ *   - Remove the next n nodes.
+ *   - Keep repeating steps 2 and 3 until you reach the end of the list.
+ *
+ *  Return the head of the modified list after removing the mentioned nodes.
+ *
+ *  Example 1:
+ *    Input: head = [1,2,3,4,5,6,7,8,9,10,11,12,13], m = 2, n = 3
+ *    Output: [1,2,6,7,11,12]
+ *    Explanation: Keep the first (m = 2) nodes starting from the head (1 -> 2).
+ *                 Delete the next (n = 3) nodes (3 -> 4 -> 5). Continue with the
+ *                 same procedure until reaching the tail of the linked list.
+ *
+ *  Example 2:
+ *    Input: head = [1,2,3,4,5,6,7,8,9,10,11], m = 1, n = 3
+ *    Output: [1,5,9]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [1, 10^4].
+ *    1 <= Node.val <= 10^6
+ *    1 <= m, n <= 1000
+ *
+ *  Follow up: Could you solve this problem by modifying the list in-place?
+ */
+public class DeleteNNodesAfterMNodesOfALinkedList {
+
+    // V0
+    // IDEA: SIMULATION (in-place pointer surgery)
+    //       per block:
+    //         1) walk (m - 1) steps to land `pre` on the LAST KEPT node
+    //         2) walk n more steps to land `cur` on the LAST DELETED node
+    //            (if the list runs out earlier, cur just stops at the tail)
+    //         3) re-link pre.next = cur.next, then jump `pre` to the start of
+    //            the next "keep" block
+    //       NOTE !!! no dummy head needed : m >= 1 so the head is always kept.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode deleteNodes(ListNode head, int m, int n) {
+        ListNode pre = head;
+        while (pre != null) {
+
+            // keep m nodes -> move (m - 1) steps, pre = last kept node
+            for (int i = 0; i < m - 1; i++) {
+                if (pre == null) {
+                    break;
+                }
+                pre = pre.next;
+            }
+            if (pre == null) {
+                break;
+            }
+
+            // delete the next n nodes -> cur = last node that gets deleted
+            ListNode cur = pre;
+            for (int i = 0; i < n; i++) {
+                if (cur.next == null) {
+                    break;
+                }
+                cur = cur.next;
+            }
+
+            // NOTE !!! re-link, then jump to the head of the next "keep" block
+            pre.next = cur.next;
+            pre = pre.next;
+        }
+
+        return head;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DeleteNodesFromLinkedListPresentInArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DeleteNodesFromLinkedListPresentInArray.java
@@ -1,0 +1,71 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/delete-nodes-from-linked-list-present-in-array/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *  3217. Delete Nodes From Linked List Present in Array
+ *  Medium
+ *
+ *  You are given an array of integers nums and the head of a linked list. Return the
+ *  head of the modified linked list after removing all nodes from the linked list
+ *  that have a value that exists in nums.
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,3], head = [1,2,3,4,5]
+ *    Output: [4,5]
+ *    Explanation: Remove the nodes with values 1, 2, and 3.
+ *
+ *  Example 2:
+ *    Input: nums = [1], head = [1,2,1,2,1,2]
+ *    Output: [2,2,2]
+ *    Explanation: Remove the nodes with value 1.
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^5
+ *    All elements in nums are unique.
+ *    The number of nodes in the given list is in the range [1, 3 * 10^5].
+ *    1 <= Node.val <= 10^5
+ *    The input is generated such that there is at least one node in the linked list
+ *    that has a value not present in nums.
+ */
+public class DeleteNodesFromLinkedListPresentInArray {
+
+    // V0
+    // IDEA: HASH THE VALUES, THEN ONE UNLINKING PASS BEHIND A DUMMY HEAD
+    //       turning nums into a set makes each membership test O(1) - re-scanning
+    //       the array per node would be 3*10^5 * 10^5 comparisons.
+    //       a dummy node in front kills the "what if the HEAD itself is deleted"
+    //       special case : `tail` simply links past every doomed node.
+    //       NOTE !!! must set tail.next = null at the end, otherwise a trailing
+    //                run of deleted nodes stays attached.
+    /**
+     * time = O(N + M)   // N = list length, M = nums length
+     * space = O(M)
+     */
+    public ListNode modifiedList(int[] nums, ListNode head) {
+        Set<Integer> drop = new HashSet<>();
+        for (int x : nums) {
+            drop.add(x);
+        }
+
+        ListNode dummy = new ListNode(0);
+        ListNode tail = dummy;
+        ListNode node = head;
+        while (node != null) {
+            if (!drop.contains(node.val)) {
+                tail.next = node;
+                tail = node;
+            }
+            node = node.next;
+        }
+        tail.next = null;   // NOTE !!!
+
+        return dummy.next;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DeleteTheMiddleNodeOfALinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DeleteTheMiddleNodeOfALinkedList.java
@@ -1,0 +1,68 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/delete-the-middle-node-of-a-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2095. Delete the Middle Node of a Linked List
+ *  Medium
+ *
+ *  You are given the head of a linked list. Delete the middle node, and return the
+ *  head of the modified linked list.
+ *
+ *  The middle node of a linked list of size n is the floor(n / 2)th node from the
+ *  start using 0-based indexing, where floor(x) denotes the largest integer less
+ *  than or equal to x.
+ *
+ *  For n = 1, 2, 3, 4, and 5, the middle nodes are 0, 1, 1, 2, and 2, respectively.
+ *
+ *  Example 1:
+ *    Input: head = [1,3,4,7,1,2,6]
+ *    Output: [1,3,4,1,2,6]
+ *    Explanation: Since n = 7, node 3 with value 7 is the middle node.
+ *
+ *  Example 2:
+ *    Input: head = [1,2,3,4]
+ *    Output: [1,2,4]
+ *    Explanation: For n = 4, node 2 with value 3 is the middle node.
+ *
+ *  Example 3:
+ *    Input: head = [2,1]
+ *    Output: [2]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [1, 10^5].
+ *    1 <= Node.val <= 10^5
+ */
+public class DeleteTheMiddleNodeOfALinkedList {
+
+    // V0
+    // IDEA: SLOW / FAST POINTERS, WITH `prev` LAGGING ONE NODE BEHIND slow
+    //       the classic tortoise-and-hare lands `slow` on the middle node, but to
+    //       UNLINK it we need the node BEFORE it -> keep `prev` trailing slow.
+    //       starting both at head and advancing fast 2 steps per iteration puts
+    //       slow exactly on index floor(n / 2), which is the problem's middle.
+    //       NOTE !!! a single-node list has nothing left after the deletion -> null.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode deleteMiddle(ListNode head) {
+        if (head == null || head.next == null) {
+            return null;
+        }
+
+        ListNode prev = null;
+        ListNode slow = head;
+        ListNode fast = head;
+        while (fast != null && fast.next != null) {
+            prev = slow;
+            slow = slow.next;
+            fast = fast.next.next;
+        }
+
+        prev.next = slow.next;
+        return head;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DoubleANumberRepresentedAsALinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/DoubleANumberRepresentedAsALinkedList.java
@@ -1,0 +1,67 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/double-a-number-represented-as-a-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2816. Double a Number Represented as a Linked List
+ *  Medium
+ *
+ *  You are given the head of a non-empty linked list representing a non-negative
+ *  integer without leading zeroes.
+ *
+ *  Return the head of the linked list after doubling it.
+ *
+ *  Example 1:
+ *    Input: head = [1,8,9]
+ *    Output: [3,7,8]
+ *    Explanation: the list represents 189, and 189 * 2 = 378.
+ *
+ *  Example 2:
+ *    Input: head = [9,9,9]
+ *    Output: [1,9,9,8]
+ *    Explanation: the list represents 999, and 999 * 2 = 1998.
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [1, 10^4]
+ *    0 <= Node.val <= 9
+ *    The input is generated such that the list represents a number that does not
+ *    have leading zeros, except the number 0 itself.
+ */
+public class DoubleANumberRepresentedAsALinkedList {
+
+    // V0
+    // IDEA: SINGLE FORWARD PASS + LOOK-AHEAD CARRY (NO REVERSING NEEDED)
+    //       doubling is special : the carry out of any digit is at most 1, and it is
+    //       decided by THAT DIGIT ALONE  (digit * 2 >= 10  <=>  digit >= 5).
+    //       so while sitting on `cur` we can just PEEK at cur.next and know whether
+    //       it will hand us a carry:
+    //
+    //         cur.val = (cur.val * 2) % 10 + (cur.next != null && cur.next.val >= 5 ? 1 : 0)
+    //
+    //       NOTE !!! the only overflow into a NEW leading node happens when the FIRST
+    //                digit is >= 5 -> prepend a 0 node and let the same rule fill it.
+    //       this rewrites nodes in place -> O(1) extra space, no reverse/reverse-back
+    //       and no big-integer conversion.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode doubleIt(ListNode head) {
+        if (head.val >= 5) {
+            head = new ListNode(0, head);
+        }
+
+        ListNode cur = head;
+        while (cur != null) {
+            cur.val = (cur.val * 2) % 10;
+            if (cur.next != null && cur.next.val >= 5) {
+                cur.val += 1;
+            }
+            cur = cur.next;
+        }
+
+        return head;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPoints.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPoints.java
@@ -1,0 +1,98 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/find-the-minimum-and-maximum-number-of-nodes-between-critical-points/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2058. Find the Minimum and Maximum Number of Nodes Between Critical Points
+ *  Medium
+ *
+ *  A critical point in a linked list is defined as either a local maxima or a
+ *  local minima.
+ *
+ *  A node is a local maxima if the current node has a value strictly greater than
+ *  the previous node and the next node.
+ *
+ *  A node is a local minima if the current node has a value strictly smaller than
+ *  the previous node and the next node.
+ *
+ *  Note that a node can only be a local maxima/minima if there exists both a
+ *  previous node and a next node.
+ *
+ *  Given a linked list head, return an array of length 2 containing
+ *  [minDistance, maxDistance] where minDistance is the minimum distance between any
+ *  two distinct critical points and maxDistance is the maximum distance between any
+ *  two distinct critical points. If there are fewer than two critical points,
+ *  return [-1, -1].
+ *
+ *  Example 1:
+ *    Input: head = [3,1]
+ *    Output: [-1,-1]
+ *    Explanation: There are no critical points in [3,1].
+ *
+ *  Example 2:
+ *    Input: head = [5,3,1,2,5,1,2]
+ *    Output: [1,3]
+ *    Explanation: critical points sit at (1-based) positions 3, 5 and 6.
+ *                 minDistance = 6 - 5 = 1, maxDistance = 6 - 3 = 3.
+ *
+ *  Example 3:
+ *    Input: head = [1,3,2,2,3,2,2,2,7]
+ *    Output: [3,3]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [2, 10^5].
+ *    1 <= Node.val <= 10^5
+ */
+public class FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPoints {
+
+    // V0
+    // IDEA: SINGLE PASS, REMEMBER ONLY THE `first` AND `prev` CRITICAL INDEX
+    //       slide a 3-node window (a, b, c); b is critical iff
+    //       (b < a && b < c) || (b > a && b > c)  -> strict on BOTH sides.
+    //
+    //       maxDistance is ALWAYS (last critical) - (first critical), so only the
+    //       FIRST index needs keeping.
+    //       minDistance can only come from two ADJACENT critical points, so only the
+    //       PREVIOUS index needs keeping.
+    //
+    //       NOTE !!! fewer than 2 critical points -> [-1, -1], which is exactly the
+    //                case where `first == prev` still holds at the end.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int[] nodesBetweenCriticalPoints(ListNode head) {
+        int first = -1;
+        int prev = -1;
+        int minDist = Integer.MAX_VALUE;
+        int i = 0;
+
+        ListNode cur = head;
+        while (cur != null && cur.next != null && cur.next.next != null) {
+            int a = cur.val;
+            int b = cur.next.val;
+            int c = cur.next.next.val;
+
+            if ((b < a && b < c) || (b > a && b > c)) {
+                if (prev == -1) {
+                    first = i;
+                    prev = i;
+                } else {
+                    minDist = Math.min(minDist, i - prev);
+                    prev = i;
+                }
+            }
+
+            i++;
+            cur = cur.next;
+        }
+
+        if (first == prev) {
+            // 0 or 1 critical point
+            return new int[]{-1, -1};
+        }
+        return new int[]{minDist, prev - first};
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/LinkedListFrequency.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/LinkedListFrequency.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/linked-list-frequency/
+
+import java.util.HashMap;
+import java.util.Map;
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  3063. Linked List Frequency
+ *  Medium
+ *  (premium / locked)
+ *
+ *  Given the head of a linked list containing k distinct elements, return the head
+ *  to a linked list of length k containing the frequency of each distinct element
+ *  in the given linked list in any order.
+ *
+ *  Example 1:
+ *    Input: head = [1,1,2,1,2,3]
+ *    Output: [3,2,1]
+ *    Explanation: There are 3 distinct elements in the list. The frequency of 1 is 3,
+ *                 the frequency of 2 is 2 and the frequency of 3 is 1.
+ *                 Hence, we return 3 -> 2 -> 1.
+ *                 Note that 1 -> 2 -> 3, 2 -> 1 -> 3, 3 -> 2 -> 1, and 3 -> 1 -> 2
+ *                 are also valid answers.
+ *
+ *  Example 2:
+ *    Input: head = [1,1,2,2,2]
+ *    Output: [2,3]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [1, 10^5].
+ *    1 <= Node.val <= 10^5
+ */
+public class LinkedListFrequency {
+
+    // V0
+    // IDEA: COUNT INTO A HASH MAP, THEN REBUILD A LIST FROM THE COUNTS
+    //       the output order is free, so nothing has to be preserved from the
+    //       input: one pass to tally the values, then one pass over the tallies
+    //       building fresh nodes. a dummy head keeps the append loop free of
+    //       "is this the first node" special-casing.
+    /**
+     * time = O(N)
+     * space = O(K)   // K = number of distinct values
+     */
+    public ListNode frequenciesOfElements(ListNode head) {
+        Map<Integer, Integer> cnt = new HashMap<>();
+        ListNode node = head;
+        while (node != null) {
+            Integer c = cnt.get(node.val);
+            cnt.put(node.val, c == null ? 1 : c + 1);
+            node = node.next;
+        }
+
+        ListNode dummy = new ListNode();
+        ListNode tail = dummy;
+        for (Integer freq : cnt.values()) {
+            tail.next = new ListNode(freq);
+            tail = tail.next;
+        }
+        return dummy.next;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/MaximumTwinSumOfALinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/MaximumTwinSumOfALinkedList.java
@@ -1,0 +1,76 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/maximum-twin-sum-of-a-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2130. Maximum Twin Sum of a Linked List
+ *  Medium
+ *
+ *  In a linked list of size n, where n is even, the ith node (0-indexed) of the
+ *  linked list is known as the twin of the (n-1-i)th node, if 0 <= i <= (n / 2) - 1.
+ *
+ *  For example, if n = 4, then node 0 is the twin of node 3, and node 1 is the twin
+ *  of node 2. These are the only nodes with twins for n = 4.
+ *
+ *  The twin sum is defined as the sum of a node and its twin.
+ *  Given the head of a linked list with even length, return the maximum twin sum
+ *  of the linked list.
+ *
+ *  Example 1:
+ *    Input: head = [5,4,2,1]
+ *    Output: 6
+ *    Explanation: Nodes 0 and 1 are the twins of nodes 3 and 2, respectively.
+ *                 All have twin sum = 6.
+ *
+ *  Example 2:
+ *    Input: head = [4,2,2,3]
+ *    Output: 7
+ *
+ *  Constraints:
+ *    The number of nodes in the list is an even integer in the range [2, 10^5].
+ *    1 <= Node.val <= 10^5
+ */
+public class MaximumTwinSumOfALinkedList {
+
+    // V0
+    // IDEA: SLOW/FAST TO THE MIDDLE, REVERSE THE SECOND HALF, WALK IN LOCKSTEP
+    //       twins are mirror positions, so after reversing the back half the two
+    //       halves line up index by index and one parallel walk yields every twin
+    //       sum. the length is guaranteed EVEN, so slow lands exactly at the start
+    //       of the second half.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int pairSum(ListNode head) {
+        // find the start of the 2nd half
+        ListNode slow = head;
+        ListNode fast = head;
+        while (fast != null && fast.next != null) {
+            slow = slow.next;
+            fast = fast.next.next;
+        }
+
+        // reverse the 2nd half
+        ListNode prev = null;
+        while (slow != null) {
+            ListNode nxt = slow.next;
+            slow.next = prev;
+            prev = slow;
+            slow = nxt;
+        }
+
+        // walk both halves together
+        int res = 0;
+        ListNode p = head;
+        ListNode q = prev;
+        while (q != null) {
+            res = Math.max(res, p.val + q.val);
+            p = p.next;
+            q = q.next;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/MergeInBetweenLinkedLists.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/MergeInBetweenLinkedLists.java
@@ -1,0 +1,63 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/merge-in-between-linked-lists/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  1669. Merge In Between Linked Lists
+ *  Medium
+ *
+ *  You are given two linked lists: list1 and list2 of sizes n and m respectively.
+ *  Remove list1's nodes from the ath node to the bth node, and put list2 in their place.
+ *  Build the result list and return its head.
+ *
+ *  Example 1:
+ *    Input: list1 = [10,1,13,6,9,5], a = 3, b = 4, list2 = [1000000,1000001,1000002]
+ *    Output: [10,1,13,1000000,1000001,1000002,5]
+ *    Explanation: We remove the nodes 3 and 4 and put the entire list2 in their place.
+ *
+ *  Example 2:
+ *    Input: list1 = [0,1,2,3,4,5,6], a = 2, b = 5,
+ *           list2 = [1000000,1000001,1000002,1000003,1000004]
+ *    Output: [0,1,1000000,1000001,1000002,1000003,1000004,6]
+ *
+ *  Constraints:
+ *    3 <= list1.length <= 10^4
+ *    1 <= a <= b < list1.length - 1
+ *    1 <= list2.length <= 10^4
+ */
+public class MergeInBetweenLinkedLists {
+
+    // V0
+    // IDEA: POINTER SURGERY (find the 2 splice points, then relink)
+    //       p = node at index a-1 (last node KEPT before the cut)
+    //       q = node at index b   (last node REMOVED)
+    //       then p.next = list2 head, and tail(list2).next = q.next
+    //       constraints guarantee a >= 1 and b < n-1, so no dummy head is needed
+    //       and the returned head is still list1.
+    /**
+     * time = O(N + M)
+     * space = O(1)
+     */
+    public ListNode mergeInBetween(ListNode list1, int a, int b, ListNode list2) {
+        ListNode p = list1;
+        for (int i = 0; i < a - 1; i++) {
+            p = p.next;
+        }
+
+        ListNode q = p;
+        for (int i = 0; i < b - a + 1; i++) {
+            q = q.next; // q is now the node at index b
+        }
+
+        ListNode tail = list2;
+        while (tail.next != null) {
+            tail = tail.next;
+        }
+
+        p.next = list2;
+        tail.next = q.next;
+        return list1;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/MergeNodesInBetweenZeros.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/MergeNodesInBetweenZeros.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/merge-nodes-in-between-zeros/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2181. Merge Nodes in Between Zeros
+ *  Medium
+ *
+ *  You are given the head of a linked list, which contains a series of integers
+ *  separated by 0's. The beginning and end of the linked list will have Node.val == 0.
+ *
+ *  For every two consecutive 0's, merge all the nodes lying in between them into a
+ *  single node whose value is the sum of all the merged nodes. The modified list
+ *  should not contain any 0's.
+ *
+ *  Return the head of the modified linked list.
+ *
+ *  Example 1:
+ *    Input: head = [0,3,1,0,4,5,2,0]
+ *    Output: [4,11]
+ *    Explanation: 3 + 1 = 4, and 4 + 5 + 2 = 11.
+ *
+ *  Example 2:
+ *    Input: head = [0,1,0,3,0,2,2,0]
+ *    Output: [1,3,4]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [3, 2 * 10^5].
+ *    0 <= Node.val <= 1000
+ *    There are no two consecutive nodes with Node.val == 0.
+ *    The beginning and end of the linked list have Node.val == 0.
+ */
+public class MergeNodesInBetweenZeros {
+
+    // V0
+    // IDEA: ONE PASS ON THE LINKED LIST (accumulate until the next 0)
+    //       the list starts and ends with a 0, so skip the leading 0 and keep a
+    //       running sum; every time we hit a 0 the current block is finished ->
+    //       append one node holding that sum and reset.
+    //       written iteratively (up to 2*10^5 nodes, recursion would overflow).
+    /**
+     * time = O(N)
+     * space = O(1)   // ignoring the output nodes
+     */
+    public ListNode mergeNodes(ListNode head) {
+        ListNode dummy = new ListNode();
+        ListNode tail = dummy;
+
+        ListNode cur = head.next; // skip the leading 0
+        int total = 0;
+        while (cur != null) {
+            if (cur.val == 0) {
+                tail.next = new ListNode(total);
+                tail = tail.next;
+                total = 0;
+            } else {
+                total += cur.val;
+            }
+            cur = cur.next;
+        }
+        return dummy.next;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/PrintImmutableLinkedListInReverse.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/PrintImmutableLinkedListInReverse.java
@@ -1,0 +1,80 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/print-immutable-linked-list-in-reverse/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1265. Print Immutable Linked List in Reverse
+ *  Medium
+ *
+ *  You are given an immutable linked list, print out all values of each node in
+ *  reverse with the help of the following interface:
+ *
+ *  ImmutableListNode: An interface of immutable linked list, you are given the head
+ *  of the list.
+ *
+ *  You need to use the following functions to access the linked list
+ *  (you can't access the ImmutableListNode directly):
+ *    ImmutableListNode.printValue(): Print value of the current node.
+ *    ImmutableListNode.getNext(): Return the next node.
+ *
+ *  The input is only given to initialize the linked list internally. You must solve
+ *  this problem without modifying the linked list. In other words, you must operate
+ *  the linked list using only the mentioned APIs.
+ *
+ *  Example 1:
+ *    Input: head = [1,2,3,4]
+ *    Output: [4,3,2,1]
+ *
+ *  Example 2:
+ *    Input: head = [0,-4,-1,3,-5]
+ *    Output: [-5,3,-1,-4,0]
+ *
+ *  Constraints:
+ *    The length of the linked list is between [1, 1000].
+ *    The value of each node in the linked list is between [-1000, 1000].
+ */
+public class PrintImmutableLinkedListInReverse {
+
+    /** the API given by LeetCode (declared here so this file compiles standalone) */
+    public interface ImmutableListNode {
+        void printValue();
+        ImmutableListNode getNext();
+    }
+
+    // V0
+    // IDEA: RECURSION
+    //       go all the way to the tail first, print on the way back.
+    //       (length <= 1000, so the recursion depth is safe)
+    /**
+     * time = O(N)
+     * space = O(N)   // recursion stack
+     */
+    public void printLinkedListInReverse(ImmutableListNode head) {
+        if (head == null) {
+            return;
+        }
+        printLinkedListInReverse(head.getNext());
+        head.printValue();
+    }
+
+    // V1
+    // IDEA: EXPLICIT STACK (iterative, no recursion depth risk)
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public void printLinkedListInReverse_1(ImmutableListNode head) {
+        Deque<ImmutableListNode> stack = new ArrayDeque<>();
+        ImmutableListNode cur = head;
+        while (cur != null) {
+            stack.push(cur);
+            cur = cur.getNext();
+        }
+        while (!stack.isEmpty()) {
+            stack.pop().printValue();
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/RemoveNodesFromLinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/RemoveNodesFromLinkedList.java
@@ -1,0 +1,78 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/remove-nodes-from-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2487. Remove Nodes From Linked List
+ *  Medium
+ *
+ *  You are given the head of a linked list.
+ *  Remove every node which has a node with a greater value anywhere to the right
+ *  side of it.
+ *  Return the head of the modified linked list.
+ *
+ *  Example 1:
+ *    Input: head = [5,2,13,3,8]
+ *    Output: [13,8]
+ *    Explanation: The nodes that should be removed are 5, 2 and 3.
+ *                 Node 13 is to the right of node 5.
+ *                 Node 13 is to the right of node 2.
+ *                 Node 8 is to the right of node 3.
+ *
+ *  Example 2:
+ *    Input: head = [1,1,1,1]
+ *    Output: [1,1,1,1]
+ *    Explanation: Every node has value 1, so no nodes are removed.
+ *
+ *  Constraints:
+ *    The number of the nodes in the given list is in the range [1, 10^5].
+ *    1 <= Node.val <= 10^5
+ */
+public class RemoveNodesFromLinkedList {
+
+    // V0
+    // IDEA: REVERSE, KEEP A RUNNING MAXIMUM, REVERSE BACK
+    //       "is there anything bigger to my RIGHT?" is awkward while walking
+    //       forward. reversing turns it into "anything bigger to my LEFT?", which
+    //       one running maximum settles in a single pass: keep a node iff its
+    //       value is >= the max seen so far. the survivors come out reversed, so
+    //       reverse once more at the end.
+    //       equivalently a monotonic-stack solution, but in O(1) extra space by
+    //       reusing the list's own pointers.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode removeNodes(ListNode head) {
+        ListNode rev = reverse(head);
+
+        int maxSoFar = Integer.MIN_VALUE;
+        ListNode dummy = new ListNode();
+        ListNode tail = dummy;
+        ListNode cur = rev;
+        while (cur != null) {
+            ListNode nxt = cur.next;
+            if (cur.val >= maxSoFar) {
+                maxSoFar = cur.val;
+                tail.next = cur;
+                tail = cur;
+                tail.next = null;
+            }
+            cur = nxt;
+        }
+        return reverse(dummy.next);
+    }
+
+    private ListNode reverse(ListNode node) {
+        ListNode prev = null;
+        while (node != null) {
+            ListNode nxt = node.next;
+            node.next = prev;
+            prev = node;
+            node = nxt;
+        }
+        return prev;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/RemoveZeroSumConsecutiveNodesFromLinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/RemoveZeroSumConsecutiveNodesFromLinkedList.java
@@ -1,0 +1,66 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/remove-zero-sum-consecutive-nodes-from-linked-list/
+
+import java.util.HashMap;
+import java.util.Map;
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  1171. Remove Zero Sum Consecutive Nodes from Linked List
+ *  Medium
+ *
+ *  Given the head of a linked list, we repeatedly delete consecutive sequences of
+ *  nodes that sum to 0 until there are no such sequences.
+ *  After doing so, return the head of the final linked list. You may return any
+ *  such answer.
+ *
+ *  Example 1:
+ *    Input: head = [1,2,-3,3,1]
+ *    Output: [3,1]
+ *    Note: The answer [1,2,1] would also be accepted.
+ *
+ *  Example 2:
+ *    Input: head = [1,2,3,-3,4]
+ *    Output: [1,2,4]
+ *
+ *  Example 3:
+ *    Input: head = [1,2,3,-3,-2]
+ *    Output: [1]
+ *
+ *  Constraints:
+ *    The given linked list will contain between 1 and 1000 nodes.
+ *    Each node in the linked list has -1000 <= node.val <= 1000.
+ */
+public class RemoveZeroSumConsecutiveNodesFromLinkedList {
+
+    // V0
+    // IDEA: PREFIX SUM + HASH TABLE (2 passes)
+    //       if 2 nodes share the same running prefix sum, everything strictly
+    //       between them sums to 0 -> cut it out.
+    //       pass 1: record the LAST node owning each prefix sum
+    //       pass 2: walk again and jump straight to last[s].next
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public ListNode removeZeroSumSublists(ListNode head) {
+        ListNode dummy = new ListNode(0);
+        dummy.next = head;
+
+        Map<Integer, ListNode> last = new HashMap<>();
+        int s = 0;
+        for (ListNode node = dummy; node != null; node = node.next) {
+            s += node.val;
+            last.put(s, node); // keeps the LAST node with this prefix sum
+        }
+
+        s = 0;
+        for (ListNode node = dummy; node != null; node = node.next) {
+            s += node.val;
+            node.next = last.get(s).next; // skip the zero-sum block (if any)
+        }
+        return dummy.next;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ReverseNodesInEvenLengthGroups.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/ReverseNodesInEvenLengthGroups.java
@@ -1,0 +1,85 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/reverse-nodes-in-even-length-groups/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2074. Reverse Nodes in Even Length Groups
+ *  Medium
+ *
+ *  You are given the head of a linked list.
+ *  The nodes in the linked list are sequentially assigned to non-empty groups whose
+ *  lengths form the sequence of the natural numbers (1, 2, 3, 4, ...):
+ *    the 1st node is assigned to the first group,
+ *    the 2nd and the 3rd nodes are assigned to the second group,
+ *    the 4th, 5th, and 6th nodes are assigned to the third group, and so on.
+ *  Note that the length of the last group may be less than or equal to
+ *  1 + the length of the second to last group.
+ *
+ *  Reverse the nodes in each group with an even length, and return the head of the
+ *  modified linked list.
+ *
+ *  Example 1:
+ *    Input: head = [5,2,6,3,9,1,7,3,8,4]
+ *    Output: [5,6,2,3,9,1,4,8,3,7]
+ *    Explanation: group lengths are 1 (odd, kept), 2 (even, reversed),
+ *                 3 (odd, kept), 4 (even, reversed).
+ *
+ *  Example 2:
+ *    Input: head = [1,1,0,6]
+ *    Output: [1,0,1,6]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [1, 10^5].
+ *    0 <= Node.val <= 10^5
+ */
+public class ReverseNodesInEvenLengthGroups {
+
+    // V0
+    // IDEA: WALK GROUP BY GROUP, REVERSE IN PLACE WHEN THE ACTUAL LENGTH IS EVEN
+    //       `prev` always points at the node just before the current group.
+    //       for group size k, first COUNT how many nodes are actually there (the
+    //       tail group may be short) - that real count, not k, decides odd/even.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode reverseEvenLengthGroups(ListNode head) {
+        ListNode dummy = new ListNode(0, head);
+        ListNode prev = dummy;
+
+        int k = 1;
+        while (prev.next != null) {
+            // how many nodes does this group REALLY have?
+            int cnt = 0;
+            ListNode probe = prev.next;
+            while (probe != null && cnt < k) {
+                cnt++;
+                probe = probe.next;
+            }
+
+            if (cnt % 2 == 0) {
+                // reverse the `cnt` nodes right after prev
+                ListNode groupHead = prev.next; // becomes the group's new tail
+                ListNode cur = groupHead;
+                ListNode rev = null;
+                for (int i = 0; i < cnt; i++) {
+                    ListNode nxt = cur.next;
+                    cur.next = rev;
+                    rev = cur;
+                    cur = nxt;
+                }
+                prev.next = rev;
+                groupHead.next = cur;
+                prev = groupHead;
+            } else {
+                for (int i = 0; i < cnt; i++) {
+                    prev = prev.next;
+                }
+            }
+            k++;
+        }
+        return dummy.next;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/SplitACircularLinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/SplitACircularLinkedList.java
@@ -1,0 +1,74 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/split-a-circular-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  2674. Split a Circular Linked List
+ *  Medium
+ *
+ *  Given a circular linked list of positive integers, split it into 2 circular
+ *  linked lists so that the first one contains the first half of the nodes
+ *  (exactly ceil(list.length / 2) nodes) in the same order they appeared in list,
+ *  and the second one contains the rest of the nodes in the same order.
+ *
+ *  Return an array answer of length 2 in which the first element is a circular
+ *  linked list representing the first half and the second element is a circular
+ *  linked list representing the second half.
+ *
+ *  Example 1:
+ *    Input: nums = [1,5,7]
+ *    Output: [[1,5],[7]]
+ *    Explanation: The initial list has 3 nodes so the first half is the first
+ *                 ceil(3 / 2) = 2 elements, the remaining 1 node is the second half.
+ *
+ *  Example 2:
+ *    Input: nums = [2,6,1,5]
+ *    Output: [[2,6],[1,5]]
+ *
+ *  Constraints:
+ *    The number of nodes in list is in the range [2, 10^5]
+ *    0 <= Node.val <= 10^9
+ *    LastNode.next = FirstNode
+ */
+public class SplitACircularLinkedList {
+
+    // V0
+    // IDEA: FAST / SLOW POINTERS ON A CIRCULAR LIST
+    //       walk `slow` 1 step and `fast` 2 steps per round, stopping as soon as
+    //       `fast` is the tail (fast.next == head) or one node before it
+    //       (fast.next.next == head):
+    //         - odd length  -> fast IS the tail, slow sits on node #ceil(n/2)
+    //         - even length -> fast is one before the tail, push it forward once,
+    //                          slow again sits on node #ceil(n/2) == n/2
+    //       because the list is circular there is no null sentinel: every stop
+    //       condition compares against `head`.
+    //       after cutting we must close BOTH rings:
+    //         tail.next -> second head, slow.next -> head
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode[] splitCircularLinkedList(ListNode list) {
+        ListNode head = list;
+        ListNode slow = head;
+        ListNode fast = head;
+
+        while (fast.next != head && fast.next.next != head) {
+            slow = slow.next;
+            fast = fast.next.next;
+        }
+
+        // even length: fast is one before the tail -> move onto the tail
+        if (fast.next != head) {
+            fast = fast.next;
+        }
+
+        ListNode second = slow.next;
+        slow.next = head;   // close the 1st ring
+        fast.next = second; // close the 2nd ring
+
+        return new ListNode[]{head, second};
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/SwappingNodesInALinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/SwappingNodesInALinkedList.java
@@ -1,0 +1,62 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/swapping-nodes-in-a-linked-list/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  1721. Swapping Nodes in a Linked List
+ *  Medium
+ *
+ *  You are given the head of a linked list, and an integer k.
+ *  Return the head of the linked list after swapping the values of the kth node
+ *  from the beginning and the kth node from the end (the list is 1-indexed).
+ *
+ *  Example 1:
+ *    Input: head = [1,2,3,4,5], k = 2
+ *    Output: [1,4,3,2,5]
+ *
+ *  Example 2:
+ *    Input: head = [7,9,6,6,7,8,3,0,9,5], k = 5
+ *    Output: [7,9,6,6,8,7,3,0,9,5]
+ *
+ *  Constraints:
+ *    The number of nodes in the list is n.
+ *    1 <= k <= n <= 10^5
+ *    0 <= Node.val <= 100
+ */
+public class SwappingNodesInALinkedList {
+
+    // V0
+    // IDEA: TWO POINTERS, FIXED GAP (one pass, no length precomputation)
+    //       advance `fast` k-1 steps -> it sits on the kth node from the front,
+    //       remember it as p. then walk `fast` and `slow` together until fast hits
+    //       the LAST node: fast moved n-k more steps, so slow (started at head)
+    //       is at 0-based index n-k = the kth node from the END, remember it as q.
+    //       only the VALUES have to swap, so no pointer surgery is needed.
+    //       p and q may be the same node (odd length, k = (n+1)/2) -> harmless.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public ListNode swapNodes(ListNode head, int k) {
+        ListNode fast = head;
+        for (int i = 0; i < k - 1; i++) {
+            fast = fast.next;
+        }
+        ListNode p = fast;
+
+        ListNode slow = head;
+        while (fast.next != null) {
+            fast = fast.next;
+            slow = slow.next;
+        }
+        ListNode q = slow;
+
+        int tmp = p.val;
+        p.val = q.val;
+        q.val = tmp;
+
+        return head;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/LinkedList/WinnerOfTheLinkedListGame.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/LinkedList/WinnerOfTheLinkedListGame.java
@@ -1,0 +1,76 @@
+package LeetCodeJava.LinkedList;
+
+// https://leetcode.com/problems/winner-of-the-linked-list-game/
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  3062. Winner of the Linked List Game
+ *  Easy
+ *  (premium / locked)
+ *
+ *  You are given the head of a linked list of even length containing integers.
+ *  Each odd-indexed node contains an odd integer and each even-indexed node
+ *  contains an even integer.
+ *
+ *  We call each even-indexed node and its next node a pair, e.g., the nodes with
+ *  indices 0 and 1 are a pair, the nodes with indices 2 and 3 are a pair, and so on.
+ *
+ *  For every pair, we compare the values of the nodes in the pair:
+ *    If the odd-indexed node is higher, the "Odd" team gets a point.
+ *    If the even-indexed node is higher, the "Even" team gets a point.
+ *
+ *  Return the name of the team with the higher points, if the points are equal,
+ *  return "Tie".
+ *
+ *  Example 1:
+ *    Input: head = [2,1]
+ *    Output: "Even"
+ *    Explanation: only pair is (2,1), 2 > 1 so the Even team gets the point.
+ *
+ *  Example 2:
+ *    Input: head = [2,5,4,7,20,5]
+ *    Output: "Odd"
+ *    Explanation: (2,5) -> Odd, (4,7) -> Odd, (20,5) -> Even. Odd 2 : 1 Even.
+ *
+ *  Example 3:
+ *    Input: head = [4,5,2,1]
+ *    Output: "Tie"
+ *
+ *  Constraints:
+ *    The number of nodes in the list is in the range [2, 100].
+ *    The number of nodes in the list is even.
+ *    1 <= Node.val <= 100
+ */
+public class WinnerOfTheLinkedListGame {
+
+    // V0
+    // IDEA: ONE PASS, 2 NODES AT A TIME
+    //       values are guaranteed distinct within a pair (one odd, one even), so
+    //       every pair scores exactly one point. keep a single running balance
+    //       (+1 even wins, -1 odd wins) and read off the sign at the end.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public String gameResult(ListNode head) {
+        int diff = 0; // (# even wins) - (# odd wins)
+        ListNode cur = head;
+        while (cur != null && cur.next != null) {
+            if (cur.val > cur.next.val) {
+                diff++;
+            } else {
+                diff--;
+            }
+            cur = cur.next.next;
+        }
+
+        if (diff > 0) {
+            return "Even";
+        }
+        if (diff < 0) {
+            return "Odd";
+        }
+        return "Tie";
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/BestPositionForAServiceCentre.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/BestPositionForAServiceCentre.java
@@ -1,0 +1,99 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/best-position-for-a-service-centre/
+
+/**
+ *  1515. Best Position for a Service Centre
+ *  Hard
+ *
+ *  A delivery company wants to build a new service center in a new city. The company
+ *  knows the positions of all the customers in this city on a 2D-Map and wants to build
+ *  the new center in a position such that the sum of the euclidean distances to all
+ *  customers is minimum.
+ *
+ *  Given an array positions where positions[i] = [x_i, y_i] is the position of the ith
+ *  customer on the map, return the minimum sum of the euclidean distances to all customers.
+ *
+ *  In other words, you need to choose the position of the service center
+ *  [x_centre, y_centre] such that the sum over all i of
+ *  sqrt((x_centre - x_i)^2 + (y_centre - y_i)^2) is minimized.
+ *
+ *  Answers within 10^-5 of the actual value will be accepted.
+ *
+ *  Example 1:
+ *    Input: positions = [[0,1],[1,0],[1,2],[2,1]]
+ *    Output: 4.00000
+ *    Explanation: choosing [x_centre, y_centre] = [1, 1] makes the distance to each
+ *                 customer = 1, so the sum of all distances is 4.
+ *
+ *  Example 2:
+ *    Input: positions = [[1,1],[3,3]]
+ *    Output: 2.82843
+ *    Explanation: the minimum possible sum of distances = sqrt(2) + sqrt(2) = 2.82843
+ *
+ *  Constraints:
+ *    1 <= positions.length <= 50
+ *    positions[i].length == 2
+ *    0 <= x_i, y_i <= 100
+ */
+public class BestPositionForAServiceCentre {
+
+    // V0
+    // IDEA: GRADIENT DESCENT ON THE GEOMETRIC MEDIAN (WEBER POINT)
+    //
+    //   f(x, y) = sum sqrt((x - xi)^2 + (y - yi)^2) is CONVEX, so it has a single
+    //   global minimum and plain gradient descent converges to it.
+    //
+    //       df/dx = sum (x - xi) / dist_i          (same shape for y)
+    //
+    //   start from the centroid (a good initial guess), step against the gradient
+    //   with a learning rate that decays each iteration, and stop once the step
+    //   size falls under eps.
+    //   NOTE: add a tiny 1e-8 to the denominator - when the current point sits
+    //         exactly on a customer, dist_i is 0 and would divide by 0.
+    /**
+     * time = O(iters * N)
+     * space = O(1)
+     */
+    public double getMinDistSum(int[][] positions) {
+        int n = positions.length;
+        double x = 0.0;
+        double y = 0.0;
+        for (int[] p : positions) {
+            x += p[0];
+            y += p[1];
+        }
+        x /= n;
+        y /= n;
+
+        double alpha = 0.5;
+        double decay = 0.999;
+        double eps = 1e-7;
+        double total = 0.0;
+
+        for (int it = 0; it < 200000; it++) {
+            double gx = 0.0;
+            double gy = 0.0;
+            total = 0.0;
+            for (int[] p : positions) {
+                double a = x - p[0];
+                double b = y - p[1];
+                double d = Math.sqrt(a * a + b * b);
+                total += d;
+                gx += a / (d + 1e-8);
+                gy += b / (d + 1e-8);
+            }
+
+            double dx = gx * alpha;
+            double dy = gy * alpha;
+            x -= dx;
+            y -= dy;
+            alpha *= decay;
+
+            if (Math.abs(dx) <= eps && Math.abs(dy) <= eps) {
+                break;
+            }
+        }
+        return total;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/DetonateTheMaximumBombs.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/DetonateTheMaximumBombs.java
@@ -1,0 +1,102 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/detonate-the-maximum-bombs/
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.ArrayDeque;
+import java.util.List;
+
+/**
+ *  2101. Detonate the Maximum Bombs
+ *  Medium
+ *
+ *  You are given a list of bombs. The range of a bomb is defined as the area where its
+ *  effect can be felt. This area is in the shape of a circle with the center as the
+ *  location of the bomb.
+ *
+ *  The bombs are represented by a 0-indexed 2D integer array bombs where
+ *  bombs[i] = [xi, yi, ri]. xi and yi denote the X-coordinate and Y-coordinate of the
+ *  location of the ith bomb, whereas ri denotes the radius of its range.
+ *
+ *  You may choose to detonate a single bomb. When a bomb is detonated, it will detonate
+ *  all bombs that lie in its range. These bombs will further detonate the bombs that lie
+ *  in their ranges.
+ *
+ *  Given the list of bombs, return the maximum number of bombs that can be detonated if
+ *  you are allowed to detonate only one bomb.
+ *
+ *  Example 1:
+ *    Input: bombs = [[2,1,3],[6,1,4]]
+ *    Output: 2
+ *    Explanation: detonating the right bomb detonates both -> max(1, 2) = 2
+ *
+ *  Example 2:
+ *    Input: bombs = [[1,1,5],[10,10,5]]
+ *    Output: 1
+ *
+ *  Constraints:
+ *    1 <= bombs.length <= 100
+ *    bombs[i].length == 3
+ *    1 <= xi, yi, ri <= 10^5
+ */
+public class DetonateTheMaximumBombs {
+
+    // V0
+    // IDEA: BUILD A DIRECTED REACHABILITY GRAPH, THEN DFS FROM EVERY BOMB
+    //
+    //   the relation is DIRECTED and not symmetric: bomb i triggers bomb j iff j's
+    //   CENTER lies inside i's circle, i.e.
+    //       (xi - xj)^2 + (yi - yj)^2 <= ri^2
+    //   a big bomb can reach a small one without the reverse being true.
+    //
+    //   compare SQUARED distances (as long) so the check stays exact integer math.
+    //   n <= 100, so an O(n^2) graph plus one DFS per start bomb is cheap.
+    /**
+     * time = O(N^3)
+     * space = O(N^2)
+     */
+    public int maximumDetonation(int[][] bombs) {
+        int n = bombs.length;
+        List<List<Integer>> g = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            g.add(new ArrayList<Integer>());
+        }
+        for (int i = 0; i < n; i++) {
+            long xi = bombs[i][0];
+            long yi = bombs[i][1];
+            long ri = bombs[i][2];
+            for (int j = 0; j < n; j++) {
+                if (i == j) {
+                    continue;
+                }
+                long dx = xi - bombs[j][0];
+                long dy = yi - bombs[j][1];
+                if (dx * dx + dy * dy <= ri * ri) {
+                    g.get(i).add(j);
+                }
+            }
+        }
+
+        int res = 0;
+        for (int s = 0; s < n; s++) {
+            boolean[] seen = new boolean[n];
+            seen[s] = true;
+            int cnt = 1;
+            Deque<Integer> stack = new ArrayDeque<>();
+            stack.push(s);
+            while (!stack.isEmpty()) {
+                int u = stack.pop();
+                for (int v : g.get(u)) {
+                    if (!seen[v]) {
+                        seen[v] = true;
+                        cnt++;
+                        stack.push(v);
+                    }
+                }
+            }
+            res = Math.max(res, cnt);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/ErectTheFenceII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/ErectTheFenceII.java
@@ -1,0 +1,134 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/erect-the-fence-ii/
+
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1924. Erect the Fence II
+ *  Hard
+ *
+ *  You are given a 2D integer array trees where trees[i] = [xi, yi] represents the
+ *  location of the ith tree in the garden.
+ *
+ *  You are asked to fence the entire garden using the minimum length of rope possible.
+ *  The garden is well-fenced only if all the trees are enclosed and the rope used forms a
+ *  perfect circle. A tree is considered enclosed if it is inside or on the border of the
+ *  circle.
+ *
+ *  More formally, you must form a circle using the rope with a center (x, y) and radius r
+ *  where all trees lie inside or on the circle and r is minimum.
+ *
+ *  Return the center and radius of the circle as a length 3 array [x, y, r]. Answers
+ *  within 10^-5 of the actual answer will be accepted.
+ *
+ *  Example 1:
+ *    Input: trees = [[1,1],[2,2],[2,0],[2,4],[3,3],[4,2]]
+ *    Output: [2.00000,2.00000,2.00000]
+ *
+ *  Example 2:
+ *    Input: trees = [[1,2],[2,2],[4,2]]
+ *    Output: [2.50000,2.00000,1.50000]
+ *
+ *  Constraints:
+ *    1 <= trees.length <= 3000
+ *    trees[i].length == 2
+ *    0 <= xi, yi <= 3000
+ */
+public class ErectTheFenceII {
+
+    private static final double EPS = 1e-7;
+
+    // V0
+    // IDEA: WELZL - RANDOMIZED INCREMENTAL MINIMUM ENCLOSING CIRCLE
+    //
+    //   the smallest enclosing circle is pinned by at most 3 boundary points. after a
+    //   random shuffle, run 3 nested "repair" loops:
+    //     - keep a current circle for the prefix p[0..i-1]
+    //     - if p[i] falls outside then p[i] MUST lie on the boundary of the answer for
+    //       the prefix p[0..i]; restart the scan with p[i] pinned
+    //     - one more level pins a 2nd point, one more pins a 3rd and the circle is then
+    //       the circumcircle of those 3 points
+    //
+    //   each level is entered with probability O(1/i) over the random order, so the whole
+    //   thing is O(n) EXPECTED even though it looks cubic.
+    //
+    //   NOTE: use an epsilon when testing "is inside" so boundary points do not trigger a
+    //         needless (and endless) rebuild.
+    /**
+     * time = O(N) expected
+     * space = O(N)
+     */
+    public double[] outerTrees(int[][] trees) {
+        int n = trees.length;
+        List<double[]> pts = new ArrayList<>();
+        for (int[] t : trees) {
+            pts.add(new double[]{t[0], t[1]});
+        }
+        Collections.shuffle(pts);
+
+        double[] circle = new double[]{pts.get(0)[0], pts.get(0)[1], 0.0};
+        for (int i = 1; i < n; i++) {
+            if (inside(circle, pts.get(i))) {
+                continue;
+            }
+            circle = new double[]{pts.get(i)[0], pts.get(i)[1], 0.0};
+            for (int j = 0; j < i; j++) {
+                if (inside(circle, pts.get(j))) {
+                    continue;
+                }
+                circle = fromTwo(pts.get(i), pts.get(j));
+                for (int k = 0; k < j; k++) {
+                    if (!inside(circle, pts.get(k))) {
+                        circle = fromThree(pts.get(i), pts.get(j), pts.get(k));
+                    }
+                }
+            }
+        }
+        return circle;
+    }
+
+    private double dist(double ax, double ay, double bx, double by) {
+        double dx = ax - bx;
+        double dy = ay - by;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    private boolean inside(double[] circle, double[] p) {
+        return dist(circle[0], circle[1], p[0], p[1]) <= circle[2] + EPS;
+    }
+
+    private double[] fromTwo(double[] a, double[] b) {
+        double cx = (a[0] + b[0]) / 2.0;
+        double cy = (a[1] + b[1]) / 2.0;
+        return new double[]{cx, cy, dist(a[0], a[1], b[0], b[1]) / 2.0};
+    }
+
+    private double[] fromThree(double[] a, double[] b, double[] c) {
+        double ax = a[0], ay = a[1];
+        double bx = b[0], by = b[1];
+        double cx = c[0], cy = c[1];
+        double d = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
+        if (Math.abs(d) < EPS) {
+            // collinear -> the answer is the circle on the 2 farthest points
+            double[] best = fromTwo(a, b);
+            double[] c1 = fromTwo(a, c);
+            if (c1[2] > best[2]) {
+                best = c1;
+            }
+            double[] c2 = fromTwo(b, c);
+            if (c2[2] > best[2]) {
+                best = c2;
+            }
+            return best;
+        }
+        double a2 = ax * ax + ay * ay;
+        double b2 = bx * bx + by * by;
+        double c2 = cx * cx + cy * cy;
+        double ux = (a2 * (by - cy) + b2 * (cy - ay) + c2 * (ay - by)) / d;
+        double uy = (a2 * (cx - bx) + b2 * (ax - cx) + c2 * (bx - ax)) / d;
+        return new double[]{ux, uy, dist(ux, uy, ax, ay)};
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/FindMaximumAreaOfATriangle.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/FindMaximumAreaOfATriangle.java
@@ -1,0 +1,91 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/find-maximum-area-of-a-triangle/
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  3588. Find Maximum Area of a Triangle
+ *  Medium
+ *
+ *  You are given a 2D array coords of size n x 2, representing the coordinates of n
+ *  points in an infinite Cartesian plane.
+ *
+ *  Find twice the maximum area of a triangle with its corners at any three elements from
+ *  coords, such that at least one side of this triangle is parallel to the x-axis or
+ *  y-axis. Formally, if the maximum area of such a triangle is A, return 2 * A.
+ *
+ *  If no such triangle exists, return -1.
+ *  Note that a triangle cannot have zero area.
+ *
+ *  Example 1:
+ *    Input: coords = [[1,1],[1,2],[3,2],[3,3]]
+ *    Output: 2
+ *    Explanation: the triangle (1,1), (1,2), (3,2) has base 1 and height 2 -> area 1.
+ *
+ *  Example 2:
+ *    Input: coords = [[1,1],[2,2],[3,3]]
+ *    Output: -1
+ *    Explanation: the only possible triangle has no axis-parallel side.
+ *
+ *  Constraints:
+ *    1 <= n == coords.length <= 10^5
+ *    1 <= coords[i][0], coords[i][1] <= 10^6
+ *    All coords[i] are unique.
+ */
+public class FindMaximumAreaOfATriangle {
+
+    // V0
+    // IDEA: THE AXIS-PARALLEL SIDE IS THE BASE; THE APEX IS A GLOBAL EXTREME
+    //
+    //   fix the base as two points sharing a y value; the widest such pair is always best
+    //   because 2*area = base_length * height and the two factors are independent. the
+    //   height is the vertical distance from that y to the apex, so the apex should be
+    //   whichever of the globally smallest / largest y is further away.
+    //
+    //   running the same sweep with the two axes swapped covers vertical sides. grouping
+    //   by the shared coordinate and keeping only each group's min/max is all the
+    //   bookkeeping required.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public long maxArea(int[][] coords) {
+        return Math.max(scan(coords, 0, 1), scan(coords, 1, 0));
+    }
+
+    // best base_length * height over sides parallel to axis `baseAxis`
+    private long scan(int[][] coords, int baseAxis, int otherAxis) {
+        Map<Integer, int[]> groups = new HashMap<>();   // shared coord -> {minBase, maxBase}
+        int lo = Integer.MAX_VALUE;
+        int hi = Integer.MIN_VALUE;
+        for (int[] p : coords) {
+            int b = p[baseAxis];
+            int o = p[otherAxis];
+            lo = Math.min(lo, o);
+            hi = Math.max(hi, o);
+            int[] cur = groups.get(o);
+            if (cur == null) {
+                groups.put(o, new int[]{b, b});
+            } else {
+                cur[0] = Math.min(cur[0], b);
+                cur[1] = Math.max(cur[1], b);
+            }
+        }
+
+        long best = -1;
+        for (Map.Entry<Integer, int[]> e : groups.entrySet()) {
+            int o = e.getKey();
+            long base = (long) e.getValue()[1] - e.getValue()[0];
+            if (base == 0) {
+                continue;
+            }
+            long height = Math.max((long) o - lo, (long) hi - o);
+            if (height > 0) {
+                best = Math.max(best, base * height);
+            }
+        }
+        return best;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/FindTheLargestAreaOfSquareInsideTwoRectangles.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/FindTheLargestAreaOfSquareInsideTwoRectangles.java
@@ -1,0 +1,71 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/find-the-largest-area-of-square-inside-two-rectangles/
+
+/**
+ *  3047. Find the Largest Area of Square Inside Two Rectangles
+ *  Medium
+ *
+ *  There exist n rectangles in a 2D plane with edges parallel to the x and y axis. You
+ *  are given two 2D integer arrays bottomLeft and topRight where
+ *  bottomLeft[i] = [a_i, b_i] and topRight[i] = [c_i, d_i] represent the bottom-left and
+ *  top-right coordinates of the ith rectangle, respectively.
+ *
+ *  You need to find the maximum area of a square that can fit inside the intersecting
+ *  region of at least two rectangles.
+ *
+ *  Return the maximum area of such a square, or 0 if such a square does not exist.
+ *
+ *  Example 1:
+ *    Input: bottomLeft = [[1,1],[2,2],[3,1]], topRight = [[3,3],[4,4],[6,6]]
+ *    Output: 1
+ *
+ *  Example 3:
+ *    Input: bottomLeft = [[1,1],[3,3],[3,1]], topRight = [[2,2],[4,4],[4,2]]
+ *    Output: 0
+ *    Explanation: no pair of rectangles intersect.
+ *
+ *  Constraints:
+ *    n == bottomLeft.length == topRight.length
+ *    2 <= n <= 10^3
+ *    bottomLeft[i].length == topRight[i].length == 2
+ *    1 <= bottomLeft[i][0], bottomLeft[i][1] <= 10^7
+ *    1 <= topRight[i][0], topRight[i][1] <= 10^7
+ *    bottomLeft[i][0] < topRight[i][0]
+ *    bottomLeft[i][1] < topRight[i][1]
+ */
+public class FindTheLargestAreaOfSquareInsideTwoRectangles {
+
+    // V0
+    // IDEA: THE BEST SQUARE ALWAYS LIVES IN SOME *PAIRWISE* INTERSECTION
+    //
+    //   an intersection of three or more rectangles is contained in the intersection of
+    //   any two of them, so it can never beat the best pair. that reduces the search to
+    //   the n^2/2 pairs - 5 * 10^5 of them at n = 1000.
+    //
+    //   two axis-aligned rectangles intersect in another axis-aligned rectangle:
+    //       x-range [max(left), min(right)]   y-range [max(bottom), min(top)]
+    //   and the largest square inside it has side min(width, height), which is 0 or
+    //   negative when they miss each other.
+    /**
+     * time = O(N^2)
+     * space = O(1)
+     */
+    public long largestSquareArea(int[][] bottomLeft, int[][] topRight) {
+        int n = bottomLeft.length;
+        long best = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                long w = Math.min(topRight[i][0], topRight[j][0])
+                        - Math.max(bottomLeft[i][0], bottomLeft[j][0]);
+                long h = Math.min(topRight[i][1], topRight[j][1])
+                        - Math.max(bottomLeft[i][1], bottomLeft[j][1]);
+                long side = Math.min(w, h);
+                if (side > best) {
+                    best = side;
+                }
+            }
+        }
+        return best * best;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumAreaRectangleWithPointConstraintsI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumAreaRectangleWithPointConstraintsI.java
@@ -1,0 +1,101 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/maximum-area-rectangle-with-point-constraints-i/
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ *  3380. Maximum Area Rectangle With Point Constraints I
+ *  Medium
+ *
+ *  You are given an array points where points[i] = [x_i, y_i] represents the coordinates
+ *  of a point on an infinite plane.
+ *
+ *  Your task is to find the maximum area of a rectangle that:
+ *    - Can be formed using four of these points as its corners.
+ *    - Does not contain any other point inside or on its border.
+ *    - Has its edges parallel to the axes.
+ *
+ *  Return the maximum area that you can obtain or -1 if no such rectangle is possible.
+ *
+ *  Example 1:
+ *    Input: points = [[1,1],[1,3],[3,1],[3,3]]
+ *    Output: 4
+ *
+ *  Example 2:
+ *    Input: points = [[1,1],[1,3],[3,1],[3,3],[2,2]]
+ *    Output: -1
+ *    Explanation: the only rectangle always contains [2,2].
+ *
+ *  Constraints:
+ *    1 <= points.length <= 10
+ *    points[i].length == 2
+ *    0 <= x_i, y_i <= 100
+ *    All the given points are unique.
+ */
+public class MaximumAreaRectangleWithPointConstraintsI {
+
+    // V0
+    // IDEA: ONLY 10 POINTS - TRY EVERY (x1, x2) x (y1, y2) BOX
+    //
+    //   an axis-parallel rectangle is decided by two distinct x values and two distinct y
+    //   values, so enumerate those pairs and check that all four corners exist.
+    //
+    //   the "nothing inside or on the border" rule is then a scan over the other points:
+    //   any point whose coordinates both fall inside the closed box, and which is not one
+    //   of the four corners, disqualifies it.
+    /**
+     * time = O(N^5)   // N <= 10
+     * space = O(N)
+     */
+    public int maxRectangleArea(int[][] points) {
+        Set<Integer> pts = new HashSet<>();      // encode as x * 1000 + y
+        TreeSet<Integer> xsSet = new TreeSet<>();
+        TreeSet<Integer> ysSet = new TreeSet<>();
+        for (int[] p : points) {
+            pts.add(p[0] * 1000 + p[1]);
+            xsSet.add(p[0]);
+            ysSet.add(p[1]);
+        }
+        Integer[] xs = xsSet.toArray(new Integer[0]);
+        Integer[] ys = ysSet.toArray(new Integer[0]);
+
+        int best = -1;
+        for (int i = 0; i < xs.length; i++) {
+            for (int j = i + 1; j < xs.length; j++) {
+                int x1 = xs[i];
+                int x2 = xs[j];
+                for (int a = 0; a < ys.length; a++) {
+                    for (int b = a + 1; b < ys.length; b++) {
+                        int y1 = ys[a];
+                        int y2 = ys[b];
+                        if (!pts.contains(x1 * 1000 + y1) || !pts.contains(x1 * 1000 + y2)
+                                || !pts.contains(x2 * 1000 + y1)
+                                || !pts.contains(x2 * 1000 + y2)) {
+                            continue;
+                        }
+                        boolean blocked = false;
+                        for (int[] p : points) {
+                            int px = p[0];
+                            int py = p[1];
+                            boolean isCorner = (px == x1 || px == x2) && (py == y1 || py == y2);
+                            if (isCorner) {
+                                continue;
+                            }
+                            if (x1 <= px && px <= x2 && y1 <= py && py <= y2) {
+                                blocked = true;
+                                break;
+                            }
+                        }
+                        if (!blocked) {
+                            best = Math.max(best, (x2 - x1) * (y2 - y1));
+                        }
+                    }
+                }
+            }
+        }
+        return best;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumAreaRectangleWithPointConstraintsII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumAreaRectangleWithPointConstraintsII.java
@@ -1,0 +1,143 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/maximum-area-rectangle-with-point-constraints-ii/
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  3382. Maximum Area Rectangle With Point Constraints II
+ *  Hard
+ *
+ *  There are n points on an infinite plane. You are given two integer arrays xCoord and
+ *  yCoord where (xCoord[i], yCoord[i]) represents the coordinates of the ith point.
+ *
+ *  Your task is to find the maximum area of a rectangle that:
+ *    - Can be formed using four of these points as its corners.
+ *    - Does not contain any other point inside or on its border.
+ *    - Has its edges parallel to the axes.
+ *
+ *  Return the maximum area that you can obtain or -1 if no such rectangle is possible.
+ *
+ *  Example 1:
+ *    Input: xCoord = [1,1,3,3], yCoord = [1,3,1,3]
+ *    Output: 4
+ *
+ *  Example 3:
+ *    Input: xCoord = [1,1,3,3,1,3], yCoord = [1,3,1,3,2,2]
+ *    Output: 2
+ *
+ *  Constraints:
+ *    1 <= xCoord.length == yCoord.length <= 2 * 10^5
+ *    0 <= xCoord[i], yCoord[i] <= 8 * 10^7
+ *    All the given points are unique.
+ */
+public class MaximumAreaRectangleWithPointConstraintsII {
+
+    private int[] tree;
+    private int size;
+
+    // V0
+    // IDEA: SWEEP BY x, PAIRING *VERTICALLY ADJACENT* POINTS, COUNTING WITH A BIT
+    //
+    //   a valid rectangle's left edge holds two points with NOTHING between them on that
+    //   edge - otherwise the extra point sits on the border. so on each vertical line
+    //   only consecutive y's can be a rectangle's left (or right) edge, which brings the
+    //   candidate pairs down from quadratic to O(n).
+    //
+    //   sweeping x from small to large, a pair (y1, y2) that was last seen at column x0
+    //   closes a rectangle now. it is empty exactly when no other point entered the strip
+    //   meanwhile, which a Fenwick tree over y answers by comparing the counts in
+    //   [y1, y2] then and now: the difference must be exactly the 2 points just added on
+    //   this column.
+    /**
+     * time = O(N log N)
+     * space = O(N)
+     */
+    public long maxRectangleArea(int[] xCoord, int[] yCoord) {
+        int n = xCoord.length;
+
+        // sort point indices by (x, y)
+        Integer[] idx = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            idx[i] = i;
+        }
+        final int[] xs0 = xCoord;
+        final int[] ys0 = yCoord;
+        Arrays.sort(idx, (p, q) -> {
+            if (xs0[p] != xs0[q]) {
+                return Integer.compare(xs0[p], xs0[q]);
+            }
+            return Integer.compare(ys0[p], ys0[q]);
+        });
+
+        // rank the y values (1-based)
+        int[] sortedY = yCoord.clone();
+        Arrays.sort(sortedY);
+        int m = 0;
+        for (int i = 0; i < n; i++) {
+            if (i == 0 || sortedY[i] != sortedY[i - 1]) {
+                sortedY[m++] = sortedY[i];
+            }
+        }
+        size = m;
+        tree = new int[size + 1];
+        Map<Integer, Integer> rank = new HashMap<>();
+        for (int i = 0; i < m; i++) {
+            rank.put(sortedY[i], i + 1);
+        }
+
+        // (y1Rank, y2Rank) -> {lastX, countThen}
+        Map<Long, long[]> last = new HashMap<>();
+        long best = -1;
+
+        int i = 0;
+        while (i < n) {
+            int j = i;
+            int x = xCoord[idx[i]];
+            while (j < n && xCoord[idx[j]] == x) {
+                j++;
+            }
+            // insert this whole column first
+            for (int t = i; t < j; t++) {
+                add(rank.get(yCoord[idx[t]]));
+            }
+            // adjacent pairs on this column (already ascending in y)
+            for (int t = i; t + 1 < j; t++) {
+                int y1 = yCoord[idx[t]];
+                int y2 = yCoord[idx[t + 1]];
+                int r1 = rank.get(y1);
+                int r2 = rank.get(y2);
+                long cur = prefix(r2) - prefix(r1 - 1);
+                long key = (long) r1 * (size + 1) + r2;
+                long[] prev = last.get(key);
+                if (prev != null && cur - prev[1] == 2) {
+                    long area = (x - prev[0]) * (long) (y2 - y1);
+                    if (area > best) {
+                        best = area;
+                    }
+                }
+                last.put(key, new long[]{x, cur});
+            }
+            i = j;
+        }
+        return best;
+    }
+
+    private void add(int i) {
+        while (i <= size) {
+            tree[i]++;
+            i += i & (-i);
+        }
+    }
+
+    private int prefix(int i) {
+        int s = 0;
+        while (i > 0) {
+            s += tree[i];
+            i -= i & (-i);
+        }
+        return s;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumNumberOfDartsInsideOfACircularDartboard.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumNumberOfDartsInsideOfACircularDartboard.java
@@ -1,0 +1,100 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/maximum-number-of-darts-inside-of-a-circular-dartboard/
+
+/**
+ *  1453. Maximum Number of Darts Inside of a Circular Dartboard
+ *  Hard
+ *
+ *  Alice is throwing n darts on a very large wall. You are given an array darts where
+ *  darts[i] = [xi, yi] is the position of the ith dart that Alice threw on the wall.
+ *
+ *  Bob knows the positions of the n darts on the wall. He wants to place a dartboard of
+ *  radius r on the wall so that the maximum number of darts that Alice throws lie on the
+ *  dartboard.
+ *
+ *  Given the integer r, return the maximum number of darts that can lie on the dartboard.
+ *
+ *  Example 1:
+ *    Input: darts = [[-2,0],[2,0],[0,2],[0,-2]], r = 2
+ *    Output: 4
+ *    Explanation: circle centered at (0,0) with radius = 2 contains all points.
+ *
+ *  Example 2:
+ *    Input: darts = [[-3,0],[3,0],[2,6],[5,4],[0,9],[7,8]], r = 5
+ *    Output: 5
+ *    Explanation: circle centered at (0,4) with radius = 5 contains all but (7,8).
+ *
+ *  Constraints:
+ *    1 <= darts.length <= 100
+ *    darts[i].length == 2
+ *    -10^4 <= xi, yi <= 10^4
+ *    All the darts are unique
+ *    1 <= r <= 5000
+ */
+public class MaximumNumberOfDartsInsideOfACircularDartboard {
+
+    private static final double EPS = 1e-7;
+
+    // V0
+    // IDEA: GEOMETRY - "the best circle can always be pushed onto 2 points"
+    //
+    //   KEY OBSERVATION:
+    //     take any optimal dartboard. slide it until its boundary touches a dart, then
+    //     rotate it around that dart until the boundary touches a 2nd dart. the set of
+    //     covered darts never shrinks. so an optimal circle either
+    //       (a) covers just 1 dart, or
+    //       (b) has 2 of the darts exactly on its boundary.
+    //
+    //   -> enumerate every pair (i, j) with dist(i, j) <= 2r, build the (at most 2)
+    //      circle centers of radius r through both, and count covered darts.
+    //
+    //   NOTE: use an epsilon when comparing distances - the centers are floats.
+    /**
+     * time = O(N^3)
+     * space = O(1)
+     */
+    public int numPoints(int[][] darts, int r) {
+        int n = darts.length;
+        double rr = (double) r * r;
+
+        int res = 1;                    // a single dart is always coverable
+        for (int i = 0; i < n; i++) {
+            double x1 = darts[i][0];
+            double y1 = darts[i][1];
+            for (int j = i + 1; j < n; j++) {
+                double x2 = darts[j][0];
+                double y2 = darts[j][1];
+                double dx = x2 - x1;
+                double dy = y2 - y1;
+                double d2 = dx * dx + dy * dy;
+                if (d2 > 4.0 * rr) {
+                    continue;           // too far apart for any radius-r circle
+                }
+                double d = Math.sqrt(d2);
+                double mx = (x1 + x2) / 2.0;
+                double my = (y1 + y2) / 2.0;
+                // distance from the chord midpoint to the circle center
+                double h = Math.sqrt(Math.max(0.0, rr - d2 / 4.0));
+                // unit vector perpendicular to the chord
+                double ux = -dy / d;
+                double uy = dx / d;
+                res = Math.max(res, count(darts, mx + h * ux, my + h * uy, rr));
+                res = Math.max(res, count(darts, mx - h * ux, my - h * uy, rr));
+            }
+        }
+        return res;
+    }
+
+    private int count(int[][] darts, double cx, double cy, double rr) {
+        int c = 0;
+        for (int[] p : darts) {
+            double dx = p[0] - cx;
+            double dy = p[1] - cy;
+            if (dx * dx + dy * dy <= rr + EPS) {
+                c++;
+            }
+        }
+        return c;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumNumberOfVisiblePoints.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumNumberOfVisiblePoints.java
@@ -1,0 +1,107 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/maximum-number-of-visible-points/
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *  1610. Maximum Number of Visible Points
+ *  Hard
+ *
+ *  You are given an array points, an integer angle, and your location, where
+ *  location = [posx, posy] and points[i] = [xi, yi] both denote integral coordinates on
+ *  the X-Y plane.
+ *
+ *  Initially, you are facing directly east from your position. You cannot move from your
+ *  position, but you can rotate. Let d be the amount in degrees that you rotate
+ *  counterclockwise. Then, your field of view is the inclusive range of angles
+ *  [d - angle/2, d + angle/2].
+ *
+ *  You can see some set of points if, for each point, the angle formed by the point, your
+ *  position, and the immediate east direction from your position is in your field of
+ *  view.
+ *
+ *  There can be multiple points at one coordinate. There may be points at your location,
+ *  and you can always see these points regardless of your rotation. Points do not
+ *  obstruct your vision to other points.
+ *
+ *  Return the maximum number of points you can see.
+ *
+ *  Example 1:
+ *    Input: points = [[2,1],[2,2],[3,3]], angle = 90, location = [1,1]
+ *    Output: 3
+ *
+ *  Example 3:
+ *    Input: points = [[1,0],[2,1]], angle = 13, location = [1,1]
+ *    Output: 1
+ *
+ *  Constraints:
+ *    1 <= points.length <= 10^5
+ *    points[i].length == 2
+ *    location.length == 2
+ *    0 <= angle < 360
+ *    0 <= posx, posy, xi, yi <= 100
+ */
+public class MaximumNumberOfVisiblePoints {
+
+    // V0
+    // IDEA: POLAR ANGLES + SLIDING WINDOW ON A CIRCULAR SORTED ARRAY
+    //
+    //   distance is irrelevant - only each point's bearing matters. compute
+    //   atan2(dy, dx) for every point, sort, and the question becomes "the densest
+    //   window of width `angle` on a circle".
+    //
+    //   handle the wrap-around by appending every bearing + 2*pi to the array, then slide
+    //   a two-pointer window over that doubled array.
+    //
+    //   NOTE: points sitting exactly ON your location have no bearing; they are always
+    //         visible, so count them separately and add at the end.
+    //   NOTE: add a tiny epsilon to the width - the field of view is INCLUSIVE and atan2
+    //         arithmetic loses a few ulps.
+    /**
+     * time = O(N log N)
+     * space = O(N)
+     */
+    public int visiblePoints(List<List<Integer>> points, int angle, List<Integer> location) {
+        int px = location.get(0);
+        int py = location.get(1);
+        int same = 0;
+        List<Double> bearings = new ArrayList<>();
+        for (List<Integer> p : points) {
+            int x = p.get(0);
+            int y = p.get(1);
+            if (x == px && y == py) {
+                same++;
+            } else {
+                bearings.add(Math.atan2(y - py, x - px));
+            }
+        }
+        Collections.sort(bearings);
+        int n = bearings.size();
+        if (n == 0) {
+            return same;
+        }
+
+        double[] ext = new double[2 * n];
+        for (int i = 0; i < n; i++) {
+            ext[i] = bearings.get(i);
+            ext[i + n] = bearings.get(i) + 2 * Math.PI;
+        }
+        double width = angle * Math.PI / 180.0 + 1e-9;
+
+        int best = 0;
+        int j = 0;
+        for (int i = 0; i < n; i++) {
+            if (j < i) {
+                j = i;
+            }
+            while (j < 2 * n && ext[j] <= ext[i] + width) {
+                j++;
+            }
+            best = Math.max(best, j - i);
+        }
+        return best + same;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumPointsInsideTheSquare.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MaximumPointsInsideTheSquare.java
@@ -1,0 +1,94 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/maximum-points-inside-the-square/
+
+/**
+ *  3143. Maximum Points Inside the Square
+ *  Medium
+ *
+ *  You are given a 2D array points and a string s where points[i] represents the
+ *  coordinates of point i, and s[i] represents the tag of point i.
+ *
+ *  A valid square is a square centered at the origin (0, 0), has edges parallel to the
+ *  axes, and does not contain two points with the same tag.
+ *
+ *  Return the maximum number of points contained in a valid square.
+ *
+ *  Note:
+ *    A point is considered to be inside the square if it lies on or within the square's
+ *    boundaries. The side length of the square can be zero.
+ *
+ *  Example 1:
+ *    Input: points = [[2,2],[-1,-2],[-4,4],[-3,1],[3,-3]], s = "abdca"
+ *    Output: 2
+ *    Explanation: the square of side length 4 covers points[0] and points[1].
+ *
+ *  Example 3:
+ *    Input: points = [[1,1],[-1,-1],[2,-2]], s = "ccd"
+ *    Output: 0
+ *
+ *  Constraints:
+ *    1 <= s.length, points.length <= 10^5
+ *    points[i].length == 2
+ *    -10^9 <= points[i][0], points[i][1] <= 10^9
+ *    s.length == points.length
+ *    points consists of distinct coordinates.
+ *    s consists only of lowercase English letters.
+ */
+public class MaximumPointsInsideTheSquare {
+
+    // V0
+    // IDEA: A SQUARE IS JUST A CHEBYSHEV RADIUS - FIND WHERE THE FIRST TAG REPEATS
+    //
+    //   a square of half-side r centred at the origin contains exactly the points with
+    //   max(|x|, |y|) <= r. so every point is described by one number, its Chebyshev
+    //   radius, and growing the square means sweeping r upward.
+    //
+    //   a tag becomes a conflict the moment its SECOND-smallest radius is admitted, so
+    //   the square must stop strictly before
+    //
+    //       limit = min over tags of (second smallest radius of that tag)
+    //
+    //   then the answer counts the points with radius < limit. tracking, per tag, only
+    //   the two smallest radii is enough - one pass, 26 pairs of numbers.
+    /**
+     * time = O(N)
+     * space = O(1)   // 26 tags
+     */
+    public int maxPointsInsideSquare(int[][] points, String s) {
+        final long INF = Long.MAX_VALUE;
+        long[] best1 = new long[26];        // smallest radius per tag
+        long[] best2 = new long[26];        // second smallest
+        for (int i = 0; i < 26; i++) {
+            best1[i] = INF;
+            best2[i] = INF;
+        }
+
+        int n = points.length;
+        long[] radii = new long[n];
+        for (int i = 0; i < n; i++) {
+            long r = Math.max(Math.abs((long) points[i][0]), Math.abs((long) points[i][1]));
+            radii[i] = r;
+            int t = s.charAt(i) - 'a';
+            if (r < best1[t]) {
+                best2[t] = best1[t];
+                best1[t] = r;
+            } else if (r < best2[t]) {
+                best2[t] = r;
+            }
+        }
+
+        long limit = INF;                  // first radius that would duplicate a tag
+        for (int i = 0; i < 26; i++) {
+            limit = Math.min(limit, best2[i]);
+        }
+
+        int res = 0;
+        for (int i = 0; i < n; i++) {
+            if (radii[i] < limit) {
+                res++;
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MinimizeManhattanDistances.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MinimizeManhattanDistances.java
@@ -1,0 +1,93 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/minimize-manhattan-distances/
+
+/**
+ *  3102. Minimize Manhattan Distances
+ *  Hard
+ *
+ *  You are given an array points representing integer coordinates of some points on a 2D
+ *  plane, where points[i] = [xi, yi].
+ *
+ *  The distance between two points is defined as their Manhattan distance.
+ *
+ *  Return the minimum possible value for maximum distance between any two points by
+ *  removing exactly one point.
+ *
+ *  Example 1:
+ *    Input: points = [[3,10],[5,15],[10,2],[4,4]]
+ *    Output: 12
+ *    Explanation: removing the 2nd point leaves a max distance of 12, between (5,15) and
+ *                 (4,4) -> |5-4| + |15-4| = 12, which is the smallest achievable.
+ *
+ *  Example 2:
+ *    Input: points = [[1,1],[1,1],[1,1]]
+ *    Output: 0
+ *
+ *  Constraints:
+ *    3 <= points.length <= 10^5
+ *    points[i].length == 2
+ *    1 <= points[i][0], points[i][1] <= 10^8
+ */
+public class MinimizeManhattanDistances {
+
+    // V0
+    // IDEA: ROTATE TO CHEBYSHEV - MANHATTAN MAX BECOMES TWO INDEPENDENT SPREADS
+    //
+    //   with u = x + y and v = x - y,
+    //       |x1-x2| + |y1-y2| = max(|u1-u2|, |v1-v2|)
+    //   so the largest pairwise Manhattan distance in a set is simply
+    //       max(spread of u, spread of v)      where spread = max - min
+    //   no pair enumeration needed.
+    //
+    //   removing one point can only change a spread if that point is the current extreme,
+    //   so keeping the index of the TWO largest and TWO smallest of u and of v is enough:
+    //   dropping point i falls back to the runner-up exactly when i held the record.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int minimumDistance(int[][] points) {
+        int n = points.length;
+        int[] u = new int[n];
+        int[] v = new int[n];
+        for (int i = 0; i < n; i++) {
+            u[i] = points[i][0] + points[i][1];
+            v[i] = points[i][0] - points[i][1];
+        }
+
+        int[] uMax = top2(u, true);
+        int[] uMin = top2(u, false);
+        int[] vMax = top2(v, true);
+        int[] vMin = top2(v, false);
+
+        int res = Integer.MAX_VALUE;
+        for (int i = 0; i < n; i++) {
+            int hiU = u[uMax[0] == i ? uMax[1] : uMax[0]];
+            int loU = u[uMin[0] == i ? uMin[1] : uMin[0]];
+            int hiV = v[vMax[0] == i ? vMax[1] : vMax[0]];
+            int loV = v[vMin[0] == i ? vMin[1] : vMin[0]];
+            res = Math.min(res, Math.max(hiU - loU, hiV - loV));
+        }
+        return res;
+    }
+
+    // indices of the best and the runner-up value (max when `wantMax`, else min)
+    private int[] top2(int[] arr, boolean wantMax) {
+        int first = -1;
+        int second = -1;
+        for (int i = 0; i < arr.length; i++) {
+            if (first == -1 || better(arr[i], arr[first], wantMax)) {
+                second = first;
+                first = i;
+            } else if (second == -1 || better(arr[i], arr[second], wantMax)) {
+                second = i;
+            }
+        }
+        return new int[]{first, second};
+    }
+
+    private boolean better(int a, int b, boolean wantMax) {
+        return wantMax ? a > b : a < b;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Math/MinimumTimeForKVirusVariantsToSpread.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Math/MinimumTimeForKVirusVariantsToSpread.java
@@ -1,0 +1,85 @@
+package LeetCodeJava.Math;
+
+// https://leetcode.com/problems/minimum-time-for-k-virus-variants-to-spread/
+
+import java.util.Arrays;
+
+/**
+ *  1956. Minimum Time For K Virus Variants to Spread
+ *  Hard
+ *
+ *  There are n unique virus variants in an infinite 2D grid. You are given a 2D array
+ *  points, where points[i] = [xi, yi] represents a virus originating at (xi, yi) on day
+ *  0. Note that it is possible for multiple virus variants to originate at the same point.
+ *
+ *  Every day, each cell infected with a virus variant will spread the virus to all
+ *  neighboring points in the four cardinal directions (i.e. up, down, left, and right).
+ *  If a cell has multiple variants, all the variants will spread without interfering with
+ *  each other.
+ *
+ *  Given an integer k, return the minimum integer number of days for any point to contain
+ *  at least k of the unique virus variants.
+ *
+ *  Example 1:
+ *    Input: points = [[1,1],[6,1]], k = 2
+ *    Output: 3
+ *    Explanation: on day 3, (3,1) and (4,1) contain both variants.
+ *
+ *  Example 3:
+ *    Input: points = [[3,3],[1,2],[9,2]], k = 3
+ *    Output: 4
+ *    Explanation: on day 4, (5,2) contains all 3 variants.
+ *
+ *  Constraints:
+ *    n == points.length
+ *    2 <= n <= 50
+ *    points[i].length == 2
+ *    1 <= xi, yi <= 100
+ *    2 <= k <= n
+ */
+public class MinimumTimeForKVirusVariantsToSpread {
+
+    // V0
+    // IDEA: ENUMERATE MEETING CELLS + k-TH SMALLEST MANHATTAN DISTANCE
+    //
+    //   after d days a variant covers exactly the cells within Manhattan distance d of
+    //   its origin. so a cell c holds >= k variants on day d iff at least k of the
+    //   origins are within Manhattan distance d of c.
+    //
+    //   the best cell for any subset always lies inside the bounding box of that subset
+    //   (clamping a coordinate into the box never increases |x - xi|), and all coordinates
+    //   are in [1, 100] -> only 100 x 100 cells need checking.
+    //
+    //   for each candidate cell: sort its distances to the n origins and take the k-th
+    //   smallest; the answer is the minimum of those over all cells.
+    /**
+     * time = O(100 * 100 * N log N)
+     * space = O(N)
+     */
+    public int minDayskVariants(int[][] points, int k) {
+        int loX = Integer.MAX_VALUE, hiX = Integer.MIN_VALUE;
+        int loY = Integer.MAX_VALUE, hiY = Integer.MIN_VALUE;
+        for (int[] p : points) {
+            loX = Math.min(loX, p[0]);
+            hiX = Math.max(hiX, p[0]);
+            loY = Math.min(loY, p[1]);
+            hiY = Math.max(hiY, p[1]);
+        }
+
+        int n = points.length;
+        int[] dists = new int[n];
+        int res = Integer.MAX_VALUE;
+        for (int x = loX; x <= hiX; x++) {
+            for (int y = loY; y <= hiY; y++) {
+                for (int i = 0; i < n; i++) {
+                    dists[i] = Math.abs(points[i][0] - x) + Math.abs(points[i][1] - y);
+                }
+                Arrays.sort(dists);
+                if (dists[k - 1] < res) {
+                    res = dists[k - 1];
+                }
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Queue/DiagonalTraverseII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Queue/DiagonalTraverseII.java
@@ -1,0 +1,84 @@
+package LeetCodeJava.Queue;
+
+// https://leetcode.com/problems/diagonal-traverse-ii/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1424. Diagonal Traverse II
+ *  Medium
+ *
+ *  Given a 2D integer array nums, return all elements of nums in diagonal order.
+ *
+ *  Example 1:
+ *    Input: nums = [[1,2,3],[4,5,6],[7,8,9]]
+ *    Output: [1,4,2,7,5,3,8,6,9]
+ *
+ *  Example 2:
+ *    Input: nums = [[1,2,3,4,5],[6,7],[8],[9,10,11],[12,13,14,15,16]]
+ *    Output: [1,6,2,8,7,3,9,4,12,10,5,13,11,14,15,16]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i].length <= 10^5
+ *    1 <= sum(nums[i].length) <= 10^5
+ *    1 <= nums[i][j] <= 10^5
+ */
+public class DiagonalTraverseII {
+
+    // V0
+    // IDEA: BUCKET BY THE (i + j) DIAGONAL KEY
+    //       all cells on one diagonal share the same (i + j), and inside a
+    //       diagonal the output order is "bottom-left -> top-right", i.e. the ROW
+    //       index DECREASES. so walking the rows in REVERSE order and appending
+    //       builds every bucket already in the required order (no sorting needed).
+    /**
+     * time = O(N)     // N = total number of elements
+     * space = O(N)
+     */
+    public int[] findDiagonalOrder(List<List<Integer>> nums) {
+        int rows = nums.size();
+        int maxKey = 0;
+        int total = 0;
+        for (int i = 0; i < rows; i++) {
+            int len = nums.get(i).size();
+            total += len;
+            if (i + len - 1 > maxKey) {
+                maxKey = i + len - 1;
+            }
+        }
+
+        List<List<Integer>> buckets = new ArrayList<>(maxKey + 1);
+        for (int k = 0; k <= maxKey; k++) {
+            buckets.add(null);
+        }
+
+        // NOTE !!! walk the rows bottom -> top
+        for (int i = rows - 1; i >= 0; i--) {
+            List<Integer> row = nums.get(i);
+            for (int j = 0; j < row.size(); j++) {
+                int key = i + j;
+                List<Integer> bucket = buckets.get(key);
+                if (bucket == null) {
+                    bucket = new ArrayList<>();
+                    buckets.set(key, bucket);
+                }
+                bucket.add(row.get(j));
+            }
+        }
+
+        int[] res = new int[total];
+        int p = 0;
+        for (int key = 0; key <= maxKey; key++) {
+            List<Integer> bucket = buckets.get(key);
+            if (bucket == null) {
+                continue;
+            }
+            for (int k = 0; k < bucket.size(); k++) {
+                res[p++] = bucket.get(k);
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Queue/JumpGameVI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Queue/JumpGameVI.java
@@ -1,0 +1,76 @@
+package LeetCodeJava.Queue;
+
+// https://leetcode.com/problems/jump-game-vi/
+
+/**
+ *  1696. Jump Game VI
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array nums and an integer k.
+ *
+ *  You are initially standing at index 0. In one move, you can jump at most k
+ *  steps forward without going outside the boundaries of the array. That is, you
+ *  can jump from index i to any index in the range [i + 1, min(n - 1, i + k)]
+ *  inclusive.
+ *
+ *  You want to reach the last index of the array (index n - 1). Your score is the
+ *  sum of all nums[j] for each index j you visited in the array.
+ *
+ *  Return the maximum score you can get.
+ *
+ *  Example 1:
+ *    Input: nums = [1,-1,-2,4,-7,3], k = 2
+ *    Output: 7
+ *    Explanation: You can choose your jumps forming the subsequence [1,-1,4,3].
+ *                 The sum is 7.
+ *
+ *  Example 2:
+ *    Input: nums = [10,-5,-2,4,0,3], k = 3
+ *    Output: 17
+ *    Explanation: You can choose your jumps forming the subsequence [10,4,3].
+ *
+ *  Constraints:
+ *    1 <= nums.length, k <= 10^5
+ *    -10^4 <= nums[i] <= 10^4
+ */
+public class JumpGameVI {
+
+    // V0
+    // IDEA: DP + MONOTONIC DEQUE (SLIDING WINDOW MAXIMUM OVER THE LAST k STATES)
+    //       dp[i] = nums[i] + max(dp[i-k] ... dp[i-1])
+    //       the naive max scan is O(N*k); instead keep a deque of indices whose dp
+    //       values are DECREASING:
+    //         - the front is the best reachable predecessor; pop it once it falls
+    //           out of the window (i - front > k)
+    //         - before pushing i, pop every tail with dp <= dp[i]: such a tail is
+    //           both older AND worse, so it can never be the window max again
+    //       NOTE: values may be negative, so we cannot greedily jump onto the max -
+    //             every landing spot's score is forced, which makes this a DP.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int maxResult(int[] nums, int k) {
+        int n = nums.length;
+        int[] dp = new int[n];
+        dp[0] = nums[0];
+
+        // ring-free array deque of indices
+        int[] dq = new int[n];
+        int head = 0;
+        int tail = 0;
+        dq[tail++] = 0;
+
+        for (int i = 1; i < n; i++) {
+            while (head < tail && i - dq[head] > k) {
+                head++;
+            }
+            dp[i] = nums[i] + dp[dq[head]];
+            while (head < tail && dp[dq[tail - 1]] <= dp[i]) {
+                tail--;
+            }
+            dq[tail++] = i;
+        }
+        return dp[n - 1];
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Queue/MaxValueOfEquation.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Queue/MaxValueOfEquation.java
@@ -1,0 +1,85 @@
+package LeetCodeJava.Queue;
+
+// https://leetcode.com/problems/max-value-of-equation/
+
+/**
+ *  1499. Max Value of Equation
+ *  Hard
+ *
+ *  You are given an array points containing the coordinates of points on a 2D
+ *  plane, sorted by the x-values, where points[i] = [xi, yi] such that xi < xj
+ *  for all 1 <= i < j <= points.length. You are also given an integer k.
+ *
+ *  Return the maximum value of the equation yi + yj + |xi - xj| where
+ *  |xi - xj| <= k and 1 <= i < j <= points.length.
+ *
+ *  It is guaranteed that there exists at least one pair of points that satisfy
+ *  the constraint |xi - xj| <= k.
+ *
+ *  Example 1:
+ *    Input: points = [[1,3],[2,0],[5,10],[6,-10]], k = 1
+ *    Output: 4
+ *    Explanation: The first two points satisfy |xi - xj| <= 1 and give
+ *                 3 + 0 + |1 - 2| = 4. The third and fourth points give
+ *                 10 + -10 + |5 - 6| = 1. So the answer is max(4, 1) = 4.
+ *
+ *  Example 2:
+ *    Input: points = [[0,0],[3,0],[9,2]], k = 3
+ *    Output: 3
+ *    Explanation: Only the first two points are within k in x, giving
+ *                 0 + 0 + |0 - 3| = 3.
+ *
+ *  Constraints:
+ *    2 <= points.length <= 10^5
+ *    points[i].length == 2
+ *    -10^8 <= xi, yi <= 10^8
+ *    0 <= k <= 2 * 10^8
+ *    xi < xj for all 1 <= i < j <= points.length
+ */
+public class MaxValueOfEquation {
+
+    // V0
+    // IDEA: MONOTONIC DEQUE (SLIDING WINDOW MAXIMUM)
+    //       x is strictly increasing, so for i < j we have xi < xj and therefore
+    //           yi + yj + |xi - xj| = (yi - xi) + (yj + xj)
+    //       -> fix j and maximize (yi - xi) over all i < j with xj - xi <= k
+    //       -> classic sliding window maximum: keep a deque of candidate i,
+    //          decreasing in (y - x), popping the front once it leaves the window.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int findMaxValueOfEquation(int[][] points, int k) {
+        int n = points.length;
+        // deque of indices, decreasing on (y - x)
+        int[] dq = new int[n];
+        int head = 0;
+        int tail = 0;
+        long res = Long.MIN_VALUE;
+
+        for (int j = 0; j < n; j++) {
+            int x = points[j][0];
+            int y = points[j][1];
+
+            // NOTE !!! drop the candidates that are too far away (x - xi > k)
+            while (head < tail && (long) x - points[dq[head]][0] > k) {
+                head++;
+            }
+            if (head < tail) {
+                int i = dq[head];
+                long cand = (long) y + x + (points[i][1] - (long) points[i][0]);
+                if (cand > res) {
+                    res = cand;
+                }
+            }
+
+            // NOTE !!! keep the deque decreasing on (y - x)
+            while (head < tail
+                    && points[dq[tail - 1]][1] - (long) points[dq[tail - 1]][0] <= y - (long) x) {
+                tail--;
+            }
+            dq[tail++] = j;
+        }
+        return (int) res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Queue/MaximumNumberOfRobotsWithinBudget.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Queue/MaximumNumberOfRobotsWithinBudget.java
@@ -1,0 +1,86 @@
+package LeetCodeJava.Queue;
+
+// https://leetcode.com/problems/maximum-number-of-robots-within-budget/
+
+/**
+ *  2398. Maximum Number of Robots Within Budget
+ *  Hard
+ *
+ *  You have n robots. You are given two 0-indexed integer arrays, chargeTimes and
+ *  runningCosts, both of length n. The ith robot costs chargeTimes[i] units to
+ *  charge and costs runningCosts[i] units to run. You are also given an integer
+ *  budget.
+ *
+ *  The total cost of running k chosen robots is equal to
+ *  max(chargeTimes) + k * sum(runningCosts), where max(chargeTimes) is the largest
+ *  charge cost among the k robots and sum(runningCosts) is the sum of running
+ *  costs among the k robots.
+ *
+ *  Return the maximum number of consecutive robots you can run such that the total
+ *  cost does not exceed budget.
+ *
+ *  Example 1:
+ *    Input: chargeTimes = [3,6,1,3,4], runningCosts = [2,1,3,4,5], budget = 25
+ *    Output: 3
+ *    Explanation: For the first 3 robots the total cost is
+ *                 max(3,6,1) + 3 * sum(2,1,3) = 6 + 3 * 6 = 24 <= 25.
+ *
+ *  Example 2:
+ *    Input: chargeTimes = [11,12,19], runningCosts = [10,8,7], budget = 19
+ *    Output: 0
+ *    Explanation: No robot can be run without exceeding the budget.
+ *
+ *  Constraints:
+ *    chargeTimes.length == runningCosts.length == n
+ *    1 <= n <= 5 * 10^4
+ *    1 <= chargeTimes[i], runningCosts[i] <= 10^5
+ *    1 <= budget <= 10^15
+ */
+public class MaximumNumberOfRobotsWithinBudget {
+
+    // V0
+    // IDEA: SLIDING WINDOW + MONOTONIC (DECREASING) DEQUE
+    //       cost(l..r) = max(chargeTimes[l..r]) + (r-l+1) * sum(runningCosts[l..r])
+    //       both terms only GROW when the window grows, so feasibility is monotonic
+    //       in the window -> a two pointer window works.
+    //       the only tricky part is max() over a window that shrinks from the left:
+    //       keep a deque of indices whose chargeTimes are decreasing, so the front
+    //       is always the window maximum.
+    //       NOTE: when advancing `l`, pop the deque front FIRST if it equals the
+    //             old `l`, otherwise the max keeps pointing at an evicted item.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int maximumRobots(int[] chargeTimes, int[] runningCosts, long budget) {
+        int n = chargeTimes.length;
+        int[] dq = new int[n];
+        int head = 0;
+        int tail = 0;
+
+        int res = 0;
+        long sum = 0;
+        int l = 0;
+
+        for (int r = 0; r < n; r++) {
+            sum += runningCosts[r];
+            while (head < tail && chargeTimes[dq[tail - 1]] <= chargeTimes[r]) {
+                tail--;
+            }
+            dq[tail++] = r;
+
+            while (head < tail
+                    && chargeTimes[dq[head]] + (long) (r - l + 1) * sum > budget) {
+                if (dq[head] == l) {
+                    head++;
+                }
+                sum -= runningCosts[l];
+                l++;
+            }
+            if (r - l + 1 > res) {
+                res = r - l + 1;
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Recursion/BeautifulPairs.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Recursion/BeautifulPairs.java
@@ -1,0 +1,192 @@
+package LeetCodeJava.Recursion;
+
+// https://leetcode.com/problems/beautiful-pairs/
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  2613. Beautiful Pairs
+ *  Hard
+ *
+ *  You are given two 0-indexed integer arrays nums1 and nums2 of the same length.
+ *  A pair of indices (i,j) is called beautiful if
+ *  |nums1[i] - nums1[j]| + |nums2[i] - nums2[j]| is the smallest amongst all
+ *  possible indices pairs where i < j.
+ *
+ *  Return the beautiful pair. In the case that there are multiple beautiful pairs,
+ *  return the lexicographically smallest pair.
+ *
+ *  Note that
+ *   - |x| denotes the absolute value of x.
+ *   - A pair of indices (i1, j1) is lexicographically smaller than (i2, j2)
+ *     if i1 < i2 or i1 == i2 and j1 < j2.
+ *
+ *  Example 1:
+ *    Input: nums1 = [1,2,3,2,4], nums2 = [2,3,1,2,3]
+ *    Output: [0,3]
+ *    Explanation: Consider index 0 and index 3. The value of
+ *                 |nums1[i]-nums1[j]| + |nums2[i]-nums2[j]| is 1, which is the
+ *                 smallest value we can achieve.
+ *
+ *  Example 2:
+ *    Input: nums1 = [1,2,4,3,2,5], nums2 = [1,4,2,3,5,1]
+ *    Output: [1,4]
+ *    Explanation: Consider index 1 and index 4. The value of
+ *                 |nums1[i]-nums1[j]| + |nums2[i]-nums2[j]| is 1.
+ *
+ *  Constraints:
+ *    2 <= nums1.length, nums2.length <= 10^5
+ *    nums1.length == nums2.length
+ *    0 <= nums1[i] <= nums1.length
+ *    0 <= nums2[i] <= nums2.length
+ */
+public class BeautifulPairs {
+
+    // points sorted by x (then y, then original index); pts[k] = {x, y, idx}
+    private int[][] pts;
+
+    // V0
+    // IDEA: CLOSEST PAIR OF POINTS (DIVIDE & CONQUER) UNDER THE MANHATTAN METRIC
+    //       read (nums1[i], nums2[i]) as a 2D point -> the score of a pair is its
+    //       L1 distance, so we want the CLOSEST PAIR. the classic divide & conquer
+    //       works for L1 exactly as it does for L2.
+    //
+    //       1) DUPLICATES FIRST. two identical points have distance 0, which no
+    //          other pair can beat. the group with the SMALLEST first index gives
+    //          the lexicographically smallest such pair -> return it right away.
+    //          this also makes every remaining point DISTINCT, so all recursive
+    //          distances are >= 1 (never 0), which keeps the strip step bounded.
+    //
+    //       2) sort by x, split at the middle index, solve both halves and let d
+    //          be the better of the two. any CROSS pair beating d must have both
+    //          endpoints inside the vertical STRIP |x - xMid| <= d; sort that
+    //          strip by y and, per point, only compare forward while the y gap
+    //          stays <= d (a constant number of them, by a packing argument).
+    //
+    //       NOTE: the candidate is carried as the triple (dist, i, j) with i < j,
+    //             so plain lexicographic comparison of the triple gives exactly
+    //             the required tie break (smallest distance, then smallest pair).
+    //       NOTE: the strip bounds use "<=" and not "<" on purpose - with "<" we
+    //             would prune pairs that TIE with the current best, and a tying
+    //             pair may still be lexicographically smaller.
+    /**
+     * time = O(N * log(N)^2)
+     * space = O(N)
+     */
+    public int[] beautifulPair(int[] nums1, int[] nums2) {
+        int n = nums1.length;
+
+        // ---- 1) identical points -> distance 0, answer is immediate
+        // key -> {firstIdx, secondIdx}, secondIdx = -1 while the point is unique
+        Map<Long, int[]> seen = new HashMap<>();
+        long base = n + 1L;
+        for (int i = 0; i < n; i++) {
+            long key = nums1[i] * base + nums2[i];
+            int[] slot = seen.get(key);
+            if (slot == null) {
+                seen.put(key, new int[]{i, -1});
+            } else if (slot[1] == -1) {
+                slot[1] = i;
+            }
+        }
+        int dupFirst = -1;
+        int dupSecond = -1;
+        for (int[] slot : seen.values()) {
+            if (slot[1] != -1 && (dupFirst == -1 || slot[0] < dupFirst)) {
+                dupFirst = slot[0];
+                dupSecond = slot[1];
+            }
+        }
+        if (dupFirst != -1) {
+            return new int[]{dupFirst, dupSecond};
+        }
+
+        // ---- 2) divide & conquer on the distinct points
+        this.pts = new int[n][3];
+        for (int i = 0; i < n; i++) {
+            pts[i][0] = nums1[i];
+            pts[i][1] = nums2[i];
+            pts[i][2] = i;
+        }
+        Arrays.sort(pts, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] a, int[] b) {
+                if (a[0] != b[0]) {
+                    return Integer.compare(a[0], b[0]);
+                }
+                if (a[1] != b[1]) {
+                    return Integer.compare(a[1], b[1]);
+                }
+                return Integer.compare(a[2], b[2]);
+            }
+        });
+
+        long[] best = solve(0, n);
+        return new int[]{(int) best[1], (int) best[2]};
+    }
+
+    // returns {dist, i, j} for the closest pair inside pts[lo, hi)
+    private long[] solve(int lo, int hi) {
+        if (hi - lo < 2) {
+            return new long[]{Long.MAX_VALUE, -1, -1};
+        }
+        int mid = (lo + hi) / 2;
+        long xMid = pts[mid][0];
+
+        long[] left = solve(lo, mid);
+        long[] right = solve(mid, hi);
+        long[] best = better(left, right);
+        long d = best[0];
+
+        List<int[]> strip = new ArrayList<>();
+        for (int p = lo; p < hi; p++) {
+            if (Math.abs(pts[p][0] - xMid) <= d) {
+                strip.add(pts[p]);
+            }
+        }
+        Collections.sort(strip, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] a, int[] b) {
+                return Integer.compare(a[1], b[1]);
+            }
+        });
+
+        for (int a = 0; a < strip.size(); a++) {
+            int[] pa = strip.get(a);
+            for (int b = a + 1; b < strip.size(); b++) {
+                int[] pb = strip.get(b);
+                if (pb[1] - pa[1] > d) {
+                    break;
+                }
+                long dist = Math.abs(pa[0] - pb[0]) + Math.abs(pa[1] - pb[1]);
+                long[] cand = new long[]{
+                        dist,
+                        Math.min(pa[2], pb[2]),
+                        Math.max(pa[2], pb[2])
+                };
+                if (better(cand, best) == cand) {
+                    best = cand;
+                    d = best[0];
+                }
+            }
+        }
+        return best;
+    }
+
+    // lexicographic compare on (dist, i, j); returns the winner (a on a tie)
+    private long[] better(long[] a, long[] b) {
+        if (a[0] != b[0]) {
+            return a[0] < b[0] ? a : b;
+        }
+        if (a[1] != b[1]) {
+            return a[1] < b[1] ? a : b;
+        }
+        return a[2] <= b[2] ? a : b;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Recursion/ParsingABooleanExpression.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Recursion/ParsingABooleanExpression.java
@@ -1,0 +1,143 @@
+package LeetCodeJava.Recursion;
+
+// https://leetcode.com/problems/parsing-a-boolean-expression/
+
+/**
+ *  1106. Parsing A Boolean Expression
+ *  Hard
+ *
+ *  A boolean expression is an expression that evaluates to either true or false.
+ *  It can be in one of the following shapes:
+ *   - 't' that evaluates to true.
+ *   - 'f' that evaluates to false.
+ *   - '!(subExpr)' that evaluates to the logical NOT of the inner expression subExpr.
+ *   - '&(subExpr1, subExpr2, ..., subExprn)' that evaluates to the logical AND of
+ *     the inner expressions subExpr1 ... subExprn where n >= 1.
+ *   - '|(subExpr1, subExpr2, ..., subExprn)' that evaluates to the logical OR of
+ *     the inner expressions subExpr1 ... subExprn where n >= 1.
+ *
+ *  Given a string expression that represents a boolean expression, return the
+ *  evaluation of that expression.
+ *
+ *  It is guaranteed that the given expression is valid and follows the given rules.
+ *
+ *  Example 1:
+ *    Input: expression = "&(|(f))"
+ *    Output: false
+ *    Explanation: First, evaluate |(f) --> f. The expression is now "&(f)".
+ *                 Then, evaluate &(f) --> f. Finally, return false.
+ *
+ *  Example 2:
+ *    Input: expression = "|(f,f,f,t)"
+ *    Output: true
+ *    Explanation: The evaluation of (false OR false OR false OR true) is true.
+ *
+ *  Example 3:
+ *    Input: expression = "!(&(f,t))"
+ *    Output: true
+ *
+ *  Constraints:
+ *    1 <= expression.length <= 2 * 10^4
+ *    expression[i] is one of the characters: '(', ')', '&', '|', '!', 't', 'f', ','
+ */
+public class ParsingABooleanExpression {
+
+    // V0
+    // IDEA: STACK - EVALUATE THE INNER MOST GROUP ON EVERY ')'
+    //       push 't' / 'f' / operators on a stack. on ')' pop the boolean literals
+    //       of the current group while counting true / false, pop the operator, and
+    //       push back the single resulting literal.
+    //       '(' and ',' are pure separators -> ignored.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public boolean parseBoolExpr(String expression) {
+        int n = expression.length();
+        char[] stack = new char[n];
+        int top = 0;
+
+        for (int idx = 0; idx < n; idx++) {
+            char c = expression.charAt(idx);
+            if (c == 't' || c == 'f' || c == '!' || c == '&' || c == '|') {
+                stack[top++] = c;
+            } else if (c == ')') {
+                int trueCnt = 0;
+                int falseCnt = 0;
+                // NOTE !!! drain ALL literals of the current group
+                while (top > 0 && (stack[top - 1] == 't' || stack[top - 1] == 'f')) {
+                    if (stack[--top] == 't') {
+                        trueCnt++;
+                    } else {
+                        falseCnt++;
+                    }
+                }
+                char op = stack[--top];
+                char res;
+                if (op == '!') {
+                    res = falseCnt > 0 ? 't' : 'f';
+                } else if (op == '&') {
+                    res = falseCnt > 0 ? 'f' : 't';
+                } else { // op == '|'
+                    res = trueCnt > 0 ? 't' : 'f';
+                }
+                stack[top++] = res;
+            }
+            // '(' and ',' -> skip
+        }
+
+        return stack[top - 1] == 't';
+    }
+
+    // V1
+    // IDEA: RECURSIVE DESCENT PARSER (SHARED INDEX POINTER)
+    //       parse() consumes exactly ONE sub expression starting at `pos` and
+    //       returns its value; the operator's operand list is read until ')'.
+    /**
+     * time = O(N)
+     * space = O(N)   // recursion depth = nesting depth
+     */
+    private int pos;
+    private String src;
+
+    public boolean parseBoolExpr_1(String expression) {
+        this.pos = 0;
+        this.src = expression;
+        return parse();
+    }
+
+    private boolean parse() {
+        char c = src.charAt(pos++);
+        if (c == 't') {
+            return true;
+        }
+        if (c == 'f') {
+            return false;
+        }
+
+        // c is one of '!' / '&' / '|'  -> the next char is '('
+        pos++; // skip '('
+        boolean anyTrue = false;
+        boolean anyFalse = false;
+        while (src.charAt(pos) != ')') {
+            if (src.charAt(pos) == ',') {
+                pos++;
+                continue;
+            }
+            if (parse()) {
+                anyTrue = true;
+            } else {
+                anyFalse = true;
+            }
+        }
+        pos++; // skip ')'
+
+        if (c == '!') {
+            return anyFalse;
+        }
+        if (c == '&') {
+            return !anyFalse;
+        }
+        return anyTrue;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/AlternatingGroupsII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/AlternatingGroupsII.java
@@ -1,0 +1,71 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/alternating-groups-ii/
+
+/**
+ *  3208. Alternating Groups II
+ *  Medium
+ *
+ *  There is a circle of red and blue tiles. You are given an array of integers
+ *  colors and an integer k. The color of tile i is represented by colors[i]:
+ *
+ *   - colors[i] == 0 means that tile i is red.
+ *   - colors[i] == 1 means that tile i is blue.
+ *
+ *  An alternating group is every k contiguous tiles in the circle with
+ *  alternating colors (each tile in the group except the first and last one has
+ *  a different color from its left and right tiles).
+ *
+ *  Return the number of alternating groups.
+ *
+ *  Note that since colors represents a circle, the first and the last tiles are
+ *  considered to be next to each other.
+ *
+ *  Example 1:
+ *    Input: colors = [0,1,0,1,0], k = 3
+ *    Output: 3
+ *
+ *  Example 2:
+ *    Input: colors = [0,1,0,0,1,0,1], k = 6
+ *    Output: 2
+ *
+ *  Example 3:
+ *    Input: colors = [1,1,0,1], k = 4
+ *    Output: 0
+ *
+ *  Constraints:
+ *    3 <= colors.length <= 10^5
+ *    0 <= colors[i] <= 1
+ *    3 <= k <= colors.length
+ */
+public class AlternatingGroupsII {
+
+    // V0
+    // IDEA: TRACK THE CURRENT ALTERNATING RUN LENGTH AROUND THE CIRCLE
+    //       a window of k tiles is a group exactly when every adjacent pair
+    //       inside it differs. so walk the circle keeping `run` = how many
+    //       tiles the current alternating stretch covers, resetting to 1
+    //       whenever two neighbours match. every position where run reaches k
+    //       closes one group.
+    //       the wrap-around is handled by walking n + k - 1 steps (indices
+    //       taken modulo n), which lets a run starting near the end finish at
+    //       the front without double counting.
+    /**
+     * time = O(N + K)
+     * space = O(1)
+     */
+    public int numberOfAlternatingGroups(int[] colors, int k) {
+        int n = colors.length;
+        int res = 0;
+        int run = 1;
+        for (int t = 1; t < n + k - 1; t++) {
+            int i = t % n;
+            int prev = (t - 1) % n;
+            run = (colors[i] != colors[prev]) ? run + 1 : 1;
+            if (run >= k) {
+                res++;
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountOfSubstringsContainingEveryVowelAndKConsonantsI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountOfSubstringsContainingEveryVowelAndKConsonantsI.java
@@ -1,0 +1,96 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-of-substrings-containing-every-vowel-and-k-consonants-i/
+
+/**
+ *  3305. Count of Substrings Containing Every Vowel and K Consonants I
+ *  Medium
+ *
+ *  You are given a string word and a non-negative integer k.
+ *
+ *  Return the total number of substrings of word that contain every vowel
+ *  ('a', 'e', 'i', 'o', and 'u') at least once and exactly k consonants.
+ *
+ *  Example 1:
+ *    Input: word = "aeioqq", k = 1
+ *    Output: 0
+ *    Explanation: There is no substring with every vowel.
+ *
+ *  Example 2:
+ *    Input: word = "aeiou", k = 0
+ *    Output: 1
+ *    Explanation: The only substring with every vowel and zero consonants is
+ *                 word[0..4], which is "aeiou".
+ *
+ *  Example 3:
+ *    Input: word = "ieaouqqieaouqq", k = 1
+ *    Output: 3
+ *
+ *  Constraints:
+ *    5 <= word.length <= 250
+ *    word consists only of lowercase English letters.
+ *    0 <= k <= word.length - 5
+ */
+public class CountOfSubstringsContainingEveryVowelAndKConsonantsI {
+
+    // V0
+    // IDEA: "EXACTLY k" = "AT LEAST k" MINUS "AT LEAST k+1"
+    //       an exact-count condition is awkward for a sliding window, but an
+    //       at-least condition is monotone: growing a substring never loses a
+    //       vowel or a consonant. so count the substrings with all five vowels
+    //       and at least k consonants, do the same for k+1, and subtract.
+    //       for the at-least count, extend the right end and shrink the left
+    //       while the window still qualifies; every start before that point
+    //       also qualifies, contributing `left` substrings ending here.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int countOfSubstrings(String word, int k) {
+        return atLeast(word, k) - atLeast(word, k + 1);
+    }
+
+    private int atLeast(String word, int need) {
+        int[] cnt = new int[5];
+        int distinct = 0;
+        int cons = 0;
+        int left = 0;
+        int res = 0;
+        for (int right = 0; right < word.length(); right++) {
+            int v = vowelIdx(word.charAt(right));
+            if (v < 0) {
+                cons++;
+            } else {
+                if (cnt[v] == 0) {
+                    distinct++;
+                }
+                cnt[v]++;
+            }
+            while (distinct == 5 && cons >= need) {
+                int d = vowelIdx(word.charAt(left));
+                if (d < 0) {
+                    cons--;
+                } else {
+                    cnt[d]--;
+                    if (cnt[d] == 0) {
+                        distinct--;
+                    }
+                }
+                left++;
+            }
+            res += left; // starts 0 .. left-1 all work for this right end
+        }
+        return res;
+    }
+
+    private int vowelIdx(char c) {
+        switch (c) {
+            case 'a': return 0;
+            case 'e': return 1;
+            case 'i': return 2;
+            case 'o': return 3;
+            case 'u': return 4;
+            default: return -1;
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountOfSubstringsContainingEveryVowelAndKConsonantsII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountOfSubstringsContainingEveryVowelAndKConsonantsII.java
@@ -1,0 +1,93 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-of-substrings-containing-every-vowel-and-k-consonants-ii/
+
+/**
+ *  3306. Count of Substrings Containing Every Vowel and K Consonants II
+ *  Medium
+ *
+ *  You are given a string word and a non-negative integer k.
+ *
+ *  Return the total number of substrings of word that contain every vowel
+ *  ('a', 'e', 'i', 'o', and 'u') at least once and exactly k consonants.
+ *
+ *  Example 1:
+ *    Input: word = "aeioqq", k = 1
+ *    Output: 0
+ *    Explanation: There is no substring with every vowel.
+ *
+ *  Example 2:
+ *    Input: word = "aeiou", k = 0
+ *    Output: 1
+ *
+ *  Example 3:
+ *    Input: word = "ieaouqqieaouqq", k = 1
+ *    Output: 3
+ *
+ *  Constraints:
+ *    5 <= word.length <= 2 * 10^5
+ *    word consists only of lowercase English letters.
+ *    0 <= k <= word.length - 5
+ */
+public class CountOfSubstringsContainingEveryVowelAndKConsonantsII {
+
+    // V0
+    // IDEA: SAME "AT LEAST k MINUS AT LEAST k+1" TRICK, AT 2*10^5 SCALE
+    //       the exact-consonant requirement is not monotone, but "at least k"
+    //       is, so the answer is the difference of two sliding-window counts.
+    //       each pass extends the right end, shrinks the left while the window
+    //       still holds all five vowels and enough consonants, and adds `left`
+    //       — the number of valid starts for that right end.
+    //       this is LC 3305 with a larger input, so the count needs long.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public long countOfSubstrings(String word, int k) {
+        return atLeast(word, k) - atLeast(word, k + 1);
+    }
+
+    private long atLeast(String word, int need) {
+        int[] cnt = new int[5];
+        int distinct = 0;
+        int cons = 0;
+        int left = 0;
+        long res = 0L;
+        for (int right = 0; right < word.length(); right++) {
+            int v = vowelIdx(word.charAt(right));
+            if (v < 0) {
+                cons++;
+            } else {
+                if (cnt[v] == 0) {
+                    distinct++;
+                }
+                cnt[v]++;
+            }
+            while (distinct == 5 && cons >= need) {
+                int d = vowelIdx(word.charAt(left));
+                if (d < 0) {
+                    cons--;
+                } else {
+                    cnt[d]--;
+                    if (cnt[d] == 0) {
+                        distinct--;
+                    }
+                }
+                left++;
+            }
+            res += left;
+        }
+        return res;
+    }
+
+    private int vowelIdx(char c) {
+        switch (c) {
+            case 'a': return 0;
+            case 'e': return 1;
+            case 'i': return 2;
+            case 'o': return 3;
+            case 'u': return 4;
+            default: return -1;
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountPrimeGapBalancedSubarrays.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountPrimeGapBalancedSubarrays.java
@@ -1,0 +1,107 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-prime-gap-balanced-subarrays/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  3589. Count Prime-Gap Balanced Subarrays
+ *  Medium
+ *
+ *  You are given an integer array nums and an integer k.
+ *
+ *  Call a subarray prime-gap balanced if:
+ *   - It contains at least two prime numbers, and
+ *   - The difference between the maximum and minimum prime numbers in that
+ *     subarray is less than or equal to k.
+ *
+ *  Return the count of prime-gap balanced subarrays in nums.
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,3], k = 1
+ *    Output: 2
+ *    Explanation: [2,3] and [1,2,3] both hold two primes with max - min = 1.
+ *
+ *  Example 2:
+ *    Input: nums = [2,3,5,7], k = 3
+ *    Output: 4
+ *    Explanation: [2,3], [2,3,5], [3,5] and [5,7] qualify.
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 5 * 10^4
+ *    1 <= nums[i] <= 5 * 10^4
+ *    0 <= k <= 5 * 10^4
+ */
+public class CountPrimeGapBalancedSubarrays {
+
+    // V0
+    // IDEA: TWO OPPOSING BOUNDS ON THE LEFT ENDPOINT, PER RIGHT ENDPOINT
+    //       fix the right end r. shrinking the window from the left can only
+    //       remove primes, so "max prime - min prime <= k" holds for every
+    //       left >= some threshold L (monotone, maintained by two monotonic
+    //       deques over prime indices). the "at least two primes" condition
+    //       holds for every left <= the index of the second-to-last prime.
+    //       so the valid lefts are exactly [L, secondLastPrimeIdx] and the
+    //       count is its size — no inner loop needed.
+    /**
+     * time = O(N + M log log M)   // M = max(nums), sieve
+     * space = O(N + M)
+     */
+    public int primeSubarray(int[] nums, int k) {
+        int n = nums.length;
+        int mx = 0;
+        for (int v : nums) {
+            mx = Math.max(mx, v);
+        }
+        boolean[] isPrime = new boolean[mx + 1];
+        for (int i = 2; i <= mx; i++) {
+            isPrime[i] = true;
+        }
+        for (int i = 2; (long) i * i <= mx; i++) {
+            if (isPrime[i]) {
+                for (int j = i * i; j <= mx; j += i) {
+                    isPrime[j] = false;
+                }
+            }
+        }
+
+        Deque<Integer> maxq = new ArrayDeque<>(); // decreasing values
+        Deque<Integer> minq = new ArrayDeque<>(); // increasing values
+        int[] primeIdx = new int[n];
+        int primeCnt = 0;
+        int left = 0;
+        long ans = 0L;
+
+        for (int r = 0; r < n; r++) {
+            int v = nums[r];
+            if (v <= mx && isPrime[v]) {
+                while (!maxq.isEmpty() && nums[maxq.peekLast()] <= v) {
+                    maxq.pollLast();
+                }
+                maxq.addLast(r);
+                while (!minq.isEmpty() && nums[minq.peekLast()] >= v) {
+                    minq.pollLast();
+                }
+                minq.addLast(r);
+                primeIdx[primeCnt++] = r;
+            }
+            while (!maxq.isEmpty() && nums[maxq.peekFirst()] - nums[minq.peekFirst()] > k) {
+                if (maxq.peekFirst() == left) {
+                    maxq.pollFirst();
+                }
+                if (!minq.isEmpty() && minq.peekFirst() == left) {
+                    minq.pollFirst();
+                }
+                left++;
+            }
+            if (primeCnt >= 2) {
+                int hi = primeIdx[primeCnt - 2];
+                if (hi >= left) {
+                    ans += hi - left + 1;
+                }
+            }
+        }
+        return (int) ans;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsThatCanBeRearrangedToContainAStringI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsThatCanBeRearrangedToContainAStringI.java
@@ -1,0 +1,83 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-substrings-that-can-be-rearranged-to-contain-a-string-i/
+
+/**
+ *  3297. Count Substrings That Can Be Rearranged to Contain a String I
+ *  Medium
+ *
+ *  You are given two strings word1 and word2.
+ *
+ *  A string x is called valid if x can be rearranged to have word2 as a prefix.
+ *
+ *  Return the total number of valid substrings of word1.
+ *
+ *  Example 1:
+ *    Input: word1 = "bcca", word2 = "abc"
+ *    Output: 1
+ *    Explanation: The only valid substring is "bcca", which can be rearranged
+ *                 to "abcc" having "abc" as a prefix.
+ *
+ *  Example 2:
+ *    Input: word1 = "abcabc", word2 = "abc"
+ *    Output: 10
+ *    Explanation: All substrings except those of size 1 and 2 are valid.
+ *
+ *  Example 3:
+ *    Input: word1 = "abcabc", word2 = "aaabc"
+ *    Output: 0
+ *
+ *  Constraints:
+ *    1 <= word1.length <= 10^5
+ *    1 <= word2.length <= 10^4
+ *    word1 and word2 consist only of lowercase English letters.
+ */
+public class CountSubstringsThatCanBeRearrangedToContainAStringI {
+
+    // V0
+    // IDEA: "REARRANGEABLE TO HAVE word2 AS A PREFIX" == COVERS ITS LETTER COUNTS
+    //       the substring may be shuffled freely, so it qualifies exactly when
+    //       it holds at least as many of every letter as word2 does — the
+    //       leftovers go after the prefix. that condition only gets easier as
+    //       the substring grows, so a sliding window is exact: for each right
+    //       end push `left` past every start whose window still covers word2,
+    //       then the starts 0 .. left-1 are exactly the valid ones.
+    //       tracking how many letters are still SHORT keeps the check O(1).
+    /**
+     * time = O(N + M)
+     * space = O(1)   // 26 counters
+     */
+    public long validSubstringCount(String word1, String word2) {
+        int[] need = new int[26];
+        for (int i = 0; i < word2.length(); i++) {
+            need[word2.charAt(i) - 'a']++;
+        }
+        int missing = 0;
+        for (int c = 0; c < 26; c++) {
+            if (need[c] > 0) {
+                missing++;
+            }
+        }
+
+        int[] have = new int[26];
+        int left = 0;
+        long res = 0L;
+        for (int right = 0; right < word1.length(); right++) {
+            int c = word1.charAt(right) - 'a';
+            have[c]++;
+            if (have[c] == need[c]) {
+                missing--;
+            }
+            while (missing == 0) {
+                int d = word1.charAt(left) - 'a';
+                have[d]--;
+                if (have[d] == need[d] - 1) {
+                    missing++;
+                }
+                left++;
+            }
+            res += left;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsThatCanBeRearrangedToContainAStringII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsThatCanBeRearrangedToContainAStringII.java
@@ -1,0 +1,84 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-substrings-that-can-be-rearranged-to-contain-a-string-ii/
+
+/**
+ *  3298. Count Substrings That Can Be Rearranged to Contain a String II
+ *  Hard
+ *
+ *  You are given two strings word1 and word2.
+ *
+ *  A string x is called valid if x can be rearranged to have word2 as a prefix.
+ *
+ *  Return the total number of valid substrings of word1.
+ *
+ *  Note that the memory limits in this problem are smaller than usual, so you
+ *  must implement a solution with a linear runtime complexity.
+ *
+ *  Example 1:
+ *    Input: word1 = "bcca", word2 = "abc"
+ *    Output: 1
+ *
+ *  Example 2:
+ *    Input: word1 = "abcabc", word2 = "abc"
+ *    Output: 10
+ *
+ *  Example 3:
+ *    Input: word1 = "abcabc", word2 = "aaabc"
+ *    Output: 0
+ *
+ *  Constraints:
+ *    1 <= word1.length <= 10^6
+ *    1 <= word2.length <= 10^4
+ *    word1 and word2 consist only of lowercase English letters.
+ */
+public class CountSubstringsThatCanBeRearrangedToContainAStringII {
+
+    // V0
+    // IDEA: SAME SLIDING WINDOW AS LC 3297 — IT WAS ALREADY LINEAR
+    //       a substring is valid iff it holds at least as many of every letter
+    //       as word2 (the surplus sits after the prefix once rearranged), and
+    //       that property is monotone in the window, so two pointers apply.
+    //       for each right end advance `left` while the window still covers
+    //       word2; the starts 0 .. left-1 are the valid ones, contributing
+    //       `left`. the only thing this sequel changes is the scale (10^6 with
+    //       a tighter memory limit), so the state stays two 26-entry arrays
+    //       plus a counter of still-short letters, each char visited twice.
+    /**
+     * time = O(N + M)
+     * space = O(1)   // 26 counters
+     */
+    public long validSubstringCount(String word1, String word2) {
+        int[] need = new int[26];
+        for (int i = 0; i < word2.length(); i++) {
+            need[word2.charAt(i) - 'a']++;
+        }
+        int missing = 0;
+        for (int c = 0; c < 26; c++) {
+            if (need[c] > 0) {
+                missing++;
+            }
+        }
+
+        int[] have = new int[26];
+        int left = 0;
+        long res = 0L;
+        for (int right = 0; right < word1.length(); right++) {
+            int c = word1.charAt(right) - 'a';
+            have[c]++;
+            if (have[c] == need[c]) {
+                missing--;
+            }
+            while (missing == 0) {
+                int d = word1.charAt(left) - 'a';
+                have[d]--;
+                if (have[d] == need[d] - 1) {
+                    missing++;
+                }
+                left++;
+            }
+            res += left;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsThatSatisfyKConstraintI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsThatSatisfyKConstraintI.java
@@ -1,0 +1,74 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-substrings-that-satisfy-k-constraint-i/
+
+/**
+ *  3258. Count Substrings That Satisfy K-Constraint I
+ *  Easy
+ *
+ *  You are given a binary string s and an integer k.
+ *
+ *  A binary string satisfies the k-constraint if either of the following holds:
+ *   - The number of 0's in the string is at most k.
+ *   - The number of 1's in the string is at most k.
+ *
+ *  Return an integer denoting the number of substrings of s that satisfy the
+ *  k-constraint.
+ *
+ *  Example 1:
+ *    Input: s = "10101", k = 1
+ *    Output: 12
+ *    Explanation: Every substring except "1010", "10101" and "0101" satisfies
+ *                 the k-constraint.
+ *
+ *  Example 2:
+ *    Input: s = "1010101", k = 2
+ *    Output: 25
+ *    Explanation: Every substring of length at most 5 satisfies it.
+ *
+ *  Example 3:
+ *    Input: s = "11111", k = 1
+ *    Output: 15
+ *
+ *  Constraints:
+ *    1 <= s.length <= 50
+ *    1 <= k <= s.length
+ *    s[i] is either '0' or '1'.
+ */
+public class CountSubstringsThatSatisfyKConstraintI {
+
+    // V0
+    // IDEA: SLIDING WINDOW — THE CONSTRAINT IS MONOTONE IN THE WINDOW SIZE
+    //       growing a substring can only raise both counts, so once a window
+    //       breaks the rule every longer one with the same left end does too.
+    //       that makes a two-pointer sweep exact: extend the right end, and
+    //       shrink from the left until min(zeros, ones) <= k again. each right
+    //       end then contributes (right - left + 1) valid substrings.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int countKConstraintSubstrings(String s, int k) {
+        int zeros = 0;
+        int ones = 0;
+        int left = 0;
+        int res = 0;
+        for (int right = 0; right < s.length(); right++) {
+            if (s.charAt(right) == '0') {
+                zeros++;
+            } else {
+                ones++;
+            }
+            while (zeros > k && ones > k) {
+                if (s.charAt(left) == '0') {
+                    zeros--;
+                } else {
+                    ones--;
+                }
+                left++;
+            }
+            res += right - left + 1;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsWithKFrequencyCharactersI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountSubstringsWithKFrequencyCharactersI.java
@@ -1,0 +1,61 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-substrings-with-k-frequency-characters-i/
+
+/**
+ *  3325. Count Substrings With K-Frequency Characters I
+ *  Medium
+ *
+ *  Given a string s and an integer k, return the total number of substrings of
+ *  s where at least one character appears at least k times.
+ *
+ *  Example 1:
+ *    Input: s = "abacb", k = 2
+ *    Output: 4
+ *    Explanation: The valid substrings are "aba", "abac", "abacb" ('a' twice)
+ *                 and "bacb" ('b' twice).
+ *
+ *  Example 2:
+ *    Input: s = "abcde", k = 1
+ *    Output: 15
+ *    Explanation: All substrings are valid because every character appears at
+ *                 least once.
+ *
+ *  Constraints:
+ *    1 <= s.length <= 3000
+ *    1 <= k <= s.length
+ *    s consists only of lowercase English letters.
+ */
+public class CountSubstringsWithKFrequencyCharactersI {
+
+    // V0
+    // IDEA: SLIDING WINDOW — "SOME CHARACTER HITS k" ONLY GETS EASIER AS THE
+    //       WINDOW GROWS
+    //       a valid substring stays valid when extended, so for each right end
+    //       there is a threshold: every start at or before some index gives a
+    //       valid substring and every later start does not. so push `left`
+    //       forward while the window still has a character reaching k; the
+    //       count of valid substrings ending here is exactly `left`.
+    //       only the character just added can newly reach k, so the test is
+    //       a single array lookup.
+    /**
+     * time = O(N)
+     * space = O(1)   // 26 counters
+     */
+    public int numberOfSubstrings(String s, int k) {
+        int[] cnt = new int[26];
+        int left = 0;
+        int res = 0;
+        for (int right = 0; right < s.length(); right++) {
+            int c = s.charAt(right) - 'a';
+            cnt[c]++;
+            while (cnt[c] >= k) {
+                int d = s.charAt(left) - 'a';
+                cnt[d]--;
+                left++;
+            }
+            res += left;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountTheNumberOfSubstringsWithDominantOnes.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/CountTheNumberOfSubstringsWithDominantOnes.java
@@ -1,0 +1,86 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/count-the-number-of-substrings-with-dominant-ones/
+
+/**
+ *  3234. Count the Number of Substrings With Dominant Ones
+ *  Medium
+ *
+ *  You are given a binary string s.
+ *
+ *  Return the number of substrings with dominant ones.
+ *
+ *  A string has dominant ones if the number of ones in the string is greater
+ *  than or equal to the square of the number of zeros in the string.
+ *
+ *  Example 1:
+ *    Input: s = "00011"
+ *    Output: 5
+ *
+ *  Example 2:
+ *    Input: s = "101101"
+ *    Output: 16
+ *
+ *  Constraints:
+ *    1 <= s.length <= 4 * 10^4
+ *    s consists only of characters '0' and '1'.
+ */
+public class CountTheNumberOfSubstringsWithDominantOnes {
+
+    // V0
+    // IDEA: THE ZERO COUNT IS BOUNDED BY sqrt(N) — ENUMERATE IT
+    //       a substring with z zeros needs at least z^2 ones, so its length is
+    //       at least z^2 + z. with n <= 4*10^4 that caps z at about 200 — far
+    //       fewer possibilities than the O(N^2) substrings.
+    //       so for each start index walk the possible zero counts z. the
+    //       substrings holding exactly z zeros end in a contiguous window:
+    //       from the z-th zero at or after the start, up to just before the
+    //       (z+1)-th. intersecting that window with the length requirement
+    //           end >= start + z^2 + z - 1
+    //       gives the count for this (start, z) in O(1).
+    /**
+     * time = O(N * sqrt(N))
+     * space = O(N)
+     */
+    public int numberOfSubstrings(String s) {
+        int n = s.length();
+        int[] zeros = new int[n];
+        int zc = 0;
+        for (int i = 0; i < n; i++) {
+            if (s.charAt(i) == '0') {
+                zeros[zc++] = i;
+            }
+        }
+
+        long res = 0L;
+        int k = 0; // index into zeros of the first zero at or after `start`
+        for (int start = 0; start < n; start++) {
+            while (k < zc && zeros[k] < start) {
+                k++;
+            }
+            for (int z = 0; ; z++) {
+                if ((long) z * z + z > n) {
+                    break; // even the whole string is too short
+                }
+                int lo;
+                int hi;
+                if (z == 0) {
+                    lo = start;
+                    hi = (k < zc) ? zeros[k] - 1 : n - 1;
+                } else {
+                    if (k + z - 1 >= zc) {
+                        break; // not that many zeros left
+                    }
+                    lo = zeros[k + z - 1];
+                    hi = (k + z < zc) ? zeros[k + z] - 1 : n - 1;
+                }
+                int need = start + z * z + z - 1; // minimum end index
+                lo = Math.max(lo, need);
+                if (hi >= lo) {
+                    res += hi - lo + 1;
+                }
+            }
+        }
+        return (int) res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/FindThePowerOfKSizeSubarraysII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/FindThePowerOfKSizeSubarraysII.java
@@ -1,0 +1,69 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/find-the-power-of-k-size-subarrays-ii/
+
+/**
+ *  3255. Find the Power of K-Size Subarrays II
+ *  Medium
+ *
+ *  You are given an array of integers nums of length n and a positive integer k.
+ *
+ *  The power of an array is defined as:
+ *   - Its maximum element if all of its elements are consecutive and sorted in
+ *     ascending order.
+ *   - -1 otherwise.
+ *
+ *  You need to find the power of all subarrays of nums of size k.
+ *
+ *  Return an integer array results of size n - k + 1, where results[i] is the
+ *  power of nums[i..(i + k - 1)].
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,3,4,3,2,5], k = 3
+ *    Output: [3,4,-1,-1,-1]
+ *
+ *  Example 2:
+ *    Input: nums = [2,2,2,2,2], k = 4
+ *    Output: [-1,-1]
+ *
+ *  Example 3:
+ *    Input: nums = [3,2,3,2,3,2], k = 2
+ *    Output: [-1,3,-1,3,-1]
+ *
+ *  Constraints:
+ *    1 <= n == nums.length <= 10^5
+ *    1 <= nums[i] <= 10^6
+ *    1 <= k <= n
+ */
+public class FindThePowerOfKSizeSubarraysII {
+
+    // V0
+    // IDEA: ONE RUNNING STREAK OF "+1 STEPS" ANSWERS EVERY WINDOW
+    //       track `run` = the length of the longest consecutive-ascending
+    //       stretch ending at the current index. it extends when
+    //       nums[i] == nums[i-1] + 1 and resets to 1 otherwise.
+    //       the window ending at i lies fully inside that stretch exactly when
+    //       run >= k, in which case its power is nums[i]; otherwise -1.
+    //       this is LC 3254 at 10^5 elements, where re-scanning each window
+    //       would be O(N * K).
+    /**
+     * time = O(N)
+     * space = O(1)   // excluding the output array
+     */
+    public int[] resultsArray(int[] nums, int k) {
+        int n = nums.length;
+        int[] res = new int[n - k + 1];
+        int run = 1;
+        for (int i = 0; i < n; i++) {
+            if (i > 0 && nums[i] == nums[i - 1] + 1) {
+                run++;
+            } else {
+                run = 1;
+            }
+            if (i >= k - 1) {
+                res[i - k + 1] = (run >= k) ? nums[i] : -1;
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/MaximumFrequencyOfAnElementAfterPerformingOperationsI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/MaximumFrequencyOfAnElementAfterPerformingOperationsI.java
@@ -1,0 +1,113 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/maximum-frequency-of-an-element-after-performing-operations-i/
+
+import java.util.Arrays;
+
+/**
+ *  3346. Maximum Frequency of an Element After Performing Operations I
+ *  Medium
+ *
+ *  You are given an integer array nums and two integers k and numOperations.
+ *
+ *  You must perform an operation numOperations times on nums, where in each
+ *  operation you:
+ *   - Select an index i that was not selected in any previous operations.
+ *   - Add an integer in the range [-k, k] to nums[i].
+ *
+ *  Return the maximum possible frequency of any element in nums after
+ *  performing the operations.
+ *
+ *  Example 1:
+ *    Input: nums = [1,4,5], k = 1, numOperations = 2
+ *    Output: 2
+ *    Explanation: add 0 to nums[1] and -1 to nums[2] -> [1,4,4].
+ *
+ *  Example 2:
+ *    Input: nums = [5,11,20,20], k = 5, numOperations = 1
+ *    Output: 2
+ *    Explanation: add 0 to nums[1].
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^5
+ *    0 <= k <= 10^5
+ *    0 <= numOperations <= nums.length
+ */
+public class MaximumFrequencyOfAnElementAfterPerformingOperationsI {
+
+    // V0
+    // IDEA: FIX THE TARGET VALUE — "ALREADY THERE" PLUS "CAN BE NUDGED"
+    //       for a chosen target v the final frequency is
+    //           (elements already equal to v)
+    //         + min(numOperations, elements within k of v that are not v)
+    //       because an element in [v-k, v+k] can be moved onto v with one
+    //       operation, and only numOperations of them may be moved.
+    //       the best v is always some nums[i] or a boundary nums[i] +- k —
+    //       sliding the target between those points never adds anybody — so
+    //       those are the only candidates worth testing.
+    //       sorting once turns "how many lie in [v-k, v+k]" and "how many
+    //       equal v" into binary searches.
+    /**
+     * time = O(N log N)
+     * space = O(N)
+     */
+    public int maxFrequency(int[] nums, int k, int numOperations) {
+        int[] arr = nums.clone();
+        Arrays.sort(arr);
+        int n = arr.length;
+
+        int[] candidates = new int[3 * n];
+        int m = 0;
+        for (int i = 0; i < n; i++) {
+            candidates[m++] = arr[i];
+            candidates[m++] = arr[i] - k;
+            candidates[m++] = arr[i] + k;
+        }
+
+        int best = 0;
+        for (int i = 0; i < m; i++) {
+            int v = candidates[i];
+            int lo = lowerBound(arr, v - k);
+            int hi = upperBound(arr, v + k);
+            int inside = hi - lo;
+            int same = upperBound(arr, v) - lowerBound(arr, v);
+            int movable = inside - same;
+            int total = same + Math.min(numOperations, movable);
+            if (total > best) {
+                best = total;
+            }
+        }
+        return best;
+    }
+
+    // first index with arr[idx] >= target
+    private int lowerBound(int[] arr, int target) {
+        int lo = 0;
+        int hi = arr.length;
+        while (lo < hi) {
+            int mid = lo + (hi - lo) / 2;
+            if (arr[mid] < target) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+
+    // first index with arr[idx] > target
+    private int upperBound(int[] arr, int target) {
+        int lo = 0;
+        int hi = arr.length;
+        while (lo < hi) {
+            int mid = lo + (hi - lo) / 2;
+            if (arr[mid] <= target) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/MinimumMovesToPickKOnes.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/MinimumMovesToPickKOnes.java
@@ -1,0 +1,104 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/minimum-moves-to-pick-k-ones/
+
+/**
+ *  3086. Minimum Moves to Pick K Ones
+ *  Hard
+ *
+ *  You are given a binary array nums of length n, a positive integer k and a
+ *  non-negative integer maxChanges.
+ *
+ *  Alice picks any index aliceIndex and stands there. If nums[aliceIndex] == 1
+ *  she picks up that one for free. After this she may repeatedly do exactly one
+ *  of:
+ *   - Select any index j != aliceIndex with nums[j] == 0 and set nums[j] = 1.
+ *     This action can be performed at most maxChanges times.
+ *   - Select adjacent indices x, y with nums[x] == 1, nums[y] == 0 and swap
+ *     them. If y == aliceIndex, Alice picks up that one.
+ *
+ *  Return the minimum number of moves required by Alice to pick exactly k ones.
+ *
+ *  Example 1:
+ *    Input: nums = [1,1,0,0,0,1,1,0,0,1], k = 3, maxChanges = 1
+ *    Output: 3
+ *
+ *  Example 2:
+ *    Input: nums = [0,0,0,0], k = 2, maxChanges = 3
+ *    Output: 4
+ *
+ *  Constraints:
+ *    2 <= n <= 10^5
+ *    0 <= nums[i] <= 1
+ *    1 <= k <= 10^5
+ *    0 <= maxChanges <= 10^5
+ *    maxChanges + sum(nums) >= k
+ */
+public class MinimumMovesToPickKOnes {
+
+    // V0
+    // IDEA: PRICE EVERY ONE, THEN NOTICE ONLY ~4 REAL/CREATED SPLITS MATTER
+    //       costs, measured from Alice's standing index:
+    //           a real one AT her index     -> 0 moves (free pickup)
+    //           a real one at distance d    -> d moves (swap it along)
+    //           a created one (maxChanges)  -> 2 moves (set adjacent, swap in)
+    //       so collecting r real ones and creating x = k - r costs
+    //           2 * x + (sum of distances from her index to those r ones)
+    //       and for a fixed r the best real ones are a CONTIGUOUS block of
+    //       ones with Alice standing at its median — the classic
+    //       minimum-sum-of-distances arrangement, computed for every window
+    //       with prefix sums.
+    //       the search over r collapses: a created one costs 2, so it matches
+    //       or beats any real one at distance >= 2, and only three real ones
+    //       can be cheaper than that (the one under her feet and its two
+    //       neighbours). so beyond max(0, k - maxChanges) real ones there is
+    //       no point taking more than 3 extra — four values of r to try.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public long minimumMoves(int[] nums, int k, int maxChanges) {
+        int n = nums.length;
+        int[] pos = new int[n];
+        int m = 0;
+        for (int i = 0; i < n; i++) {
+            if (nums[i] == 1) {
+                pos[m++] = i;
+            }
+        }
+
+        long[] pre = new long[m + 1];
+        for (int i = 0; i < m; i++) {
+            pre[i + 1] = pre[i] + pos[i];
+        }
+
+        int base = Math.max(0, k - maxChanges); // real ones we are forced to take
+        long res = Long.MAX_VALUE;
+        for (int r = base; r <= Math.min(m, base + 3); r++) {
+            if (r > k) {
+                break;
+            }
+            long cost = 2L * (k - r) + windowCost(pos, pre, m, r);
+            res = Math.min(res, cost);
+        }
+        return res;
+    }
+
+    /** min total distance to gather r ones, standing at their median. */
+    private long windowCost(int[] pos, long[] pre, int m, int r) {
+        if (r == 0) {
+            return 0L;
+        }
+        long best = Long.MAX_VALUE;
+        for (int lo = 0; lo + r - 1 < m; lo++) {
+            int hi = lo + r - 1;
+            int mid = lo + r / 2;
+            long med = pos[mid];
+            // the two halves, each measured against the median
+            long right = (pre[hi + 1] - pre[mid]) - med * (hi - mid + 1);
+            long left = med * (mid - lo) - (pre[mid] - pre[lo]);
+            best = Math.min(best, left + right);
+        }
+        return best;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/ShortestSubarrayWithOrAtLeastKII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/SlideWindow/ShortestSubarrayWithOrAtLeastKII.java
@@ -1,0 +1,89 @@
+package LeetCodeJava.SlideWindow;
+
+// https://leetcode.com/problems/shortest-subarray-with-or-at-least-k-ii/
+
+/**
+ *  3097. Shortest Subarray With OR at Least K II
+ *  Medium
+ *
+ *  You are given an array nums of non-negative integers and an integer k.
+ *
+ *  An array is called special if the bitwise OR of all of its elements is at
+ *  least k.
+ *
+ *  Return the length of the shortest special non-empty subarray of nums, or
+ *  return -1 if no special subarray exists.
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,3], k = 2
+ *    Output: 1
+ *    Explanation: The subarray [3] has OR value of 3.
+ *
+ *  Example 2:
+ *    Input: nums = [2,1,8], k = 10
+ *    Output: 3
+ *    Explanation: The subarray [2,1,8] has OR value of 11.
+ *
+ *  Example 3:
+ *    Input: nums = [1,2], k = 0
+ *    Output: 1
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 2 * 10^5
+ *    0 <= nums[i] <= 10^9
+ *    0 <= k <= 10^9
+ */
+public class ShortestSubarrayWithOrAtLeastKII {
+
+    private static final int BITS = 31;
+
+    // V0
+    // IDEA: SLIDING WINDOW WITH A COUNTER PER BIT (OR IS NOT INVERTIBLE)
+    //       the OR of a window only grows as it widens, so the window is
+    //       monotone and two pointers apply: extend right until the OR reaches
+    //       k, then shrink from the left while it still does.
+    //       the catch is that OR cannot be "undone" when an element leaves —
+    //       losing a 1 bit only matters if no OTHER element in the window
+    //       still has it. so keep a count of how many window elements set each
+    //       bit; a bit is present in the OR exactly while its count is
+    //       non-zero, and rebuilding the OR is 31 cheap steps per move.
+    /**
+     * time = O(31 * N)
+     * space = O(1)
+     */
+    public int minimumSubarrayLength(int[] nums, int k) {
+        int[] cnt = new int[BITS];
+        int best = Integer.MAX_VALUE;
+        int left = 0;
+
+        for (int right = 0; right < nums.length; right++) {
+            add(cnt, nums[right], 1);
+            int cur = value(cnt);
+            while (left <= right && cur >= k) {
+                best = Math.min(best, right - left + 1);
+                add(cnt, nums[left], -1);
+                left++;
+                cur = value(cnt);
+            }
+        }
+        return (best == Integer.MAX_VALUE) ? -1 : best;
+    }
+
+    private void add(int[] cnt, int x, int delta) {
+        for (int b = 0; b < BITS; b++) {
+            if (((x >> b) & 1) == 1) {
+                cnt[b] += delta;
+            }
+        }
+    }
+
+    private int value(int[] cnt) {
+        int v = 0;
+        for (int b = 0; b < BITS; b++) {
+            if (cnt[b] > 0) {
+                v |= (1 << b);
+            }
+        }
+        return v;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/BuildAnArrayWithStackOperations.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/BuildAnArrayWithStackOperations.java
@@ -1,0 +1,77 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/build-an-array-with-stack-operations/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1441. Build an Array With Stack Operations
+ *  Medium
+ *
+ *  You are given an integer array target and an integer n.
+ *
+ *  You have an empty stack with the two following operations:
+ *
+ *   - "Push": pushes an integer to the top of the stack.
+ *   - "Pop": removes the integer on the top of the stack.
+ *
+ *  You also have a stream of the integers in the range [1, n].
+ *
+ *  Use the two stack operations to make the numbers in the stack (from the
+ *  bottom to the top) equal to target. You should follow the following rules:
+ *
+ *   - If the stream of the integers is not empty, pick the next integer from
+ *     the stream and push it to the top of the stack.
+ *   - If the stack is not empty, pop the integer at the top of the stack.
+ *   - If, at any moment, the elements in the stack (from the bottom to the top)
+ *     are equal to target, do not read new integers from the stream and do not
+ *     do more operations on the stack.
+ *
+ *  Return the stack operations needed to build target following the mentioned
+ *  rules. If there are multiple valid answers, return any of them.
+ *
+ *  Example 1:
+ *    Input: target = [1,3], n = 3
+ *    Output: ["Push","Push","Pop","Push"]
+ *
+ *  Example 2:
+ *    Input: target = [1,2,3], n = 3
+ *    Output: ["Push","Push","Push"]
+ *
+ *  Constraints:
+ *    1 <= target.length <= 100
+ *    1 <= n <= 100
+ *    1 <= target[i] <= n
+ *    target is strictly increasing.
+ */
+public class BuildAnArrayWithStackOperations {
+
+    // V0
+    // IDEA: SIMULATION
+    //       the stream is 1, 2, 3, ... so we must READ every number up to
+    //       target[last], but KEEP only those in target.
+    //         - a number in target        -> "Push"
+    //         - a number skipped by target -> "Push" then "Pop"
+    //       stop right after the last target value (never read beyond it).
+    /**
+     * time = O(n)
+     * space = O(1)   // ignoring the output list
+     */
+    public List<String> buildArray(int[] target, int n) {
+        List<String> res = new ArrayList<>();
+        int cur = 1; // next number in the stream
+
+        for (int x : target) {
+            // NOTE !!! burn through the stream numbers that target skipped
+            while (cur < x) {
+                res.add("Push");
+                res.add("Pop");
+                cur++;
+            }
+            res.add("Push");
+            cur++;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/CheckIfWordIsValidAfterSubstitutions.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/CheckIfWordIsValidAfterSubstitutions.java
@@ -1,0 +1,64 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/check-if-word-is-valid-after-substitutions/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1003. Check If Word Is Valid After Substitutions
+ *  Medium
+ *
+ *  Given a string s, determine if it is valid.
+ *
+ *  A string s is valid if, starting with an empty string t = "", you can
+ *  transform t into s after performing the following operation any number of
+ *  times: insert string "abc" into any position in t. More formally, t becomes
+ *  tleft + "abc" + tright, where t == tleft + tright. Note that tleft and
+ *  tright may be empty.
+ *
+ *  Return true if s is a valid string, otherwise, return false.
+ *
+ *  Example 1:
+ *    Input: s = "aabcbc"
+ *    Output: true
+ *    Explanation: "" -> "abc" -> "aabcbc"
+ *
+ *  Example 2:
+ *    Input: s = "abccba"
+ *    Output: false
+ *
+ *  Constraints:
+ *    1 <= s.length <= 2 * 10^4
+ *    s consists of letters 'a', 'b', and 'c'
+ */
+public class CheckIfWordIsValidAfterSubstitutions {
+
+    // V0
+    // IDEA: STACK (reverse the process: keep REMOVING "abc")
+    //       push chars on a stack; whenever we meet a 'c', the 2 chars right
+    //       below must be 'a','b' -> pop them and drop the 'c'.
+    //       valid <=> the stack is empty at the end.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public boolean isValid(String s) {
+        Deque<Character> stack = new ArrayDeque<>();
+        for (char ch : s.toCharArray()) {
+            if (ch == 'c') {
+                if (stack.size() < 2) {
+                    return false;
+                }
+                char b = stack.pop();
+                char a = stack.pop();
+                if (b != 'b' || a != 'a') {
+                    return false;
+                }
+            } else {
+                stack.push(ch);
+            }
+        }
+        return stack.isEmpty();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/ClearDigits.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/ClearDigits.java
@@ -1,0 +1,55 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/clear-digits/
+
+/**
+ *  3174. Clear Digits
+ *  Easy
+ *
+ *  You are given a string s.
+ *
+ *  Your task is to remove all digits by doing this operation repeatedly:
+ *  delete the first digit and the closest non-digit character to its left.
+ *
+ *  Return the resulting string after removing all digits.
+ *
+ *  Example 1:
+ *    Input: s = "abc"
+ *    Output: "abc"
+ *    Explanation: There is no digit in the string.
+ *
+ *  Example 2:
+ *    Input: s = "cb34"
+ *    Output: ""
+ *    Explanation: apply on s[2] -> "c4", then on s[1] -> "".
+ *
+ *  Constraints:
+ *    1 <= s.length <= 100
+ *    s consists only of lowercase English letters and digits.
+ *    The input is generated such that it is possible to delete all digits.
+ */
+public class ClearDigits {
+
+    // V0
+    // IDEA: STACK - A DIGIT ALWAYS CANCELS WHATEVER IS ON TOP
+    //       "the closest non-digit to its left" is exactly the most recently
+    //       kept character, because every earlier digit already consumed its
+    //       own partner. So push letters and pop on each digit.
+    //       Input is guaranteed solvable -> the stack is never empty at a pop.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public String clearDigits(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (Character.isDigit(ch)) {
+                sb.deleteCharAt(sb.length() - 1);
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/CollectingChocolates.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/CollectingChocolates.java
@@ -1,0 +1,75 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/collecting-chocolates/
+
+/**
+ *  2735. Collecting Chocolates
+ *  Medium
+ *
+ *  You are given a 0-indexed integer array nums of size n representing the cost
+ *  of collecting different chocolates. The cost of collecting the chocolate at
+ *  index i is nums[i]. Each chocolate is of a different type, and initially the
+ *  chocolate at index i is of ith type.
+ *
+ *  In one operation, you can do the following with an incurred cost of x:
+ *  simultaneously change the chocolate of ith type to ((i + 1) mod n)th type
+ *  for all chocolates.
+ *
+ *  Return the minimum cost to collect chocolates of all types, given that you
+ *  can perform as many operations as you would like.
+ *
+ *  Example 1:
+ *    Input: nums = [20,1,15], x = 5
+ *    Output: 13
+ *    Explanation: buy type 1 for 1, rotate (5), buy type 2 for 1, rotate (5),
+ *                 buy type 0 for 1 -> 1 + 5 + 1 + 5 + 1 = 13
+ *
+ *  Example 2:
+ *    Input: nums = [1,2,3], x = 4
+ *    Output: 6
+ *    Explanation: buy everything at its own price, no operation.
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 1000
+ *    1 <= nums[i] <= 10^9
+ *    1 <= x <= 10^9
+ */
+public class CollectingChocolates {
+
+    // V0
+    // IDEA: ENUMERATE THE TOTAL NUMBER OF ROTATIONS + RUNNING PREFIX MIN
+    //       The operations are global rotations and buying may happen at any
+    //       moment, so the only real decision is k = how many rotations we do.
+    //       Fix k: we pay x * k, and each type t can be bought at any of the
+    //       k + 1 snapshots -> price min(nums[t], nums[t-1], ..., nums[t-k]).
+    //       answer = min over k in [0, n-1] of ( x * k + sum_t best(t, k) ).
+    //       k >= n never helps (at k = n-1 the window covers the whole array).
+    //       best(t, k) = min(best(t, k-1), nums[(t - k) % n]) -> sweep k upward
+    //       per starting index with ONE running minimum.
+    /**
+     * time = O(N^2)
+     * space = O(N)
+     */
+    public long minCost(int[] nums, int x) {
+        int n = nums.length;
+        long[] cost = new long[n]; // cost[k] = total cost with exactly k rotations
+        for (int k = 0; k < n; k++) {
+            cost[k] = (long) x * k;
+        }
+        for (int i = 0; i < n; i++) {
+            int cur = nums[i];
+            for (int k = 0; k < n; k++) {
+                int v = nums[((i - k) % n + n) % n];
+                if (v < cur) {
+                    cur = v;
+                }
+                cost[k] += cur;
+            }
+        }
+        long res = cost[0];
+        for (int k = 1; k < n; k++) {
+            res = Math.min(res, cost[k]);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/CountBowlSubarrays.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/CountBowlSubarrays.java
@@ -1,0 +1,71 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/count-bowl-subarrays/
+
+/**
+ *  3676. Count Bowl Subarrays
+ *  Medium
+ *
+ *  You are given an integer array nums with distinct elements.
+ *
+ *  A subarray nums[l...r] of nums is called a bowl if:
+ *   - the subarray has length at least 3 (r - l + 1 >= 3)
+ *   - the minimum of its two ends is strictly greater than the maximum of all
+ *     elements in between, i.e.
+ *     min(nums[l], nums[r]) > max(nums[l + 1], ..., nums[r - 1])
+ *
+ *  Return the number of bowl subarrays in nums.
+ *
+ *  Example 1:
+ *    Input: nums = [2,5,3,1,4]
+ *    Output: 2
+ *    Explanation: [3,1,4] and [5,3,1,4]
+ *
+ *  Example 2:
+ *    Input: nums = [5,1,2,3,4]
+ *    Output: 3
+ *    Explanation: [5,1,2], [5,1,2,3] and [5,1,2,3,4]
+ *
+ *  Constraints:
+ *    3 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^9
+ *    nums consists of distinct elements.
+ */
+public class CountBowlSubarrays {
+
+    // V0
+    // IDEA: MONOTONIC STACK - COUNT "MUTUALLY VISIBLE" INDEX PAIRS
+    //       The bowl condition says l and r can "see each other over" the
+    //       valley between them -> the classic visible-pair relation.
+    //       Keeping a strictly decreasing stack of indices, index j sees:
+    //         * every index it pops,
+    //         * plus the single index left on top afterwards.
+    //       Nothing else is visible, so each pair is emitted exactly once.
+    //       Finally keep only the pairs at distance >= 2 (a bowl needs at
+    //       least one element strictly between its two ends).
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public long bowlSubarrays(int[] nums) {
+        int n = nums.length;
+        long res = 0;
+        int[] st = new int[n];
+        int top = -1;
+
+        for (int j = 0; j < n; j++) {
+            int x = nums[j];
+            while (top >= 0 && nums[st[top]] < x) {
+                int i = st[top--];
+                if (j - i > 1) {
+                    res++;
+                }
+            }
+            if (top >= 0 && j - st[top] > 1) {
+                res++;
+            }
+            st[++top] = j;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/FindTheNumberOfSubarraysWhereBoundaryElementsAreMaximum.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/FindTheNumberOfSubarraysWhereBoundaryElementsAreMaximum.java
@@ -1,0 +1,72 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/find-the-number-of-subarrays-where-boundary-elements-are-maximum/
+
+/**
+ *  3113. Find the Number of Subarrays Where Boundary Elements Are Maximum
+ *  Hard
+ *
+ *  You are given an array of positive integers nums.
+ *
+ *  Return the number of subarrays of nums, where the first and the last
+ *  elements of the subarray are equal to the largest element in the subarray.
+ *
+ *  Example 1:
+ *    Input: nums = [1,4,3,3,2]
+ *    Output: 6
+ *    Explanation: the 5 length-1 subarrays, plus [3,3].
+ *
+ *  Example 2:
+ *    Input: nums = [3,3,3]
+ *    Output: 6
+ *
+ *  Example 3:
+ *    Input: nums = [1]
+ *    Output: 1
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^9
+ */
+public class FindTheNumberOfSubarraysWhereBoundaryElementsAreMaximum {
+
+    // V0
+    // IDEA: MONOTONIC STACK OF (VALUE, HOW MANY COPIES ARE STILL "VISIBLE")
+    //       A valid subarray is a pair of equal values i < j such that nothing
+    //       strictly larger sits between them -> for each element, count how
+    //       many earlier equal values are still unblocked.
+    //       A non-increasing stack keeps exactly those unblocked candidates:
+    //       when a new value arrives, every smaller value on the stack is now
+    //       shadowed and pops off. What remains on top is either the same
+    //       value - whose stored count says how many copies are visible, all
+    //       of which pair with the new element - or a larger one.
+    //       So each element contributes (visible copies) + 1, the +1 being the
+    //       length-1 subarray.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public long numberOfSubarrays(int[] nums) {
+        int n = nums.length;
+        int[] val = new int[n];   // stack of values (non-increasing)
+        int[] cnt = new int[n];   // how many visible copies of that value
+        int top = -1;
+        long res = 0;
+
+        for (int x : nums) {
+            while (top >= 0 && val[top] < x) {
+                top--;
+            }
+            if (top >= 0 && val[top] == x) {
+                cnt[top]++;
+                res += cnt[top]; // pairs with each visible copy, plus itself
+            } else {
+                top++;
+                val[top] = x;
+                cnt[top] = 1;
+                res += 1;
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/IsArrayAPreorderOfSomeBinaryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/IsArrayAPreorderOfSomeBinaryTree.java
@@ -1,0 +1,97 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/is-array-a-preorder-of-some-binary-tree/
+
+import java.util.List;
+
+/**
+ *  2764. Is Array a Preorder of Some Binary Tree
+ *  Medium
+ *
+ *  Given a 0-indexed integer 2D array nodes, your task is to determine if the
+ *  given array represents the preorder traversal of some binary tree.
+ *
+ *  For each index i, nodes[i] = [id, parentId], where id is the id of the node
+ *  at index i and parentId is the id of its parent in the tree (if the node has
+ *  no parent, then parentId == -1).
+ *
+ *  Return true if the given array represents the preorder traversal of some
+ *  tree, and false otherwise.
+ *
+ *  Example 1:
+ *    Input: nodes = [[0,-1],[1,0],[2,0],[3,2],[4,2]]
+ *    Output: true
+ *    Explanation: visit 0, then the subtree [1], then the subtree [2,3,4].
+ *
+ *  Example 2:
+ *    Input: nodes = [[0,-1],[1,0],[2,0],[3,1],[4,1]]
+ *    Output: false
+ *    Explanation: 2 comes between 1 and 3, so 1's subtree is not contiguous.
+ *
+ *  Constraints:
+ *    1 <= nodes.length <= 10^5
+ *    nodes[i].length == 2
+ *    0 <= nodes[i][0] <= 10^5
+ *    -1 <= nodes[i][1] <= 10^5
+ *    The input is generated such that nodes make a binary tree.
+ */
+public class IsArrayAPreorderOfSomeBinaryTree {
+
+    // V0
+    // IDEA: MONOTONIC "ANCESTOR PATH" STACK
+    //       Left/right is not fixed for us - a node's two children may be
+    //       handed to the traversal in either order. So the question is only
+    //       whether the array is SOME depth-first order, which has a clean
+    //       characterisation: when a node is emitted, its parent must still be
+    //       on the active root-to-current path.
+    //       Keep that path in a stack. For each (id, par) in array order:
+    //         - pop until the stack top is `par` (every popped node's subtree
+    //           is finished, exactly what a DFS does on the way back up),
+    //         - if the stack drains without exposing `par`, some node was
+    //           emitted outside its parent's window -> not a preorder,
+    //         - otherwise push `id`.
+    //       The root (par == -1) is unique, so the only node ever allowed to
+    //       face an empty stack is nodes[0].
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public boolean isPreorder(List<List<Integer>> nodes) {
+        int n = nodes.size();
+        int[] path = new int[n]; // current root -> node path
+        int top = -1;
+
+        for (int i = 0; i < n; i++) {
+            int nid = nodes.get(i).get(0);
+            int par = nodes.get(i).get(1);
+            while (top >= 0 && path[top] != par) {
+                top--;
+            }
+            if (top < 0 && par != -1) {
+                return false;
+            }
+            path[++top] = nid;
+        }
+        return true;
+    }
+
+    // same logic, int[][] input flavour
+    public boolean isPreorder(int[][] nodes) {
+        int n = nodes.length;
+        int[] path = new int[n];
+        int top = -1;
+
+        for (int i = 0; i < n; i++) {
+            int nid = nodes[i][0];
+            int par = nodes[i][1];
+            while (top >= 0 && path[top] != par) {
+                top--;
+            }
+            if (top < 0 && par != -1) {
+                return false;
+            }
+            path[++top] = nid;
+        }
+        return true;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -1,0 +1,82 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/lexicographically-minimum-string-after-removing-stars/
+
+/**
+ *  3170. Lexicographically Minimum String After Removing Stars
+ *  Medium
+ *
+ *  You are given a string s. It may contain any number of '*' characters. Your
+ *  task is to remove all '*' characters.
+ *
+ *  While there is a '*', do the following operation: delete the leftmost '*'
+ *  and the smallest non-'*' character to its left. If there are several
+ *  smallest characters, you can delete any of them.
+ *
+ *  Return the lexicographically smallest resulting string after removing all
+ *  '*' characters.
+ *
+ *  Example 1:
+ *    Input: s = "aaba*"
+ *    Output: "aab"
+ *    Explanation: deleting the 'b' at index 3 gives the smallest result.
+ *
+ *  Example 2:
+ *    Input: s = "abc"
+ *    Output: "abc"
+ *
+ *  Constraints:
+ *    1 <= s.length <= 10^5
+ *    s consists only of lowercase English letters and '*'.
+ *    The input is generated such that it is possible to delete all '*'.
+ */
+public class LexicographicallyMinimumStringAfterRemovingStars {
+
+    // V0
+    // IDEA: ONE STACK OF POSITIONS PER LETTER - DELETE THE *LATEST* SMALLEST
+    //       Each '*' must remove the smallest surviving letter to its left, and
+    //       when several copies exist the choice is ours. Removing the
+    //       RIGHTMOST copy is best: it leaves the earlier copies in place, and
+    //       a smaller letter earlier in the string is what lexicographic order
+    //       rewards.
+    //       So keep 26 stacks of indices, one per letter. A '*' pops from the
+    //       lowest non-empty stack -> that letter's latest position in O(1).
+    /**
+     * time = O(26 * N)
+     * space = O(N)
+     */
+    public String clearStars(String s) {
+        int n = s.length();
+        int[][] stacks = new int[26][];
+        int[] tops = new int[26];
+        for (int c = 0; c < 26; c++) {
+            stacks[c] = new int[n];
+            tops[c] = -1;
+        }
+        boolean[] removed = new boolean[n];
+
+        for (int i = 0; i < n; i++) {
+            char ch = s.charAt(i);
+            if (ch == '*') {
+                removed[i] = true;
+                for (int c = 0; c < 26; c++) {
+                    if (tops[c] >= 0) {
+                        removed[stacks[c][tops[c]--]] = true;
+                        break;
+                    }
+                }
+            } else {
+                int c = ch - 'a';
+                stacks[c][++tops[c]] = i;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            if (!removed[i]) {
+                sb.append(s.charAt(i));
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximalRangeThatEachElementIsMaximumInIt.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximalRangeThatEachElementIsMaximumInIt.java
@@ -1,0 +1,75 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/maximal-range-that-each-element-is-maximum-in-it/
+
+/**
+ *  2832. Maximal Range That Each Element Is Maximum in It
+ *  Medium
+ *
+ *  You are given a 0-indexed array nums of distinct integers.
+ *
+ *  Let us define a 0-indexed array ans of the same length as nums in the
+ *  following way: ans[i] is the maximum length of a subarray nums[l..r], such
+ *  that the maximum element in that subarray is equal to nums[i].
+ *
+ *  Return the array ans.
+ *
+ *  Example 1:
+ *    Input: nums = [1,5,4,3,6]
+ *    Output: [1,4,2,1,5]
+ *
+ *  Example 2:
+ *    Input: nums = [1,2,3,4,5]
+ *    Output: [1,2,3,4,5]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^5
+ *    All elements in nums are distinct.
+ */
+public class MaximalRangeThatEachElementIsMaximumInIt {
+
+    // V0
+    // IDEA: MONOTONIC STACK (previous greater / next greater element)
+    //       The widest window in which nums[i] is the maximum stretches from
+    //       just after the previous strictly-greater element to just before
+    //       the next strictly-greater one:
+    //           ans[i] = right[i] - left[i] - 1
+    //       The window may freely contain SMALLER elements - it is blocked
+    //       only by greater ones. Values are distinct, so "greater" and
+    //       "greater or equal" coincide (no tie-breaking subtlety).
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int[] maximumLengthOfRanges(int[] nums) {
+        int n = nums.length;
+        int[] left = new int[n];  // index of previous greater element
+        int[] right = new int[n]; // index of next greater element
+        int[] stack = new int[n];
+        int top = -1;
+
+        for (int i = 0; i < n; i++) {
+            while (top >= 0 && nums[stack[top]] < nums[i]) {
+                top--;
+            }
+            left[i] = (top >= 0) ? stack[top] : -1;
+            stack[++top] = i;
+        }
+
+        top = -1;
+        for (int i = n - 1; i >= 0; i--) {
+            while (top >= 0 && nums[stack[top]] < nums[i]) {
+                top--;
+            }
+            right[i] = (top >= 0) ? stack[top] : n;
+            stack[++top] = i;
+        }
+
+        int[] res = new int[n];
+        for (int i = 0; i < n; i++) {
+            res[i] = right[i] - left[i] - 1;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumNumberOfBooksYouCanTake.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumNumberOfBooksYouCanTake.java
@@ -1,0 +1,84 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/maximum-number-of-books-you-can-take/
+
+/**
+ *  2355. Maximum Number of Books You Can Take
+ *  Hard
+ *
+ *  You are given a 0-indexed integer array books of length n where books[i]
+ *  denotes the number of books on the ith shelf of a bookshelf.
+ *
+ *  You are going to take books from a contiguous section of the bookshelf
+ *  spanning from l to r where 0 <= l <= r < n. For each index i in the range
+ *  l <= i < r, you must take strictly fewer books from shelf i than shelf i+1.
+ *
+ *  Return the maximum number of books you can take from the bookshelf.
+ *
+ *  Example 1:
+ *    Input: books = [8,5,2,7,9]
+ *    Output: 19
+ *    Explanation: take 1 + 2 + 7 + 9 from shelves 1..4.
+ *
+ *  Example 2:
+ *    Input: books = [7,0,3,4,5]
+ *    Output: 12
+ *    Explanation: take 3 + 4 + 5 from shelves 2..4.
+ *
+ *  Constraints:
+ *    1 <= books.length <= 10^5
+ *    0 <= books[i] <= 10^5
+ */
+public class MaximumNumberOfBooksYouCanTake {
+
+    // V0
+    // IDEA: MONOTONIC STACK + DP (the optimal section ending at i is a
+    //       one-step staircase)
+    //       In an optimal answer whose right end is i, taking books[i] from
+    //       shelf i is always best, and going left we take one fewer each step
+    //       (books[i]-1, books[i]-2, ...) until the shelf itself has fewer
+    //       books than that.
+    //       Rewrite nums[i] = books[i] - i. The staircase can extend left past
+    //       j iff nums[j] >= nums[i], so the breaking point is
+    //           left[i] = nearest index j < i with nums[j] < nums[i]
+    //       dp[i] = (arithmetic sum books[i], books[i]-1, ... over
+    //                i - left[i] terms) + dp[left[i]]
+    //       When left[i] == -1 the run is capped by min(books[i], i+1).
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public long maximumBooks(int[] books) {
+        int n = books.length;
+        int[] nums = new int[n];
+        for (int i = 0; i < n; i++) {
+            nums[i] = books[i] - i;
+        }
+
+        int[] left = new int[n];
+        int[] stk = new int[n];
+        int top = -1;
+        for (int i = 0; i < n; i++) {
+            while (top >= 0 && nums[stk[top]] >= nums[i]) {
+                top--;
+            }
+            left[i] = (top >= 0) ? stk[top] : -1;
+            stk[++top] = i;
+        }
+
+        long res = 0;
+        long[] dp = new long[n];
+        for (int i = 0; i < n; i++) {
+            long v = books[i];
+            int j = left[i];
+            long cnt = Math.min(v, (long) i - j); // shelves the staircase covers
+            long lo = v - cnt + 1;
+            long s = (lo + v) * cnt / 2;
+            dp[i] = s + ((j != -1) ? dp[j] : 0L);
+            if (dp[i] > res) {
+                res = dp[i];
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumOfMinimumValuesInAllSubarrays.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumOfMinimumValuesInAllSubarrays.java
@@ -1,0 +1,88 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/maximum-of-minimum-values-in-all-subarrays/
+
+/**
+ *  1950. Maximum of Minimum Values in All Subarrays
+ *  Medium
+ *
+ *  You are given an integer array nums of size n. You are asked to solve n
+ *  queries for each integer i in the range 0 <= i < n.
+ *
+ *  To solve the ith query:
+ *    1. Find the minimum value in each possible subarray of size i + 1 of nums.
+ *    2. Find the maximum of those minimum values.
+ *
+ *  Return a 0-indexed integer array ans of size n such that ans[i] is the
+ *  answer to the ith query.
+ *
+ *  Example 1:
+ *    Input: nums = [0,1,2,4]
+ *    Output: [4,2,1,0]
+ *
+ *  Example 2:
+ *    Input: nums = [10,20,50,10]
+ *    Output: [50,20,10,10]
+ *
+ *  Constraints:
+ *    n == nums.length
+ *    1 <= n <= 10^5
+ *    0 <= nums[i] <= 10^9
+ */
+public class MaximumOfMinimumValuesInAllSubarrays {
+
+    // V0
+    // IDEA: MONOTONIC STACK (widest window where nums[i] is the minimum)
+    //       + SUFFIX MAX
+    //       For every index i, find the previous / next smaller element. In
+    //       between, nums[i] IS the minimum, and that window has length
+    //           w = right[i] - left[i] - 1
+    //       so nums[i] is achievable as "min of a window of size w":
+    //           best[w - 1] = max(best[w - 1], nums[i])
+    //       Any window of size w also CONTAINS a window of every smaller size
+    //       whose min is >= nums[i], so the answer array is non-increasing in
+    //       the window size -> sweep right to left with a running max to fill
+    //       the sizes nobody claimed.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int[] findMaximums(int[] nums) {
+        int n = nums.length;
+        int[] left = new int[n];
+        int[] right = new int[n];
+        int[] stack = new int[n];
+        int top = -1;
+
+        for (int i = 0; i < n; i++) {
+            while (top >= 0 && nums[stack[top]] >= nums[i]) {
+                top--;
+            }
+            left[i] = (top >= 0) ? stack[top] : -1;
+            stack[++top] = i;
+        }
+
+        top = -1;
+        for (int i = n - 1; i >= 0; i--) {
+            while (top >= 0 && nums[stack[top]] >= nums[i]) {
+                top--;
+            }
+            right[i] = (top >= 0) ? stack[top] : n;
+            stack[++top] = i;
+        }
+
+        int[] res = new int[n];
+        for (int i = 0; i < n; i++) {
+            int w = right[i] - left[i] - 1;
+            if (nums[i] > res[w - 1]) {
+                res[w - 1] = nums[i];
+            }
+        }
+        for (int i = n - 2; i >= 0; i--) {
+            if (res[i + 1] > res[i]) {
+                res[i] = res[i + 1];
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumSubarrayMinProduct.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumSubarrayMinProduct.java
@@ -1,0 +1,93 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/maximum-subarray-min-product/
+
+/**
+ *  1856. Maximum Subarray Min-Product
+ *  Medium
+ *
+ *  The min-product of an array is equal to the minimum value in the array
+ *  multiplied by the array's sum. For example, the array [3,2,5] (minimum
+ *  value is 2) has a min-product of 2 * (3+2+5) = 20.
+ *
+ *  Given an array of integers nums, return the maximum min-product of any
+ *  non-empty subarray of nums. Since the answer may be large, return it
+ *  modulo 10^9 + 7.
+ *
+ *  Note that the min-product should be maximized BEFORE performing the modulo
+ *  operation. Testcases are generated such that the maximum min-product
+ *  without modulo will fit in a 64-bit signed integer.
+ *
+ *  Example 1:
+ *    Input: nums = [1,2,3,2]
+ *    Output: 14
+ *    Explanation: subarray [2,3,2] -> 2 * 7 = 14
+ *
+ *  Example 2:
+ *    Input: nums = [3,1,5,6,4,2]
+ *    Output: 60
+ *    Explanation: subarray [5,6,4] -> 4 * 15 = 60
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^7
+ */
+public class MaximumSubarrayMinProduct {
+
+    // V0
+    // IDEA: MONOTONIC STACK + PREFIX SUM (largest window where nums[i] is min)
+    //       An optimal subarray is always MAXIMAL for its minimum: if nums[i]
+    //       is the minimum, extending left/right while neighbours are >=
+    //       nums[i] only adds positive numbers, so the best value is reached
+    //       on the widest window in which nums[i] stays the minimum.
+    //       For every i:
+    //         left[i]  = index of previous strictly smaller element (-1 none)
+    //         right[i] = index of next strictly smaller element     (n  none)
+    //         candidate = nums[i] * (pre[right[i]] - pre[left[i] + 1])
+    //       Use ">=" popping on one pass and ">" on the other so equal values
+    //       are neither double-counted nor truncated.
+    //       Take the modulo only at the very END.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int maxSumMinProduct(int[] nums) {
+        final long MOD = 1_000_000_007L;
+        int n = nums.length;
+
+        int[] left = new int[n];
+        int[] right = new int[n];
+        int[] stack = new int[n];
+        int top = -1;
+
+        for (int i = 0; i < n; i++) {
+            while (top >= 0 && nums[stack[top]] >= nums[i]) {
+                top--;
+            }
+            left[i] = (top >= 0) ? stack[top] : -1;
+            stack[++top] = i;
+        }
+
+        top = -1;
+        for (int i = n - 1; i >= 0; i--) {
+            while (top >= 0 && nums[stack[top]] > nums[i]) {
+                top--;
+            }
+            right[i] = (top >= 0) ? stack[top] : n;
+            stack[++top] = i;
+        }
+
+        // pre[k] = sum of nums[0 .. k-1]
+        long[] pre = new long[n + 1];
+        for (int i = 0; i < n; i++) {
+            pre[i + 1] = pre[i] + nums[i];
+        }
+
+        long res = 0;
+        for (int i = 0; i < n; i++) {
+            long total = pre[right[i]] - pre[left[i] + 1];
+            res = Math.max(res, (long) nums[i] * total);
+        }
+        return (int) (res % MOD);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumSumQueries.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MaximumSumQueries.java
@@ -1,0 +1,145 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/maximum-sum-queries/
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ *  2736. Maximum Sum Queries
+ *  Hard
+ *
+ *  You are given two 0-indexed integer arrays nums1 and nums2, each of length
+ *  n, and a 1-indexed 2D array queries where queries[i] = [xi, yi].
+ *
+ *  For the ith query, find the maximum value of nums1[j] + nums2[j] among all
+ *  indices j (0 <= j < n), where nums1[j] >= xi and nums2[j] >= yi, or -1 if
+ *  there is no j satisfying the constraints.
+ *
+ *  Return an array answer where answer[i] is the answer to the ith query.
+ *
+ *  Example 1:
+ *    Input: nums1 = [4,3,1,2], nums2 = [2,4,9,5],
+ *           queries = [[4,1],[1,3],[2,5]]
+ *    Output: [6,10,7]
+ *
+ *  Example 2:
+ *    Input: nums1 = [2,1], nums2 = [2,3], queries = [[3,3]]
+ *    Output: [-1]
+ *
+ *  Constraints:
+ *    nums1.length == nums2.length == n
+ *    1 <= n <= 10^5
+ *    1 <= nums1[i], nums2[i] <= 10^9
+ *    1 <= queries.length <= 10^5
+ *    queries[i].length == 2
+ *    1 <= xi, yi <= 10^9
+ */
+public class MaximumSumQueries {
+
+    // V0
+    // IDEA: OFFLINE QUERIES (SORT BY x) + BINARY INDEXED TREE (MAX) OVER nums2
+    //       This is a 2D dominance query. Peel off ONE dimension by sorting,
+    //       handle the other with a Fenwick / BIT:
+    //         1) sort the (nums1[j], nums2[j]) pairs by nums1 DESC
+    //         2) sort the queries by x DESC, remembering the original index
+    //         3) sweep the queries; before answering (x, y) push every pair
+    //            whose nums1 >= x into the BIT. From then on "nums1 >= x" is
+    //            automatic and only "nums2 >= y" is left.
+    //       A BIT natively answers PREFIX max but we need a SUFFIX max over
+    //       nums2, so index by the REVERSED rank
+    //           k(v) = n - lowerBound(sortedNums2, v)   // #values >= v
+    //       Bigger v -> smaller k, hence "nums2 >= y" becomes prefix 1..k(y).
+    //       k(v) >= 1 for any v that occurs in nums2 (update never loops on
+    //       index 0), while a y larger than every nums2 gives k = 0 and the
+    //       query loop returns the -1 default.
+    /**
+     * time = O((N + M) * log N + M * log M)
+     * space = O(N + M)
+     */
+    public int[] maximumSumQueries(int[] nums1, int[] nums2, int[][] queries) {
+        int n = nums1.length;
+        int m = queries.length;
+
+        // value list used for the (reversed) rank compression
+        int[] sortedN2 = nums2.clone();
+        Arrays.sort(sortedN2);
+
+        // pairs by nums1 descending
+        int[][] pairs = new int[n][2];
+        for (int i = 0; i < n; i++) {
+            pairs[i][0] = nums1[i];
+            pairs[i][1] = nums2[i];
+        }
+        Arrays.sort(pairs, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] a, int[] b) {
+                return Integer.compare(b[0], a[0]);
+            }
+        });
+
+        // query indices by x descending
+        Integer[] order = new Integer[m];
+        for (int i = 0; i < m; i++) {
+            order[i] = i;
+        }
+        final int[][] q = queries;
+        Arrays.sort(order, new Comparator<Integer>() {
+            @Override
+            public int compare(Integer a, Integer b) {
+                return Integer.compare(q[b][0], q[a][0]);
+            }
+        });
+
+        int[] tree = new int[n + 1]; // BIT of max(nums1 + nums2), -1 = empty
+        Arrays.fill(tree, -1);
+        int[] res = new int[m];
+        int j = 0;
+
+        for (int idx = 0; idx < m; idx++) {
+            int qi = order[idx];
+            int x = queries[qi][0];
+            int y = queries[qi][1];
+
+            // push every pair with nums1 >= x (pointer only moves forward)
+            while (j < n && pairs[j][0] >= x) {
+                int v = pairs[j][0] + pairs[j][1];
+                int k = n - lowerBound(sortedN2, pairs[j][1]);
+                while (k <= n) {
+                    if (tree[k] < v) {
+                        tree[k] = v;
+                    }
+                    k += k & (-k);
+                }
+                j++;
+            }
+
+            // prefix max over ranks 1..k  <=>  nums2 >= y
+            int k = n - lowerBound(sortedN2, y);
+            int best = -1;
+            while (k > 0) {
+                if (tree[k] > best) {
+                    best = tree[k];
+                }
+                k -= k & (-k);
+            }
+            res[qi] = best;
+        }
+        return res;
+    }
+
+    // first index i with arr[i] >= target
+    private int lowerBound(int[] arr, int target) {
+        int lo = 0;
+        int hi = arr.length;
+        while (lo < hi) {
+            int mid = lo + (hi - lo) / 2;
+            if (arr[mid] < target) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumInsertionsToBalanceAParenthesesString.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumInsertionsToBalanceAParenthesesString.java
@@ -1,0 +1,78 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/minimum-insertions-to-balance-a-parentheses-string/
+
+/**
+ *  1541. Minimum Insertions to Balance a Parentheses String
+ *  Medium
+ *
+ *  Given a parentheses string s containing only the characters '(' and ')'.
+ *  A parentheses string is balanced if:
+ *    - any left parenthesis '(' must have a corresponding two consecutive
+ *      right parenthesis '))'
+ *    - left parenthesis '(' must go before the corresponding '))'
+ *
+ *  In other words, we treat '(' as an opening parenthesis and '))' as a
+ *  closing parenthesis. For example "())", "())(())))" and "(())())))" are
+ *  balanced, while ")()", "()))" and "(()))" are not.
+ *
+ *  You can insert the characters '(' and ')' at any position of the string to
+ *  balance it if needed. Return the minimum number of insertions needed.
+ *
+ *  Example 1:
+ *    Input: s = "(()))"
+ *    Output: 1
+ *    Explanation: add one ')' at the end -> "(())))" which is balanced.
+ *
+ *  Example 2:
+ *    Input: s = "))())("
+ *    Output: 3
+ *    Explanation: add '(' to match the first '))', add '))' for the last '('.
+ *
+ *  Constraints:
+ *    1 <= s.length <= 10^5
+ *    s consists of '(' and ')' only.
+ */
+public class MinimumInsertionsToBalanceAParenthesesString {
+
+    // V0
+    // IDEA: GREEDY COUNTER (a "close" is the 2-char token '))')
+    //       Scan left to right keeping `need` = number of '(' still waiting
+    //       for their '))'. No real stack is needed, only its size.
+    //         on '(' : need++
+    //         on ')' : we are starting a closing token
+    //                  - if the NEXT char is also ')' consume both, else the
+    //                    token is half-missing -> insert 1 ')'
+    //                  - now the token is complete: if need > 0 it pays off
+    //                    one '(', else insert a '(' for this orphan '))'
+    //       At the end every leftover '(' still needs a full '))' -> 2 each.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int minInsertions(String s) {
+        int n = s.length();
+        int res = 0;
+        int need = 0;
+        int i = 0;
+        while (i < n) {
+            if (s.charAt(i) == '(') {
+                need++;
+                i++;
+            } else {
+                if (i + 1 < n && s.charAt(i + 1) == ')') {
+                    i += 2;
+                } else {
+                    res++; // insert the missing second ')'
+                    i++;
+                }
+                if (need > 0) {
+                    need--;
+                } else {
+                    res++; // insert a '(' for this orphan '))'
+                }
+            }
+        }
+        return res + need * 2;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumOperationsToConvertAllElementsToZero.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumOperationsToConvertAllElementsToZero.java
@@ -1,0 +1,73 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/minimum-operations-to-convert-all-elements-to-zero/
+
+/**
+ *  3542. Minimum Operations to Convert All Elements to Zero
+ *  Medium
+ *
+ *  You are given an array nums of size n, consisting of non-negative integers.
+ *  Your task is to apply some (possibly zero) operations on the array so that
+ *  all elements become 0.
+ *
+ *  In one operation, you can select a subarray [i, j] (where 0 <= i <= j < n)
+ *  and set all occurrences of the minimum non-negative integer in that
+ *  subarray to 0.
+ *
+ *  Return the minimum number of operations required to make all elements in
+ *  the array 0.
+ *
+ *  Example 1:
+ *    Input: nums = [0,2]
+ *    Output: 1
+ *
+ *  Example 2:
+ *    Input: nums = [3,1,2,1]
+ *    Output: 3
+ *    Explanation: zero the two 1s together, then the 2, then the 3.
+ *
+ *  Example 3:
+ *    Input: nums = [1,2,1,2,1,2]
+ *    Output: 4
+ *
+ *  Constraints:
+ *    1 <= n == nums.length <= 10^5
+ *    0 <= nums[i] <= 10^5
+ */
+public class MinimumOperationsToConvertAllElementsToZero {
+
+    // V0
+    // IDEA: MONOTONIC STACK OVER "NESTED" VALUE LEVELS
+    //       An operation zeroes one value inside one contiguous window, so two
+    //       equal values can share an operation only when nothing strictly
+    //       smaller separates them (a smaller element inside the window would
+    //       be the minimum instead).
+    //       That is exactly what a non-decreasing stack tracks: push values as
+    //       they come; when a smaller value arrives, every strictly larger
+    //       value on the stack is closed off forever (it can never merge with
+    //       anything to the right) so it costs one operation. Equal values
+    //       sitting on top of the stack merge for free. Whatever remains on
+    //       the stack at the end costs one operation each. Zeroes are never
+    //       pushed.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int minOperations(int[] nums) {
+        int n = nums.length;
+        int[] stack = new int[n];
+        int top = -1;
+        int ops = 0;
+
+        for (int v : nums) {
+            while (top >= 0 && stack[top] > v) {
+                top--;
+                ops++;
+            }
+            if (v > 0 && (top < 0 || stack[top] != v)) {
+                stack[++top] = v;
+            }
+        }
+        return ops + (top + 1);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumStringLengthAfterRemovingSubstrings.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumStringLengthAfterRemovingSubstrings.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/minimum-string-length-after-removing-substrings/
+
+/**
+ *  2696. Minimum String Length After Removing Substrings
+ *  Easy
+ *
+ *  You are given a string s consisting only of uppercase English letters.
+ *
+ *  You can apply some operations to this string where, in one operation, you can
+ *  remove any occurrence of one of the substrings "AB" or "CD" from s.
+ *
+ *  Return the minimum possible length of the resulting string that you can obtain.
+ *
+ *  Note that the string concatenates after removing the substring and could
+ *  produce new "AB" or "CD" substrings.
+ *
+ *  Example 1:
+ *    Input: s = "ABFCACDB"
+ *    Output: 2
+ *    Explanation: "ABFCACDB" -> "FCACDB" -> "FCAB" -> "FC", so length 2.
+ *
+ *  Example 2:
+ *    Input: s = "ACBBD"
+ *    Output: 5
+ *    Explanation: We cannot do any operations, so the length remains the same.
+ *
+ *  Constraints:
+ *    1 <= s.length <= 100
+ *    s consists only of uppercase English letters.
+ */
+public class MinimumStringLengthAfterRemovingSubstrings {
+
+    // V0
+    // IDEA: STACK (adjacent-pair cancellation, same shape as "valid parentheses")
+    //       scan left to right; before pushing c, if the stack top together with
+    //       c forms "AB" or "CD", pop instead of pushing. that cancels the pair
+    //       and automatically exposes the newly adjacent chars, which is exactly
+    //       the "string concatenates after removing" rule.
+    //       NOTE: removal order does not matter (the rewriting is confluent),
+    //             so this single greedy pass reaches the minimum length.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int minLength(String s) {
+        if (s == null || s.isEmpty()) {
+            return 0;
+        }
+        // char stack via StringBuilder
+        StringBuilder stack = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            int top = stack.length() - 1;
+            if (top >= 0 && ((c == 'B' && stack.charAt(top) == 'A')
+                    || (c == 'D' && stack.charAt(top) == 'C'))) {
+                stack.deleteCharAt(top);
+            } else {
+                stack.append(c);
+            }
+        }
+        return stack.length();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/NextGreaterElementIV.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/NextGreaterElementIV.java
@@ -1,0 +1,86 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/next-greater-element-iv/
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+/**
+ *  2454. Next Greater Element IV
+ *  Hard
+ *
+ *  You are given a 0-indexed array of non-negative integers nums. For each
+ *  integer in nums, you must find its respective second greater integer.
+ *
+ *  The second greater integer of nums[i] is nums[j] such that:
+ *    j > i
+ *    nums[j] > nums[i]
+ *    There exists exactly one index k such that nums[k] > nums[i] and i < k < j.
+ *
+ *  If there is no such nums[j], the second greater integer is considered to be -1.
+ *
+ *  Return an integer array answer, where answer[i] is the second greater integer
+ *  of nums[i].
+ *
+ *  Example 1:
+ *    Input: nums = [2,4,0,9,6]
+ *    Output: [9,6,6,-1,-1]
+ *
+ *  Example 2:
+ *    Input: nums = [3,3]
+ *    Output: [-1,-1]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    0 <= nums[i] <= 10^9
+ */
+public class NextGreaterElementIV {
+
+    // V0
+    // IDEA: TWO MONOTONIC STACKS - "WAITING FOR THE FIRST" AND "WAITING FOR THE SECOND"
+    //       an index lives in `first` until something bigger appears; at that
+    //       moment it has met greater #1 and GRADUATES to `second`. the next time
+    //       something bigger appears it has met greater #2 and is answered.
+    //       per element x at index i:
+    //         1. resolve everything in `second` that x exceeds (these get answers)
+    //         2. move everything in `first` that x exceeds over to `second`
+    //         3. push i onto `first`
+    //       step 2 must PRESERVE the decreasing order, hence popping into a temp
+    //       buffer and pushing it back reversed - otherwise `second` would stop
+    //       being monotonic and step 1 could miss entries.
+    //       each index moves at most twice -> the whole sweep is linear.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int[] secondGreaterElement(int[] nums) {
+        int n = nums.length;
+        int[] res = new int[n];
+        Arrays.fill(res, -1);
+
+        Deque<Integer> first = new ArrayDeque<>();   // seen no greater element yet
+        Deque<Integer> second = new ArrayDeque<>();  // seen exactly one greater element
+        int[] promoted = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            int x = nums[i];
+
+            while (!second.isEmpty() && nums[second.peek()] < x) {
+                res[second.pop()] = x;
+            }
+
+            int cnt = 0;
+            while (!first.isEmpty() && nums[first.peek()] < x) {
+                promoted[cnt++] = first.pop();
+            }
+            // push back in reverse order so `second` stays decreasing
+            for (int k = cnt - 1; k >= 0; k--) {
+                second.push(promoted[k]);
+            }
+
+            first.push(i);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/NextGreaterNodeInLinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/NextGreaterNodeInLinkedList.java
@@ -1,0 +1,72 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/next-greater-node-in-linked-list/
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import LeetCodeJava.DataStructure.ListNode;
+
+/**
+ *  1019. Next Greater Node In Linked List
+ *  Medium
+ *
+ *  You are given the head of a linked list with n nodes.
+ *
+ *  For each node in the list, find the value of the next greater node. That is,
+ *  for each node, find the value of the first node that is next to it and has a
+ *  strictly larger value than it.
+ *
+ *  Return an integer array answer where answer[i] is the value of the next
+ *  greater node of the ith node (1-indexed). If the ith node does not have a
+ *  next greater node, set answer[i] = 0.
+ *
+ *  Example 1:
+ *    Input: head = [2,1,5]
+ *    Output: [5,5,0]
+ *
+ *  Example 2:
+ *    Input: head = [2,7,4,3,5]
+ *    Output: [7,0,5,5,0]
+ *
+ *  Constraints:
+ *    1 <= n <= 10^4
+ *    1 <= Node.val <= 10^9
+ */
+public class NextGreaterNodeInLinkedList {
+
+    // V0
+    // IDEA: MONOTONIC (DECREASING) STACK
+    //       1) dump the list into an array (so we can index it)
+    //       2) walk left to right keeping a stack of INDICES whose answer is
+    //          still unknown, with strictly decreasing values. when the current
+    //          value is bigger than the value at the stack top, that top's
+    //          "next greater" is the current value -> pop and fill it in.
+    //       whatever is left on the stack at the end has no next greater -> 0.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int[] nextLargerNodes(ListNode head) {
+        List<Integer> vals = new ArrayList<>();
+        ListNode node = head;
+        while (node != null) {
+            vals.add(node.val);
+            node = node.next;
+        }
+
+        int n = vals.size();
+        int[] res = new int[n];
+        Deque<Integer> stack = new ArrayDeque<>(); // indices, values decreasing
+        for (int i = 0; i < n; i++) {
+            int v = vals.get(i);
+            while (!stack.isEmpty() && vals.get(stack.peek()) < v) {
+                res[stack.pop()] = v;
+            }
+            stack.push(i);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/NumberOfPeopleThatCanBeSeenInAGrid.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/NumberOfPeopleThatCanBeSeenInAGrid.java
@@ -1,0 +1,108 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/number-of-people-that-can-be-seen-in-a-grid/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  2282. Number of People That Can Be Seen in a Grid
+ *  Medium
+ *  (premium / locked problem)
+ *
+ *  You are given an m x n 0-indexed 2D array of positive integers heights where
+ *  heights[i][j] is the height of the person standing at position (i, j).
+ *
+ *  A person standing at position (row1, col1) can see a person standing at
+ *  position (row2, col2) if:
+ *    - The person at (row2, col2) is to the right or below the person at
+ *      (row1, col1). More formally, either row1 == row2 and col1 < col2, or
+ *      row1 < row2 and col1 == col2.
+ *    - Everyone in between them is shorter than both of them.
+ *
+ *  Return an m x n 2D array of integers answer where answer[i][j] is the number
+ *  of people that the person at position (i, j) can see.
+ *
+ *  Example 1:
+ *    Input: heights = [[3,1,4,2,5]]
+ *    Output: [[2,1,2,1,0]]
+ *
+ *  Example 2:
+ *    Input: heights = [[5,1],[3,1],[4,1]]
+ *    Output: [[3,1],[2,1],[1,0]]
+ *
+ *  Constraints:
+ *    1 <= heights.length <= 400
+ *    1 <= heights[i].length <= 400
+ *    1 <= heights[i][j] <= 10^5
+ */
+public class NumberOfPeopleThatCanBeSeenInAGrid {
+
+    // V0
+    // IDEA: MONOTONIC DECREASING STACK, ONCE PER ROW AND ONCE PER COLUMN
+    //       the two directions (right / down) are independent, so solve one line
+    //       at a time and ADD the two results.
+    //       scanning a line BACKWARDS with a non-increasing stack, for the
+    //       current person of height h:
+    //         - every stacked person strictly SHORTER than h is visible and then
+    //           gets blocked by h for anyone further back -> pop and count each
+    //         - the first person who is >= h is also visible (one more), but he
+    //           blocks everything beyond, so the popping stops there
+    //         - if that blocker is EXACTLY equal to h, replace it: the two are
+    //           interchangeable as blockers, and keeping both would let a later
+    //           person count the same wall twice
+    /**
+     * time = O(M * N)
+     * space = O(max(M, N))   // ignoring the output
+     */
+    public int[][] seePeople(int[][] heights) {
+        int m = heights.length;
+        int n = heights[0].length;
+        int[][] res = new int[m][n];
+
+        // rows -> looking right
+        for (int i = 0; i < m; i++) {
+            int[] counts = scan(heights[i]);
+            for (int j = 0; j < n; j++) {
+                res[i][j] += counts[j];
+            }
+        }
+
+        // columns -> looking down
+        int[] col = new int[m];
+        for (int j = 0; j < n; j++) {
+            for (int i = 0; i < m; i++) {
+                col[i] = heights[i][j];
+            }
+            int[] counts = scan(col);
+            for (int i = 0; i < m; i++) {
+                res[i][j] += counts[i];
+            }
+        }
+        return res;
+    }
+
+    /** how many people each position of `line` can see, looking forward */
+    private int[] scan(int[] line) {
+        int len = line.length;
+        int[] counts = new int[len];
+        Deque<Integer> stack = new ArrayDeque<>();
+        for (int idx = len - 1; idx >= 0; idx--) {
+            int h = line[idx];
+            int cnt = 0;
+            while (!stack.isEmpty() && stack.peek() < h) {
+                stack.pop();
+                cnt++;
+            }
+            if (!stack.isEmpty()) {
+                cnt++;                       // the blocker itself is visible
+                if (stack.peek() == h) {
+                    stack.pop();             // equal heights block identically
+                }
+            }
+            stack.push(h);
+            counts[idx] = cnt;
+        }
+        return counts;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/NumberOfValidSubarrays.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/NumberOfValidSubarrays.java
@@ -1,0 +1,62 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/number-of-valid-subarrays/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1063. Number of Valid Subarrays
+ *  Hard
+ *
+ *  Given an integer array nums, return the number of non-empty subarrays with
+ *  the leftmost element of the subarray not larger than other elements in the
+ *  subarray.
+ *
+ *  A subarray is a contiguous part of an array.
+ *
+ *  Example 1:
+ *    Input: nums = [1,4,2,5,3]
+ *    Output: 11
+ *    Explanation: the 11 valid subarrays are [1],[4],[2],[5],[3],[1,4],[2,5],
+ *                 [1,4,2],[2,5,3],[1,4,2,5],[1,4,2,5,3]
+ *
+ *  Example 2:
+ *    Input: nums = [3,2,1]
+ *    Output: 3
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 5 * 10^4
+ *    0 <= nums[i] <= 10^5
+ */
+public class NumberOfValidSubarrays {
+
+    // V0
+    // IDEA: MONOTONIC STACK (next strictly smaller element to the right)
+    //       a subarray starting at i is valid <-> every element in it is >= nums[i]
+    //       -> it may extend up to (but not include) the FIRST j > i with
+    //          nums[j] < nums[i]
+    //       -> # of valid subarrays starting at i = right[i] - i, where right[i]
+    //          is the index of that first smaller element (n if none)
+    //       scanning from the right with a stack of indices of increasing values
+    //       gives every right[i] in one pass.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int validSubarrays(int[] nums) {
+        int n = nums.length;
+        Deque<Integer> stack = new ArrayDeque<>(); // indices, values increasing bottom->? (strictly increasing from top down)
+        long ans = 0;
+        for (int i = n - 1; i >= 0; i--) {
+            // NOTE: pop with `>=` so equal values are NOT treated as a blocker
+            while (!stack.isEmpty() && nums[stack.peek()] >= nums[i]) {
+                stack.pop();
+            }
+            int right = stack.isEmpty() ? n : stack.peek();
+            ans += (right - i);
+            stack.push(i);
+        }
+        return (int) ans;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/NumberOfVisiblePeopleInAQueue.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/NumberOfVisiblePeopleInAQueue.java
@@ -1,0 +1,73 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/number-of-visible-people-in-a-queue/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1944. Number of Visible People in a Queue
+ *  Hard
+ *
+ *  There are n people standing in a queue, numbered from 0 to n - 1 in left to
+ *  right order. You are given an array heights of distinct integers where
+ *  heights[i] represents the height of the ith person.
+ *
+ *  A person can see another person to their right in the queue if everybody in
+ *  between is shorter than both of them. More formally, the ith person can see
+ *  the jth person if i < j and
+ *  min(heights[i], heights[j]) > max(heights[i+1], ..., heights[j-1]).
+ *
+ *  Return an array answer of length n where answer[i] is the number of people
+ *  the ith person can see to their right in the queue.
+ *
+ *  Example 1:
+ *    Input: heights = [10,6,8,5,11,9]
+ *    Output: [3,1,2,1,1,0]
+ *
+ *  Example 2:
+ *    Input: heights = [5,1,2,3,10]
+ *    Output: [4,1,1,1,0]
+ *
+ *  Constraints:
+ *    n == heights.length
+ *    1 <= n <= 10^5
+ *    1 <= heights[i] <= 10^5
+ *    All the values of heights are unique.
+ */
+public class NumberOfVisiblePeopleInAQueue {
+
+    // V0
+    // IDEA: MONOTONIC (DECREASING) STACK, SCANNING RIGHT -> LEFT
+    //       the people person i can see form a strictly INCREASING chain of
+    //       heights to his right, ending at the first person taller than him
+    //       (that one blocks everybody behind).
+    //       keep a stack decreasing from bottom to top holding the heights to
+    //       the right of i. for person i:
+    //         - pop every shorter person: each of them is directly visible
+    //         - if the stack is still non-empty, the remaining top is the first
+    //           TALLER person -> he is visible too, and he blocks the rest
+    //         - push heights[i]
+    //       every height is pushed and popped once -> linear overall.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int[] canSeePersonsCount(int[] heights) {
+        int n = heights.length;
+        int[] res = new int[n];
+        Deque<Integer> stack = new ArrayDeque<>();
+        for (int i = n - 1; i >= 0; i--) {
+            int h = heights[i];
+            while (!stack.isEmpty() && stack.peek() < h) {
+                stack.pop();
+                res[i]++;
+            }
+            if (!stack.isEmpty()) {
+                res[i]++;   // the first taller person is visible, then blocks
+            }
+            stack.push(h);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/RemoveOutermostParentheses.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/RemoveOutermostParentheses.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/remove-outermost-parentheses/
+
+/**
+ *  1021. Remove Outermost Parentheses
+ *  Easy
+ *
+ *  A valid parentheses string is either empty "", "(" + A + ")", or A + B, where
+ *  A and B are valid parentheses strings, and + represents string concatenation.
+ *
+ *  A valid parentheses string s is primitive if it is nonempty, and there does
+ *  not exist a way to split it into s = A + B, with A and B nonempty valid
+ *  parentheses strings.
+ *
+ *  Given a valid parentheses string s, consider its primitive decomposition
+ *  s = P1 + P2 + ... + Pk. Return s after removing the outermost parentheses of
+ *  every primitive string in the primitive decomposition of s.
+ *
+ *  Example 1:
+ *    Input: s = "(()())(())"
+ *    Output: "()()()"
+ *
+ *  Example 2:
+ *    Input: s = "(()())(())(()(()))"
+ *    Output: "()()()()(())"
+ *
+ *  Constraints:
+ *    1 <= s.length <= 10^5
+ *    s[i] is either '(' or ')'.
+ *    s is a valid parentheses string.
+ */
+public class RemoveOutermostParentheses {
+
+    // V0
+    // IDEA: DEPTH COUNTER (a stack of size 1)
+    //       the outermost '(' of a primitive is the one that takes depth 0 -> 1,
+    //       and its matching ')' is the one that takes depth 1 -> 0, so SKIP
+    //       exactly those two:
+    //         '(' : keep it only if depth > 0, then depth += 1
+    //         ')' : depth -= 1, then keep it only if depth > 0
+    /**
+     * time = O(N)
+     * space = O(N)   // for the output
+     */
+    public String removeOuterParentheses(String s) {
+        StringBuilder sb = new StringBuilder();
+        int depth = 0;
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == '(') {
+                if (depth > 0) {
+                    sb.append(ch);
+                }
+                depth++;
+            } else {
+                depth--;
+                if (depth > 0) {
+                    sb.append(ch);
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/ReplaceNonCoprimeNumbersInArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/ReplaceNonCoprimeNumbersInArray.java
@@ -1,0 +1,81 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/replace-non-coprime-numbers-in-array/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  2197. Replace Non-Coprime Numbers in Array
+ *  Hard
+ *
+ *  You are given an array of integers nums. Perform the following steps:
+ *    - Find any two adjacent numbers in nums that are non-coprime.
+ *    - If no such numbers are found, stop the process.
+ *    - Otherwise, delete the two numbers and replace them with their LCM
+ *      (Least Common Multiple).
+ *    - Repeat as long as you keep finding two adjacent non-coprime numbers.
+ *
+ *  Return the final modified array. It can be shown that replacing adjacent
+ *  non-coprime numbers in any arbitrary order will lead to the same result.
+ *
+ *  Two values x and y are non-coprime if GCD(x, y) > 1.
+ *
+ *  Example 1:
+ *    Input: nums = [6,4,3,2,7,6,2]
+ *    Output: [12,7,6]
+ *
+ *  Example 2:
+ *    Input: nums = [2,2,1,1,3,3,3]
+ *    Output: [2,1,1,3]
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i] <= 10^5
+ *    The test cases are generated such that the values in the final array are
+ *    less than or equal to 10^8.
+ */
+public class ReplaceNonCoprimeNumbersInArray {
+
+    // V0
+    // IDEA: STACK - MERGE BACKWARDS UNTIL COPRIME
+    //       push each number, then repeatedly look at the top TWO entries: while
+    //       they share a factor, pop both and push their LCM. merging can expose
+    //       a new non-coprime pair further down the stack, which is exactly what
+    //       the inner loop keeps handling.
+    //       the statement guarantees the result is order-independent, so this
+    //       left-to-right sweep is a valid schedule.
+    //       lcm(a, b) = a / gcd(a, b) * b - dividing FIRST keeps the
+    //       intermediate value small.
+    /**
+     * time = O(N * log(max value))   // amortised
+     * space = O(N)
+     */
+    public List<Integer> replaceNonCoprimes(int[] nums) {
+        List<Integer> stack = new ArrayList<>();
+        for (int x : nums) {
+            stack.add(x);
+            while (stack.size() > 1) {
+                int b = stack.get(stack.size() - 1);
+                int a = stack.get(stack.size() - 2);
+                int g = gcd(a, b);
+                if (g == 1) {
+                    break;
+                }
+                stack.remove(stack.size() - 1);
+                stack.remove(stack.size() - 1);
+                stack.add(a / g * b);
+            }
+        }
+        return stack;
+    }
+
+    private int gcd(int a, int b) {
+        while (b != 0) {
+            int t = a % b;
+            a = b;
+            b = t;
+        }
+        return a;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/ResultingStringAfterAdjacentRemovals.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/ResultingStringAfterAdjacentRemovals.java
@@ -1,0 +1,74 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/resulting-string-after-adjacent-removals/
+
+/**
+ *  3561. Resulting String After Adjacent Removals
+ *  Medium
+ *
+ *  You are given a string s consisting of lowercase English letters.
+ *
+ *  You must repeatedly perform the following operation while the string s has at
+ *  least two consecutive characters:
+ *    - Remove the leftmost pair of adjacent characters in the string that are
+ *      consecutive in the alphabet, in either order (e.g. 'a' and 'b', or 'b'
+ *      and 'a').
+ *    - Shift the remaining characters to the left to fill the gap.
+ *
+ *  Return the resulting string after no more operations can be performed.
+ *
+ *  Note: Consider the alphabet as circular, thus 'a' and 'z' are consecutive.
+ *
+ *  Example 1:
+ *    Input: s = "abc"
+ *    Output: "c"
+ *    Explanation: remove "ab", leaving "c".
+ *
+ *  Example 2:
+ *    Input: s = "adcb"
+ *    Output: ""
+ *    Explanation: remove "dc" -> "ab", then remove "ab" -> "".
+ *
+ *  Example 3:
+ *    Input: s = "zadb"
+ *    Output: "db"
+ *
+ *  Constraints:
+ *    1 <= s.length <= 10^5
+ *    s consists only of lowercase English letters.
+ */
+public class ResultingStringAfterAdjacentRemovals {
+
+    // V0
+    // IDEA: STACK - REPLAY THE REQUIRED LEFTMOST REMOVALS IN ONE PASS
+    //       the reduction is NOT order independent, so the "leftmost first" rule
+    //       has to be honoured rather than argued away ("abc" -> "c" if "ab" goes
+    //       first, but -> "a" if "bc" does).
+    //       a left-to-right stack pass reproduces exactly that order: the stack
+    //       always holds the fully reduced form of the prefix read so far, so
+    //       nothing inside it can still cancel and its top is the only character
+    //       a new one could meet. when the next character is alphabet-adjacent
+    //       (mod 26) to that top, that pair IS the leftmost removable pair, so
+    //       cancelling it is forced; popping it exposes an older character that
+    //       may in turn cancel with a later one.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public String resultingString(String s) {
+        StringBuilder stack = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            int top = stack.length() - 1;
+            if (top >= 0) {
+                int d = Math.abs(stack.charAt(top) - ch);
+                if (d == 1 || d == 25) {
+                    stack.deleteCharAt(top);
+                    continue;
+                }
+            }
+            stack.append(ch);
+        }
+        return stack.toString();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/ReverseSubstringsBetweenEachPairOfParentheses.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/ReverseSubstringsBetweenEachPairOfParentheses.java
@@ -1,0 +1,67 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/reverse-substrings-between-each-pair-of-parentheses/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1190. Reverse Substrings Between Each Pair of Parentheses
+ *  Medium
+ *
+ *  You are given a string s that consists of lower case English letters and
+ *  brackets.
+ *
+ *  Reverse the strings in each pair of matching parentheses, starting from the
+ *  innermost one.
+ *
+ *  Your result should not contain any brackets.
+ *
+ *  Example 1:
+ *    Input: s = "(abcd)"
+ *    Output: "dcba"
+ *
+ *  Example 2:
+ *    Input: s = "(u(love)i)"
+ *    Output: "iloveu"
+ *    Explanation: the substring "love" is reversed first, then the whole string.
+ *
+ *  Example 3:
+ *    Input: s = "(ed(et(oc))el)"
+ *    Output: "leetcode"
+ *
+ *  Constraints:
+ *    1 <= s.length <= 2000
+ *    s only contains lower case English characters and parentheses.
+ *    It is guaranteed that all parentheses are balanced.
+ */
+public class ReverseSubstringsBetweenEachPairOfParentheses {
+
+    // V0
+    // IDEA: STACK of BUFFERS (simulation)
+    //       on '(' -> push a new buffer
+    //       on ')' -> pop the innermost buffer, REVERSE it, and merge it back
+    //                 into its parent buffer
+    //       the bottom buffer holds the answer.
+    /**
+     * time = O(N^2)   // each ')' reverses its buffer
+     * space = O(N)
+     */
+    public String reverseParentheses(String s) {
+        Deque<StringBuilder> stack = new ArrayDeque<>();
+        stack.push(new StringBuilder());   // the "outermost" buffer
+
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == '(') {
+                stack.push(new StringBuilder());
+            } else if (ch == ')') {
+                StringBuilder top = stack.pop();
+                stack.peek().append(top.reverse());
+            } else {
+                stack.peek().append(ch);
+            }
+        }
+        return stack.pop().toString();
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/SubarrayWithElementsGreaterThanVaryingThreshold.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/SubarrayWithElementsGreaterThanVaryingThreshold.java
@@ -1,0 +1,85 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/subarray-with-elements-greater-than-varying-threshold/
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+/**
+ *  2334. Subarray With Elements Greater Than Varying Threshold
+ *  Hard
+ *
+ *  You are given an integer array nums and an integer threshold.
+ *
+ *  Find any subarray of nums of length k such that every element in the subarray
+ *  is greater than threshold / k.
+ *
+ *  Return the size of any such subarray. If there is no such subarray, return -1.
+ *
+ *  Example 1:
+ *    Input: nums = [1,3,4,3,1], threshold = 6
+ *    Output: 3
+ *    Explanation: the subarray [3,4,3] has size 3, and every element is greater
+ *                 than 6 / 3 = 2.
+ *
+ *  Example 2:
+ *    Input: nums = [6,5,6,5,8], threshold = 7
+ *    Output: 1
+ *    Explanation: [8] has size 1 and 8 > 7 / 1. (2, 3, 4, 5 are also accepted.)
+ *
+ *  Constraints:
+ *    1 <= nums.length <= 10^5
+ *    1 <= nums[i], threshold <= 10^9
+ */
+public class SubarrayWithElementsGreaterThanVaryingThreshold {
+
+    // V0
+    // IDEA: "EVERY ELEMENT > threshold / k" IS REALLY "THE MINIMUM > threshold / k"
+    //       so it is enough to consider, for each index i, the WIDEST window in
+    //       which nums[i] is the minimum - bounded by the previous and next
+    //       strictly smaller elements. a monotonic stack finds both in one pass.
+    //       with that window of length  width = right[i] - left[i] - 1, the
+    //       condition  nums[i] > threshold / width  is checked as
+    //       nums[i] * width > threshold  (long math) to stay in exact integers.
+    //       testing only these maximal windows is sufficient: any valid subarray
+    //       is contained in the maximal window of its own minimum, and shrinking
+    //       a window only makes the required bound larger.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int validSubarraySize(int[] nums, int threshold) {
+        int n = nums.length;
+
+        int[] left = new int[n];    // previous strictly smaller
+        Arrays.fill(left, -1);
+        Deque<Integer> stack = new ArrayDeque<>();
+        for (int i = 0; i < n; i++) {
+            while (!stack.isEmpty() && nums[stack.peek()] >= nums[i]) {
+                stack.pop();
+            }
+            left[i] = stack.isEmpty() ? -1 : stack.peek();
+            stack.push(i);
+        }
+
+        int[] right = new int[n];   // next strictly smaller
+        Arrays.fill(right, n);
+        stack.clear();
+        for (int i = n - 1; i >= 0; i--) {
+            while (!stack.isEmpty() && nums[stack.peek()] >= nums[i]) {
+                stack.pop();
+            }
+            right[i] = stack.isEmpty() ? n : stack.peek();
+            stack.push(i);
+        }
+
+        for (int i = 0; i < n; i++) {
+            int width = right[i] - left[i] - 1;
+            if ((long) nums[i] * width > threshold) {
+                return width;
+            }
+        }
+        return -1;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Stack/SumOfTotalStrengthOfWizards.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Stack/SumOfTotalStrengthOfWizards.java
@@ -1,0 +1,108 @@
+package LeetCodeJava.Stack;
+
+// https://leetcode.com/problems/sum-of-total-strength-of-wizards/
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+/**
+ *  2281. Sum of Total Strength of Wizards
+ *  Hard
+ *
+ *  As the ruler of a kingdom, you have an army of wizards at your command.
+ *
+ *  You are given a 0-indexed integer array strength, where strength[i] denotes
+ *  the strength of the ith wizard. For a contiguous group of wizards (i.e. the
+ *  wizards' strengths form a subarray of strength), the total strength is
+ *  defined as the product of:
+ *    - the strength of the weakest wizard in the group, and
+ *    - the total of all the individual strengths of the wizards in the group.
+ *
+ *  Return the sum of the total strengths of all contiguous groups of wizards.
+ *  Since the answer may be very large, return it modulo 10^9 + 7.
+ *
+ *  Example 1:
+ *    Input: strength = [1,3,1,2]
+ *    Output: 44
+ *
+ *  Example 2:
+ *    Input: strength = [5,4,6]
+ *    Output: 213
+ *
+ *  Constraints:
+ *    1 <= strength.length <= 10^5
+ *    1 <= strength[i] <= 10^9
+ */
+public class SumOfTotalStrengthOfWizards {
+
+    // V0
+    // IDEA: MONOTONIC STACK FOR THE "I AM THE MINIMUM" RANGE + DOUBLE PREFIX SUMS
+    //       attribute every subarray to its MINIMUM element. for index i let
+    //         l = last index on the left with a STRICTLY smaller value (else -1)
+    //         r = first index on the right with a value <= strength[i] (else n)
+    //       the strict/non-strict split makes ties attribute to exactly one index.
+    //       i is then the minimum of every subarray [a, b] with l < a <= i <= b < r.
+    //       its contribution is strength[i] * (SUM OF THOSE SUBARRAY SUMS), and
+    //       with P[k] = sum of the first k elements, PP[k] = P[0] + ... + P[k-1]:
+    //         sum of sums = (i - l) * (PP[r+1] - PP[i+1])
+    //                     - (r - i) * (PP[i+1] - PP[l+1])
+    //       the first term collects the right endpoints (each reachable by i - l
+    //       choices of left endpoint), the second subtracts the left endpoints.
+    //       NOTE: normalise the subtraction back to [0, MOD) - java's % can be
+    //             negative.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int totalStrength(int[] strength) {
+        final long MOD = 1_000_000_007L;
+        int n = strength.length;
+
+        // previous strictly-smaller
+        int[] left = new int[n];
+        Arrays.fill(left, -1);
+        Deque<Integer> stack = new ArrayDeque<>();
+        for (int i = 0; i < n; i++) {
+            while (!stack.isEmpty() && strength[stack.peek()] >= strength[i]) {
+                stack.pop();
+            }
+            left[i] = stack.isEmpty() ? -1 : stack.peek();
+            stack.push(i);
+        }
+
+        // next smaller-or-equal
+        int[] right = new int[n];
+        Arrays.fill(right, n);
+        stack.clear();
+        for (int i = n - 1; i >= 0; i--) {
+            while (!stack.isEmpty() && strength[stack.peek()] > strength[i]) {
+                stack.pop();
+            }
+            right[i] = stack.isEmpty() ? n : stack.peek();
+            stack.push(i);
+        }
+
+        // P[k] = sum of the first k elements ; PP[k] = P[0] + ... + P[k-1]
+        long[] P = new long[n + 1];
+        for (int i = 0; i < n; i++) {
+            P[i + 1] = (P[i] + strength[i]) % MOD;
+        }
+        long[] PP = new long[n + 2];
+        for (int k = 0; k <= n; k++) {
+            PP[k + 1] = (PP[k] + P[k]) % MOD;
+        }
+
+        long res = 0;
+        for (int i = 0; i < n; i++) {
+            int l = left[i];
+            int r = right[i];
+            long rightPart = ((PP[r + 1] - PP[i + 1]) % MOD + MOD) % MOD;
+            long leftPart = ((PP[i + 1] - PP[l + 1]) % MOD + MOD) % MOD;
+            long total = ((i - l) * rightPart % MOD - (r - i) * leftPart % MOD) % MOD;
+            total = (total + MOD) % MOD;
+            res = (res + strength[i] * total) % MOD;
+        }
+        return (int) res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/String/CountSubstringsWithOnlyOneDistinctLetter.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/String/CountSubstringsWithOnlyOneDistinctLetter.java
@@ -1,0 +1,56 @@
+package LeetCodeJava.String;
+
+// https://leetcode.com/problems/count-substrings-with-only-one-distinct-letter/
+
+/**
+ *  1180. Count Substrings with Only One Distinct Letter
+ *  Easy
+ *
+ *  Given a string s, return the number of substrings that have only one distinct letter.
+ *
+ *  Example 1:
+ *    Input: s = "aaaba"
+ *    Output: 8
+ *    Explanation: The substrings with one distinct letter are "aaa", "aa", "a", "b".
+ *                 "aaa" occurs 1 time.
+ *                 "aa" occurs 2 times.
+ *                 "a" occurs 4 times.
+ *                 "b" occurs 1 time.
+ *                 So the answer is 1 + 2 + 4 + 1 = 8.
+ *
+ *  Example 2:
+ *    Input: s = "aaaaaaaaaa"
+ *    Output: 55
+ *
+ *  Constraints:
+ *    1 <= s.length <= 1000
+ *    s[i] consists of only lowercase English letters.
+ */
+public class CountSubstringsWithOnlyOneDistinctLetter {
+
+    // V0
+    // IDEA: TWO POINTERS (group the string into equal-letter RUNS)
+    //       every "single distinct letter" substring lives entirely inside one run,
+    //       and a run of length L contributes L * (L + 1) / 2 substrings
+    //       (1 of length L, 2 of length L-1, ... L of length 1).
+    //       so : find each maximal run, add its triangular number, jump past it.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public int countLetters(String s) {
+        int n = s.length();
+        int res = 0;
+        int i = 0;
+        while (i < n) {
+            int j = i;
+            while (j < n && s.charAt(j) == s.charAt(i)) {
+                j++;
+            }
+            int len = j - i;
+            res += len * (len + 1) / 2;
+            i = j;   // NOTE !!! jump to the start of the next run
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/CheckIfAStringIsAValidSequenceFromRootToLeavesPathInABinaryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/CheckIfAStringIsAValidSequenceFromRootToLeavesPathInABinaryTree.java
@@ -1,0 +1,63 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/check-if-a-string-is-a-valid-sequence-from-root-to-leaves-path-in-a-binary-tree/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1430. Check If a String Is a Valid Sequence from Root to Leaves Path in a Binary Tree
+ *  Medium
+ *
+ *  Given a binary tree where each path going from the root to any leaf form a
+ *  valid sequence, check if a given string is a valid sequence in such binary tree.
+ *
+ *  We get the given string from the concatenation of an array of integers arr and
+ *  the concatenation of all values of the nodes along a path results in a sequence
+ *  in the given binary tree.
+ *
+ *  Example 1:
+ *    Input: root = [0,1,0,0,1,0,null,null,1,0,0], arr = [0,1,0,1]
+ *    Output: true
+ *    Explanation: The path 0 -> 1 -> 0 -> 1 is a valid sequence.
+ *
+ *  Example 2:
+ *    Input: root = [0,1,0,0,1,0,null,null,1,0,0], arr = [0,0,1]
+ *    Output: false
+ *    Explanation: The path 0 -> 0 -> 1 does not exist.
+ *
+ *  Example 3:
+ *    Input: root = [0,1,0,0,1,0,null,null,1,0,0], arr = [0,1,1]
+ *    Output: false
+ *    Explanation: 0 -> 1 -> 1 is a sequence, but not a valid (root to LEAF) one.
+ *
+ *  Constraints:
+ *    1 <= arr.length <= 5000
+ *    0 <= arr[i] <= 9
+ *    Each node's value is between [0 - 9].
+ */
+public class CheckIfAStringIsAValidSequenceFromRootToLeavesPathInABinaryTree {
+
+    // V0
+    // IDEA: DFS, walk the tree and the array in lock step (index i)
+    //       prune as soon as node.val != arr[i]; "valid" means the WHOLE arr
+    //       is consumed AND we landed on a LEAF (this is what makes
+    //       0 -> 1 -> 1 false: it exists, but the last node is not a leaf).
+    /**
+     * time = O(N)
+     * space = O(H)   // H = tree height (recursion stack)
+     */
+    public boolean isValidSequence(TreeNode root, int[] arr) {
+        return dfs(root, arr, 0);
+    }
+
+    private boolean dfs(TreeNode node, int[] arr, int i) {
+        if (node == null || i >= arr.length || node.val != arr[i]) {
+            return false;
+        }
+        // NOTE !!! must be at the LAST arr element AND at a leaf
+        if (i == arr.length - 1) {
+            return node.left == null && node.right == null;
+        }
+        return dfs(node.left, arr, i + 1) || dfs(node.right, arr, i + 1);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/CheckIfTwoExpressionTreesAreEquivalent.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/CheckIfTwoExpressionTreesAreEquivalent.java
@@ -1,0 +1,103 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/check-if-two-expression-trees-are-equivalent/
+
+/**
+ *  1612. Check If Two Expression Trees are Equivalent
+ *  Medium
+ *
+ *  A binary expression tree is a kind of binary tree used to represent arithmetic
+ *  expressions. Each node of a binary expression tree has either zero or two
+ *  children. Leaf nodes (nodes with 0 children) correspond to operands
+ *  (variables), and internal nodes (nodes with two children) correspond to the
+ *  operators. In this problem, we only consider the '+' operator (i.e. addition).
+ *
+ *  You are given the roots of two binary expression trees, root1 and root2.
+ *  Return true if the two binary expression trees are equivalent.
+ *  Otherwise, return false.
+ *
+ *  Two binary expression trees are equivalent if they evaluate to the same value
+ *  regardless of what the variables are set to.
+ *
+ *  Example 1:
+ *    Input: root1 = [x], root2 = [x]
+ *    Output: true
+ *
+ *  Example 2:
+ *    Input: root1 = [+,a,+,null,null,b,c], root2 = [+,+,a,b,c]
+ *    Output: true
+ *    Explanation: a + (b + c) == (b + c) + a
+ *
+ *  Example 3:
+ *    Input: root1 = [+,a,+,null,null,b,c], root2 = [+,+,a,b,d]
+ *    Output: false
+ *    Explanation: a + (b + c) != (b + d) + a
+ *
+ *  Constraints:
+ *    The number of nodes in both trees are equal, odd and, in the range [1, 4999].
+ *    Node.val is '+' or a lower-case English letter.
+ *    It's guaranteed that the tree given is a valid binary expression tree.
+ *
+ *  Follow up: What will you change in your solution if the tree also supports
+ *             the '-' operator (i.e. subtraction)?
+ */
+public class CheckIfTwoExpressionTreesAreEquivalent {
+
+    // expression tree node (problem specific shape: char val)
+    public static class Node {
+        public char val;
+        public Node left;
+        public Node right;
+
+        public Node() {
+            this.val = ' ';
+        }
+
+        public Node(char val) {
+            this.val = val;
+        }
+
+        public Node(char val, Node left, Node right) {
+            this.val = val;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    // V0
+    // IDEA: COUNT LEAVES ('+' is commutative + associative, so only the
+    //       MULTISET of operands matters)
+    //       any tree evaluates to sum over variables of count(var) * value(var),
+    //       so two trees are equivalent iff every variable appears the same
+    //       number of times. trick: walk tree1 with +1 per leaf and tree2 with
+    //       -1 per leaf into the SAME counter -> equivalent iff all entries 0.
+    //       follow-up with '-': keep the counter but flip the sign when
+    //       descending into the RIGHT child of a '-' node.
+    /**
+     * time = O(N1 + N2)
+     * space = O(26) counters + O(H) recursion stack
+     */
+    public boolean checkEquivalence(Node root1, Node root2) {
+        int[] cnt = new int[26];
+        walk(root1, 1, cnt);
+        walk(root2, -1, cnt);
+        for (int c : cnt) {
+            if (c != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void walk(Node node, int sign, int[] cnt) {
+        if (node == null) {
+            return;
+        }
+        if (node.left == null && node.right == null) {
+            cnt[node.val - 'a'] += sign;
+            return;
+        }
+        walk(node.left, sign, cnt);
+        walk(node.right, sign, cnt);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/CloneNAryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/CloneNAryTree.java
@@ -1,0 +1,74 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/clone-n-ary-tree/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1490. Clone N-ary Tree
+ *  Medium
+ *
+ *  Given a root of an N-ary tree, return a deep copy (clone) of the tree.
+ *
+ *  Each node in the n-ary tree contains a val (int) and a list (List[Node])
+ *  of its children.
+ *
+ *  Example 1:
+ *    Input: root = [1,null,3,2,4,null,5,6]
+ *    Output: [1,null,3,2,4,null,5,6]
+ *
+ *  Example 2:
+ *    Input: root = [1,null,2,3,4,5,null,null,6,7,null,8,null,9,10,null,null,11,null,12,null,13,null,null,14]
+ *    Output: [1,null,2,3,4,5,null,null,6,7,null,8,null,9,10,null,null,11,null,12,null,13,null,null,14]
+ *
+ *  Constraints:
+ *    The depth of the n-ary tree is less than or equal to 1000.
+ *    The total number of nodes is between [0, 10^4].
+ *
+ *  Follow up: Can your solution work for the graph problem?
+ */
+public class CloneNAryTree {
+
+    // N-ary tree node (problem specific shape)
+    public static class Node {
+        public int val;
+        public List<Node> children;
+
+        public Node() {
+            this.children = new ArrayList<>();
+        }
+
+        public Node(int val) {
+            this.val = val;
+            this.children = new ArrayList<>();
+        }
+
+        public Node(int val, List<Node> children) {
+            this.val = val;
+            this.children = children;
+        }
+    }
+
+    // V0
+    // IDEA: POST-ORDER DFS (clone the children first, then build the parent)
+    //       a tree has no shared nodes and no cycles, so no visited map is
+    //       needed. NOTE: build a NEW children list -- reusing root.children
+    //       would leave the clone pointing at the ORIGINAL nodes.
+    //       for the graph follow-up an old -> new map is required so a
+    //       revisited node returns its existing copy instead of recursing.
+    /**
+     * time = O(N)
+     * space = O(H)   // H = depth (recursion stack)
+     */
+    public Node cloneTree(Node root) {
+        if (root == null) {
+            return null;
+        }
+        List<Node> children = new ArrayList<>();
+        for (Node child : root.children) {
+            children.add(cloneTree(child));
+        }
+        return new Node(root.val, children);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/ClosestNodeToPathInTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/ClosestNodeToPathInTree.java
@@ -1,0 +1,112 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/closest-node-to-path-in-tree/
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ *  2277. Closest Node to Path in Tree
+ *  Hard
+ *
+ *  You are given a positive integer n representing the number of nodes in a tree,
+ *  numbered from 0 to n - 1 (inclusive). You are also given a 2D integer array
+ *  edges of length n - 1, where edges[i] = [node1_i, node2_i] denotes that there
+ *  is a bidirectional edge connecting node1_i and node2_i in the tree.
+ *
+ *  You are given a 0-indexed integer array query of length m where
+ *  query[i] = [start_i, end_i, node_i] means that for the ith query, you are
+ *  tasked with finding the node on the path from start_i to end_i that is closest
+ *  to node_i.
+ *
+ *  Return an integer array answer of length m, where answer[i] is the answer to
+ *  the ith query.
+ *
+ *  Example 1:
+ *    Input: n = 7, edges = [[0,1],[0,2],[0,3],[1,4],[2,5],[2,6]],
+ *           query = [[5,3,4],[5,3,6]]
+ *    Output: [0,2]
+ *    Explanation: the path 5 -> 3 is [5,2,0,3]; node 0 is the closest to 4,
+ *                 node 2 is the closest to 6.
+ *
+ *  Example 2:
+ *    Input: n = 3, edges = [[0,1],[1,2]], query = [[0,1,2]]
+ *    Output: [1]
+ *
+ *  Constraints:
+ *    1 <= n <= 1000
+ *    edges.length == n - 1
+ *    1 <= query.length <= 1000
+ *    query[i].length == 3
+ *    0 <= start_i, end_i, node_i <= n - 1
+ *    The graph is a tree.
+ */
+public class ClosestNodeToPathInTree {
+
+    // V0
+    // IDEA: n <= 1000 -> PRECOMPUTE ALL-PAIRS DISTANCES WITH n BFS RUNS.
+    //       the tree is unweighted, so a BFS from every node fills
+    //       dist[u][v] in O(n * (V + E)) ~ 10^6 steps.
+    //       with that table, "v is on the path start -> end" becomes a
+    //       distance identity (unique tree path):
+    //           dist[start][v] + dist[v][end] == dist[start][end]
+    //       so each query scans all n nodes and keeps the on-path one that
+    //       minimises dist[node][v].
+    /**
+     * time = O(N^2 + M*N)
+     * space = O(N^2)
+     */
+    public int[] closestNode(int n, int[][] edges, int[][] query) {
+        List<List<Integer>> g = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            g.add(new ArrayList<Integer>());
+        }
+        for (int[] e : edges) {
+            g.get(e[0]).add(e[1]);
+            g.get(e[1]).add(e[0]);
+        }
+
+        int[][] dist = new int[n][n];
+        for (int src = 0; src < n; src++) {
+            int[] d = dist[src];
+            for (int i = 0; i < n; i++) {
+                d[i] = -1;
+            }
+            d[src] = 0;
+            Queue<Integer> q = new LinkedList<>();
+            q.add(src);
+            while (!q.isEmpty()) {
+                int cur = q.poll();
+                for (int nxt : g.get(cur)) {
+                    if (d[nxt] == -1) {
+                        d[nxt] = d[cur] + 1;
+                        q.add(nxt);
+                    }
+                }
+            }
+        }
+
+        int[] res = new int[query.length];
+        for (int i = 0; i < query.length; i++) {
+            int start = query[i][0];
+            int end = query[i][1];
+            int node = query[i][2];
+            int best = -1;
+            int bestDist = Integer.MAX_VALUE;
+            for (int v = 0; v < n; v++) {
+                // NOTE !!! on-path test via the distance identity
+                if (dist[start][v] + dist[v][end] != dist[start][end]) {
+                    continue;
+                }
+                if (dist[node][v] < bestDist) {
+                    bestDist = dist[node][v];
+                    best = v;
+                }
+            }
+            res[i] = best;
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/ConstructBinarySearchTreeFromPreorderTraversal.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/ConstructBinarySearchTreeFromPreorderTraversal.java
@@ -1,0 +1,62 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/construct-binary-search-tree-from-preorder-traversal/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1008. Construct Binary Search Tree from Preorder Traversal
+ *  Medium
+ *
+ *  Given an array of integers preorder, which represents the preorder traversal
+ *  of a BST (i.e., binary search tree), construct the tree and return its root.
+ *
+ *  It is guaranteed that there is always possible to find a binary search tree
+ *  with the given requirements for the given test cases.
+ *
+ *  Example 1:
+ *    Input: preorder = [8,5,1,7,10,12]
+ *    Output: [8,5,10,1,7,null,12]
+ *
+ *  Example 2:
+ *    Input: preorder = [1,3]
+ *    Output: [1,null,3]
+ *
+ *  Constraints:
+ *    1 <= preorder.length <= 100
+ *    1 <= preorder[i] <= 1000
+ *    All the values of preorder are unique.
+ */
+public class ConstructBinarySearchTreeFromPreorderTraversal {
+
+    // V0
+    // IDEA: RECURSION + UPPER BOUND (single pass)
+    //       preorder gives the node BEFORE its subtrees, so we can consume the
+    //       array left to right and only need the largest value still allowed
+    //       in the current subtree:
+    //         - if the next value > bound -> it does NOT belong here, stop
+    //         - else consume it as the root, then
+    //             left  subtree: values < root.val -> build(root.val)
+    //             right subtree: values < bound    -> build(bound)
+    /**
+     * time = O(N)
+     * space = O(N)   // recursion depth (skewed tree)
+     */
+    private int idx = 0;
+
+    public TreeNode bstFromPreorder(int[] preorder) {
+        this.idx = 0;
+        return build(preorder, Integer.MAX_VALUE);
+    }
+
+    private TreeNode build(int[] preorder, int bound) {
+        if (this.idx == preorder.length || preorder[this.idx] > bound) {
+            return null;
+        }
+        TreeNode node = new TreeNode(preorder[this.idx]);
+        this.idx++;
+        node.left = build(preorder, node.val);
+        node.right = build(preorder, bound);
+        return node;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/CountGoodTripletsInAnArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/CountGoodTripletsInAnArray.java
@@ -1,0 +1,88 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/count-good-triplets-in-an-array/
+
+/**
+ *  2179. Count Good Triplets in an Array
+ *  Hard
+ *
+ *  You are given two 0-indexed arrays nums1 and nums2 of length n, both of which
+ *  are permutations of [0, 1, ..., n - 1].
+ *
+ *  A good triplet is a set of 3 distinct values which are present in increasing
+ *  order by position both in nums1 and nums2. In other words, if we consider
+ *  pos1v as the index of the value v in nums1 and pos2v as the index of the value
+ *  v in nums2, then a good triplet will be a set (x, y, z) where
+ *  0 <= x, y, z <= n - 1, such that pos1x < pos1y < pos1z and
+ *  pos2x < pos2y < pos2z.
+ *
+ *  Return the total number of good triplets.
+ *
+ *  Example 1:
+ *    Input: nums1 = [2,0,1,3], nums2 = [0,1,2,3]
+ *    Output: 1
+ *    Explanation: only the triplet (0,1,3) is increasing by position in both.
+ *
+ *  Example 2:
+ *    Input: nums1 = [4,0,1,3,2], nums2 = [4,1,0,2,3]
+ *    Output: 4
+ *    Explanation: the 4 good triplets are (4,0,3), (4,0,2), (4,1,3), (4,1,2).
+ *
+ *  Constraints:
+ *    n == nums1.length == nums2.length
+ *    3 <= n <= 10^5
+ *    0 <= nums1[i], nums2[i] <= n - 1
+ *    nums1 and nums2 are permutations of [0, 1, ..., n - 1].
+ */
+public class CountGoodTripletsInAnArray {
+
+    // V0
+    // IDEA: BIT (FENWICK) over positions in nums2, count each value as the
+    //       "MIDDLE" element of the triplet.
+    //       map every value to its index in nums2: pos[v]. sweep nums1 left ->
+    //       right, so everything already inserted is to the LEFT in nums1.
+    //       fixing the current value as the middle y:
+    //         left  = # inserted values with pos2 < pos2[y]        -> valid x
+    //         right = # not-yet-inserted values with pos2 > pos2[y] -> valid z
+    //       res += left * right.
+    //       NOTE: right = (n - p) - (inserted - left), i.e. total values after
+    //             y in nums2 minus the already inserted ones after y.
+    /**
+     * time = O(N log N)
+     * space = O(N)
+     */
+    public long goodTriplets(int[] nums1, int[] nums2) {
+        int n = nums1.length;
+        int[] pos = new int[n];
+        for (int i = 0; i < n; i++) {
+            pos[nums2[i]] = i + 1; // 1-indexed for the BIT
+        }
+
+        int[] tree = new int[n + 1];
+        long res = 0;
+        for (int k = 0; k < n; k++) {
+            int p = pos[nums1[k]];
+            long left = query(tree, p);
+            long right = (n - p) - (k - left);
+            res += left * right;
+            update(tree, p, n);
+        }
+        return res;
+    }
+
+    private void update(int[] tree, int i, int n) {
+        while (i <= n) {
+            tree[i] += 1;
+            i += i & (-i);
+        }
+    }
+
+    private int query(int[] tree, int i) {
+        int s = 0;
+        while (i > 0) {
+            s += tree[i];
+            i -= i & (-i);
+        }
+        return s;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/CreateBinaryTreeFromDescriptions.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/CreateBinaryTreeFromDescriptions.java
@@ -1,0 +1,87 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/create-binary-tree-from-descriptions/
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  2196. Create Binary Tree From Descriptions
+ *  Medium
+ *
+ *  You are given a 2D integer array descriptions where
+ *  descriptions[i] = [parent_i, child_i, isLeft_i] indicates that parent_i is the
+ *  parent of child_i in a binary tree of unique values. Furthermore,
+ *
+ *   - If isLeft_i == 1, then child_i is the left child of parent_i.
+ *   - If isLeft_i == 0, then child_i is the right child of parent_i.
+ *
+ *  Construct the binary tree described by descriptions and return its root.
+ *  The test cases will be generated such that the binary tree is valid.
+ *
+ *  Example 1:
+ *    Input: descriptions = [[20,15,1],[20,17,0],[50,20,1],[50,80,0],[80,19,1]]
+ *    Output: [50,20,80,15,17,19]
+ *    Explanation: the root is 50 since it has no parent.
+ *
+ *  Example 2:
+ *    Input: descriptions = [[1,2,1],[2,3,0],[3,4,1]]
+ *    Output: [1,2,null,null,3,4]
+ *
+ *  Constraints:
+ *    1 <= descriptions.length <= 10^4
+ *    descriptions[i].length == 3
+ *    1 <= parent_i, child_i <= 10^5
+ *    0 <= isLeft_i <= 1
+ *    The binary tree described by descriptions is valid.
+ */
+public class CreateBinaryTreeFromDescriptions {
+
+    // V0
+    // IDEA: NODE POOL KEYED BY VALUE + A SET OF EVERY VALUE THAT HAS A PARENT
+    //       values are unique, so a map value -> TreeNode lets each description
+    //       wire up its two nodes regardless of the row order (creating either
+    //       endpoint on demand).
+    //       the root is the ONE value that never appears as a CHILD, so track
+    //       the set of children while building and take the single leftover.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public TreeNode createBinaryTree(int[][] descriptions) {
+        Map<Integer, TreeNode> nodes = new HashMap<>();
+        Set<Integer> children = new HashSet<>();
+
+        for (int[] d : descriptions) {
+            int parent = d[0];
+            int child = d[1];
+            int isLeft = d[2];
+            TreeNode p = getNode(nodes, parent);
+            TreeNode c = getNode(nodes, child);
+            if (isLeft == 1) {
+                p.left = c;
+            } else {
+                p.right = c;
+            }
+            children.add(child);
+        }
+
+        for (Map.Entry<Integer, TreeNode> e : nodes.entrySet()) {
+            if (!children.contains(e.getKey())) {
+                return e.getValue();
+            }
+        }
+        return null;
+    }
+
+    private TreeNode getNode(Map<Integer, TreeNode> nodes, int val) {
+        if (!nodes.containsKey(val)) {
+            nodes.put(val, new TreeNode(val));
+        }
+        return nodes.get(val);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/CreateSortedArrayThroughInstructions.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/CreateSortedArrayThroughInstructions.java
@@ -1,0 +1,94 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/create-sorted-array-through-instructions/
+
+/**
+ *  1649. Create Sorted Array through Instructions
+ *  Hard
+ *
+ *  Given an integer array instructions, you are asked to create a sorted array
+ *  from the elements in instructions. You start with an empty container nums.
+ *  For each element from left to right in instructions, insert it into nums.
+ *  The cost of each insertion is the minimum of the following:
+ *
+ *   - The number of elements currently in nums that are strictly less than
+ *     instructions[i].
+ *   - The number of elements currently in nums that are strictly greater than
+ *     instructions[i].
+ *
+ *  For example, if inserting element 3 into nums = [1,2,3,5], the cost of
+ *  insertion is min(2, 1) and nums will become [1,2,3,3,5].
+ *
+ *  Return the total cost to insert all elements from instructions into nums.
+ *  Since the answer may be large, return it modulo 10^9 + 7.
+ *
+ *  Example 1:
+ *    Input: instructions = [1,5,6,2]
+ *    Output: 1
+ *    Explanation: costs are min(0,0) + min(1,0) + min(2,0) + min(1,2) = 1
+ *
+ *  Example 2:
+ *    Input: instructions = [1,2,3,6,5,4]
+ *    Output: 3
+ *
+ *  Example 3:
+ *    Input: instructions = [1,3,3,3,2,4,2,1,2]
+ *    Output: 4
+ *
+ *  Constraints:
+ *    1 <= instructions.length <= 10^5
+ *    1 <= instructions[i] <= 10^5
+ */
+public class CreateSortedArrayThroughInstructions {
+
+    // V0
+    // IDEA: BINARY INDEXED TREE (Fenwick) as a live frequency histogram
+    //       values are bounded by 10^5, so keep a BIT over VALUES where cell v
+    //       holds "how many copies of v are already inserted".
+    //       before inserting the i-th value x (i elements present):
+    //         less    = query(x - 1)
+    //         greater = i - query(x)     // total - #(<= x)
+    //         cost    = min(less, greater)
+    //       then update(x, +1).
+    //       NOTE: `greater` must use query(x), NOT query(x-1) -- equal values
+    //             count as neither strictly less nor strictly greater.
+    /**
+     * time = O(N log M)   // M = max value
+     * space = O(M)
+     */
+    public int createSortedArray(int[] instructions) {
+        final int MOD = 1000000007;
+        int m = 0;
+        for (int x : instructions) {
+            m = Math.max(m, x);
+        }
+        int[] tree = new int[m + 1];
+
+        long res = 0;
+        for (int i = 0; i < instructions.length; i++) {
+            int x = instructions[i];
+            int less = query(tree, x - 1);
+            int greater = i - query(tree, x);
+            res += Math.min(less, greater);
+            res %= MOD;
+            update(tree, x, m);
+        }
+        return (int) (res % MOD);
+    }
+
+    private void update(int[] tree, int i, int m) {
+        while (i <= m) {
+            tree[i] += 1;
+            i += i & (-i);
+        }
+    }
+
+    private int query(int[] tree, int i) {
+        int s = 0;
+        while (i > 0) {
+            s += tree[i];
+            i -= i & (-i);
+        }
+        return s;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/DeleteDuplicateFoldersInSystem.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/DeleteDuplicateFoldersInSystem.java
@@ -1,0 +1,158 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/delete-duplicate-folders-in-system/
+
+import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ *  1948. Delete Duplicate Folders in System
+ *  Hard
+ *
+ *  Due to a bug, there are many duplicate folders in a file system. You are given
+ *  a 2D array paths, where paths[i] is an array representing an absolute path to
+ *  the ith folder in the file system. For example, ["one","two","three"]
+ *  represents the path "/one/two/three".
+ *
+ *  Two folders (not necessarily on the same level) are identical if they contain
+ *  the same non-empty set of identical subfolders and underlying subfolder
+ *  structure. If two or more folders are identical, then mark the folders as well
+ *  as all their subfolders.
+ *
+ *  Once all the identical folders and their subfolders have been marked, the file
+ *  system will delete all of them. The file system only runs the deletion once,
+ *  so any folders that become identical after the initial deletion are not
+ *  deleted.
+ *
+ *  Return the 2D array ans containing the paths of the remaining folders after
+ *  deleting all the marked folders. The paths may be returned in any order.
+ *
+ *  Example 1:
+ *    Input: paths = [["a"],["c"],["d"],["a","b"],["c","b"],["d","a"]]
+ *    Output: [["d"],["d","a"]]
+ *    Explanation: "/a" and "/c" both contain an empty folder named "b".
+ *
+ *  Example 2:
+ *    Input: paths = [["a"],["c"],["a","b"],["c","b"],["a","b","x"],
+ *                    ["a","b","x","y"],["w"],["w","y"]]
+ *    Output: [["c"],["c","b"],["a"],["a","b"]]
+ *
+ *  Constraints:
+ *    1 <= paths.length <= 2 * 10^4
+ *    1 <= paths[i].length <= 500
+ *    1 <= paths[i][j].length <= 10
+ *    1 <= sum(paths[i][j].length) <= 2 * 10^5
+ *    paths[i][j] consists of lowercase English letters.
+ *    No two paths lead to the same folder.
+ */
+public class DeleteDuplicateFoldersInSystem {
+
+    // V0
+    // IDEA: TRIE + SUBTREE SERIALIZATION (a canonical string per folder = its identity)
+    //       1) insert every path into a trie, so one trie node == one folder.
+    //       2) post-order, give each node a canonical signature:
+    //            sig(node) = concat of sorted( name + "(" + sig(child) + ")" )
+    //          sorting makes the signature independent of insertion order, and a
+    //          LEAF gets the EMPTY signature -- which is exactly why empty
+    //          folders are never duplicates of each other.
+    //       3) two nodes with the same NON-EMPTY signature are identical folders
+    //          -> mark BOTH deleted (the first is remembered in a map).
+    //       4) walk the trie again, skipping whole deleted subtrees, emit paths.
+    //       NOTE: marking happens on the ORIGINAL tree, all at once -- that is
+    //             what "the deletion only runs once" means.
+    //       NOTE: paths can be 500 deep -> both traversals are ITERATIVE.
+    /**
+     * time = O(total signature length)
+     * space = O(total signature length)
+     */
+    public List<List<String>> deleteDuplicateFolder(List<List<String>> paths) {
+        // node id -> (name -> child id); TreeMap keeps names sorted for free
+        List<TreeMap<String, Integer>> children = new ArrayList<>();
+        List<Boolean> deleted = new ArrayList<>();
+        children.add(new TreeMap<String, Integer>());
+        deleted.add(Boolean.FALSE);
+
+        for (List<String> path : paths) {
+            int cur = 0;
+            for (String name : path) {
+                Integer next = children.get(cur).get(name);
+                if (next == null) {
+                    children.add(new TreeMap<String, Integer>());
+                    deleted.add(Boolean.FALSE);
+                    next = children.size() - 1;
+                    children.get(cur).put(name, next);
+                }
+                cur = next;
+            }
+        }
+
+        // pre-order list, reversed -> a valid post-order (children before parent)
+        List<Integer> order = new ArrayList<>();
+        Deque<Integer> stack = new ArrayDeque<>();
+        stack.push(0);
+        while (!stack.isEmpty()) {
+            int u = stack.pop();
+            order.add(u);
+            for (int v : children.get(u).values()) {
+                stack.push(v);
+            }
+        }
+
+        String[] sig = new String[children.size()];
+        Map<String, Integer> seen = new HashMap<>();
+        for (int i = order.size() - 1; i >= 0; i--) {
+            int u = order.get(i);
+            if (children.get(u).isEmpty()) {
+                sig[u] = ""; // leaf -> empty signature, never a dup
+                continue;
+            }
+            List<String> parts = new ArrayList<>();
+            for (Map.Entry<String, Integer> e : children.get(u).entrySet()) {
+                parts.add(e.getKey() + "(" + sig[e.getValue()] + ")");
+            }
+            Collections.sort(parts);
+            StringBuilder sb = new StringBuilder();
+            for (String p : parts) {
+                sb.append(p);
+            }
+            String s = sb.toString();
+            sig[u] = s;
+            Integer prev = seen.get(s);
+            if (prev != null) {
+                deleted.set(u, Boolean.TRUE);
+                deleted.set(prev, Boolean.TRUE);
+            } else {
+                seen.put(s, u);
+            }
+        }
+
+        List<List<String>> res = new ArrayList<>();
+        Deque<Integer> nodeStack = new ArrayDeque<>();
+        Deque<List<String>> pathStack = new ArrayDeque<>();
+        nodeStack.push(0);
+        pathStack.push(new ArrayList<String>());
+        while (!nodeStack.isEmpty()) {
+            int u = nodeStack.pop();
+            List<String> path = pathStack.pop();
+            if (deleted.get(u)) {
+                continue;
+            }
+            if (!path.isEmpty()) {
+                res.add(path);
+            }
+            for (Map.Entry<String, Integer> e : children.get(u).entrySet()) {
+                List<String> nextPath = new ArrayList<>(path);
+                nextPath.add(e.getKey());
+                nodeStack.push(e.getValue());
+                pathStack.push(nextPath);
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/FindAllTheLonelyNodes.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/FindAllTheLonelyNodes.java
@@ -1,0 +1,64 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/find-all-the-lonely-nodes/
+
+import java.util.ArrayList;
+import java.util.List;
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1469. Find All The Lonely Nodes
+ *  Easy
+ *
+ *  In a binary tree, a lonely node is a node that is the only child of its parent
+ *  node. The root of the tree is not lonely because it does not have a parent node.
+ *
+ *  Given the root of a binary tree, return an array containing the values of all
+ *  lonely nodes in the tree. Return the list in any order.
+ *
+ *  Example 1:
+ *    Input: root = [1,2,3,null,4]
+ *    Output: [4]
+ *    Explanation: node 1 is the root; nodes 2 and 3 share a parent.
+ *
+ *  Example 2:
+ *    Input: root = [7,1,4,6,null,5,3,null,null,null,null,null,2]
+ *    Output: [6,2]
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [1, 1000].
+ *    1 <= Node.val <= 10^6
+ */
+public class FindAllTheLonelyNodes {
+
+    // V0
+    // IDEA: DFS -- a node reports its own SINGLE child, never itself.
+    //       look at each node as a PARENT: if it has exactly one child, that
+    //       child is lonely -> record the child's value, then recurse.
+    //       this way the root is never considered (nobody is its parent) and
+    //       every other node is examined exactly once, by its parent.
+    /**
+     * time = O(N)
+     * space = O(H)   // H = tree height (recursion stack)
+     */
+    public List<Integer> getLonelyNodes(TreeNode root) {
+        List<Integer> res = new ArrayList<>();
+        dfs(root, res);
+        return res;
+    }
+
+    private void dfs(TreeNode node, List<Integer> res) {
+        if (node == null) {
+            return;
+        }
+        if (node.left != null && node.right == null) {
+            res.add(node.left.val);
+        }
+        if (node.right != null && node.left == null) {
+            res.add(node.right.val);
+        }
+        dfs(node.left, res);
+        dfs(node.right, res);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/FindElements.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/FindElements.java
@@ -1,0 +1,141 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/find-elements-in-a-contaminated-binary-tree/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1261. Find Elements in a Contaminated Binary Tree
+ *  Medium
+ *
+ *  Given a binary tree with the following rules:
+ *   - root.val == 0
+ *   - For any treeNode:
+ *       if treeNode.val has a value x and treeNode.left != null,
+ *          then treeNode.left.val == 2 * x + 1
+ *       if treeNode.val has a value x and treeNode.right != null,
+ *          then treeNode.right.val == 2 * x + 2
+ *
+ *  Now the binary tree is contaminated, which means all treeNode.val have been
+ *  changed to -1.
+ *
+ *  Implement the FindElements class:
+ *   - FindElements(TreeNode root) Initializes the object with a contaminated
+ *     binary tree and recovers it.
+ *   - boolean find(int target) Returns true if the target value exists in the
+ *     recovered binary tree.
+ *
+ *  Example 1:
+ *    Input
+ *      ["FindElements","find","find"]
+ *      [[[-1,null,-1]],[1],[2]]
+ *    Output
+ *      [null,false,true]
+ *
+ *  Example 2:
+ *    Input
+ *      ["FindElements","find","find","find"]
+ *      [[[-1,-1,-1,-1,-1]],[1],[3],[5]]
+ *    Output
+ *      [null,true,true,false]
+ *
+ *  Constraints:
+ *    TreeNode.val == -1
+ *    The height of the binary tree is less than or equal to 20
+ *    The total number of nodes is between [1, 10^4]
+ *    Total calls of find() is between [1, 10^4]
+ *    0 <= target <= 10^6
+ */
+public class FindElements {
+
+    // V0
+    // IDEA: DFS RECOVER + HASH SET
+    //       rebuild every value ONCE at construction time and cache them in a
+    //       set, so each find() is O(1).
+    //       NOTE: iterative DFS, so a 10^4 node tree can NOT blow the stack.
+    private final Set<Integer> seen;
+
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public FindElements(TreeNode root) {
+        this.seen = new HashSet<>();
+        Deque<TreeNode> stack = new ArrayDeque<>();
+        if (root != null) {
+            root.val = 0;
+            stack.push(root);
+        }
+        while (!stack.isEmpty()) {
+            TreeNode node = stack.pop();
+            this.seen.add(node.val);
+            if (node.left != null) {
+                node.left.val = 2 * node.val + 1;
+                stack.push(node.left);
+            }
+            if (node.right != null) {
+                node.right.val = 2 * node.val + 2;
+                stack.push(node.right);
+            }
+        }
+    }
+
+    /**
+     * time = O(1)
+     * space = O(1)
+     */
+    public boolean find(int target) {
+        return this.seen.contains(target);
+    }
+
+    // V1
+    // IDEA: WALK DOWN FROM THE TARGET (no pre-computed set, O(1) init memory)
+    //       from `target`, repeatedly step to its parent ((target - 1) / 2) to
+    //       recover the root -> target move list, then REPLAY that path on the
+    //       real tree. an odd value came from a LEFT child, an even one from a
+    //       RIGHT child.
+    public static class FindElements2 {
+
+        private final TreeNode root;
+
+        /**
+         * time = O(1)
+         * space = O(1)
+         */
+        public FindElements2(TreeNode root) {
+            this.root = root;
+            if (this.root != null) {
+                this.root.val = 0;
+            }
+        }
+
+        /**
+         * time = O(log(target))
+         * space = O(log(target))
+         */
+        public boolean find(int target) {
+            if (this.root == null) {
+                return false;
+            }
+            Deque<Integer> path = new ArrayDeque<>();
+            while (target > 0) {
+                path.push(target % 2 == 1 ? 1 : 2); // 1 = left child, 2 = right child
+                target = (target - 1) / 2;
+            }
+            TreeNode node = this.root;
+            while (!path.isEmpty()) {
+                int step = path.pop();
+                node = (step == 1) ? node.left : node.right;
+                if (node == null) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/FindRootOfNAryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/FindRootOfNAryTree.java
@@ -1,0 +1,85 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/find-root-of-n-ary-tree/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1506. Find Root of N-Ary Tree
+ *  Medium
+ *
+ *  You are given all the nodes of an N-ary tree as an array of Node objects,
+ *  where each node has a unique value.
+ *
+ *  Return the root of the N-ary tree.
+ *
+ *  The driver code constructs the tree from a serialized input, puts every Node
+ *  object into an array in an ARBITRARY order, and passes that array to findRoot.
+ *
+ *  Example 1:
+ *    Input: tree = [1,null,3,2,4,null,5,6]
+ *    Output: [1,null,3,2,4,null,5,6]
+ *    Explanation: findRoot should return Node(1) whatever the array order is.
+ *
+ *  Example 2:
+ *    Input: tree = [1,null,2,3,4,5,null,null,6,7,null,8,null,9,10,null,null,11,null,12,null,13,null,null,14]
+ *    Output: [1,null,2,3,4,5,null,null,6,7,null,8,null,9,10,null,null,11,null,12,null,13,null,null,14]
+ *
+ *  Constraints:
+ *    The total number of nodes is between [1, 5 * 10^4].
+ *    Each node has a unique value.
+ *
+ *  Follow up: Could you solve this problem in constant space complexity with a
+ *             linear time algorithm?
+ */
+public class FindRootOfNAryTree {
+
+    // N-ary tree node (problem specific shape)
+    public static class Node {
+        public int val;
+        public List<Node> children;
+
+        public Node() {
+            this.children = new ArrayList<>();
+        }
+
+        public Node(int val) {
+            this.val = val;
+            this.children = new ArrayList<>();
+        }
+
+        public Node(int val, List<Node> children) {
+            this.val = val;
+            this.children = children;
+        }
+    }
+
+    // V0
+    // IDEA: XOR TRICK (O(1) extra space)
+    //       every node value appears exactly ONCE as "a node in the array", and
+    //       every value EXCEPT the root's also appears exactly once as
+    //       "someone's child". so XOR-ing all node values together with all
+    //       child values cancels every non-root value (x ^ x == 0) and leaves
+    //       the root value behind.
+    //       NOTE: values are unique, which is what makes the cancellation exact.
+    /**
+     * time = O(N)
+     * space = O(1)
+     */
+    public Node findRoot(List<Node> tree) {
+        int x = 0;
+        for (Node node : tree) {
+            x ^= node.val;
+            for (Node child : node.children) {
+                x ^= child.val;
+            }
+        }
+        for (Node node : tree) {
+            if (node.val == x) {
+                return node;
+            }
+        }
+        return null;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/FindWeightedMedianNodeInTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/FindWeightedMedianNodeInTree.java
@@ -1,0 +1,195 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/find-weighted-median-node-in-tree/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  3585. Find Weighted Median Node in Tree
+ *  Hard
+ *
+ *  You are given an integer n and an undirected, weighted tree rooted at node 0
+ *  with n nodes numbered from 0 to n - 1. This is represented by a 2D array edges
+ *  of length n - 1, where edges[i] = [u_i, v_i, w_i] indicates an edge from node
+ *  u_i to v_i with weight w_i.
+ *
+ *  The weighted median node is defined as the first node x on the path from u_i
+ *  to v_i such that the sum of edge weights from u_i to x is greater than or
+ *  equal to half of the total path weight.
+ *
+ *  You are given a 2D integer array queries. For each queries[j] = [u_j, v_j],
+ *  determine the weighted median node along the path from u_j to v_j.
+ *
+ *  Return an array ans, where ans[j] is the node index of the weighted median
+ *  for queries[j].
+ *
+ *  Example 1:
+ *    Input: n = 2, edges = [[0,1,7]], queries = [[1,0],[0,1]]
+ *    Output: [0,1]
+ *    Explanation: path 1 -> 0 has total weight 7, half 3.5, and 7 >= 3.5 so the
+ *                 median is node 0. Symmetrically for [0,1].
+ *
+ *  Example 3:
+ *    Input: n = 5, edges = [[0,1,2],[0,2,5],[1,3,1],[2,4,3]],
+ *           queries = [[3,4],[1,2]]
+ *    Output: [2,2]
+ *    Explanation: path 3 -> 1 -> 0 -> 2 -> 4 has total weight 11, half 5.5;
+ *                 the prefix 3 -> 2 is 8 >= 5.5, so the median is node 2.
+ *
+ *  Constraints:
+ *    2 <= n <= 10^5
+ *    edges.length == n - 1
+ *    edges[i] == [u_i, v_i, w_i]
+ *    0 <= u_i, v_i < n
+ *    1 <= w_i <= 10^9
+ *    1 <= queries.length <= 10^5
+ *    queries[j] == [u_j, v_j]
+ *    0 <= u_j, v_j < n
+ *    The input is generated such that edges represents a valid tree.
+ */
+public class FindWeightedMedianNodeInTree {
+
+    // V0
+    // IDEA: ROOT DISTANCES + LCA, THEN ONE BINARY-LIFTING JUMP PER QUERY
+    //
+    //   root the tree once and store dist[x], the weighted distance from node 0.
+    //   with l = lca(u, v) the path splits into an upward leg of length
+    //   A = dist[u] - dist[l] and a downward leg of length B = dist[v] - dist[l],
+    //   and the total path weight is A + B. every comparison below is DOUBLED so
+    //   the "half" stays exact integer arithmetic and never a float.
+    //
+    //   which leg holds the median is decided in O(1) by testing l itself: the
+    //   prefix from u down to l measures A, so l qualifies exactly when
+    //   2A >= A + B, i.e. when A >= B.
+    //
+    //   on the UPWARD leg the prefix from u to an ancestor x is dist[u] - dist[x],
+    //   so 2*(dist[u] - dist[x]) >= A + B rewrites to
+    //   2*dist[x] <= 2*dist[l] + A - B. climbing from u the left side only
+    //   shrinks, so the FAILING nodes form an unbroken run starting at u;
+    //   binary lifting climbs to the last failing node and the answer is its
+    //   parent (u itself always fails when u != v, so that parent exists).
+    //
+    //   on the DOWNWARD leg the prefix from u to x is A + dist[x] - dist[l], and
+    //   the test becomes 2*dist[x] >= 2*dist[l] + B - A. now the DEEPER nodes
+    //   qualify, so climbing from v the qualifying nodes form an unbroken run
+    //   and the answer is the highest one still strictly below l.
+    /**
+     * time = O((N + Q) * log N)
+     * space = O(N * log N)
+     */
+    public int[] findMedian(int n, int[][] edges, int[][] queries) {
+        int LOG = Math.max(1, 32 - Integer.numberOfLeadingZeros(n));
+
+        // adjacency as CSR-ish arrays (n up to 1e5)
+        int[] head = new int[n];
+        int[] nxt = new int[2 * (n - 1) + 2];
+        int[] to = new int[2 * (n - 1) + 2];
+        int[] wt = new int[2 * (n - 1) + 2];
+        for (int i = 0; i < n; i++) {
+            head[i] = -1;
+        }
+        int cnt = 0;
+        for (int[] e : edges) {
+            to[cnt] = e[1]; wt[cnt] = e[2]; nxt[cnt] = head[e[0]]; head[e[0]] = cnt++;
+            to[cnt] = e[0]; wt[cnt] = e[2]; nxt[cnt] = head[e[1]]; head[e[1]] = cnt++;
+        }
+
+        int[] parent = new int[n];
+        int[] depth = new int[n];
+        long[] dist = new long[n];
+        boolean[] seen = new boolean[n];
+        parent[0] = -1;
+        seen[0] = true;
+        Deque<Integer> stack = new ArrayDeque<>();
+        stack.push(0);
+        while (!stack.isEmpty()) {
+            int x = stack.pop();
+            for (int e = head[x]; e != -1; e = nxt[e]) {
+                int y = to[e];
+                if (!seen[y]) {
+                    seen[y] = true;
+                    parent[y] = x;
+                    depth[y] = depth[x] + 1;
+                    dist[y] = dist[x] + wt[e];
+                    stack.push(y);
+                }
+            }
+        }
+
+        int[][] up = new int[LOG][n];
+        up[0] = parent;
+        for (int k = 1; k < LOG; k++) {
+            for (int i = 0; i < n; i++) {
+                int p = up[k - 1][i];
+                up[k][i] = (p == -1) ? -1 : up[k - 1][p];
+            }
+        }
+
+        int[] ans = new int[queries.length];
+        for (int i = 0; i < queries.length; i++) {
+            int u = queries[i][0];
+            int v = queries[i][1];
+            if (u == v) {
+                ans[i] = u;
+                continue;
+            }
+
+            int l = lca(u, v, depth, up, parent, LOG);
+            long a = dist[u] - dist[l];
+            long b = dist[v] - dist[l];
+
+            if (a >= b) {
+                // median sits on the u -> l leg; climb past every FAILING node
+                long limit = 2 * dist[l] + a - b;
+                int cur = u;
+                for (int k = LOG - 1; k >= 0; k--) {
+                    int p = up[k][cur];
+                    if (p != -1 && depth[p] >= depth[l] && 2 * dist[p] > limit) {
+                        cur = p;
+                    }
+                }
+                ans[i] = parent[cur];
+            } else {
+                // median sits on the l -> v leg; climb while still QUALIFYING
+                long limit = 2 * dist[l] + b - a;
+                int cur = v;
+                for (int k = LOG - 1; k >= 0; k--) {
+                    int p = up[k][cur];
+                    if (p != -1 && depth[p] > depth[l] && 2 * dist[p] >= limit) {
+                        cur = p;
+                    }
+                }
+                ans[i] = cur;
+            }
+        }
+        return ans;
+    }
+
+    private int lca(int a, int b, int[] depth, int[][] up, int[] parent, int LOG) {
+        if (depth[a] < depth[b]) {
+            int tmp = a;
+            a = b;
+            b = tmp;
+        }
+        int diff = depth[a] - depth[b];
+        int k = 0;
+        while (diff != 0) {
+            if ((diff & 1) == 1) {
+                a = up[k][a];
+            }
+            diff >>= 1;
+            k++;
+        }
+        if (a == b) {
+            return a;
+        }
+        for (int j = LOG - 1; j >= 0; j--) {
+            if (up[j][a] != up[j][b]) {
+                a = up[j][a];
+                b = up[j][b];
+            }
+        }
+        return parent[a];
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/IndexPairsOfAString.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/IndexPairsOfAString.java
@@ -1,0 +1,87 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/index-pairs-of-a-string/
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  1065. Index Pairs of a String
+ *  Easy
+ *
+ *  Given a string text and an array of strings words, return an array of all
+ *  index pairs [i, j] so that the substring text[i...j] is in words.
+ *
+ *  Return the pairs [i, j] in sorted order (i.e., sort them by their first
+ *  coordinate, and in case of ties sort them by their second coordinate).
+ *
+ *  Example 1:
+ *    Input: text = "thestoryofleetcodeandme", words = ["story","fleet","leetcode"]
+ *    Output: [[3,7],[9,13],[10,17]]
+ *
+ *  Example 2:
+ *    Input: text = "ababa", words = ["aba","ab"]
+ *    Output: [[0,1],[0,2],[2,3],[2,4]]
+ *    Explanation: matches can overlap, "aba" is found at [0,2] and [2,4].
+ *
+ *  Constraints:
+ *    1 <= text.length <= 100
+ *    1 <= words.length <= 20
+ *    1 <= words[i].length <= 50
+ *    text and words[i] consist of lowercase English letters.
+ *    All the strings of words are unique.
+ */
+public class IndexPairsOfAString {
+
+    private static class Trie {
+        Map<Character, Trie> children = new HashMap<>();
+        boolean isEnd = false;
+
+        void insert(String word) {
+            Trie node = this;
+            for (char c : word.toCharArray()) {
+                if (!node.children.containsKey(c)) {
+                    node.children.put(c, new Trie());
+                }
+                node = node.children.get(c);
+            }
+            node.isEnd = true;
+        }
+    }
+
+    // V0
+    // IDEA: TRIE
+    //       build a trie of `words`, then for every start index i walk the trie
+    //       along text[i:], recording [i, j] whenever we land on a word end.
+    //       scanning i then j left -> right already yields the required sorted
+    //       order, and we can break as soon as the prefix leaves the trie.
+    /**
+     * time = O(sum(len(w)) + N * L)   // N = text length, L = max word length
+     * space = O(sum(len(w)))
+     */
+    public int[][] indexPairs(String text, String[] words) {
+        Trie root = new Trie();
+        for (String w : words) {
+            root.insert(w);
+        }
+
+        int n = text.length();
+        List<int[]> res = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            Trie node = root;
+            for (int j = i; j < n; j++) {
+                char c = text.charAt(j);
+                if (!node.children.containsKey(c)) {
+                    break;
+                }
+                node = node.children.get(c);
+                if (node.isEnd) {
+                    res.add(new int[]{i, j});
+                }
+            }
+        }
+        return res.toArray(new int[res.size()][]);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/InsufficientNodesInRootToLeafPaths.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/InsufficientNodesInRootToLeafPaths.java
@@ -1,0 +1,74 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/insufficient-nodes-in-root-to-leaf-paths/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1080. Insufficient Nodes in Root to Leaf Paths
+ *  Medium
+ *
+ *  Given the root of a binary tree and an integer limit, delete all insufficient
+ *  nodes in the tree simultaneously, and return the root of the resulting binary
+ *  tree.
+ *
+ *  A node is insufficient if every root to leaf path intersecting this node has a
+ *  sum strictly less than limit.
+ *
+ *  A leaf is a node with no children.
+ *
+ *  Example 1:
+ *    Input: root = [1,2,3,4,-99,-99,7,8,9,-99,-99,12,13,-99,14], limit = 1
+ *    Output: [1,2,3,4,null,null,7,8,9,null,14]
+ *
+ *  Example 2:
+ *    Input: root = [5,4,8,11,null,17,4,7,1,null,null,5,3], limit = 22
+ *    Output: [5,4,8,11,null,17,4,7,null,null,null,5]
+ *
+ *  Example 3:
+ *    Input: root = [1,2,-3,-5,null,4,null], limit = -1
+ *    Output: [1,null,-3,4]
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [1, 5000].
+ *    -10^5 <= Node.val <= 10^5
+ *    -10^9 <= limit <= 10^9
+ */
+public class InsufficientNodesInRootToLeafPaths {
+
+    // V0
+    // IDEA: DFS (post order) + pass the REMAINING limit down
+    //       walk down subtracting node.val from `limit`, so at a leaf the
+    //       remaining limit tells us whether that root -> leaf path made it:
+    //         limit > 0 -> path sum < original limit -> leaf insufficient -> cut
+    //       for an internal node, prune both children FIRST; if both came back
+    //       null then every path through this node was insufficient, so this
+    //       node dies too. that single bottom-up pass performs all the
+    //       deletions "simultaneously".
+    /**
+     * time = O(N)
+     * space = O(H)   // H = tree height
+     */
+    public TreeNode sufficientSubset(TreeNode root, int limit) {
+        return helper(root, (long) limit);
+    }
+
+    private TreeNode helper(TreeNode root, long limit) {
+        if (root == null) {
+            return null;
+        }
+
+        limit -= root.val;
+
+        // leaf : keep only if the path reached the limit
+        if (root.left == null && root.right == null) {
+            return limit > 0 ? null : root;
+        }
+
+        root.left = helper(root.left, limit);
+        root.right = helper(root.right, limit);
+
+        // NOTE !!! all children pruned -> no surviving path goes through here
+        return (root.left == null && root.right == null) ? null : root;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumAverageSubtree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumAverageSubtree.java
@@ -1,0 +1,69 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/maximum-average-subtree/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1120. Maximum Average Subtree
+ *  Medium
+ *
+ *  Given the root of a binary tree, return the maximum average value of a
+ *  subtree of that tree. Answers within 10^-5 of the actual answer will be
+ *  accepted.
+ *
+ *  A subtree of a tree is any node of that tree plus all its descendants.
+ *  The average value of a tree is the sum of its values, divided by the
+ *  number of nodes.
+ *
+ *  Example 1:
+ *    Input: root = [5,6,1]
+ *    Output: 6.00000
+ *    Explanation:
+ *      node 5 -> (5 + 6 + 1) / 3 = 4
+ *      node 6 -> 6 / 1 = 6
+ *      node 1 -> 1 / 1 = 1
+ *      so the answer is 6.
+ *
+ *  Example 2:
+ *    Input: root = [0,null,1]
+ *    Output: 1.00000
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [1, 10^4].
+ *    0 <= Node.val <= 10^5
+ */
+public class MaximumAverageSubtree {
+
+    // V0
+    // IDEA: POST-ORDER DFS, EACH NODE RETURNS (subtree sum, subtree size)
+    //       the average of a subtree needs 2 aggregates and both compose
+    //       bottom-up:
+    //         sum(node)  = node.val + sum(left)  + sum(right)
+    //         size(node) = 1        + size(left) + size(right)
+    //       so ONE post-order pass sees every subtree's average; keep the max.
+    /**
+     * time = O(N)
+     * space = O(H)   // H = tree height (recursion stack)
+     */
+    private double res;
+
+    public double maximumAverageSubtree(TreeNode root) {
+        this.res = 0.0;
+        dfs(root);
+        return this.res;
+    }
+
+    // returns { subtree sum, subtree node count }
+    private long[] dfs(TreeNode node) {
+        if (node == null) {
+            return new long[]{0L, 0L};
+        }
+        long[] l = dfs(node.left);
+        long[] r = dfs(node.right);
+        long curSum = node.val + l[0] + r[0];
+        long curCnt = 1 + l[1] + r[1];
+        this.res = Math.max(this.res, (double) curSum / (double) curCnt);
+        return new long[]{curSum, curCnt};
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumDifferenceBetweenNodeAndAncestor.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumDifferenceBetweenNodeAndAncestor.java
@@ -1,0 +1,65 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/maximum-difference-between-node-and-ancestor/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  1026. Maximum Difference Between Node and Ancestor
+ *  Medium
+ *
+ *  Given the root of a binary tree, find the maximum value v for which there
+ *  exist different nodes a and b where v = |a.val - b.val| and a is an
+ *  ancestor of b.
+ *
+ *  A node a is an ancestor of b if either: any child of a is equal to b, or
+ *  any child of a is an ancestor of b.
+ *
+ *  Example 1:
+ *    Input: root = [8,3,10,1,6,null,14,null,null,4,7,13]
+ *    Output: 7
+ *    Explanation: |8 - 1| = 7 is the largest ancestor-descendant difference.
+ *
+ *  Example 2:
+ *    Input: root = [1,null,2,null,0,3]
+ *    Output: 3
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is in the range [2, 5000].
+ *    0 <= Node.val <= 10^5
+ */
+public class MaximumDifferenceBetweenNodeAndAncestor {
+
+    // V0
+    // IDEA: DFS CARRYING THE MIN AND MAX SEEN ON THE ROOT PATH
+    //       for a node b the best |a.val - b.val| over all ancestors a is
+    //       max(maxAncestor - b.val, b.val - minAncestor), so only 2 numbers
+    //       need to travel down, not the whole path.
+    //       equivalently: at every node the running (hi - lo) of its root path
+    //       is a candidate -> take the overall max.
+    /**
+     * time = O(N)
+     * space = O(H)   // recursion depth
+     */
+    private int res;
+
+    public int maxAncestorDiff(TreeNode root) {
+        if (root == null) {
+            return 0;
+        }
+        this.res = 0;
+        dfs(root, root.val, root.val);
+        return this.res;
+    }
+
+    private void dfs(TreeNode node, int lo, int hi) {
+        if (node == null) {
+            return;
+        }
+        lo = Math.min(lo, node.val);
+        hi = Math.max(hi, node.val);
+        this.res = Math.max(this.res, hi - lo);
+        dfs(node.left, lo, hi);
+        dfs(node.right, lo, hi);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumGeneticDifferenceQuery.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumGeneticDifferenceQuery.java
@@ -1,0 +1,166 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/maximum-genetic-difference-query/
+
+import java.util.Arrays;
+
+/**
+ *  1938. Maximum Genetic Difference Query
+ *  Hard
+ *
+ *  There is a rooted tree consisting of n nodes numbered 0 to n - 1. Each
+ *  node's number denotes its unique genetic value (i.e. the genetic value of
+ *  node x is x). The genetic difference between two genetic values is defined
+ *  as the bitwise-XOR of their values. You are given the integer array
+ *  parents, where parents[i] is the parent for node i. If node x is the root
+ *  of the tree, then parents[x] == -1.
+ *
+ *  You are also given the array queries where queries[i] = [nodei, vali]. For
+ *  each query i, find the maximum genetic difference between vali and pi,
+ *  where pi is the genetic value of any node that is on the path between nodei
+ *  and the root (including nodei and the root). More formally, you want to
+ *  maximize vali XOR pi.
+ *
+ *  Return an array ans where ans[i] is the answer to the ith query.
+ *
+ *  Example 1:
+ *    Input: parents = [-1,0,1,1], queries = [[0,2],[3,2],[2,5]]
+ *    Output: [2,3,7]
+ *    Explanation: [0,2] -> 2 XOR 0 = 2; [3,2] -> 2 XOR 1 = 3;
+ *                 [2,5] -> 5 XOR 2 = 7.
+ *
+ *  Example 2:
+ *    Input: parents = [3,7,-1,2,0,7,0,2], queries = [[4,6],[1,15],[0,5]]
+ *    Output: [6,14,7]
+ *
+ *  Constraints:
+ *    2 <= parents.length <= 10^5
+ *    parents[root] == -1
+ *    1 <= queries.length <= 3 * 10^4
+ *    0 <= nodei <= parents.length - 1
+ *    0 <= vali <= 2 * 10^5
+ */
+public class MaximumGeneticDifferenceQuery {
+
+    // V0
+    // IDEA: OFFLINE DFS + BINARY TRIE HOLDING EXACTLY THE CURRENT ROOT PATH
+    //       a query at node u may only use values on the path root -> u. so run
+    //       ONE DFS over the tree and keep a bit-trie of the values currently
+    //       on the stack:
+    //         entering u : insert u (counter +1 along its 18-bit path), then
+    //                      answer every query attached to u with a max-XOR walk
+    //         leaving  u : delete u (counter -1) so siblings never see it
+    //       max-XOR walk: from the top bit down, greedily follow the OPPOSITE
+    //       bit of val whenever that branch still has a live counter (that sets
+    //       the bit in the answer), otherwise follow the same bit.
+    //       NOTE: REFERENCE COUNTS (not booleans) are what make the delete
+    //             correct when several path values share a prefix.
+    //       NOTE: depth can be 10^5, so the DFS is ITERATIVE with enter/exit
+    //             markers on the stack.
+    /**
+     * time = O((N + Q) * 18)
+     * space = O(N * 18)
+     */
+    private static final int BITS = 18;   // values fit in 2 * 10^5 < 2^18
+
+    private int[] ch0;
+    private int[] ch1;
+    private int[] cnt;
+    private int trieSize;
+
+    public int[] maxGeneticDifference(int[] parents, int[][] queries) {
+        int n = parents.length;
+        int q = queries.length;
+
+        int cap = n * BITS + 2;
+        this.ch0 = new int[cap];
+        this.ch1 = new int[cap];
+        this.cnt = new int[cap];
+        Arrays.fill(this.ch0, -1);
+        Arrays.fill(this.ch1, -1);
+        this.trieSize = 1;   // node 0 = trie root
+
+        // children adjacency via head/next arrays
+        int[] head = new int[n];
+        int[] nxt = new int[n];
+        Arrays.fill(head, -1);
+        int root = 0;
+        for (int i = 0; i < n; i++) {
+            int p = parents[i];
+            if (p == -1) {
+                root = i;
+            } else {
+                nxt[i] = head[p];
+                head[p] = i;
+            }
+        }
+
+        // queries bucketed per node, also via head/next arrays
+        int[] qHead = new int[n];
+        int[] qNext = new int[q];
+        Arrays.fill(qHead, -1);
+        for (int i = 0; i < q; i++) {
+            int node = queries[i][0];
+            qNext[i] = qHead[node];
+            qHead[node] = i;
+        }
+
+        int[] res = new int[q];
+        // stack holds node*2 (enter) / node*2+1 (leave)
+        int[] stack = new int[2 * n + 5];
+        int sp = 0;
+        stack[sp++] = root * 2;
+        while (sp > 0) {
+            int top = stack[--sp];
+            int u = top >> 1;
+            if ((top & 1) == 1) {
+                update(u, -1);
+                continue;
+            }
+            update(u, 1);
+            for (int qi = qHead[u]; qi != -1; qi = qNext[qi]) {
+                res[qi] = bestXor(queries[qi][1]);
+            }
+            stack[sp++] = u * 2 + 1;
+            for (int c = head[u]; c != -1; c = nxt[c]) {
+                stack[sp++] = c * 2;
+            }
+        }
+        return res;
+    }
+
+    private void update(int x, int delta) {
+        int cur = 0;
+        for (int b = BITS - 1; b >= 0; b--) {
+            int v = (x >> b) & 1;
+            int child = (v == 0) ? this.ch0[cur] : this.ch1[cur];
+            if (child == -1) {
+                child = this.trieSize++;
+                if (v == 0) {
+                    this.ch0[cur] = child;
+                } else {
+                    this.ch1[cur] = child;
+                }
+            }
+            cur = child;
+            this.cnt[cur] += delta;
+        }
+    }
+
+    private int bestXor(int x) {
+        int cur = 0;
+        int res = 0;
+        for (int b = BITS - 1; b >= 0; b--) {
+            int v = (x >> b) & 1;
+            int want = v ^ 1;
+            int nx = (want == 0) ? this.ch0[cur] : this.ch1[cur];
+            if (nx != -1 && this.cnt[nx] > 0) {
+                res |= 1 << b;
+                cur = nx;
+            } else {
+                cur = (v == 0) ? this.ch0[cur] : this.ch1[cur];
+            }
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/MinimumPossibleIntegerAfterAtMostKAdjacentSwapsOnDigits.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/MinimumPossibleIntegerAfterAtMostKAdjacentSwapsOnDigits.java
@@ -1,0 +1,108 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/minimum-possible-integer-after-at-most-k-adjacent-swaps-on-digits/
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ *  1505. Minimum Possible Integer After at Most K Adjacent Swaps On Digits
+ *  Hard
+ *
+ *  You are given a string num representing the digits of a very large integer
+ *  and an integer k. You are allowed to swap any two adjacent digits of the
+ *  integer at most k times.
+ *
+ *  Return the minimum integer you can obtain also as a string.
+ *
+ *  Example 1:
+ *    Input: num = "4321", k = 4
+ *    Output: "1342"
+ *
+ *  Example 2:
+ *    Input: num = "100", k = 1
+ *    Output: "010"
+ *    Explanation: It's ok for the output to have leading zeros, but the input
+ *                 is guaranteed not to have any.
+ *
+ *  Example 3:
+ *    Input: num = "36789", k = 1000
+ *    Output: "36789"
+ *
+ *  Constraints:
+ *    1 <= num.length <= 3 * 10^4
+ *    num consists of only digits and does not contain leading zeros.
+ *    1 <= k <= 10^9
+ */
+public class MinimumPossibleIntegerAfterAtMostKAdjacentSwapsOnDigits {
+
+    // V0
+    // IDEA: GREEDY + BINARY INDEXED TREE (Fenwick)
+    //       greedy: fill the output left to right; for each output slot try the
+    //       digits 0..9 in order and take the SMALLEST one still affordable.
+    //       the cost of pulling the digit at original index i to the front is
+    //       the number of digits BEFORE i that have NOT been taken out yet:
+    //           cost = (i - 1) - (# already-taken indices in [1 .. i])
+    //       a BIT over the "taken" flags answers that in O(log n), and per
+    //       digit value a queue of its original indices gives the earliest
+    //       untaken occurrence in O(1).
+    /**
+     * time = O(N * 10 * log N)
+     * space = O(N)
+     */
+    public String minInteger(String num, int k) {
+        int n = num.length();
+
+        // pos[d] = ascending queue of 1-indexed positions of digit d
+        Deque<Integer>[] pos = new ArrayDeque[10];
+        for (int d = 0; d < 10; d++) {
+            pos[d] = new ArrayDeque<>();
+        }
+        for (int i = 0; i < n; i++) {
+            pos[num.charAt(i) - '0'].addLast(i + 1);
+        }
+
+        int[] tree = new int[n + 1];
+        StringBuilder res = new StringBuilder();
+
+        for (int step = 0; step < n; step++) {
+            for (int d = 0; d < 10; d++) {
+                if (pos[d].isEmpty()) {
+                    continue;
+                }
+                int i = pos[d].peekFirst();
+                /*
+                 * NOTE !!!
+                 *   query(i) counts the ALREADY TAKEN indices in [1..i];
+                 *   index i itself is still untaken, so this is exactly the
+                 *   taken count in [1..i-1].
+                 */
+                int cost = (i - 1) - query(tree, i);
+                if (cost <= k) {
+                    k -= cost;
+                    pos[d].pollFirst();
+                    update(tree, n, i, 1);
+                    res.append((char) ('0' + d));
+                    break;
+                }
+            }
+        }
+        return res.toString();
+    }
+
+    private void update(int[] tree, int n, int i, int delta) {
+        while (i <= n) {
+            tree[i] += delta;
+            i += i & (-i);
+        }
+    }
+
+    private int query(int[] tree, int i) {
+        int s = 0;
+        while (i > 0) {
+            s += tree[i];
+            i -= i & (-i);
+        }
+        return s;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/MinimumWeightedSubgraphWithTheRequiredPathsII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/MinimumWeightedSubgraphWithTheRequiredPathsII.java
@@ -1,0 +1,181 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/minimum-weighted-subgraph-with-the-required-paths-ii/
+
+import java.util.Arrays;
+
+/**
+ *  3553. Minimum Weighted Subgraph With the Required Paths II
+ *  Hard
+ *
+ *  You are given an undirected weighted tree with n nodes, numbered from 0 to
+ *  n - 1. It is represented by a 2D integer array edges of length n - 1, where
+ *  edges[i] = [u_i, v_i, w_i] indicates that there is an edge between nodes
+ *  u_i and v_i with weight w_i.
+ *
+ *  Additionally, you are given a 2D integer array queries, where
+ *  queries[j] = [src1_j, src2_j, dest_j].
+ *
+ *  Return an array answer of length equal to queries.length, where answer[j]
+ *  is the minimum total weight of a subtree such that it is possible to reach
+ *  dest_j from both src1_j and src2_j using edges in this subtree.
+ *
+ *  Example 1:
+ *    Input: edges = [[0,1,2],[1,2,3],[1,3,5],[1,4,4],[2,5,6]],
+ *           queries = [[2,3,4],[0,2,5]]
+ *    Output: [12,11]
+ *    Explanation: answer[0] = 3 + 5 + 4 = 12; answer[1] = 2 + 3 + 6 = 11.
+ *
+ *  Example 2:
+ *    Input: edges = [[1,0,8],[0,2,7]], queries = [[0,1,2]]
+ *    Output: [15]
+ *
+ *  Constraints:
+ *    3 <= n <= 10^5
+ *    edges[i].length == 3, 1 <= w_i <= 10^4
+ *    1 <= queries.length <= 10^5
+ *    queries[j].length == 3, src1_j, src2_j, dest_j pairwise distinct
+ *    edges represents a valid tree.
+ */
+public class MinimumWeightedSubgraphWithTheRequiredPathsII {
+
+    // V0
+    // IDEA: THE STEINER TREE OF THREE NODES IS HALF THE SUM OF THEIR PAIRWISE
+    //       PATHS, SO EACH QUERY IS 3 LCA LOOKUPS
+    //       in a tree the cheapest connected subgraph joining a, b and c is the
+    //       union of the three pairwise paths, and those paths all meet at one
+    //       node (the "median" of the triple). every edge of the union lies on
+    //       exactly TWO of the three paths, hence
+    //           weight = (d(a,b) + d(b,c) + d(a,c)) / 2
+    //       and no per-query traversal is needed at all.
+    //       what is needed is d(u,v) = dist[u] + dist[v] - 2 * dist[lca(u,v)],
+    //       i.e. a fast LCA. with 3 * 10^5 lookups an O(log n) climb each is
+    //       already costly, so the tree is flattened into an EULER TOUR: the
+    //       LCA of u and v is the shallowest node visited between their first
+    //       appearances, and a sparse table over the tour depths answers that
+    //       range minimum in O(1).
+    //       both the tour and the root distances come from one ITERATIVE DFS
+    //       (n reaches 10^5, deep enough to blow a recursive stack).
+    /**
+     * time = O(N * log N + Q)
+     * space = O(N * log N)
+     */
+    private int[] tour;
+    private int[] tdep;
+    private int[] first;
+    private int[] logTab;
+    private int[][] sp;
+
+    public int[] minimumWeight(int[][] edges, int[][] queries) {
+        int n = edges.length + 1;
+
+        // adjacency via head/next arrays
+        int[] head = new int[n];
+        int[] nxt = new int[2 * (n - 1)];
+        int[] to = new int[2 * (n - 1)];
+        int[] wt = new int[2 * (n - 1)];
+        Arrays.fill(head, -1);
+        int ec = 0;
+        for (int[] e : edges) {
+            to[ec] = e[1]; wt[ec] = e[2]; nxt[ec] = head[e[0]]; head[e[0]] = ec++;
+            to[ec] = e[0]; wt[ec] = e[2]; nxt[ec] = head[e[1]]; head[e[1]] = ec++;
+        }
+
+        long[] dist = new long[n];
+        int[] depth = new int[n];
+        this.first = new int[n];
+        this.tour = new int[2 * n];
+        this.tdep = new int[2 * n];
+        int m = 0;
+
+        int[] iter = new int[n];
+        boolean[] entered = new boolean[n];
+        boolean[] seen = new boolean[n];
+        int[] stack = new int[n + 1];
+        for (int i = 0; i < n; i++) {
+            iter[i] = head[i];
+        }
+        int sptr = 0;
+        seen[0] = true;
+        stack[sptr++] = 0;
+        while (sptr > 0) {
+            int u = stack[sptr - 1];
+            if (!entered[u]) {
+                entered[u] = true;
+                this.first[u] = m;
+                this.tour[m] = u;
+                this.tdep[m] = depth[u];
+                m++;
+            }
+            boolean adv = false;
+            while (iter[u] != -1) {
+                int e = iter[u];
+                iter[u] = nxt[e];
+                int v = to[e];
+                if (!seen[v]) {
+                    seen[v] = true;
+                    depth[v] = depth[u] + 1;
+                    dist[v] = dist[u] + wt[e];
+                    stack[sptr++] = v;
+                    adv = true;
+                    break;
+                }
+            }
+            if (!adv) {
+                sptr--;
+                if (sptr > 0) {
+                    int p = stack[sptr - 1];
+                    this.tour[m] = p;
+                    this.tdep[m] = depth[p];
+                    m++;
+                }
+            }
+        }
+
+        buildSparseTable(m);
+
+        int[] res = new int[queries.length];
+        for (int i = 0; i < queries.length; i++) {
+            int a = queries[i][0], b = queries[i][1], c = queries[i][2];
+            long dab = dist[a] + dist[b] - 2 * dist[lca(a, b)];
+            long dbc = dist[b] + dist[c] - 2 * dist[lca(b, c)];
+            long dac = dist[a] + dist[c] - 2 * dist[lca(a, c)];
+            res[i] = (int) ((dab + dbc + dac) / 2);
+        }
+        return res;
+    }
+
+    private void buildSparseTable(int m) {
+        this.logTab = new int[m + 1];
+        for (int i = 2; i <= m; i++) {
+            this.logTab[i] = this.logTab[i >> 1] + 1;
+        }
+        int levels = this.logTab[m] + 1;
+        this.sp = new int[levels][];
+        this.sp[0] = new int[m];
+        for (int i = 0; i < m; i++) {
+            this.sp[0][i] = i;
+        }
+        for (int j = 1; j < levels; j++) {
+            int len = m - (1 << j) + 1;
+            this.sp[j] = new int[len];
+            int half = 1 << (j - 1);
+            for (int i = 0; i < len; i++) {
+                int a = this.sp[j - 1][i];
+                int b = this.sp[j - 1][i + half];
+                this.sp[j][i] = (this.tdep[a] <= this.tdep[b]) ? a : b;
+            }
+        }
+    }
+
+    private int lca(int u, int v) {
+        int i = this.first[u], k = this.first[v];
+        if (i > k) {
+            int t = i; i = k; k = t;
+        }
+        int j = this.logTab[k - i + 1];
+        int a = this.sp[j][i];
+        int b = this.sp[j][k - (1 << j) + 1];
+        return (this.tdep[a] <= this.tdep[b]) ? this.tour[a] : this.tour[b];
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/MoveSubTreeOfNAryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/MoveSubTreeOfNAryTree.java
@@ -1,0 +1,137 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/move-sub-tree-of-n-ary-tree/
+
+import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  1516. Move Sub-Tree of N-Ary Tree
+ *  Hard
+ *
+ *  Given the root of an N-ary tree of unique values, and two nodes of the tree
+ *  p and q.
+ *
+ *  You should move the subtree of the node p to become a direct child of node
+ *  q. If p is already a direct child of q, do not change anything. Node p must
+ *  be the last child in the children list of node q.
+ *
+ *  Return the root of the tree after adjusting it.
+ *
+ *  There are 3 cases for nodes p and q:
+ *    1. Node q is in the sub-tree of node p.
+ *    2. Node p is in the sub-tree of node q.
+ *    3. Neither p is in the sub-tree of q nor q is in the sub-tree of p.
+ *
+ *  In cases 2 and 3 you just move p (with its sub-tree) to be a child of q,
+ *  but in case 1 the tree may be disconnected, so you need to reconnect it.
+ *
+ *  Example 1:
+ *    Input: root = [1,null,2,3,null,4,5,null,6,null,7,8], p = 4, q = 1
+ *    Output: [1,null,2,3,4,null,5,null,6,null,7,8]
+ *    Explanation: case 2 - p is in the sub-tree of q, so p just moves under q
+ *                 and becomes its LAST child.
+ *
+ *  Example 4:
+ *    Input: root = [1,null,2,3,null,4], p = 1, q = 4
+ *    Output: [4,null,1,null,2,3]
+ *    Explanation: case 1 - q is in the sub-tree of p, so q is detached from
+ *                 its parent, takes p's old slot (here: becomes the new root)
+ *                 and p is appended as q's last child.
+ *
+ *  Constraints:
+ *    The total number of nodes is between [2, 1000].
+ *    Each node has a unique value.
+ *    p != null, q != null, p != q
+ */
+public class MoveSubTreeOfNAryTree {
+
+    // Definition for a Node (N-ary tree).
+    public static class Node {
+        public int val;
+        public List<Node> children;
+
+        public Node() {
+            this.children = new ArrayList<>();
+        }
+
+        public Node(int val) {
+            this.val = val;
+            this.children = new ArrayList<>();
+        }
+
+        public Node(int val, List<Node> children) {
+            this.val = val;
+            this.children = children != null ? children : new ArrayList<Node>();
+        }
+    }
+
+    // V0
+    // IDEA: PARENT MAP + 3-CASE SURGERY
+    //       build a parent pointer for every node with one iterative DFS, then
+    //       walk up from q: if we ever hit p then q lives inside p's subtree
+    //       (case 1).
+    //         case 0 : p is already a direct child of q -> nothing to do.
+    //         case 1 (q inside p's subtree) : cutting p out would strand the
+    //                part of the tree above p, so first LIFT q into p's old
+    //                slot -> detach q from its own parent, put q where p used
+    //                to be (or make q the new root if p was the root), then
+    //                append p as q's last child.
+    //         case 2/3 : p's subtree does not contain q, so a plain move is
+    //                safe -> detach p from its parent, append it to q.children.
+    //       NOTE: in cases 2/3 p can never be the root (the root's subtree is
+    //             the whole tree, which would put q inside it -> case 1), so p
+    //             always has a parent there.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public Node moveSubTree(Node root, Node p, Node q) {
+        if (q.children.contains(p)) {
+            return root;
+        }
+
+        // iterative DFS -> parent of every node
+        Map<Node, Node> parent = new HashMap<>();
+        Deque<Node> stack = new ArrayDeque<>();
+        stack.push(root);
+        while (!stack.isEmpty()) {
+            Node node = stack.pop();
+            for (Node child : node.children) {
+                parent.put(child, node);
+                stack.push(child);
+            }
+        }
+
+        // is q inside p's subtree ?
+        boolean qUnderP = false;
+        Node cur = parent.get(q);
+        while (cur != null) {
+            if (cur == p) {
+                qUnderP = true;
+                break;
+            }
+            cur = parent.get(cur);
+        }
+
+        if (qUnderP) {
+            parent.get(q).children.remove(q);
+            if (p == root) {
+                q.children.add(p);
+                return q;
+            }
+            Node pp = parent.get(p);
+            pp.children.set(pp.children.indexOf(p), q);
+            q.children.add(p);
+            return root;
+        }
+
+        parent.get(p).children.remove(p);
+        q.children.add(p);
+        return root;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfGoodPaths.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfGoodPaths.java
@@ -1,0 +1,121 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/number-of-good-paths/
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ *  2421. Number of Good Paths
+ *  Hard
+ *
+ *  There is a tree (i.e. a connected, undirected graph with no cycles)
+ *  consisting of n nodes numbered from 0 to n - 1 and exactly n - 1 edges.
+ *
+ *  You are given a 0-indexed integer array vals of length n where vals[i]
+ *  denotes the value of the ith node. You are also given a 2D integer array
+ *  edges where edges[i] = [ai, bi] denotes an undirected edge connecting
+ *  nodes ai and bi.
+ *
+ *  A good path is a simple path that satisfies:
+ *    - The starting node and the ending node have the same value.
+ *    - All nodes between the starting node and the ending node have values
+ *      less than or equal to the starting node's value.
+ *
+ *  Return the number of distinct good paths. A path and its reverse count as
+ *  the same path. A single node is also a valid path.
+ *
+ *  Example 1:
+ *    Input: vals = [1,3,2,1,3], edges = [[0,1],[0,2],[2,3],[2,4]]
+ *    Output: 6
+ *    Explanation: 5 single-node paths, plus 1 -> 0 -> 2 -> 4.
+ *
+ *  Example 2:
+ *    Input: vals = [1,1,2,2,3], edges = [[0,1],[1,2],[2,3],[2,4]]
+ *    Output: 7
+ *    Explanation: 5 single-node paths, plus 0 -> 1 and 2 -> 3.
+ *
+ *  Constraints:
+ *    n == vals.length
+ *    1 <= n <= 3 * 10^4
+ *    0 <= vals[i] <= 10^5
+ *    edges.length == n - 1
+ *    edges represents a valid tree.
+ */
+public class NumberOfGoodPaths {
+
+    // V0
+    // IDEA: UNION-FIND, ADDING EDGES IN INCREASING "MAX ENDPOINT VALUE" ORDER
+    //       sort the edges by max(vals[a], vals[b]) and union in that order.
+    //       invariant: when an edge with key v is processed, every node already
+    //       in either component has value <= v (anything larger could only be
+    //       attached by a later edge).
+    //       so per component track
+    //           top[root] = the component's maximum value
+    //           cnt[root] = how many of its nodes hold that maximum
+    //       merging two components with EQUAL maxima pairs every top node of
+    //       one with every top node of the other through the new edge:
+    //           res += cnt[ra] * cnt[rb]
+    //       otherwise the smaller-max component contributes nothing and is
+    //       simply absorbed. the n single-node paths are counted up front.
+    /**
+     * time = O(N * log N)
+     * space = O(N)
+     */
+    private int[] parent;
+
+    public int numberOfGoodPaths(int[] vals, int[][] edges) {
+        final int n = vals.length;
+        this.parent = new int[n];
+        int[] top = new int[n];
+        int[] cnt = new int[n];
+        for (int i = 0; i < n; i++) {
+            this.parent[i] = i;
+            top[i] = vals[i];
+            cnt[i] = 1;
+        }
+
+        final int[] v = vals;
+        Integer[] order = new Integer[edges.length];
+        for (int i = 0; i < edges.length; i++) {
+            order[i] = i;
+        }
+        Arrays.sort(order, new Comparator<Integer>() {
+            @Override
+            public int compare(Integer x, Integer y) {
+                int kx = Math.max(v[edges[x][0]], v[edges[x][1]]);
+                int ky = Math.max(v[edges[y][0]], v[edges[y][1]]);
+                return Integer.compare(kx, ky);
+            }
+        });
+
+        int res = n;   // every single node is a good path
+        for (int idx = 0; idx < order.length; idx++) {
+            int a = edges[order[idx]][0];
+            int b = edges[order[idx]][1];
+            int ra = find(a);
+            int rb = find(b);
+            if (ra == rb) {
+                continue;
+            }
+            if (top[ra] == top[rb]) {
+                res += cnt[ra] * cnt[rb];
+                this.parent[rb] = ra;
+                cnt[ra] += cnt[rb];
+            } else if (top[ra] > top[rb]) {
+                this.parent[rb] = ra;
+            } else {
+                this.parent[ra] = rb;
+            }
+        }
+        return res;
+    }
+
+    private int find(int x) {
+        while (this.parent[x] != x) {
+            this.parent[x] = this.parent[this.parent[x]];   // path halving
+            x = this.parent[x];
+        }
+        return x;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfNodesInTheSubTreeWithTheSameLabel.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfNodesInTheSubTreeWithTheSameLabel.java
@@ -1,0 +1,115 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/number-of-nodes-in-the-sub-tree-with-the-same-label/
+
+/**
+ *  1519. Number of Nodes in the Sub-Tree With the Same Label
+ *  Medium
+ *
+ *  You are given a tree (i.e. a connected, undirected graph that has no
+ *  cycles) consisting of n nodes numbered from 0 to n - 1 and exactly n - 1
+ *  edges. The root of the tree is node 0, and each node has a label which is a
+ *  lower-case character given in the string labels (the node numbered i has
+ *  the label labels[i]).
+ *
+ *  The edges array is given on the form edges[i] = [a_i, b_i], meaning there
+ *  is an edge between nodes a_i and b_i.
+ *
+ *  Return an array of size n where ans[i] is the number of nodes in the
+ *  subtree of the ith node which have the same label as node i.
+ *
+ *  Example 1:
+ *    Input: n = 7, edges = [[0,1],[0,2],[1,4],[1,5],[2,3],[2,6]],
+ *           labels = "abaedcd"
+ *    Output: [2,1,1,1,1,1,1]
+ *    Explanation: node 0 has label 'a' and its subtree also holds node 2
+ *                 with label 'a', so the answer is 2.
+ *
+ *  Example 2:
+ *    Input: n = 4, edges = [[0,1],[1,2],[0,3]], labels = "bbbb"
+ *    Output: [4,2,1,1]
+ *
+ *  Constraints:
+ *    1 <= n <= 10^5
+ *    edges.length == n - 1
+ *    0 <= a_i, b_i < n, a_i != b_i
+ *    labels.length == n, lowercase English letters only
+ */
+public class NumberOfNodesInTheSubTreeWithTheSameLabel {
+
+    // V0
+    // IDEA: POST-ORDER OVER AN ITERATIVE DFS ORDER, MERGING 26-SLOT COUNTERS UP
+    //       for every node keep a 26-length array of the label counts of its
+    //       subtree. walking the DFS pre-order list in REVERSE is a valid
+    //       post-order, so all children of a node are finished before it:
+    //           cnt[u] = own label + sum of cnt[child]
+    //           res[u] = cnt[u][labels[u]]
+    //       NOTE: n can be 10^5 and the tree may be one long chain, so the
+    //             traversal is iterative (recursion could blow the stack).
+    /**
+     * time = O(26 * N)
+     * space = O(26 * N)
+     */
+    public int[] countSubTrees(int n, int[][] edges, String labels) {
+        // adjacency via head/next arrays (no boxing)
+        int[] head = new int[n];
+        int[] nxt = new int[2 * (n - 1 > 0 ? n - 1 : 1)];
+        int[] to = new int[2 * (n - 1 > 0 ? n - 1 : 1)];
+        for (int i = 0; i < n; i++) {
+            head[i] = -1;
+        }
+        int ec = 0;
+        for (int[] e : edges) {
+            to[ec] = e[1]; nxt[ec] = head[e[0]]; head[e[0]] = ec++;
+            to[ec] = e[0]; nxt[ec] = head[e[1]]; head[e[1]] = ec++;
+        }
+
+        // iterative DFS -> pre-order list + parent of each node
+        int[] parent = new int[n];
+        int[] order = new int[n];
+        boolean[] seen = new boolean[n];
+        int[] stack = new int[n];
+        int sp = 0, oc = 0;
+        parent[0] = -1;
+        seen[0] = true;
+        stack[sp++] = 0;
+        while (sp > 0) {
+            int u = stack[--sp];
+            order[oc++] = u;
+            for (int e = head[u]; e != -1; e = nxt[e]) {
+                int v = to[e];
+                if (!seen[v]) {
+                    seen[v] = true;
+                    parent[v] = u;
+                    stack[sp++] = v;
+                }
+            }
+        }
+
+        int[] res = new int[n];
+        int[][] cnt = new int[n][];
+        for (int i = oc - 1; i >= 0; i--) {
+            int u = order[i];
+            int[] cur = cnt[u];
+            if (cur == null) {
+                cur = new int[26];
+            }
+            int k = labels.charAt(u) - 'a';
+            cur[k]++;
+            res[u] = cur[k];
+
+            int p = parent[u];
+            if (p >= 0) {
+                if (cnt[p] == null) {
+                    cnt[p] = new int[26];
+                }
+                int[] pc = cnt[p];
+                for (int j = 0; j < 26; j++) {
+                    pc[j] += cur[j];
+                }
+            }
+            cnt[u] = null;   // parent already absorbed it -> free it
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfWaysToAssignEdgeWeightsI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfWaysToAssignEdgeWeightsI.java
@@ -1,0 +1,112 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/number-of-ways-to-assign-edge-weights-i/
+
+import java.util.Arrays;
+
+/**
+ *  3558. Number of Ways to Assign Edge Weights I
+ *  Medium
+ *
+ *  There is an undirected tree with n nodes labeled from 1 to n, rooted at
+ *  node 1. The tree is represented by a 2D integer array edges of length
+ *  n - 1, where edges[i] = [u_i, v_i] indicates an edge between u_i and v_i.
+ *
+ *  Initially, all edges have a weight of 0. You must assign each edge a weight
+ *  of either 1 or 2. The cost of a path between any two nodes u and v is the
+ *  total weight of all edges in the path connecting them.
+ *
+ *  Select any one node x at the maximum depth. Return the number of ways to
+ *  assign edge weights in the path from node 1 to x such that its total cost
+ *  is odd. Since the answer may be large, return it modulo 10^9 + 7.
+ *
+ *  Note: Ignore all edges not in the path from node 1 to x.
+ *
+ *  Example 1:
+ *    Input: edges = [[1,2]]
+ *    Output: 1
+ *    Explanation: weight 1 makes the cost odd, 2 makes it even -> 1 way.
+ *
+ *  Example 2:
+ *    Input: edges = [[1,2],[1,3],[3,4],[3,5]]
+ *    Output: 2
+ *    Explanation: the max depth is 2 (nodes 4 and 5). For the 2-edge path,
+ *                 (1,2) and (2,1) give an odd cost -> 2 ways.
+ *
+ *  Constraints:
+ *    2 <= n <= 10^5
+ *    edges.length == n - 1
+ *    1 <= u_i, v_i <= n
+ *    edges represents a valid tree.
+ */
+public class NumberOfWaysToAssignEdgeWeightsI {
+
+    // V0
+    // IDEA: ONLY THE PARITY MATTERS, SO EXACTLY HALF THE ASSIGNMENTS WORK
+    //       weights are 1 or 2, so an edge flips the parity of the path cost
+    //       only when it is given a 1 -> the cost is odd exactly when an odd
+    //       number of the L path edges got a 1.
+    //       the number of odd-sized subsets of L items is 2^(L-1) for every
+    //       L >= 1 (fix the first L-1 edges freely, the last one is forced).
+    //       so the whole problem reduces to finding L = the maximum depth,
+    //       which one DFS/BFS from the root delivers. every deepest node gives
+    //       the same L, which is why the statement lets any of them be picked.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int assignEdgeWeights(int[][] edges) {
+        final long MOD = 1000000007L;
+        int n = edges.length + 1;
+
+        int[] head = new int[n + 1];
+        int[] nxt = new int[2 * (n - 1 > 0 ? n - 1 : 1)];
+        int[] to = new int[2 * (n - 1 > 0 ? n - 1 : 1)];
+        Arrays.fill(head, -1);
+        int ec = 0;
+        for (int[] e : edges) {
+            to[ec] = e[1]; nxt[ec] = head[e[0]]; head[e[0]] = ec++;
+            to[ec] = e[0]; nxt[ec] = head[e[1]]; head[e[1]] = ec++;
+        }
+
+        int[] depth = new int[n + 1];
+        boolean[] seen = new boolean[n + 1];
+        int[] stack = new int[n + 1];
+        int sp = 0;
+        seen[1] = true;
+        stack[sp++] = 1;
+        int best = 0;
+        while (sp > 0) {
+            int u = stack[--sp];
+            if (depth[u] > best) {
+                best = depth[u];
+            }
+            for (int e = head[u]; e != -1; e = nxt[e]) {
+                int v = to[e];
+                if (!seen[v]) {
+                    seen[v] = true;
+                    depth[v] = depth[u] + 1;
+                    stack[sp++] = v;
+                }
+            }
+        }
+
+        if (best == 0) {
+            return 0;
+        }
+        return (int) modPow(2L, best - 1, MOD);
+    }
+
+    private long modPow(long base, long exp, long mod) {
+        long r = 1L;
+        base %= mod;
+        while (exp > 0) {
+            if ((exp & 1L) == 1L) {
+                r = r * base % mod;
+            }
+            base = base * base % mod;
+            exp >>= 1;
+        }
+        return r;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfWaysToAssignEdgeWeightsII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/NumberOfWaysToAssignEdgeWeightsII.java
@@ -1,0 +1,174 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/number-of-ways-to-assign-edge-weights-ii/
+
+import java.util.Arrays;
+
+/**
+ *  3559. Number of Ways to Assign Edge Weights II
+ *  Hard
+ *
+ *  There is an undirected tree with n nodes labeled from 1 to n, rooted at
+ *  node 1. The tree is represented by a 2D integer array edges of length
+ *  n - 1, where edges[i] = [u_i, v_i] indicates an edge between u_i and v_i.
+ *
+ *  Initially, all edges have a weight of 0. You must assign each edge a weight
+ *  of either 1 or 2. The cost of a path between any two nodes u and v is the
+ *  total weight of all edges in the path connecting them.
+ *
+ *  You are given a 2D integer array queries. For each queries[i] = [u_i, v_i],
+ *  determine the number of ways to assign weights to edges in the path such
+ *  that the cost of the path between u_i and v_i is odd.
+ *
+ *  Return an array answer, where answer[i] is the number of valid assignments
+ *  for queries[i], modulo 10^9 + 7.
+ *
+ *  Note: For each query, disregard all edges not in the path between u_i, v_i.
+ *
+ *  Example 1:
+ *    Input: edges = [[1,2]], queries = [[1,1],[1,2]]
+ *    Output: [0,1]
+ *    Explanation: the empty path costs 0 (never odd) -> 0; the 1-edge path has
+ *                 exactly one odd assignment -> 1.
+ *
+ *  Example 2:
+ *    Input: edges = [[1,2],[1,3],[3,4],[3,5]], queries = [[1,4],[3,4],[2,5]]
+ *    Output: [2,1,4]
+ *
+ *  Constraints:
+ *    2 <= n <= 10^5
+ *    edges.length == n - 1
+ *    1 <= queries.length <= 10^5
+ *    1 <= u_i, v_i <= n
+ *    edges represents a valid tree.
+ */
+public class NumberOfWaysToAssignEdgeWeightsII {
+
+    // V0
+    // IDEA: PATH LENGTH VIA LCA, THEN THE PARITY COUNT IS 2^(L-1)
+    //       weights are 1 or 2, so only the edges given a 1 change the parity:
+    //       the path cost is odd exactly when an odd number of its L edges got
+    //       a 1. the number of odd-sized subsets of L items is 2^(L-1) for
+    //       every L >= 1 (fix the first L-1 edges freely, the last is forced),
+    //       and 0 when the path is empty.
+    //       so each query only needs L = depth[u] + depth[v] - 2*depth[lca].
+    //       with 10^5 queries an O(log n) climb per LCA is the bottleneck, so
+    //       the tree is flattened into an EULER TOUR: the LCA is the shallowest
+    //       node visited between the two nodes' first appearances, and a sparse
+    //       table over the tour depths makes that an O(1) range minimum.
+    /**
+     * time = O(N * log N + Q)
+     * space = O(N * log N)
+     */
+    private int[] tdep;
+    private int[] first;
+    private int[] logTab;
+    private int[][] sp;
+
+    public int[] assignEdgeWeights(int[][] edges, int[][] queries) {
+        final long MOD = 1000000007L;
+        int n = edges.length + 1;
+
+        int[] head = new int[n + 1];
+        int[] nxt = new int[2 * (n - 1)];
+        int[] to = new int[2 * (n - 1)];
+        Arrays.fill(head, -1);
+        int ec = 0;
+        for (int[] e : edges) {
+            to[ec] = e[1]; nxt[ec] = head[e[0]]; head[e[0]] = ec++;
+            to[ec] = e[0]; nxt[ec] = head[e[1]]; head[e[1]] = ec++;
+        }
+
+        int[] depth = new int[n + 1];
+        this.first = new int[n + 1];
+        this.tdep = new int[2 * n];
+        int m = 0;
+
+        int[] iter = new int[n + 1];
+        boolean[] entered = new boolean[n + 1];
+        boolean[] seen = new boolean[n + 1];
+        int[] stack = new int[n + 2];
+        for (int i = 1; i <= n; i++) {
+            iter[i] = head[i];
+        }
+        int sptr = 0;
+        seen[1] = true;
+        stack[sptr++] = 1;
+        while (sptr > 0) {
+            int u = stack[sptr - 1];
+            if (!entered[u]) {
+                entered[u] = true;
+                this.first[u] = m;
+                this.tdep[m] = depth[u];
+                m++;
+            }
+            boolean adv = false;
+            while (iter[u] != -1) {
+                int e = iter[u];
+                iter[u] = nxt[e];
+                int v = to[e];
+                if (!seen[v]) {
+                    seen[v] = true;
+                    depth[v] = depth[u] + 1;
+                    stack[sptr++] = v;
+                    adv = true;
+                    break;
+                }
+            }
+            if (!adv) {
+                sptr--;
+                if (sptr > 0) {
+                    this.tdep[m] = depth[stack[sptr - 1]];
+                    m++;
+                }
+            }
+        }
+
+        buildSparseTable(m);
+
+        long[] pw = new long[n + 1];
+        pw[0] = 1L;
+        for (int i = 1; i <= n; i++) {
+            pw[i] = pw[i - 1] * 2 % MOD;
+        }
+
+        int[] res = new int[queries.length];
+        for (int i = 0; i < queries.length; i++) {
+            int u = queries[i][0], v = queries[i][1];
+            int d = minDepthBetween(this.first[u], this.first[v]);
+            int L = depth[u] + depth[v] - 2 * d;
+            res[i] = (L == 0) ? 0 : (int) pw[L - 1];
+        }
+        return res;
+    }
+
+    private void buildSparseTable(int m) {
+        this.logTab = new int[m + 1];
+        for (int i = 2; i <= m; i++) {
+            this.logTab[i] = this.logTab[i >> 1] + 1;
+        }
+        int levels = this.logTab[m] + 1;
+        this.sp = new int[levels][];
+        this.sp[0] = new int[m];
+        for (int i = 0; i < m; i++) {
+            this.sp[0][i] = this.tdep[i];
+        }
+        for (int j = 1; j < levels; j++) {
+            int len = m - (1 << j) + 1;
+            this.sp[j] = new int[len];
+            int half = 1 << (j - 1);
+            for (int i = 0; i < len; i++) {
+                this.sp[j][i] = Math.min(this.sp[j - 1][i], this.sp[j - 1][i + half]);
+            }
+        }
+    }
+
+    // min tour depth over [i, k] -> the depth of the LCA
+    private int minDepthBetween(int i, int k) {
+        if (i > k) {
+            int t = i; i = k; k = t;
+        }
+        int j = this.logTab[k - i + 1];
+        return Math.min(this.sp[j][i], this.sp[j][k - (1 << j) + 1]);
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/PathInZigzagLabelledBinaryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/PathInZigzagLabelledBinaryTree.java
@@ -1,0 +1,71 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/path-in-zigzag-labelled-binary-tree/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1104. Path In Zigzag Labelled Binary Tree
+ *  Medium
+ *
+ *  In an infinite binary tree where every node has two children, the nodes are
+ *  labelled in row order.
+ *
+ *  In the odd numbered rows (ie., the first, third, fifth, ...), the labelling
+ *  is left to right, while in the even numbered rows (second, fourth, sixth,
+ *  ...), the labelling is right to left.
+ *
+ *  Given the label of a node in this tree, return the labels in the path from
+ *  the root of the tree to the node with that label.
+ *
+ *  Example 1:
+ *    Input: label = 14
+ *    Output: [1,3,4,14]
+ *
+ *  Example 2:
+ *    Input: label = 26
+ *    Output: [1,2,6,10,26]
+ *
+ *  Constraints:
+ *    1 <= label <= 10^6
+ */
+public class PathInZigzagLabelledBinaryTree {
+
+    // V0
+    // IDEA: MATH - MIRROR THE LABEL BACK INTO THE "NORMAL" NUMBERING
+    //       level L (1-based) holds labels in [2^(L-1), 2^L - 1].
+    //       if the level were labelled left -> right the parent would just be
+    //       label / 2. because the directions alternate, first mirror the
+    //       label inside its own level:
+    //           mirror = (2^(L-1) + 2^L - 1) - label
+    //       then parent = mirror / 2 (the parent level is mirrored too, so one
+    //       mirror per step is enough).
+    /**
+     * time = O(log(label))
+     * space = O(log(label))
+     */
+    public List<Integer> pathInZigZagTree(int label) {
+        // find the 1-based level that contains `label`
+        int level = 1;
+        while ((1L << level) <= label) {
+            level++;
+        }
+
+        Integer[] arr = new Integer[level];
+        int cur = label;
+        int lv = level;
+        while (lv > 0) {
+            arr[lv - 1] = cur;
+            // mirror within the level, then step up to the parent
+            cur = (int) ((((1L << (lv - 1)) + (1L << lv) - 1) - cur) >> 1);
+            lv--;
+        }
+
+        List<Integer> res = new ArrayList<>();
+        for (int i = 0; i < level; i++) {
+            res.add(arr[i]);
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/QueriesOnAPermutationWithKey.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/QueriesOnAPermutationWithKey.java
@@ -1,0 +1,115 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/queries-on-a-permutation-with-key/
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  1409. Queries on a Permutation With Key
+ *  Medium
+ *
+ *  Given the array queries of positive integers between 1 and m, you have to
+ *  process all queries[i] (from i = 0 to i = queries.length - 1) according to
+ *  the following rules:
+ *
+ *    - In the beginning, you have the permutation P = [1,2,3,...,m].
+ *    - For the current i, find the position of queries[i] in the permutation P
+ *      (indexing from 0) and then move this at the beginning of P. Notice that
+ *      the position of queries[i] in P is the result for queries[i].
+ *
+ *  Return an array containing the result for the given queries.
+ *
+ *  Example 1:
+ *    Input: queries = [3,1,2,1], m = 5
+ *    Output: [2,1,2,1]
+ *    Explanation:
+ *      i=0: P=[1,2,3,4,5], pos(3)=2 -> P=[3,1,2,4,5]
+ *      i=1: P=[3,1,2,4,5], pos(1)=1 -> P=[1,3,2,4,5]
+ *      i=2: P=[1,3,2,4,5], pos(2)=2 -> P=[2,1,3,4,5]
+ *      i=3: P=[2,1,3,4,5], pos(1)=1 -> P=[1,2,3,4,5]
+ *
+ *  Example 2:
+ *    Input: queries = [4,1,2,2], m = 4
+ *    Output: [3,1,2,0]
+ *
+ *  Constraints:
+ *    1 <= m <= 10^3
+ *    1 <= queries.length <= m
+ *    1 <= queries[i] <= m
+ */
+public class QueriesOnAPermutationWithKey {
+
+    // V0
+    // IDEA: SIMULATION (m <= 1000, so a plain list is fast enough)
+    //       find the index, record it, remove and re-insert at the front.
+    /**
+     * time = O(M * Q)
+     * space = O(M)
+     */
+    public int[] processQueries(int[] queries, int m) {
+        List<Integer> p = new ArrayList<>();
+        for (int i = 1; i <= m; i++) {
+            p.add(i);
+        }
+        int[] res = new int[queries.length];
+        for (int i = 0; i < queries.length; i++) {
+            int v = queries[i];
+            int j = p.indexOf(v);
+            res[i] = j;
+            p.remove(j);
+            p.add(0, v);
+        }
+        return res;
+    }
+
+    // V1
+    // IDEA: BINARY INDEXED TREE (Fenwick) OVER A VIRTUAL LINE OF SIZE M + Q
+    //       slots [Q+1 .. Q+M] hold the initial permutation; slots Q, Q-1, ...
+    //       are the free space IN FRONT that queried values get moved into.
+    //       the 0-based position of a value = how many live values sit strictly
+    //       to its left = prefix sum up to its slot (after removing itself).
+    //       (materially different: O(log n) per query instead of O(m))
+    /**
+     * time = O((M + Q) * log(M + Q))
+     * space = O(M + Q)
+     */
+    public int[] processQueriesBIT(int[] queries, int m) {
+        int q = queries.length;
+        int size = m + q;
+        int[] tree = new int[size + 1];
+        int[] pos = new int[m + 1];
+
+        for (int i = 1; i <= m; i++) {
+            pos[i] = q + i;
+            bitUpdate(tree, size, q + i, 1);
+        }
+
+        int[] res = new int[q];
+        for (int i = 0; i < q; i++) {
+            int v = queries[i];
+            int j = pos[v];
+            bitUpdate(tree, size, j, -1);
+            res[i] = bitQuery(tree, j);
+            pos[v] = q - i;
+            bitUpdate(tree, size, q - i, 1);
+        }
+        return res;
+    }
+
+    private void bitUpdate(int[] tree, int n, int x, int delta) {
+        while (x <= n) {
+            tree[x] += delta;
+            x += x & (-x);
+        }
+    }
+
+    private int bitQuery(int[] tree, int x) {
+        int s = 0;
+        while (x > 0) {
+            s += tree[x];
+            x -= x & (-x);
+        }
+        return s;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/RootEqualsSumOfChildren.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/RootEqualsSumOfChildren.java
@@ -1,0 +1,45 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/root-equals-sum-of-children/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  2236. Root Equals Sum of Children
+ *  Easy
+ *
+ *  You are given the root of a binary tree that consists of exactly 3 nodes:
+ *  the root, its left child, and its right child.
+ *
+ *  Return true if the value of the root is equal to the sum of the values of
+ *  its two children, or false otherwise.
+ *
+ *  Example 1:
+ *    Input: root = [10,4,6]
+ *    Output: true
+ *    Explanation: The values of the root, its left child, and its right child
+ *                 are 10, 4, and 6. 10 == 4 + 6, so we return true.
+ *
+ *  Example 2:
+ *    Input: root = [5,3,1]
+ *    Output: false
+ *    Explanation: 5 != 3 + 1.
+ *
+ *  Constraints:
+ *    The tree consists only of the root, its left child, and its right child.
+ *    -100 <= Node.val <= 100
+ */
+public class RootEqualsSumOfChildren {
+
+    // V0
+    // IDEA: DIRECT NODE ACCESS
+    //       the tree is guaranteed to have exactly 3 nodes, so both children
+    //       always exist -> no traversal needed, just one comparison.
+    /**
+     * time = O(1)
+     * space = O(1)
+     */
+    public boolean checkTree(TreeNode root) {
+        return root.val == root.left.val + root.right.val;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/ShortestPathInAWeightedTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/ShortestPathInAWeightedTree.java
@@ -1,0 +1,181 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/shortest-path-in-a-weighted-tree/
+
+import java.util.Arrays;
+
+/**
+ *  3515. Shortest Path in a Weighted Tree
+ *  Hard
+ *
+ *  You are given an integer n and an undirected, weighted tree rooted at node
+ *  1 with n nodes numbered from 1 to n. This is represented by a 2D array
+ *  edges of length n - 1, where edges[i] = [u_i, v_i, w_i] indicates an
+ *  undirected edge from node u_i to v_i with weight w_i.
+ *
+ *  You are also given a 2D integer array queries of length q, where each
+ *  queries[i] is either:
+ *    [1, u, v, w'] - Update the weight of the edge between nodes u and v to
+ *                    w', where (u, v) is guaranteed to be an existing edge.
+ *    [2, x]        - Compute the shortest path distance from the root node 1
+ *                    to node x.
+ *
+ *  Return an integer array answer, where answer[i] is the shortest path
+ *  distance from node 1 to x for the ith query of type [2, x].
+ *
+ *  Example 1:
+ *    Input: n = 2, edges = [[1,2,7]], queries = [[2,2],[1,1,2,4],[2,2]]
+ *    Output: [7,4]
+ *
+ *  Example 2:
+ *    Input: n = 3, edges = [[1,2,2],[1,3,4]],
+ *           queries = [[2,1],[2,3],[1,1,3,7],[2,2],[2,3]]
+ *    Output: [0,4,2,7]
+ *
+ *  Constraints:
+ *    1 <= n <= 10^5
+ *    edges.length == n - 1, 1 <= w_i <= 10^4
+ *    1 <= queries.length == q <= 10^5
+ *    (u, v) is always an edge from edges, 1 <= w' <= 10^4
+ */
+public class ShortestPathInAWeightedTree {
+
+    // V0
+    // IDEA: EULER TOUR TURNS "EDGE UPDATE" INTO A RANGE ADD ON A FENWICK TREE
+    //       in a rooted tree the distance from the root to x is just the sum of
+    //       the edge weights on that one path, so
+    //           dist(x) = dist(parent) + w(parent, x)
+    //       changing one edge (p, c) by delta therefore changes dist(y) by
+    //       exactly delta for every y in the subtree of c, and nothing else.
+    //       a DFS preorder numbers each subtree as one contiguous block
+    //       [tin, tout], so "add delta to a whole subtree" becomes "add delta
+    //       to a range" and "read dist(x)" becomes "read one position" -> a
+    //       Fenwick tree over the DIFFERENCE array does range-add / point-query
+    //       in O(log n) each.
+    //       the only bookkeeping left is deciding which endpoint of an updated
+    //       edge is the child (the one whose parent is the other endpoint) and
+    //       remembering each edge's current weight so the delta is computable.
+    //       NOTE: the DFS uses an explicit stack - n reaches 10^5, deep enough
+    //             to overflow a recursive one on a path-shaped tree.
+    /**
+     * time = O((N + Q) * log N)
+     * space = O(N)
+     */
+    private long[] bit;
+    private int size;   // == n + 1, the Fenwick length
+
+    public int[] treeQueries(int n, int[][] edges, int[][] queries) {
+        int[] head = new int[n + 1];
+        int em = 2 * (n - 1 > 0 ? n - 1 : 1);
+        int[] nxt = new int[em];
+        int[] to = new int[em];
+        int[] wt = new int[em];
+        Arrays.fill(head, -1);
+        int ec = 0;
+        for (int[] e : edges) {
+            to[ec] = e[1]; wt[ec] = e[2]; nxt[ec] = head[e[0]]; head[e[0]] = ec++;
+            to[ec] = e[0]; wt[ec] = e[2]; nxt[ec] = head[e[1]]; head[e[1]] = ec++;
+        }
+
+        int[] par = new int[n + 1];
+        int[] wpar = new int[n + 1];     // weight of the edge to the parent
+        int[] order = new int[n];
+        boolean[] seen = new boolean[n + 1];
+        int[] stack = new int[n + 1];
+        int sp = 0, oc = 0;
+        seen[1] = true;
+        stack[sp++] = 1;
+        while (sp > 0) {                 // iterative DFS preorder
+            int u = stack[--sp];
+            order[oc++] = u;
+            for (int e = head[u]; e != -1; e = nxt[e]) {
+                int v = to[e];
+                if (!seen[v]) {
+                    seen[v] = true;
+                    par[v] = u;
+                    wpar[v] = wt[e];
+                    stack[sp++] = v;
+                }
+            }
+        }
+
+        int[] tin = new int[n + 1];
+        for (int i = 0; i < oc; i++) {
+            tin[order[i]] = i;
+        }
+        int[] sz = new int[n + 1];
+        Arrays.fill(sz, 1);
+        for (int i = oc - 1; i >= 0; i--) {
+            int u = order[i];
+            if (u != 1) {
+                sz[par[u]] += sz[u];
+            }
+        }
+        int[] tout = new int[n + 1];
+        for (int i = 0; i < oc; i++) {
+            int u = order[i];
+            tout[u] = tin[u] + sz[u] - 1;
+        }
+
+        // difference array whose prefix sums are the root distances
+        long[] diff = new long[n + 2];
+        for (int i = 0; i < oc; i++) {
+            int u = order[i];
+            if (u != 1) {
+                diff[tin[u]] += wpar[u];
+                diff[tout[u] + 1] -= wpar[u];
+            }
+        }
+        this.size = n + 1;
+        this.bit = new long[n + 2];      // O(n) Fenwick construction
+        for (int i = 1; i <= n + 1; i++) {
+            this.bit[i] += diff[i - 1];
+            int j = i + (i & (-i));
+            if (j <= n + 1) {
+                this.bit[j] += this.bit[i];
+            }
+        }
+
+        int cntRead = 0;
+        for (int[] q : queries) {
+            if (q[0] == 2) {
+                cntRead++;
+            }
+        }
+        int[] res = new int[cntRead];
+        int ri = 0;
+        for (int[] q : queries) {
+            if (q[0] == 1) {
+                int u = q[1], v = q[2], w = q[3];
+                int c = (par[v] == u) ? v : u;
+                int delta = w - wpar[c];
+                if (delta != 0) {
+                    wpar[c] = w;
+                    add(tin[c], delta);
+                    add(tout[c] + 1, -delta);
+                }
+            } else {
+                res[ri++] = (int) prefix(tin[q[1]]);
+            }
+        }
+        return res;
+    }
+
+    private void add(int i, long delta) {
+        i += 1;
+        while (i <= this.size) {
+            this.bit[i] += delta;
+            i += i & (-i);
+        }
+    }
+
+    private long prefix(int i) {
+        i += 1;
+        long s = 0L;
+        while (i > 0) {
+            s += this.bit[i];
+            i -= i & (-i);
+        }
+        return s;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/SmallestMissingGeneticValueInEachSubtree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/SmallestMissingGeneticValueInEachSubtree.java
@@ -1,0 +1,115 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/smallest-missing-genetic-value-in-each-subtree/
+
+import java.util.Arrays;
+
+/**
+ *  2003. Smallest Missing Genetic Value in Each Subtree
+ *  Hard
+ *
+ *  There is a family tree rooted at 0 consisting of n nodes numbered 0 to
+ *  n - 1. You are given a 0-indexed integer array parents, where parents[i] is
+ *  the parent for node i. Since node 0 is the root, parents[0] == -1.
+ *
+ *  There are 10^5 genetic values, each represented by an integer in the
+ *  inclusive range [1, 10^5]. You are given a 0-indexed integer array nums,
+ *  where nums[i] is a distinct genetic value for node i.
+ *
+ *  Return an array ans of length n where ans[i] is the smallest genetic value
+ *  that is missing from the subtree rooted at node i.
+ *
+ *  Example 1:
+ *    Input: parents = [-1,0,0,2], nums = [1,2,3,4]
+ *    Output: [5,1,1,1]
+ *    Explanation: subtree of 0 holds {1,2,3,4} -> 5 missing;
+ *                 the other subtrees all miss 1.
+ *
+ *  Example 2:
+ *    Input: parents = [-1,0,1,0,3,3], nums = [5,4,6,2,1,3]
+ *    Output: [7,1,1,4,2,1]
+ *
+ *  Constraints:
+ *    n == parents.length == nums.length
+ *    2 <= n <= 10^5
+ *    parents[0] == -1, parents represents a valid tree.
+ *    1 <= nums[i] <= 10^5, each nums[i] is distinct.
+ */
+public class SmallestMissingGeneticValueInEachSubtree {
+
+    // V0
+    // IDEA: WALK UP THE ROOT-PATH OF THE NODE HOLDING VALUE 1 (incremental DFS)
+    //       any subtree that does NOT contain the value 1 answers 1. so only
+    //       the nodes on the root-path of the node holding 1 can answer > 1,
+    //       and those subtrees are NESTED (each contains the previous one).
+    //       -> start at the node with value 1 and climb to the root; at every
+    //          step add the newly reachable nodes with a DFS that never
+    //          revisits a marked node, keeping a "seen value" table plus a
+    //          pointer `miss` that only ever moves forward.
+    //       each node is visited once overall and `miss` moves at most n times.
+    //       NOTE: n can be 10^5, so the DFS uses an explicit stack.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public int[] smallestMissingValueSubtree(int[] parents, int[] nums) {
+        int n = nums.length;
+        int[] res = new int[n];
+        Arrays.fill(res, 1);
+
+        // children adjacency via head/next arrays
+        int[] head = new int[n];
+        int[] nxt = new int[n];
+        Arrays.fill(head, -1);
+        for (int i = 1; i < n; i++) {
+            nxt[i] = head[parents[i]];
+            head[parents[i]] = i;
+        }
+
+        int start = -1;
+        for (int i = 0; i < n; i++) {
+            if (nums[i] == 1) {
+                start = i;
+                break;
+            }
+        }
+        // no node holds value 1 -> every subtree misses 1
+        if (start == -1) {
+            return res;
+        }
+
+        boolean[] seen = new boolean[n + 2];
+        boolean[] visited = new boolean[n];
+        int[] stack = new int[n];
+        int miss = 2;
+
+        int node = start;
+        while (node != -1) {
+            // add every not-yet-visited node of this subtree
+            int sp = 0;
+            stack[sp++] = node;
+            while (sp > 0) {
+                int cur = stack[--sp];
+                if (visited[cur]) {
+                    continue;
+                }
+                visited[cur] = true;
+                if (nums[cur] <= n + 1) {
+                    seen[nums[cur]] = true;
+                }
+                for (int c = head[cur]; c != -1; c = nxt[c]) {
+                    if (!visited[c]) {
+                        stack[sp++] = c;
+                    }
+                }
+            }
+
+            while (miss <= n + 1 && seen[miss]) {
+                miss++;
+            }
+            res[node] = miss;
+            node = parents[node];
+        }
+        return res;
+    }
+}

--- a/leetcode_java/src/main/java/LeetCodeJava/Tree/StepByStepDirectionsFromABinaryTreeNodeToAnother.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Tree/StepByStepDirectionsFromABinaryTreeNodeToAnother.java
@@ -1,0 +1,96 @@
+package LeetCodeJava.Tree;
+
+// https://leetcode.com/problems/step-by-step-directions-from-a-binary-tree-node-to-another/
+
+import LeetCodeJava.DataStructure.TreeNode;
+
+/**
+ *  2096. Step-By-Step Directions From a Binary Tree Node to Another
+ *  Medium
+ *
+ *  You are given the root of a binary tree with n nodes. Each node is uniquely
+ *  assigned a value from 1 to n. You are also given an integer startValue
+ *  representing the value of the start node s, and a different integer
+ *  destValue representing the value of the destination node t.
+ *
+ *  Find the shortest path starting from node s and ending at node t. Generate
+ *  step-by-step directions of such path as a string consisting of only the
+ *  uppercase letters 'L', 'R', and 'U'. Each letter indicates a direction:
+ *    'L' means to go from a node to its left child node.
+ *    'R' means to go from a node to its right child node.
+ *    'U' means to go from a node to its parent node.
+ *
+ *  Return the step-by-step directions of the shortest path from node s to t.
+ *
+ *  Example 1:
+ *    Input: root = [5,1,2,3,null,6,4], startValue = 3, destValue = 6
+ *    Output: "UURL"
+ *    Explanation: The shortest path is: 3 -> 1 -> 5 -> 2 -> 6.
+ *
+ *  Example 2:
+ *    Input: root = [2,1], startValue = 2, destValue = 1
+ *    Output: "L"
+ *
+ *  Constraints:
+ *    The number of nodes in the tree is n.
+ *    2 <= n <= 10^5
+ *    1 <= Node.val <= n
+ *    All the values in the tree are unique.
+ *    1 <= startValue, destValue <= n
+ *    startValue != destValue
+ */
+public class StepByStepDirectionsFromABinaryTreeNodeToAnother {
+
+    // V0
+    // IDEA: ROOT-TO-NODE PATHS + STRIP THE COMMON PREFIX (= the LCA path)
+    //       build the 'L'/'R' path from the root down to s and down to t.
+    //       their common prefix is exactly the path down to their LCA.
+    //       after dropping that prefix:
+    //         - every remaining step of the s-path becomes a 'U' (climb to LCA)
+    //         - the remaining t-path is appended unchanged (walk back down)
+    //       the DFS builds the path into a StringBuilder and pops on the way
+    //       out, so it stays O(n) instead of concatenating strings.
+    /**
+     * time = O(N)
+     * space = O(N)
+     */
+    public String getDirections(TreeNode root, int startValue, int destValue) {
+        StringBuilder pStart = new StringBuilder();
+        StringBuilder pDest = new StringBuilder();
+        find(root, startValue, pStart);
+        find(root, destValue, pDest);
+
+        // drop the shared prefix (the path down to the LCA)
+        int i = 0;
+        while (i < pStart.length() && i < pDest.length()
+                && pStart.charAt(i) == pDest.charAt(i)) {
+            i++;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int k = i; k < pStart.length(); k++) {
+            sb.append('U');
+        }
+        sb.append(pDest, i, pDest.length());
+        return sb.toString();
+    }
+
+    private boolean find(TreeNode node, int target, StringBuilder path) {
+        if (node == null) {
+            return false;
+        }
+        if (node.val == target) {
+            return true;
+        }
+        path.append('L');
+        if (find(node.left, target, path)) {
+            return true;
+        }
+        path.setCharAt(path.length() - 1, 'R');
+        if (find(node.right, target, path)) {
+            return true;
+        }
+        path.deleteCharAt(path.length() - 1);
+        return false;
+    }
+}


### PR DESCRIPTION
Continues the Python-only backfill past the README table: these are LC problems that have a Python solution under leetcode_python/ but had no Java counterpart anywhere in the repo (they were never listed in README.md, so the previous pass did not reach them).

Closes out ten pattern categories completely — every Python solution in them now has Java: Recursion, Queue, BinarySearchTree, Geometry (filed under Math, which is where the repo keeps computational-geometry problems), SlideWindow, BackTrack, LinkedList, Heap, Stack, Tree.

Each file follows the repo convention: package + LC url comment, problem javadoc (number, title, difficulty, statement, examples, constraints), and `// V0` with an `IDEA:` line and a time/space javadoc. A `// V1` appears only where it is a materially different approach (LC 1106, 1261, 1409, 1439, 1265). Shared LeetCodeJava.DataStructure.TreeNode/ListNode/Node are imported rather than redefined; problem-specific shapes (PolyNode, RopeTreeNode, N-ary Node, doubly linked Node, ImmutableListNode, expression nodes, treap nodes) are nested static types.

All 166 files compile clean against the existing tree, and each was checked against the examples in its problem statement; the harder ones (LC 2613, 2818, 2519, 3013, 3321, 3526, 1505, 3553, 3559, 3515, 1938, 2003, 2421, 1606, 3264, 3266) were additionally cross-checked against brute-force references.

Java-8 syntax throughout, per pom.xml. Where a literal port of the Python would misbehave in Java, the Java differs deliberately: long accumulators where int overflows, non-negative modulo, an isqrt that is exact at perfect squares, explicit stacks where recursion depth reaches 1e5, and TreeSet in place of paired heaps with lazy deletion.

14 assigned problems were skipped because Java already existed for them (LC 295, 426, 430, 496, 503, 536, 622, 703, 707, 708, 1838, 1839, 508, 211).