### PR TITLE
wip(java): add V1/V2 alternate versions to 79 LC solutions

### DIFF
--- a/CONV_V3.md
+++ b/CONV_V3.md
@@ -1,0 +1,84 @@
+# Task: bring every listed Java LC solution up to at least 3 versions (V0, V1, V2)
+
+Work ONLY inside the git worktree: /Users/jliu/CS_basics_wt_v3
+Paths in your batch file are relative to that worktree root.
+
+## What to add
+
+Each listed file already has V0 (and sometimes V1). Add versions until the file has
+**at least three**: `// V0`, `// V1`, `// V2`. Keep the existing V0 as-is unless it is
+actually wrong — do not renumber or reorder what is already there.
+
+Format each added version exactly like the existing ones:
+
+```java
+    // V1
+    // IDEA: <one-line description of the APPROACH, e.g. "top-down memoization">
+    /**
+     * time = O(...)
+     * space = O(...)
+     */
+    public <ret> <methodName>_1(<args>) {
+        ...
+    }
+```
+
+- Method-name suffixes: V0 = bare name, V1 = `_1`, V2 = `_2`. If the file already uses
+  `_1`, your new one is `_2`. Never two methods with the same signature in one class.
+- Helper methods for a variant get the same suffix (`dfs_1`, `helper_2`) so they never collide.
+- Signature of every version must match the official LeetCode signature (same return type
+  and parameter types as V0). Only the method NAME gets the suffix.
+
+## The bar for a "version" — this is the important part
+
+Each version must be a **materially different algorithm**, not a re-spelling. Good axes:
+
+- different complexity (O(n^2) brute force vs O(n) one-pass vs O(1) math formula)
+- different paradigm (recursion vs iteration vs DP table vs bit manipulation)
+- different data structure (HashMap vs sorting vs heap vs two pointers vs prefix sum)
+- top-down memoization vs bottom-up tabulation vs space-optimized rolling array
+- brute force written deliberately as the readable reference, with the optimal one elsewhere
+
+BAD (do not do this): renaming variables, swapping a for-loop for a while-loop, converting
+a loop to a stream, extracting a helper, or reordering independent statements.
+
+If a problem genuinely only supports two sensible approaches, a legitimate third is an
+explicit **brute-force / reference implementation** clearly labelled as such:
+`// IDEA: brute force O(n^2) — kept as a readable correctness reference`. That is honest.
+Use that escape hatch rather than inventing a fake distinction.
+
+If even that is impossible, leave the file at 2 versions and report it as SKIPPED with the
+reason. Do not pad.
+
+## Design / data-structure problems (LRU cache, iterators, stacks, etc.)
+
+The top-level class IS the required API, so you cannot suffix its methods. Instead add
+alternate whole implementations as nested static classes with the same public API:
+
+```java
+    // V1
+    // IDEA: TreeMap-backed alternative to the two-stack V0
+    /**
+     * time = O(log n) per op, space = O(n)
+     */
+    public static class <ClassName>V1 {
+        ... same constructor + method names as the outer class ...
+    }
+```
+
+## Verify before you finish — REQUIRED
+
+1. Compile: from /Users/jliu/CS_basics_wt_v3/leetcode_java run
+   `javac -nowarn -d /tmp/v3_<BATCH> -sourcepath src/main/java <your files...>`
+   Fix every error.
+
+2. Cross-check the versions agree. Write a THROWAWAY harness OUTSIDE the repo
+   (use /tmp/, never add files to the worktree) that runs V0, V1 and V2 on the
+   LeetCode examples plus a handful of edge cases, and asserts they return the same
+   answer. Where the problem allows cheap random inputs, also fuzz a few hundred cases
+   comparing the versions against each other. If they disagree, the new version is wrong —
+   fix it. Delete the harness when done.
+
+This cross-check is the point of the task: three versions that disagree are worse than one.
+
+Do not modify README.md. Do not create new .java files in the repo. Do not commit.

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/EmployeeFreeTime.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/EmployeeFreeTime.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.PriorityQueue;
 
 /**
  *  759. Employee Free Time
@@ -89,6 +90,114 @@ public class EmployeeFreeTime {
                 res.add(new Interval(prevEnd, cur.start));
             }
             prevEnd = Math.max(prevEnd, cur.end);
+        }
+        return res;
+    }
+
+    // V1
+    // IDEA: K-WAY MERGE WITH A MIN-HEAP — every employee's list is already sorted,
+    //       so pull intervals in global start order via a heap of (employee, index)
+    //       and record the gap whenever the next interval starts after the max end.
+    /**
+     * time = O(n log k), k = number of employees
+     * space = O(k)
+     */
+    public List<Interval> employeeFreeTime_1(final List<List<Interval>> schedule) {
+        List<Interval> res = new ArrayList<>();
+        if (schedule == null || schedule.isEmpty()) {
+            return res;
+        }
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>() {
+            @Override
+            public int compare(int[] a, int[] b) {
+                return Integer.compare(schedule.get(a[0]).get(a[1]).start,
+                        schedule.get(b[0]).get(b[1]).start);
+            }
+        });
+        for (int e = 0; e < schedule.size(); e++) {
+            List<Interval> emp = schedule.get(e);
+            if (emp != null && !emp.isEmpty()) {
+                pq.add(new int[]{e, 0});
+            }
+        }
+        if (pq.isEmpty()) {
+            return res;
+        }
+
+        int prevEnd = Integer.MIN_VALUE;
+        boolean first = true;
+        while (!pq.isEmpty()) {
+            int[] cur = pq.poll();
+            Interval iv = schedule.get(cur[0]).get(cur[1]);
+            if (first) {
+                prevEnd = iv.end;
+                first = false;
+            } else {
+                if (iv.start > prevEnd) {
+                    res.add(new Interval(prevEnd, iv.start));
+                }
+                prevEnd = Math.max(prevEnd, iv.end);
+            }
+            if (cur[1] + 1 < schedule.get(cur[0]).size()) {
+                pq.add(new int[]{cur[0], cur[1] + 1});
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: SWEEP LINE — turn every interval into two boundary events (+1 on start,
+    //       -1 on end), sort them, and track how many employees are busy; a stretch
+    //       between the moment the counter hits 0 and the next event is free time.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public List<Interval> employeeFreeTime_2(List<List<Interval>> schedule) {
+        List<Interval> res = new ArrayList<>();
+        if (schedule == null || schedule.isEmpty()) {
+            return res;
+        }
+
+        List<int[]> events = new ArrayList<>();
+        for (List<Interval> emp : schedule) {
+            if (emp == null) {
+                continue;
+            }
+            for (Interval iv : emp) {
+                events.add(new int[]{iv.start, 1});
+                events.add(new int[]{iv.end, -1});
+            }
+        }
+        if (events.isEmpty()) {
+            return res;
+        }
+
+        Collections.sort(events, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] a, int[] b) {
+                if (a[0] != b[0]) {
+                    return Integer.compare(a[0], b[0]);
+                }
+                // at the same x, process starts (+1) before ends (-1) so that
+                // touching intervals produce no zero-length free slot
+                return Integer.compare(b[1], a[1]);
+            }
+        });
+
+        int active = 0;
+        int gapStart = Integer.MIN_VALUE;
+        boolean hasGapStart = false;
+        for (int[] e : events) {
+            if (active == 0 && hasGapStart && e[0] > gapStart) {
+                res.add(new Interval(gapStart, e[0]));
+            }
+            active += e[1];
+            if (active == 0) {
+                gapStart = e[0];
+                hasGapStart = true;
+            }
         }
         return res;
     }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/FairCandySwap.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/FairCandySwap.java
@@ -2,6 +2,7 @@ package LeetCodeJava.Array;
 
 // https://leetcode.com/problems/fair-candy-swap/
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -66,6 +67,62 @@ public class FairCandySwap {
         for (int a : aliceSizes) {
             if (bobSet.contains(a + delta)) {
                 return new int[]{a, a + delta};
+            }
+        }
+        return new int[]{}; // unreachable, a valid answer is guaranteed
+    }
+
+    // V1
+    // IDEA: SORT + BINARY SEARCH — same b = a + (sumB - sumA) / 2 identity, but the
+    //       lookup is done on a sorted copy of bob's boxes instead of a hash set,
+    //       trading O(m) memory for O(log m) probes.
+    /**
+     * time = O(n log n + m log m)
+     * space = O(m)
+     */
+    public int[] fairCandySwap_1(int[] aliceSizes, int[] bobSizes) {
+        int sumA = 0;
+        int sumB = 0;
+        for (int a : aliceSizes) {
+            sumA += a;
+        }
+        for (int b : bobSizes) {
+            sumB += b;
+        }
+        int delta = (sumB - sumA) / 2;
+
+        int[] sortedB = bobSizes.clone();
+        Arrays.sort(sortedB);
+        for (int a : aliceSizes) {
+            if (Arrays.binarySearch(sortedB, a + delta) >= 0) {
+                return new int[]{a, a + delta};
+            }
+        }
+        return new int[]{}; // unreachable, a valid answer is guaranteed
+    }
+
+    // V2
+    // IDEA: brute force O(n*m) — try every (a, b) pair and test the swap directly;
+    //       kept as a readable correctness reference for the math above.
+    /**
+     * time = O(n * m)
+     * space = O(1)
+     */
+    public int[] fairCandySwap_2(int[] aliceSizes, int[] bobSizes) {
+        int sumA = 0;
+        int sumB = 0;
+        for (int a : aliceSizes) {
+            sumA += a;
+        }
+        for (int b : bobSizes) {
+            sumB += b;
+        }
+
+        for (int a : aliceSizes) {
+            for (int b : bobSizes) {
+                if (sumA - a + b == sumB - b + a) {
+                    return new int[]{a, b};
+                }
             }
         }
         return new int[]{}; // unreachable, a valid answer is guaranteed

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/FindAllNumbersDisappearedInAnArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/FindAllNumbersDisappearedInAnArray.java
@@ -80,4 +80,34 @@ public class FindAllNumbersDisappearedInAnArray {
         }
         return res;
     }
+
+    // V2
+    // IDEA: CYCLIC SORT — repeatedly swap nums[i] to its home slot (value v -> index
+    //       v - 1); afterwards any index i whose value != i + 1 is a missing number.
+    /**
+     * time = O(n)   (each swap puts one value in its final place)
+     * space = O(1)  (excluding the output list)
+     */
+    public List<Integer> findDisappearedNumbers_2(int[] nums) {
+        List<Integer> res = new ArrayList<>();
+        if (nums == null || nums.length == 0) {
+            return res;
+        }
+        int n = nums.length;
+        for (int i = 0; i < n; i++) {
+            // stop when the value already sits at its home slot (also breaks dup cycles)
+            while (nums[i] != nums[nums[i] - 1]) {
+                int j = nums[i] - 1;
+                int tmp = nums[i];
+                nums[i] = nums[j];
+                nums[j] = tmp;
+            }
+        }
+        for (int i = 0; i < n; i++) {
+            if (nums[i] != i + 1) {
+                res.add(i + 1);
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/FindWinnerOnATicTacToeGame.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/FindWinnerOnATicTacToeGame.java
@@ -83,4 +83,73 @@ public class FindWinnerOnATicTacToeGame {
 
         return moves.length == n * n ? "Draw" : "Pending";
     }
+
+    // V1
+    // IDEA: SIMULATE THE BOARD — replay the moves onto a 3x3 char grid, then test
+    //       all 8 winning lines explicitly for each player.
+    /**
+     * time = O(n + 8) = O(1)
+     * space = O(1)  (fixed 3x3 grid)
+     */
+    public String tictactoe_1(int[][] moves) {
+        char[][] g = new char[3][3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                g[i][j] = ' ';
+            }
+        }
+        for (int i = 0; i < moves.length; i++) {
+            g[moves[i][0]][moves[i][1]] = (i % 2 == 0) ? 'X' : 'O';
+        }
+
+        char[] players = new char[]{'X', 'O'};
+        for (char p : players) {
+            for (int i = 0; i < 3; i++) {
+                if (g[i][0] == p && g[i][1] == p && g[i][2] == p) {
+                    return p == 'X' ? "A" : "B";
+                }
+                if (g[0][i] == p && g[1][i] == p && g[2][i] == p) {
+                    return p == 'X' ? "A" : "B";
+                }
+            }
+            if (g[0][0] == p && g[1][1] == p && g[2][2] == p) {
+                return p == 'X' ? "A" : "B";
+            }
+            if (g[0][2] == p && g[1][1] == p && g[2][0] == p) {
+                return p == 'X' ? "A" : "B";
+            }
+        }
+
+        return moves.length == 9 ? "Draw" : "Pending";
+    }
+
+    // V2
+    // IDEA: BITMASK — pack each player's cells into a 9-bit mask (cell (r,c) -> bit
+    //       r*3+c); a player wins iff their mask covers one of the 8 winning masks.
+    /**
+     * time = O(n + 8) = O(1)
+     * space = O(1)
+     */
+    public String tictactoe_2(int[][] moves) {
+        int[] mask = new int[2]; // mask[0] = A ('X'), mask[1] = B ('O')
+        for (int i = 0; i < moves.length; i++) {
+            mask[i % 2] |= 1 << (moves[i][0] * 3 + moves[i][1]);
+        }
+
+        int[] wins = {
+                0b000000111, 0b000111000, 0b111000000, // rows
+                0b001001001, 0b010010010, 0b100100100, // cols
+                0b100010001, 0b001010100                // diagonals
+        };
+        for (int w : wins) {
+            if ((mask[0] & w) == w) {
+                return "A";
+            }
+            if ((mask[1] & w) == w) {
+                return "B";
+            }
+        }
+
+        return moves.length == 9 ? "Draw" : "Pending";
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/FizzBuzz.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/FizzBuzz.java
@@ -53,4 +53,57 @@ public class FizzBuzz {
 
         return res;
     }
+
+    // V1
+    // IDEA: NO MODULO — keep two rolling counters and reset them when they reach
+    //       3 / 5, so the loop never performs a division.
+    /**
+     * time = O(n)
+     * space = O(1) (excluding output)
+     */
+    public List<String> fizzBuzz_1(int n) {
+        List<String> res = new ArrayList<>();
+        int fizz = 0;
+        int buzz = 0;
+
+        for (int i = 1; i <= n; i++) {
+            fizz++;
+            buzz++;
+            if (fizz == 3 && buzz == 5) {
+                res.add("FizzBuzz");
+                fizz = 0;
+                buzz = 0;
+            } else if (fizz == 3) {
+                res.add("Fizz");
+                fizz = 0;
+            } else if (buzz == 5) {
+                res.add("Buzz");
+                buzz = 0;
+            } else {
+                res.add(String.valueOf(i));
+            }
+        }
+
+        return res;
+    }
+
+    // V2
+    // IDEA: LOOKUP TABLE — the answer pattern repeats with period 15, so index a
+    //       precomputed cycle by i % 15 and fall back to the number itself.
+    /**
+     * time = O(n)
+     * space = O(1) (a fixed 15-entry table, excluding output)
+     */
+    public List<String> fizzBuzz_2(int n) {
+        String[] cycle = {"FizzBuzz", "", "", "Fizz", "", "Buzz", "Fizz", "",
+                "", "Fizz", "Buzz", "", "Fizz", "", ""};
+        List<String> res = new ArrayList<>();
+
+        for (int i = 1; i <= n; i++) {
+            String s = cycle[i % 15];
+            res.add(s.isEmpty() ? String.valueOf(i) : s);
+        }
+
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/ImageSmoother.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/ImageSmoother.java
@@ -65,4 +65,78 @@ public class ImageSmoother {
         }
         return res;
     }
+
+
+    // V1
+    // IDEA: 2D PREFIX SUM (integral image) - each 3x3 neighbourhood sum becomes O(1)
+    /**
+     * time = O(m * n)
+     * space = O(m * n)
+     */
+    public int[][] imageSmoother_1(int[][] img) {
+        if (img == null || img.length == 0 || img[0].length == 0) {
+            return img;
+        }
+        int m = img.length;
+        int n = img[0].length;
+
+        int[][] pre = new int[m + 1][n + 1];
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                pre[i + 1][j + 1] = img[i][j] + pre[i][j + 1] + pre[i + 1][j] - pre[i][j];
+            }
+        }
+
+        int[][] res = new int[m][n];
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                int r1 = Math.max(0, i - 1);
+                int r2 = Math.min(m - 1, i + 1);
+                int c1 = Math.max(0, j - 1);
+                int c2 = Math.min(n - 1, j + 1);
+                int sum = pre[r2 + 1][c2 + 1] - pre[r1][c2 + 1] - pre[r2 + 1][c1] + pre[r1][c1];
+                int cnt = (r2 - r1 + 1) * (c2 - c1 + 1);
+                res[i][j] = sum / cnt;
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: BIT PACKING in-place - values fit in 8 bits, so stash the smoothed value
+    //       in bits 8..15 of the SAME cell, then unpack (O(1) auxiliary space)
+    /**
+     * time = O(m * n)
+     * space = O(1) extra (beyond the returned matrix)
+     */
+    public int[][] imageSmoother_2(int[][] img) {
+        if (img == null || img.length == 0 || img[0].length == 0) {
+            return img;
+        }
+        int m = img.length;
+        int n = img[0].length;
+
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                int sum = 0;
+                int cnt = 0;
+                for (int r = Math.max(0, i - 1); r <= Math.min(m - 1, i + 1); r++) {
+                    for (int c = Math.max(0, j - 1); c <= Math.min(n - 1, j + 1); c++) {
+                        sum += img[r][c] & 0xFF; // only the ORIGINAL low byte
+                        cnt++;
+                    }
+                }
+                img[i][j] |= (sum / cnt) << 8;
+            }
+        }
+
+        int[][] res = new int[m][n];
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                res[i][j] = img[i][j] >> 8;
+                img[i][j] &= 0xFF; // restore the input matrix
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/LargestNumberAtLeastTwiceOfOthers.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/LargestNumberAtLeastTwiceOfOthers.java
@@ -1,5 +1,7 @@
 package LeetCodeJava.Array;
 
+import java.util.Arrays;
+
 // https://leetcode.com/problems/largest-number-at-least-twice-of-others/
 
 /**
@@ -48,5 +50,54 @@ public class LargestNumberAtLeastTwiceOfOthers {
             }
         }
         return best >= 2 * second ? bestIdx : -1;
+    }
+
+
+    // V1
+    // IDEA: two pass - locate the max index, then verify it against every other element
+    /**
+     * time = O(n)
+     * space = O(1)
+     */
+    public int dominantIndex_1(int[] nums) {
+        int maxIdx = 0;
+        for (int i = 1; i < nums.length; i++) {
+            if (nums[i] > nums[maxIdx]) {
+                maxIdx = i;
+            }
+        }
+        for (int i = 0; i < nums.length; i++) {
+            if (i == maxIdx) {
+                continue;
+            }
+            if (nums[maxIdx] < 2 * nums[i]) {
+                return -1;
+            }
+        }
+        return maxIdx;
+    }
+
+    // V2
+    // IDEA: SORTING a copy - the two biggest values sit at the tail, then map back to an index
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int dominantIndex_2(int[] nums) {
+        int n = nums.length;
+        int[] sorted = nums.clone();
+        Arrays.sort(sorted);
+
+        int largest = sorted[n - 1];
+        int second = n >= 2 ? sorted[n - 2] : 0;
+        if (largest < 2 * second) {
+            return -1;
+        }
+        for (int i = 0; i < n; i++) {
+            if (nums[i] == largest) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/LargestTimeForGivenDigits.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/LargestTimeForGivenDigits.java
@@ -103,4 +103,43 @@ public class LargestTimeForGivenDigits {
         }
         return "";
     }
+
+
+    // V2
+    // IDEA: BACKTRACKING - build permutations recursively with a used[] mask
+    //       instead of the hand-unrolled nested loops of V0
+    /**
+     * time = O(1) (4! = 24 leaves)
+     * space = O(1)
+     */
+    public String largestTimeFromDigits_2(int[] arr) {
+        int[] perm = new int[4];
+        boolean[] used = new boolean[4];
+        int[] best = new int[] { -1 };
+        dfs_2(arr, used, perm, 0, best);
+        if (best[0] < 0) {
+            return "";
+        }
+        return String.format("%02d:%02d", best[0] / 60, best[0] % 60);
+    }
+
+    private void dfs_2(int[] arr, boolean[] used, int[] perm, int depth, int[] best) {
+        if (depth == 4) {
+            int hour = perm[0] * 10 + perm[1];
+            int min = perm[2] * 10 + perm[3];
+            if (hour < 24 && min < 60) {
+                best[0] = Math.max(best[0], hour * 60 + min);
+            }
+            return;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (used[i]) {
+                continue;
+            }
+            used[i] = true;
+            perm[depth] = arr[i];
+            dfs_2(arr, used, perm, depth + 1, best);
+            used[i] = false;
+        }
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/LemonadeChange.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/LemonadeChange.java
@@ -1,5 +1,8 @@
 package LeetCodeJava.Array;
 
+import java.util.Map;
+import java.util.TreeMap;
+
 // https://leetcode.com/problems/lemonade-change/
 
 /**
@@ -66,5 +69,82 @@ public class LemonadeChange {
             }
         }
         return true;
+    }
+
+
+    // V1
+    // IDEA: general change-making over a TreeMap "wallet" of the bills actually held -
+    //       pay each customer's change with the LARGEST usable bill first.
+    //       (generalises to any denomination set, unlike the two-counter V0)
+    /**
+     * time = O(n log d), d = number of distinct denominations
+     * space = O(d)
+     */
+    public boolean lemonadeChange_1(int[] bills) {
+        if (bills == null || bills.length == 0) {
+            return true;
+        }
+        TreeMap<Integer, Integer> wallet = new TreeMap<>();
+        for (int b : bills) {
+            int change = b - 5;
+            while (change > 0) {
+                Map.Entry<Integer, Integer> e = wallet.floorEntry(change);
+                if (e == null) {
+                    return false;
+                }
+                int bill = e.getKey();
+                int cnt = e.getValue();
+                int use = Math.min(cnt, change / bill);
+                change -= use * bill;
+                if (use == cnt) {
+                    wallet.remove(bill);
+                } else {
+                    wallet.put(bill, cnt - use);
+                }
+            }
+            Integer had = wallet.get(b);
+            wallet.put(b, had == null ? 1 : had + 1);
+        }
+        return true;
+    }
+
+    // V2
+    // IDEA: brute force - recursively try EVERY way of making change ($20 can be
+    //       10+5 or 5+5+5); kept as a readable correctness reference that proves
+    //       the greedy of V0 never misses a feasible schedule. Exponential in the
+    //       number of $20 bills, so small inputs only.
+    /**
+     * time = O(2^t), t = count of $20 bills
+     * space = O(n) recursion depth
+     */
+    public boolean lemonadeChange_2(int[] bills) {
+        if (bills == null || bills.length == 0) {
+            return true;
+        }
+        return dfs_2(bills, 0, 0, 0);
+    }
+
+    private boolean dfs_2(int[] bills, int i, int five, int ten) {
+        if (i == bills.length) {
+            return true;
+        }
+        int b = bills[i];
+        if (b == 5) {
+            return dfs_2(bills, i + 1, five + 1, ten);
+        }
+        if (b == 10) {
+            if (five == 0) {
+                return false;
+            }
+            return dfs_2(bills, i + 1, five - 1, ten + 1);
+        }
+        // b == 20 -> two possible ways of giving $15 back
+        if (ten > 0 && five > 0 && dfs_2(bills, i + 1, five - 1, ten - 1)) {
+            return true;
+        }
+        if (five >= 3 && dfs_2(bills, i + 1, five - 3, ten)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/LonelyPixelI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/LonelyPixelI.java
@@ -1,5 +1,7 @@
 package LeetCodeJava.Array;
 
+import java.util.Arrays;
+
 // https://leetcode.com/problems/lonely-pixel-i/
 
 /**
@@ -60,6 +62,86 @@ public class LonelyPixelI {
                 if (picture[i][j] == 'B' && cols[j] == 1) {
                     res++;
                 }
+            }
+        }
+        return res;
+    }
+
+
+    // V1
+    // IDEA: brute force O(m*n*(m+n)) - for every 'B' rescan its own row and column.
+    //       Kept as a readable correctness reference for the counting solution above.
+    /**
+     * time = O(m * n * (m + n))
+     * space = O(1)
+     */
+    public int findLonelyPixel_1(char[][] picture) {
+        if (picture == null || picture.length == 0 || picture[0].length == 0) {
+            return 0;
+        }
+        int m = picture.length;
+        int n = picture[0].length;
+        int res = 0;
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                if (picture[i][j] != 'B') {
+                    continue;
+                }
+                boolean lonely = true;
+                for (int c = 0; c < n && lonely; c++) {
+                    if (c != j && picture[i][c] == 'B') {
+                        lonely = false;
+                    }
+                }
+                for (int r = 0; r < m && lonely; r++) {
+                    if (r != i && picture[r][j] == 'B') {
+                        lonely = false;
+                    }
+                }
+                if (lonely) {
+                    res++;
+                }
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: store the POSITION of the unique 'B' per row / per column instead of a
+    //       count (-1 = none, -2 = more than one). A pixel is lonely iff the row
+    //       record and the column record point at each other, so the final pass is
+    //       O(m) and never touches the grid again.
+    /**
+     * time = O(m * n)
+     * space = O(m + n)
+     */
+    public int findLonelyPixel_2(char[][] picture) {
+        if (picture == null || picture.length == 0 || picture[0].length == 0) {
+            return 0;
+        }
+        int m = picture.length;
+        int n = picture[0].length;
+
+        int[] rowMark = new int[m];
+        int[] colMark = new int[n];
+        Arrays.fill(rowMark, -1);
+        Arrays.fill(colMark, -1);
+
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                if (picture[i][j] != 'B') {
+                    continue;
+                }
+                rowMark[i] = (rowMark[i] == -1) ? j : -2;
+                colMark[j] = (colMark[j] == -1) ? i : -2;
+            }
+        }
+
+        int res = 0;
+        for (int i = 0; i < m; i++) {
+            int j = rowMark[i];
+            if (j >= 0 && colMark[j] == i) {
+                res++;
             }
         }
         return res;

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/LonelyPixelII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/LonelyPixelII.java
@@ -4,6 +4,8 @@ package LeetCodeJava.Array;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *  533. Lonely Pixel II
@@ -80,6 +82,120 @@ public class LonelyPixelII {
             }
             for (int j = 0; j < n; j++) {
                 if (picture[i][j] == 'B' && cols[j] == target) {
+                    res++;
+                }
+            }
+        }
+        return res;
+    }
+
+
+    // V1
+    // IDEA: COLUMN driven - for each column holding exactly `target` B's, take the
+    //       rows that own them; if those rows are all identical and each has exactly
+    //       `target` B's, that column contributes `target` lonely pixels.
+    //       No hashing of rows needed.
+    /**
+     * time = O(m * n * target)
+     * space = O(m)
+     */
+    public int findBlackPixel_1(char[][] picture, int target) {
+        if (picture == null || picture.length == 0 || picture[0].length == 0) {
+            return 0;
+        }
+        int m = picture.length;
+        int n = picture[0].length;
+        int res = 0;
+
+        for (int c = 0; c < n; c++) {
+            List<Integer> owners = new ArrayList<>();
+            for (int r = 0; r < m; r++) {
+                if (picture[r][c] == 'B') {
+                    owners.add(r);
+                }
+            }
+            if (owners.size() != target) {
+                continue;
+            }
+            int first = owners.get(0);
+            int cnt = 0;
+            for (int j = 0; j < n; j++) {
+                if (picture[first][j] == 'B') {
+                    cnt++;
+                }
+            }
+            if (cnt != target) {
+                continue;
+            }
+            boolean allSame = true;
+            for (int k = 1; k < owners.size() && allSame; k++) {
+                int r = owners.get(k);
+                for (int j = 0; j < n; j++) {
+                    if (picture[r][j] != picture[first][j]) {
+                        allSame = false;
+                        break;
+                    }
+                }
+            }
+            if (allSame) {
+                res += target;
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force - transcribe the definition literally for every 'B' pixel
+    //       (row count, column count, and "every row with a B in this column equals
+    //       my row"). Kept as a readable correctness reference.
+    /**
+     * time = O(m^2 * n^2)
+     * space = O(1)
+     */
+    public int findBlackPixel_2(char[][] picture, int target) {
+        if (picture == null || picture.length == 0 || picture[0].length == 0) {
+            return 0;
+        }
+        int m = picture.length;
+        int n = picture[0].length;
+        int res = 0;
+
+        for (int r = 0; r < m; r++) {
+            for (int c = 0; c < n; c++) {
+                if (picture[r][c] != 'B') {
+                    continue;
+                }
+                int rowCnt = 0;
+                for (int j = 0; j < n; j++) {
+                    if (picture[r][j] == 'B') {
+                        rowCnt++;
+                    }
+                }
+                if (rowCnt != target) {
+                    continue;
+                }
+                int colCnt = 0;
+                for (int i = 0; i < m; i++) {
+                    if (picture[i][c] == 'B') {
+                        colCnt++;
+                    }
+                }
+                if (colCnt != target) {
+                    continue;
+                }
+                boolean ok = true;
+                for (int i = 0; i < m && ok; i++) {
+                    if (i == r || picture[i][c] != 'B') {
+                        continue;
+                    }
+                    for (int j = 0; j < n; j++) {
+                        if (picture[i][j] != picture[r][j]) {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                if (ok) {
                     res++;
                 }
             }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/MaximumLengthOfSubarrayWithPositiveProduct.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/MaximumLengthOfSubarrayWithPositiveProduct.java
@@ -109,4 +109,28 @@ public class MaximumLengthOfSubarrayWithPositiveProduct {
         }
         return res;
     }
+
+    // V2
+    // IDEA: brute force O(n^2) — expand every start index and track the running
+    //       sign; kept as a readable correctness reference
+    /**
+     * time = O(n^2)
+     * space = O(1)
+     */
+    public int getMaxLen_2(int[] nums) {
+        int res = 0;
+        for (int i = 0; i < nums.length; i++) {
+            int sign = 1;
+            for (int j = i; j < nums.length; j++) {
+                if (nums[j] == 0) {
+                    break;
+                }
+                sign = (nums[j] > 0) ? sign : -sign;
+                if (sign > 0) {
+                    res = Math.max(res, j - i + 1);
+                }
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/MinimumIncrementToMakeArrayUnique.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/MinimumIncrementToMakeArrayUnique.java
@@ -92,4 +92,46 @@ public class MinimumIncrementToMakeArrayUnique {
         }
         return res;
     }
+
+    // V2
+    // IDEA: UNION FIND — find(x) returns the smallest still-free value >= x, then
+    //       that slot is linked to x + 1 so it is skipped next time (path compression)
+    /**
+     * time = O(n * alpha(m)) ~ O(n), m = max value + n
+     * space = O(m)
+     */
+    public int minIncrementForUnique_2(int[] nums) {
+        if (nums == null || nums.length <= 1) {
+            return 0;
+        }
+        int max = 0;
+        for (int x : nums) {
+            max = Math.max(max, x);
+        }
+        // every duplicate can be pushed at most n slots past max
+        int[] parent = new int[max + nums.length + 2];
+        Arrays.fill(parent, -1); // -1 = this value is still free
+
+        int res = 0;
+        for (int x : nums) {
+            int slot = find_2(parent, x);
+            res += slot - x;
+            parent[slot] = slot + 1; // slot is taken now -> next candidate is slot + 1
+        }
+        return res;
+    }
+
+    private int find_2(int[] parent, int x) {
+        int root = x;
+        while (parent[root] != -1) {
+            root = parent[root];
+        }
+        // path compression
+        while (parent[x] != -1) {
+            int next = parent[x];
+            parent[x] = root;
+            x = next;
+        }
+        return root;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/MinimumLightsToIlluminateARoad.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/MinimumLightsToIlluminateARoad.java
@@ -1,5 +1,8 @@
 package LeetCodeJava.Array;
 
+import java.util.ArrayList;
+import java.util.List;
+
 // https://leetcode.com/problems/minimum-lights-to-illuminate-a-road/
 
 /**
@@ -81,6 +84,71 @@ public class MinimumLightsToIlluminateARoad {
                 res++;
                 // new bulb at i + 1 lights up i, i + 1, i + 2
                 i += 3;
+            } else {
+                i++;
+            }
+        }
+        return res;
+    }
+
+    // V1
+    // IDEA: INTERVAL MERGE — build the lit intervals, sort by left edge, sweep them
+    //       and pay ceil(gap / 3) bulbs for every dark gap in between
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int minLights_1(int[] lights) {
+        int n = lights.length;
+        List<int[]> intervals = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            int v = lights[i];
+            if (v > 0) {
+                intervals.add(new int[] { Math.max(0, i - v), Math.min(n - 1, i + v) });
+            }
+        }
+        intervals.sort((a, b) -> Integer.compare(a[0], b[0]));
+
+        int res = 0;
+        int cur = 0; // first position not yet known to be lit
+        for (int[] p : intervals) {
+            if (p[0] > cur) {
+                int gap = p[0] - cur;
+                res += (gap + 2) / 3; // each new bulb lights 3 consecutive spots
+            }
+            cur = Math.max(cur, p[1] + 1);
+        }
+        if (cur < n) {
+            res += (n - cur + 2) / 3;
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) — literally paint every position each working bulb
+    //       reaches, then greedily cover the dark spots; readable reference
+    /**
+     * time = O(n^2)
+     * space = O(n)
+     */
+    public int minLights_2(int[] lights) {
+        int n = lights.length;
+        boolean[] lit = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            int v = lights[i];
+            if (v > 0) {
+                for (int j = Math.max(0, i - v); j <= Math.min(n - 1, i + v); j++) {
+                    lit[j] = true;
+                }
+            }
+        }
+
+        int res = 0;
+        int i = 0;
+        while (i < n) {
+            if (!lit[i]) {
+                res++;
+                i += 3; // a new bulb placed at i + 1 covers i, i + 1, i + 2
             } else {
                 i++;
             }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/MonotonicArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/MonotonicArray.java
@@ -1,5 +1,7 @@
 package LeetCodeJava.Array;
 
+import java.util.Arrays;
+
 // https://leetcode.com/problems/monotonic-array/
 
 /**
@@ -55,6 +57,53 @@ public class MonotonicArray {
             }
             if (!increasing && !decreasing) {
                 return false;
+            }
+        }
+        return true;
+    }
+
+    // V1
+    // IDEA: SORT — the array is monotonic iff it already equals its ascending sort
+    //       or that same sort read backwards
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public boolean isMonotonic_1(int[] nums) {
+        int n = nums.length;
+        int[] asc = nums.clone();
+        Arrays.sort(asc);
+        if (Arrays.equals(nums, asc)) {
+            return true;
+        }
+        for (int i = 0; i < n; i++) {
+            if (nums[i] != asc[n - 1 - i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) — check the definition directly over every pair i < j;
+    //       kept as a readable correctness reference
+    /**
+     * time = O(n^2)
+     * space = O(1)
+     */
+    public boolean isMonotonic_2(int[] nums) {
+        return checkAllPairs_2(nums, true) || checkAllPairs_2(nums, false);
+    }
+
+    private boolean checkAllPairs_2(int[] nums, boolean nonDecreasing) {
+        for (int i = 0; i < nums.length; i++) {
+            for (int j = i + 1; j < nums.length; j++) {
+                if (nonDecreasing && nums[i] > nums[j]) {
+                    return false;
+                }
+                if (!nonDecreasing && nums[i] < nums[j]) {
+                    return false;
+                }
             }
         }
         return true;

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/NRepeatedElementInSize2NArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/NRepeatedElementInSize2NArray.java
@@ -76,4 +76,27 @@ public class NRepeatedElementInSize2NArray {
         }
         return -1;
     }
+
+    // V2
+    // IDEA: COUNTING ARRAY — values are bounded by 10^4, so bucket-count them and
+    //       return the one value whose count is greater than 1
+    /**
+     * time = O(n + m), m = 10^4
+     * space = O(m)
+     */
+    public int repeatedNTimes_2(int[] nums) {
+        int[] cnt = new int[10001];
+        for (int x : nums) {
+            cnt[x]++;
+        }
+        int best = -1;
+        int bestCnt = 1;
+        for (int v = 0; v < cnt.length; v++) {
+            if (cnt[v] > bestCnt) {
+                bestCnt = cnt[v];
+                best = v;
+            }
+        }
+        return best;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/NonDecreasingArray.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/NonDecreasingArray.java
@@ -58,4 +58,79 @@ public class NonDecreasingArray {
         }
         return true;
     }
+
+    // V1
+    // IDEA: LOCATE THE SINGLE DROP, then verify both candidate repairs on copies
+    //       (unlike V0 this leaves the input array untouched)
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public boolean checkPossibility_1(int[] nums) {
+        if (nums == null || nums.length <= 2) {
+            return true;
+        }
+        int bad = -1;
+        for (int i = 1; i < nums.length; i++) {
+            if (nums[i - 1] > nums[i]) {
+                if (bad != -1) {
+                    return false; // two drops -> one edit can never be enough
+                }
+                bad = i;
+            }
+        }
+        if (bad == -1) {
+            return true;
+        }
+        int[] lower = nums.clone();
+        lower[bad - 1] = lower[bad];
+        if (isNonDecreasing_1(lower)) {
+            return true;
+        }
+        int[] raise = nums.clone();
+        raise[bad] = raise[bad - 1];
+        return isNonDecreasing_1(raise);
+    }
+
+    private boolean isNonDecreasing_1(int[] arr) {
+        for (int i = 1; i < arr.length; i++) {
+            if (arr[i - 1] > arr[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) — rewrite each index with a neighbour value (if any
+    //       legal replacement exists, a neighbour value is one) and re-check
+    /**
+     * time = O(n^2)
+     * space = O(n)
+     */
+    public boolean checkPossibility_2(int[] nums) {
+        if (nums == null || nums.length <= 2) {
+            return true;
+        }
+        if (isNonDecreasing_2(nums)) {
+            return true; // zero edits needed
+        }
+        for (int i = 0; i < nums.length; i++) {
+            int[] cand = nums.clone();
+            cand[i] = (i > 0) ? nums[i - 1] : nums[i + 1];
+            if (isNonDecreasing_2(cand)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isNonDecreasing_2(int[] arr) {
+        for (int i = 1; i < arr.length; i++) {
+            if (arr[i - 1] > arr[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/NumberOfSubarraysWithBoundedMaximum.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/NumberOfSubarraysWithBoundedMaximum.java
@@ -1,5 +1,8 @@
 package LeetCodeJava.Array;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 // https://leetcode.com/problems/number-of-subarrays-with-bounded-maximum/
 
 /**
@@ -71,5 +74,45 @@ public class NumberOfSubarraysWithBoundedMaximum {
             }
         }
         return res;
+    }
+
+    // V2
+    // IDEA: MONOTONIC STACK — for every index whose value is inside [left, right],
+    //       count the subarrays it is the maximum of: (i - prevGE) * (nextGreater - i).
+    //       Ties use >= on the left and > on the right, so every subarray is
+    //       attributed to exactly one index.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int numSubarrayBoundedMax_2(int[] nums, int left, int right) {
+        int n = nums.length;
+        int[] prevGE = new int[n]; // last j < i with nums[j] >= nums[i], else -1
+        int[] nextG = new int[n];  // first j > i with nums[j] >  nums[i], else n
+
+        Deque<Integer> st = new ArrayDeque<>();
+        for (int i = 0; i < n; i++) {
+            while (!st.isEmpty() && nums[st.peek()] < nums[i]) {
+                st.pop();
+            }
+            prevGE[i] = st.isEmpty() ? -1 : st.peek();
+            st.push(i);
+        }
+        st.clear();
+        for (int i = n - 1; i >= 0; i--) {
+            while (!st.isEmpty() && nums[st.peek()] <= nums[i]) {
+                st.pop();
+            }
+            nextG[i] = st.isEmpty() ? n : st.peek();
+            st.push(i);
+        }
+
+        long res = 0;
+        for (int i = 0; i < n; i++) {
+            if (nums[i] >= left && nums[i] <= right) {
+                res += (long) (i - prevGE[i]) * (nextG[i] - i);
+            }
+        }
+        return (int) res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/OneBitAnd2BitCharacters.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/OneBitAnd2BitCharacters.java
@@ -61,4 +61,28 @@ public class OneBitAnd2BitCharacters {
         }
         return ones % 2 == 0;
     }
+
+    // V2
+    // IDEA: DP REACHABILITY — boundary[i] = "a character may start at index i".
+    //       Propagate forward; the last char is one-bit iff a char starts at n - 1.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public boolean isOneBitCharacter_2(int[] bits) {
+        int n = bits.length;
+        boolean[] boundary = new boolean[n + 1];
+        boundary[0] = true;
+        for (int i = 0; i < n; i++) {
+            if (!boundary[i]) {
+                continue;
+            }
+            if (bits[i] == 0) {
+                boundary[i + 1] = true; // one-bit char "0"
+            } else if (i + 2 <= n) {
+                boundary[i + 2] = true; // two-bit char "10" / "11"
+            }
+        }
+        return boundary[n - 1];
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/PartitionArrayIntoDisjointIntervals.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/PartitionArrayIntoDisjointIntervals.java
@@ -54,4 +54,54 @@ public class PartitionArrayIntoDisjointIntervals {
         }
         return partitionIdx + 1;
     }
+
+    // V1
+    // IDEA: PREFIX MAX + SUFFIX MIN — the cut is the first i with
+    //       max(nums[0..i]) <= min(nums[i+1..n-1])
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int partitionDisjoint_1(int[] nums) {
+        int n = nums.length;
+        int[] suffixMin = new int[n];
+        suffixMin[n - 1] = nums[n - 1];
+        for (int i = n - 2; i >= 0; i--) {
+            suffixMin[i] = Math.min(nums[i], suffixMin[i + 1]);
+        }
+
+        int prefixMax = Integer.MIN_VALUE;
+        for (int i = 0; i < n - 1; i++) {
+            prefixMax = Math.max(prefixMax, nums[i]);
+            if (prefixMax <= suffixMin[i + 1]) {
+                return i + 1;
+            }
+        }
+        return n - 1; // the problem guarantees a valid cut exists
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) — for every cut recompute max(left) and min(right)
+    //       from scratch; kept as a readable correctness reference
+    /**
+     * time = O(n^2)
+     * space = O(1)
+     */
+    public int partitionDisjoint_2(int[] nums) {
+        int n = nums.length;
+        for (int cut = 1; cut < n; cut++) {
+            int leftMax = Integer.MIN_VALUE;
+            for (int i = 0; i < cut; i++) {
+                leftMax = Math.max(leftMax, nums[i]);
+            }
+            int rightMin = Integer.MAX_VALUE;
+            for (int i = cut; i < n; i++) {
+                rightMin = Math.min(rightMin, nums[i]);
+            }
+            if (leftMax <= rightMin) {
+                return cut;
+            }
+        }
+        return n - 1;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/PascalSTriangle.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/PascalSTriangle.java
@@ -54,4 +54,51 @@ public class PascalSTriangle {
 
         return res;
     }
+
+    // V1
+    // IDEA: BINOMIAL FORMULA — walk each row with C(i, j+1) = C(i, j) * (i - j) / (j + 1),
+    //       so no previous row is consulted at all
+    /**
+     * time = O(numRows^2)
+     * space = O(1) (excluding output)
+     */
+    public List<List<Integer>> generate_1(int numRows) {
+        List<List<Integer>> res = new ArrayList<>();
+        for (int i = 0; i < numRows; i++) {
+            List<Integer> row = new ArrayList<>();
+            long c = 1; // C(i, 0)
+            for (int j = 0; j <= i; j++) {
+                row.add((int) c);
+                c = c * (i - j) / (j + 1);
+            }
+            res.add(row);
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: RECURSION — generate(n) = generate(n - 1) plus one more row built from
+    //       the last row of that result
+    /**
+     * time = O(numRows^2)
+     * space = O(numRows) recursion depth (excluding output)
+     */
+    public List<List<Integer>> generate_2(int numRows) {
+        if (numRows <= 0) {
+            return new ArrayList<>();
+        }
+        List<List<Integer>> res = generate_2(numRows - 1);
+        int i = numRows - 1; // index of the row we are about to build
+        List<Integer> row = new ArrayList<>();
+        row.add(1);
+        if (i > 0) {
+            List<Integer> prev = res.get(i - 1);
+            for (int j = 1; j < i; j++) {
+                row.add(prev.get(j - 1) + prev.get(j));
+            }
+            row.add(1);
+        }
+        res.add(row);
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/ShortestWordDistanceIII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/ShortestWordDistanceIII.java
@@ -1,5 +1,8 @@
 package LeetCodeJava.Array;
 
+
+import java.util.ArrayList;
+import java.util.List;
 // https://leetcode.com/problems/shortest-word-distance-iii/
 
 /**
@@ -66,4 +69,77 @@ public class ShortestWordDistanceIII {
 
         return res;
     }
+
+    // V1
+    // IDEA: COLLECT THE OCCURRENCE INDEX LISTS FIRST, THEN MERGE THEM WITH
+    //       TWO POINTERS (min gap between 2 sorted index lists). If the 2 words
+    //       are the same, the answer is the min gap of ADJACENT indexes.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int shortestWordDistance_1(String[] wordsDict, String word1, String word2) {
+        List<Integer> idx1 = new ArrayList<>();
+        List<Integer> idx2 = new ArrayList<>();
+        for (int i = 0; i < wordsDict.length; i++) {
+            if (wordsDict[i].equals(word1)) {
+                idx1.add(i);
+            }
+            if (wordsDict[i].equals(word2)) {
+                idx2.add(i);
+            }
+        }
+
+        int res = Integer.MAX_VALUE;
+
+        if (word1.equals(word2)) {
+            // same word -> min distance of 2 consecutive occurrences
+            for (int i = 1; i < idx1.size(); i++) {
+                res = Math.min(res, idx1.get(i) - idx1.get(i - 1));
+            }
+            return res;
+        }
+
+        // 2 sorted lists -> classic merge, advance the smaller pointer
+        int a = 0;
+        int b = 0;
+        while (a < idx1.size() && b < idx2.size()) {
+            int i = idx1.get(a);
+            int j = idx2.get(b);
+            res = Math.min(res, Math.abs(i - j));
+            if (i < j) {
+                a++;
+            } else {
+                b++;
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) - compare every (word1 idx, word2 idx) pair.
+    //       Kept as a readable correctness reference.
+    /**
+     * time = O(n^2)
+     * space = O(1)
+     */
+    public int shortestWordDistance_2(String[] wordsDict, String word1, String word2) {
+        int res = Integer.MAX_VALUE;
+        for (int i = 0; i < wordsDict.length; i++) {
+            if (!wordsDict[i].equals(word1)) {
+                continue;
+            }
+            for (int j = 0; j < wordsDict.length; j++) {
+                // when word1 == word2 the 2 picks must still be different elements
+                if (i == j) {
+                    continue;
+                }
+                if (wordsDict[j].equals(word2)) {
+                    res = Math.min(res, Math.abs(i - j));
+                }
+            }
+        }
+        return res;
+    }
+
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/SortArrayByParityII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/SortArrayByParityII.java
@@ -54,4 +54,57 @@ public class SortArrayByParityII {
         }
         return nums;
     }
+
+    // V1
+    // IDEA: extra output array - stream the input once, dropping even values on
+    //       even slots (0,2,4...) and odd values on odd slots (1,3,5...).
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int[] sortArrayByParityII_1(int[] nums) {
+        int n = nums.length;
+        int[] res = new int[n];
+        int even = 0;
+        int odd = 1;
+        for (int v : nums) {
+            if (v % 2 == 0) {
+                res[even] = v;
+                even += 2;
+            } else {
+                res[odd] = v;
+                odd += 2;
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) - for every badly placed index, linear scan for a
+    //       partner that is badly placed the other way and swap them.
+    //       Kept as a readable correctness reference.
+    /**
+     * time = O(n^2)
+     * space = O(n) (works on a copy so the input is untouched)
+     */
+    public int[] sortArrayByParityII_2(int[] nums) {
+        int[] res = nums.clone();
+        int n = res.length;
+        for (int i = 0; i < n; i++) {
+            if (res[i] % 2 == i % 2) {
+                continue; // already fine
+            }
+            for (int j = i + 1; j < n; j++) {
+                // res[j] is misplaced too, and its value fits index i
+                if (res[j] % 2 != j % 2 && res[j] % 2 == i % 2) {
+                    int tmp = res[i];
+                    res[i] = res[j];
+                    res[j] = tmp;
+                    break;
+                }
+            }
+        }
+        return res;
+    }
+
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/SpiralMatrixII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/SpiralMatrixII.java
@@ -70,4 +70,73 @@ public class SpiralMatrixII {
 
         return res;
     }
+
+    // V1
+    // IDEA: DIRECTION VECTOR SIMULATION - walk 1 cell at a time and turn right
+    //       whenever the next cell is out of the board or already filled (!= 0)
+    /**
+     * time = O(n^2)
+     * space = O(1) (excluding output)
+     */
+    public int[][] generateMatrix_1(int n) {
+        int[][] res = new int[n][n];
+        int[] dr = new int[]{0, 1, 0, -1};
+        int[] dc = new int[]{1, 0, -1, 0};
+
+        int r = 0;
+        int c = 0;
+        int dir = 0;
+
+        for (int val = 1; val <= n * n; val++) {
+            res[r][c] = val;
+            int nr = r + dr[dir];
+            int nc = c + dc[dir];
+            // NOTE !!! 0 means "not filled yet" (values start from 1)
+            if (nr < 0 || nr >= n || nc < 0 || nc >= n || res[nr][nc] != 0) {
+                dir = (dir + 1) % 4;
+                nr = r + dr[dir];
+                nc = c + dc[dir];
+            }
+            r = nr;
+            c = nc;
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: RECURSION - fill the outermost ring, then recurse on the inner
+    //       (n-2) x (n-2) square with the next value
+    /**
+     * time = O(n^2)
+     * space = O(n) recursion depth
+     */
+    public int[][] generateMatrix_2(int n) {
+        int[][] res = new int[n][n];
+        fillRing_2(res, 0, n - 1, 1);
+        return res;
+    }
+
+    private void fillRing_2(int[][] m, int lo, int hi, int val) {
+        if (lo > hi) {
+            return;
+        }
+        if (lo == hi) {
+            m[lo][lo] = val;
+            return;
+        }
+        for (int c = lo; c <= hi; c++) {
+            m[lo][c] = val++;
+        }
+        for (int r = lo + 1; r <= hi; r++) {
+            m[r][hi] = val++;
+        }
+        for (int c = hi - 1; c >= lo; c--) {
+            m[hi][c] = val++;
+        }
+        for (int r = hi - 1; r >= lo + 1; r--) {
+            m[r][lo] = val++;
+        }
+        fillRing_2(m, lo + 1, hi - 1, val);
+    }
+
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Array/ValidTicTacToeState.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Array/ValidTicTacToeState.java
@@ -1,5 +1,9 @@
 package LeetCodeJava.Array;
 
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Deque;
+import java.util.ArrayDeque;
 // https://leetcode.com/problems/valid-tic-tac-toe-state/
 
 /**
@@ -95,5 +99,117 @@ public class ValidTicTacToeState {
             return true;
         }
         return false;
+    }
+
+
+    // V1
+    // IDEA: REVERSE SIMULATION — undo the last move step by step. A board is reachable
+    //       iff we can peel pieces back to the empty board, and no intermediate board
+    //       was already a finished (won) game.
+    /**
+     * time = O(1)  // bounded by the fixed 3x3 board (< 3000 undo paths)
+     * space = O(1)
+     */
+    public boolean validTicTacToe_1(String[] board) {
+        char[] cells = new char[9];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                cells[i * 3 + j] = board[i].charAt(j);
+            }
+        }
+        return canUndo_1(cells);
+    }
+
+    private boolean canUndo_1(char[] cells) {
+        int xCnt = 0, oCnt = 0;
+        for (char c : cells) {
+            if (c == 'X') {
+                xCnt++;
+            } else if (c == 'O') {
+                oCnt++;
+            }
+        }
+        if (xCnt == 0 && oCnt == 0) {
+            return true;
+        }
+        if (xCnt != oCnt && xCnt != oCnt + 1) {
+            return false;
+        }
+        // whoever has just moved (X moves first, so X leads by 0 or 1)
+        char last = (xCnt == oCnt + 1) ? 'X' : 'O';
+        for (int i = 0; i < 9; i++) {
+            if (cells[i] != last) {
+                continue;
+            }
+            cells[i] = ' ';
+            // the predecessor board must NOT already be a finished game
+            boolean finished = isWinFlat_1(cells, 'X') || isWinFlat_1(cells, 'O');
+            boolean ok = !finished && canUndo_1(cells);
+            cells[i] = last;
+            if (ok) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isWinFlat_1(char[] c, char p) {
+        int[][] lines = new int[][] {
+                { 0, 1, 2 }, { 3, 4, 5 }, { 6, 7, 8 },
+                { 0, 3, 6 }, { 1, 4, 7 }, { 2, 5, 8 },
+                { 0, 4, 8 }, { 2, 4, 6 } };
+        for (int[] l : lines) {
+            if (c[l[0]] == p && c[l[1]] == p && c[l[2]] == p) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // V2
+    // IDEA: brute force — BFS every state reachable from the empty board (only a few
+    //       thousand exist) and test membership; kept as a readable correctness reference
+    /**
+     * time = O(1)  // <= 3^9 states, fixed board size
+     * space = O(1)
+     */
+    public boolean validTicTacToe_2(String[] board) {
+        String target = board[0] + board[1] + board[2];
+
+        String empty = "         ";
+        Set<String> reachable = new HashSet<>();
+        Deque<String> q = new ArrayDeque<>();
+        reachable.add(empty);
+        q.add(empty);
+
+        while (!q.isEmpty()) {
+            String cur = q.poll();
+            char[] arr = cur.toCharArray();
+            // once someone has won the game stops -> no successor state
+            if (isWinFlat_1(arr, 'X') || isWinFlat_1(arr, 'O')) {
+                continue;
+            }
+            int xCnt = 0, oCnt = 0;
+            for (char c : arr) {
+                if (c == 'X') {
+                    xCnt++;
+                } else if (c == 'O') {
+                    oCnt++;
+                }
+            }
+            char turn = (xCnt == oCnt) ? 'X' : 'O';
+            for (int i = 0; i < 9; i++) {
+                if (arr[i] != ' ') {
+                    continue;
+                }
+                arr[i] = turn;
+                String next = new String(arr);
+                arr[i] = ' ';
+                if (reachable.add(next)) {
+                    q.add(next);
+                }
+            }
+        }
+        return reachable.contains(target);
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SudokuSolver.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BackTrack/SudokuSolver.java
@@ -91,4 +91,140 @@ public class SudokuSolver {
         }
         return false;
     }
+
+    // V1
+    // IDEA: bitmask constraint propagation + MRV heuristic (always fill the empty
+    //       cell that has the FEWEST remaining candidates first) -> far smaller
+    //       search tree than scanning cells in fixed order
+    /**
+     * time = O(9^m) worst case, m = number of empty cells (MRV prunes heavily in practice)
+     * space = O(m) recursion depth
+     */
+    public void solveSudoku_1(char[][] board) {
+        if (board == null || board.length != 9 || board[0].length != 9) {
+            return;
+        }
+        int[] rowMask = new int[9];
+        int[] colMask = new int[9];
+        int[] boxMask = new int[9];
+        for (int r = 0; r < 9; r++) {
+            for (int c = 0; c < 9; c++) {
+                if (board[r][c] != '.') {
+                    int bit = 1 << (board[r][c] - '1');
+                    rowMask[r] |= bit;
+                    colMask[c] |= bit;
+                    boxMask[boxIdx(r, c)] |= bit;
+                }
+            }
+        }
+        solve_1(board, rowMask, colMask, boxMask);
+    }
+
+    private boolean solve_1(char[][] board, int[] rowMask, int[] colMask, int[] boxMask) {
+        // MRV: pick the empty cell with the least candidates
+        int bestR = -1;
+        int bestC = -1;
+        int bestCand = 0;
+        int bestCnt = 10;
+        for (int r = 0; r < 9; r++) {
+            for (int c = 0; c < 9; c++) {
+                if (board[r][c] != '.') {
+                    continue;
+                }
+                int used = rowMask[r] | colMask[c] | boxMask[boxIdx(r, c)];
+                int cand = ~used & 0x1FF;
+                int cnt = Integer.bitCount(cand);
+                if (cnt == 0) {
+                    return false; // dead end
+                }
+                if (cnt < bestCnt) {
+                    bestCnt = cnt;
+                    bestCand = cand;
+                    bestR = r;
+                    bestC = c;
+                    if (cnt == 1) {
+                        break;
+                    }
+                }
+            }
+        }
+        if (bestR == -1) {
+            return true; // no empty cell left
+        }
+
+        int b = boxIdx(bestR, bestC);
+        int cand = bestCand;
+        while (cand != 0) {
+            int bit = cand & -cand; // lowest set bit
+            cand -= bit;
+            rowMask[bestR] |= bit;
+            colMask[bestC] |= bit;
+            boxMask[b] |= bit;
+            board[bestR][bestC] = (char) ('1' + Integer.numberOfTrailingZeros(bit));
+
+            if (solve_1(board, rowMask, colMask, boxMask)) {
+                return true;
+            }
+
+            board[bestR][bestC] = '.';
+            rowMask[bestR] ^= bit;
+            colMask[bestC] ^= bit;
+            boxMask[b] ^= bit;
+        }
+        return false;
+    }
+
+    // V2
+    // IDEA: brute force backtracking - no precomputed state at all, every
+    //       placement is validated by re-scanning its row, column and 3x3 box.
+    //       Kept as a readable correctness reference.
+    /**
+     * time = O(9^m * 9), m = number of empty cells
+     * space = O(m) recursion depth
+     */
+    public void solveSudoku_2(char[][] board) {
+        if (board == null || board.length != 9 || board[0].length != 9) {
+            return;
+        }
+        solve_2(board, 0);
+    }
+
+    private boolean solve_2(char[][] board, int pos) {
+        if (pos == 81) {
+            return true;
+        }
+        int r = pos / 9;
+        int c = pos % 9;
+        if (board[r][c] != '.') {
+            return solve_2(board, pos + 1);
+        }
+        for (char d = '1'; d <= '9'; d++) {
+            if (!isValid_2(board, r, c, d)) {
+                continue;
+            }
+            board[r][c] = d;
+            if (solve_2(board, pos + 1)) {
+                return true;
+            }
+            board[r][c] = '.';
+        }
+        return false;
+    }
+
+    private boolean isValid_2(char[][] board, int r, int c, char d) {
+        for (int i = 0; i < 9; i++) {
+            if (board[r][i] == d) {
+                return false;
+            }
+            if (board[i][c] == d) {
+                return false;
+            }
+            int br = (r / 3) * 3 + i / 3;
+            int bc = (c / 3) * 3 + i % 3;
+            if (board[br][bc] == d) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/AllPossibleFullBinaryTrees.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/AllPossibleFullBinaryTrees.java
@@ -79,4 +79,63 @@ public class AllPossibleFullBinaryTrees {
         this.memo.put(n, res);
         return res;
     }
+
+    // V1
+    // IDEA: bottom-up DP (tabulation). Build dp[i] = every full binary tree with
+    //       i nodes from the already built smaller odd sizes, no recursion.
+    /**
+     * time = O(2^n)   // ~ Catalan number of trees
+     * space = O(2^n)
+     */
+    public List<TreeNode> allPossibleFBT_1(int n) {
+        if (n % 2 == 0) {
+            return new ArrayList<>();
+        }
+        // dp[i] = all full binary trees with i nodes (empty for even i)
+        List<List<TreeNode>> dp = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            dp.add(new ArrayList<>());
+        }
+        dp.get(1).add(new TreeNode(0));
+
+        for (int size = 3; size <= n; size += 2) {
+            List<TreeNode> cur = dp.get(size);
+            for (int leftCnt = 1; leftCnt < size - 1; leftCnt += 2) {
+                for (TreeNode left : dp.get(leftCnt)) {
+                    for (TreeNode right : dp.get(size - 1 - leftCnt)) {
+                        cur.add(new TreeNode(0, left, right));
+                    }
+                }
+            }
+        }
+        return dp.get(n);
+    }
+
+    // V2
+    // IDEA: brute force plain recursion with NO memo - every subtree list is
+    //       rebuilt from scratch. Kept as a readable correctness reference.
+    /**
+     * time = O(2^n * n)  // exponential, sub-results recomputed
+     * space = O(2^n)
+     */
+    public List<TreeNode> allPossibleFBT_2(int n) {
+        List<TreeNode> res = new ArrayList<>();
+        if (n % 2 == 0) {
+            return res;
+        }
+        if (n == 1) {
+            res.add(new TreeNode(0));
+            return res;
+        }
+        for (int leftCnt = 1; leftCnt < n - 1; leftCnt += 2) {
+            List<TreeNode> lefts = allPossibleFBT_2(leftCnt);
+            List<TreeNode> rights = allPossibleFBT_2(n - 1 - leftCnt);
+            for (TreeNode left : lefts) {
+                for (TreeNode right : rights) {
+                    res.add(new TreeNode(0, left, right));
+                }
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/FindRightInterval.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/FindRightInterval.java
@@ -4,6 +4,8 @@ package LeetCodeJava.BinarySearch;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  *  436. Find Right Interval
@@ -74,6 +76,52 @@ public class FindRightInterval {
                 }
             }
             res[i] = (l == n) ? -1 : starts[l][1];
+        }
+        return res;
+    }
+
+    // V1
+    // IDEA: TreeMap<start, idx> + ceilingEntry - let the balanced BST do the
+    //       "smallest start >= end" lookup instead of a hand rolled binary search
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int[] findRightInterval_1(int[][] intervals) {
+        int n = intervals.length;
+        TreeMap<Integer, Integer> startToIdx = new TreeMap<>();
+        for (int i = 0; i < n; i++) {
+            startToIdx.put(intervals[i][0], i); // starts are unique
+        }
+
+        int[] res = new int[n];
+        for (int i = 0; i < n; i++) {
+            Map.Entry<Integer, Integer> e = startToIdx.ceilingEntry(intervals[i][1]);
+            res[i] = (e == null) ? -1 : e.getValue();
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) - for every interval scan all others and keep the
+    //       smallest start >= end. Kept as a readable correctness reference.
+    /**
+     * time = O(n^2)
+     * space = O(1) (excluding output)
+     */
+    public int[] findRightInterval_2(int[][] intervals) {
+        int n = intervals.length;
+        int[] res = new int[n];
+        for (int i = 0; i < n; i++) {
+            int bestIdx = -1;
+            int bestStart = Integer.MAX_VALUE;
+            for (int j = 0; j < n; j++) {
+                if (intervals[j][0] >= intervals[i][1] && intervals[j][0] < bestStart) {
+                    bestStart = intervals[j][0];
+                    bestIdx = j;
+                }
+            }
+            res[i] = bestIdx;
         }
         return res;
     }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/FindSmallestLetterGreaterThanTarget.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/FindSmallestLetterGreaterThanTarget.java
@@ -60,4 +60,41 @@ public class FindSmallestLetterGreaterThanTarget {
         // NOTE !!! if no letter is bigger than target, wrap to the first one
         return letters[l % n];
     }
+
+    // V1
+    // IDEA: bucket the 26 lowercase letters into a presence table, then walk the
+    //       alphabet circularly starting right after target (no binary search)
+    /**
+     * time = O(n + 26)
+     * space = O(26) = O(1)
+     */
+    public char nextGreatestLetter_1(char[] letters, char target) {
+        boolean[] present = new boolean[26];
+        for (char ch : letters) {
+            present[ch - 'a'] = true;
+        }
+        for (int step = 1; step <= 26; step++) {
+            int idx = (target - 'a' + step) % 26;
+            if (present[idx]) {
+                return (char) ('a' + idx);
+            }
+        }
+        return letters[0]; // unreachable given the constraints
+    }
+
+    // V2
+    // IDEA: brute force O(n) linear scan - return the first letter > target,
+    //       otherwise wrap to letters[0]. Kept as a readable correctness reference.
+    /**
+     * time = O(n)
+     * space = O(1)
+     */
+    public char nextGreatestLetter_2(char[] letters, char target) {
+        for (char ch : letters) {
+            if (ch > target) {
+                return ch;
+            }
+        }
+        return letters[0];
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/HIndexII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/HIndexII.java
@@ -63,4 +63,52 @@ public class HIndexII {
         }
         return res;
     }
+
+    // V1
+    // IDEA: linear scan - walk left to right and stop at the first idx where
+    //       citations[idx] >= n - idx (that (n - idx) is the h-index)
+    /**
+     * time = O(n)
+     * space = O(1)
+     */
+    public int hIndex_1(int[] citations) {
+        if (citations == null || citations.length == 0) {
+            return 0;
+        }
+        int n = citations.length;
+        for (int i = 0; i < n; i++) {
+            if (citations[i] >= n - i) {
+                return n - i;
+            }
+        }
+        return 0;
+    }
+
+    // V2
+    // IDEA: counting / bucket sort (the H-Index I trick) - ignores the fact that
+    //       the input is sorted, so it also works on unsorted input
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int hIndex_2(int[] citations) {
+        if (citations == null || citations.length == 0) {
+            return 0;
+        }
+        int n = citations.length;
+        // bucket[c] = how many papers have exactly c citations (everything >= n
+        // is clamped into bucket[n], since the h-index can never exceed n)
+        int[] bucket = new int[n + 1];
+        for (int c : citations) {
+            bucket[Math.min(c, n)]++;
+        }
+        int cnt = 0; // papers with citations >= h
+        for (int h = n; h >= 0; h--) {
+            cnt += bucket[h];
+            if (cnt >= h) {
+                return h;
+            }
+        }
+        return 0;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/Heaters.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/Heaters.java
@@ -98,4 +98,23 @@ public class Heaters {
         }
         return res;
     }
+
+    // V2
+    // IDEA: brute force O(n * m) - for every house scan every heater and take the
+    //       closest one. Kept as a readable correctness reference.
+    /**
+     * time = O(n * m)
+     * space = O(1)
+     */
+    public int findRadius_2(int[] houses, int[] heaters) {
+        int res = 0;
+        for (int house : houses) {
+            long best = Long.MAX_VALUE;
+            for (int heater : heaters) {
+                best = Math.min(best, Math.abs((long) heater - house));
+            }
+            res = Math.max(res, (int) best);
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimizeMaxDistanceToGasStation.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimizeMaxDistanceToGasStation.java
@@ -2,6 +2,8 @@ package LeetCodeJava.BinarySearch;
 
 // https://leetcode.com/problems/minimize-max-distance-to-gas-station/
 
+import java.util.PriorityQueue;
+
 /**
  *  774. Minimize Max Distance to Gas Station
  *  Hard
@@ -73,5 +75,70 @@ public class MinimizeMaxDistanceToGasStation {
             }
         }
         return cnt <= k;
+    }
+
+    // V1
+    // IDEA: greedy with a max-heap - repeatedly give the next station to the gap
+    //       whose current sub-distance (gap / parts) is the largest
+    /**
+     * time = O(n + k log n)
+     * space = O(n)
+     */
+    public double minmaxGasDist_1(int[] stations, int k) {
+        int n = stations.length;
+        // entry = {gap length, how many equal parts it is split into}
+        PriorityQueue<double[]> pq = new PriorityQueue<>(
+                (a, b) -> Double.compare(b[0] / b[1], a[0] / a[1]));
+        for (int i = 1; i < n; i++) {
+            pq.add(new double[] { stations[i] - stations[i - 1], 1.0 });
+        }
+        if (pq.isEmpty()) {
+            return 0.0;
+        }
+        for (int i = 0; i < k; i++) {
+            double[] top = pq.poll();
+            top[1] += 1.0; // one more station inside this gap -> one more part
+            pq.add(top);
+        }
+        double[] top = pq.peek();
+        return top[0] / top[1];
+    }
+
+    // V2
+    // IDEA: brute force - same greedy as V1 but WITHOUT a heap, the widest
+    //       current sub-distance is found by a linear scan every round.
+    //       Kept as a readable correctness reference (too slow for large k).
+    /**
+     * time = O(n * k)
+     * space = O(n)
+     */
+    public double minmaxGasDist_2(int[] stations, int k) {
+        int n = stations.length;
+        if (n < 2) {
+            return 0.0;
+        }
+        double[] gaps = new double[n - 1];
+        int[] parts = new int[n - 1];
+        for (int i = 1; i < n; i++) {
+            gaps[i - 1] = stations[i] - stations[i - 1];
+            parts[i - 1] = 1;
+        }
+        for (int step = 0; step < k; step++) {
+            int bestIdx = 0;
+            double bestVal = -1.0;
+            for (int i = 0; i < gaps.length; i++) {
+                double cur = gaps[i] / parts[i];
+                if (cur > bestVal) {
+                    bestVal = cur;
+                    bestIdx = i;
+                }
+            }
+            parts[bestIdx]++;
+        }
+        double res = 0.0;
+        for (int i = 0; i < gaps.length; i++) {
+            res = Math.max(res, gaps[i] / parts[i]);
+        }
+        return res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumInitialStrengthToDefeatAllMonsters.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumInitialStrengthToDefeatAllMonsters.java
@@ -88,4 +88,82 @@ public class MinimumInitialStrengthToDefeatAllMonsters {
         }
         return true;
     }
+
+    // V1
+    // IDEA: backward greedy (no search at all) - walking right to left, the
+    //       minimum strength needed BEFORE monster i is
+    //         need(i) = max(0, monsters[i] - bonus[i],
+    //                       need(i+1) > 0 ? monsters[i] + need(i+1) : 0)
+    //       because cur -> max(0, cur - monsters[i]) after the fight.
+    /**
+     * time = O(n + m)
+     * space = O(n)
+     */
+    public long minInitialStrength_1(int[] monsters, int[][] boosts) {
+        int n = monsters.length;
+
+        long[] bonus = new long[n + 1];
+        if (boosts != null) {
+            for (int[] b : boosts) {
+                bonus[b[0]] += b[2];
+                bonus[b[1] + 1] -= b[2];
+            }
+        }
+        for (int i = 1; i < n; i++) {
+            bonus[i] += bonus[i - 1];
+        }
+
+        long need = 0; // strength required entering the (i+1)-th fight
+        for (int i = n - 1; i >= 0; i--) {
+            long req = monsters[i] - bonus[i]; // enough to beat monster i itself
+            if (need > 0) {
+                // must still hold `need` AFTER paying monsters[i]
+                req = Math.max(req, monsters[i] + need);
+            }
+            need = Math.max(0L, req);
+        }
+        return need;
+    }
+
+    // V2
+    // IDEA: brute force - bonus per monster by scanning every boost, then try
+    //       every candidate initial strength from 0 upward and simulate.
+    //       Kept as a readable correctness reference (only viable on tiny input).
+    /**
+     * time = O(n * m + answer * n)
+     * space = O(n)
+     */
+    public long minInitialStrength_2(int[] monsters, int[][] boosts) {
+        int n = monsters.length;
+        long[] bonus = new long[n];
+        if (boosts != null) {
+            for (int i = 0; i < n; i++) {
+                for (int[] b : boosts) {
+                    if (b[0] <= i && i <= b[1]) {
+                        bonus[i] += b[2];
+                    }
+                }
+            }
+        }
+
+        long limit = 0;
+        for (int m : monsters) {
+            limit += m; // this start is always enough
+        }
+        for (long start = 0; start <= limit; start++) {
+            long cur = start;
+            boolean ok = true;
+            for (int i = 0; i < n; i++) {
+                if (cur + bonus[i] < monsters[i]) {
+                    ok = false;
+                    break;
+                }
+                cur = Math.max(0L, cur - monsters[i]);
+            }
+            if (ok) {
+                return start;
+            }
+        }
+        return limit;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumNumberOfOperationsToMakeArrayContinuous.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumNumberOfOperationsToMakeArrayContinuous.java
@@ -110,4 +110,29 @@ public class MinimumNumberOfOperationsToMakeArrayContinuous {
         }
         return n - keep;
     }
+
+    // V2
+    // IDEA: brute force O(n^2) - for every distinct value x, count (by a plain
+    //       scan) how many distinct values fall inside [x, x + n - 1].
+    //       Kept as a readable correctness reference.
+    /**
+     * time = O(n^2)
+     * space = O(n)
+     */
+    public int minOperations_2(int[] nums) {
+        int n = nums.length;
+        int[] uniq = dedup(nums);
+        int m = uniq.length;
+
+        int keep = 0;
+        for (int i = 0; i < m; i++) {
+            long limit = (long) uniq[i] + n - 1;
+            int cnt = 0;
+            for (int j = i; j < m && uniq[j] <= limit; j++) {
+                cnt++;
+            }
+            keep = Math.max(keep, cnt);
+        }
+        return n - keep;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/OnlineElection.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/OnlineElection.java
@@ -4,6 +4,7 @@ package LeetCodeJava.BinarySearch;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  *  911. Online Election
@@ -86,5 +87,68 @@ public class OnlineElection {
             }
         }
         return this.leads[res];
+    }
+
+    // V1
+    // IDEA: same precomputed leader-after-each-vote idea, but the "last vote time
+    //       <= t" lookup is delegated to a TreeMap floorEntry instead of a
+    //       hand-rolled binary search over the times array.
+    /**
+     * time = O(n log n) ctor, O(log n) per q()
+     * space = O(n)
+     */
+    public static class OnlineElectionV1 {
+
+        private final TreeMap<Integer, Integer> timeToLead = new TreeMap<>();
+
+        public OnlineElectionV1(int[] persons, int[] times) {
+            Map<Integer, Integer> count = new HashMap<>();
+            int lead = -1;
+            for (int i = 0; i < persons.length; i++) {
+                int p = persons[i];
+                int c = count.getOrDefault(p, 0) + 1;
+                count.put(p, c);
+                if (c >= count.getOrDefault(lead, 0)) {
+                    lead = p;
+                }
+                timeToLead.put(times[i], lead);
+            }
+        }
+
+        public int q(int t) {
+            return timeToLead.floorEntry(t).getValue();
+        }
+    }
+
+    // V2
+    // IDEA: brute force -- no precomputation at all, every q() replays the votes
+    //       up to time t and recounts. Kept as a readable correctness reference.
+    /**
+     * time = O(1) ctor, O(n) per q()
+     * space = O(n) for the recount map
+     */
+    public static class OnlineElectionV2 {
+
+        private final int[] persons;
+        private final int[] times;
+
+        public OnlineElectionV2(int[] persons, int[] times) {
+            this.persons = persons;
+            this.times = times;
+        }
+
+        public int q(int t) {
+            Map<Integer, Integer> count = new HashMap<>();
+            int lead = -1;
+            for (int i = 0; i < this.times.length && this.times[i] <= t; i++) {
+                int p = this.persons[i];
+                int c = count.getOrDefault(p, 0) + 1;
+                count.put(p, c);
+                if (c >= count.getOrDefault(lead, 0)) {
+                    lead = p;
+                }
+            }
+            return lead;
+        }
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/SqrtX.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearch/SqrtX.java
@@ -74,4 +74,26 @@ public class SqrtX {
         }
         return (int) r;
     }
+
+    // V2
+    // IDEA: build the answer bit by bit from the high bit down; greedily keep a
+    //       bit whenever the candidate still satisfies cand * cand <= x.
+    //       (sqrt(2^31 - 1) < 2^16, so bits 15..0 are enough)
+    /**
+     * time = O(16) = O(1)
+     * space = O(1)
+     */
+    public int mySqrt_2(int x) {
+        if (x <= 1) {
+            return x;
+        }
+        int res = 0;
+        for (int bit = 15; bit >= 0; bit--) {
+            int cand = res | (1 << bit);
+            if ((long) cand * cand <= x) {
+                res = cand;
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/BuildBinaryExpressionTreeFromInfixExpression.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/BuildBinaryExpressionTreeFromInfixExpression.java
@@ -118,4 +118,121 @@ public class BuildBinaryExpressionTreeFromInfixExpression {
         }
         return 0;
     }
+
+    // cursor used by the V1 recursive-descent parser
+    private int pos_1;
+
+    // V1
+    // IDEA: recursive-descent parser over the grammar
+    //         expr   := term (('+'|'-') term)*
+    //         term   := factor (('*'|'/') factor)*
+    //         factor := digit | '(' expr ')'
+    //       Precedence is encoded in the grammar itself instead of in a stack,
+    //       and the left-folding loop gives left associativity.
+    /**
+     * time = O(n)
+     * space = O(n)   // recursion depth on nested parentheses
+     */
+    public NodeX expTree_1(String s) {
+        pos_1 = 0;
+        return parseExpr_1(s);
+    }
+
+    private NodeX parseExpr_1(String s) {
+        NodeX left = parseTerm_1(s);
+        while (pos_1 < s.length() && (s.charAt(pos_1) == '+' || s.charAt(pos_1) == '-')) {
+            char op = s.charAt(pos_1++);
+            NodeX right = parseTerm_1(s);
+            left = new NodeX(op, left, right);
+        }
+        return left;
+    }
+
+    private NodeX parseTerm_1(String s) {
+        NodeX left = parseFactor_1(s);
+        while (pos_1 < s.length() && (s.charAt(pos_1) == '*' || s.charAt(pos_1) == '/')) {
+            char op = s.charAt(pos_1++);
+            NodeX right = parseFactor_1(s);
+            left = new NodeX(op, left, right);
+        }
+        return left;
+    }
+
+    private NodeX parseFactor_1(String s) {
+        char c = s.charAt(pos_1);
+        if (c == '(') {
+            pos_1++;                      // consume '('
+            NodeX inner = parseExpr_1(s);
+            pos_1++;                      // consume ')'
+            return inner;
+        }
+        pos_1++;
+        return new NodeX(c);
+    }
+
+    // V2
+    // IDEA: divide & conquer on the substring. Strip redundant wrapping parens,
+    //       then split at the RIGHTMOST top-level (depth 0) operator of the
+    //       LOWEST precedence -- that operator is evaluated last, so it is the
+    //       root -- and recurse on the two halves.
+    /**
+     * time = O(n^2) worst case (rescans each substring)
+     * space = O(n)
+     */
+    public NodeX expTree_2(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        return buildDC_2(s, 0, s.length() - 1);
+    }
+
+    private NodeX buildDC_2(String s, int lo, int hi) {
+        // "(...)" wrapping the whole range adds nothing -> peel it off
+        while (lo < hi && s.charAt(lo) == '(' && closesAt_2(s, lo, hi)) {
+            lo++;
+            hi--;
+        }
+        if (lo == hi) {
+            return new NodeX(s.charAt(lo));
+        }
+
+        int addSub = -1;
+        int mulDiv = -1;
+        int depth = 0;
+        for (int i = lo; i <= hi; i++) {
+            char c = s.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            } else if (depth == 0) {
+                if (c == '+' || c == '-') {
+                    addSub = i;           // keep the rightmost -> left associative
+                } else if (c == '*' || c == '/') {
+                    mulDiv = i;
+                }
+            }
+        }
+
+        int split = addSub != -1 ? addSub : mulDiv;
+        return new NodeX(s.charAt(split),
+                buildDC_2(s, lo, split - 1),
+                buildDC_2(s, split + 1, hi));
+    }
+
+    // does the '(' at index lo close exactly at index hi ?
+    private boolean closesAt_2(String s, int lo, int hi) {
+        int depth = 0;
+        for (int i = lo; i <= hi; i++) {
+            if (s.charAt(i) == '(') {
+                depth++;
+            } else if (s.charAt(i) == ')') {
+                depth--;
+                if (depth == 0) {
+                    return i == hi;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ClosestBinarySearchTreeValue.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ClosestBinarySearchTreeValue.java
@@ -2,6 +2,9 @@ package LeetCodeJava.BinarySearchTree;
 
 // https://leetcode.com/problems/closest-binary-search-tree-value/
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import LeetCodeJava.DataStructure.TreeNode;
 
 /**
@@ -53,5 +56,67 @@ public class ClosestBinarySearchTreeValue {
             }
         }
         return best;
+    }
+
+    // V1
+    // IDEA: brute force -- ignore the BST ordering entirely and DFS every node,
+    //       keeping the best (closest, then smallest) value seen. Kept as a
+    //       readable correctness reference for V0 / V2.
+    /**
+     * time = O(n)
+     * space = O(h)
+     */
+    public int closestValue_1(TreeNode root, double target) {
+        return dfs_1(root, root.val, target);
+    }
+
+    private int dfs_1(TreeNode node, int best, double target) {
+        if (node == null) {
+            return best;
+        }
+        double curDiff = Math.abs(node.val - target);
+        double bestDiff = Math.abs(best - target);
+        if (curDiff < bestDiff || (curDiff == bestDiff && node.val < best)) {
+            best = node.val;
+        }
+        best = dfs_1(node.left, best, target);
+        best = dfs_1(node.right, best, target);
+        return best;
+    }
+
+    // V2
+    // IDEA: in-order traversal gives the values in sorted order, so the answer is
+    //       either the predecessor (last value <= target) or the successor (first
+    //       value > target). Walk in-order with an explicit stack and stop at the
+    //       first value > target -- no need to visit the rest of the tree.
+    /**
+     * time = O(h + k)   // k = nodes visited before passing target
+     * space = O(h)
+     */
+    public int closestValue_2(TreeNode root, double target) {
+        Deque<TreeNode> stack = new ArrayDeque<>();
+        TreeNode cur = root;
+        Integer pred = null;
+
+        while (cur != null || !stack.isEmpty()) {
+            while (cur != null) {
+                stack.push(cur);
+                cur = cur.left;
+            }
+            cur = stack.pop();
+
+            if (cur.val > target) {
+                // cur is the successor; compare it against the predecessor
+                if (pred == null) {
+                    return cur.val;
+                }
+                // NOTE !!! tie -> the smaller value (the predecessor) wins
+                return (target - pred <= cur.val - target) ? pred : cur.val;
+            }
+            pred = cur.val;
+
+            cur = cur.right;
+        }
+        return pred;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ContainsDuplicateIII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ContainsDuplicateIII.java
@@ -107,4 +107,28 @@ public class ContainsDuplicateIII {
         }
         return false;
     }
+
+    // V2
+    // IDEA: brute force O(n * indexDiff) -- for every i just test the at most
+    //       `indexDiff` earlier elements directly. Kept as a readable
+    //       correctness reference for the bucket / TreeSet versions.
+    /**
+     * time = O(n * indexDiff)
+     * space = O(1)
+     */
+    public boolean containsNearbyAlmostDuplicate_2(int[] nums, int indexDiff, int valueDiff) {
+        if (nums == null || nums.length < 2 || indexDiff <= 0 || valueDiff < 0) {
+            return false;
+        }
+
+        for (int i = 0; i < nums.length; i++) {
+            int from = Math.max(0, i - indexDiff);
+            for (int j = from; j < i; j++) {
+                if (Math.abs((long) nums[i] - nums[j]) <= valueDiff) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ConvertBinarySearchTreeToSortedDoublyLinkedList.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ConvertBinarySearchTreeToSortedDoublyLinkedList.java
@@ -136,4 +136,39 @@ public class ConvertBinarySearchTreeToSortedDoublyLinkedList {
         last.right = first;
         return first;
     }
+
+    // V2
+    // IDEA: two passes -- first materialise the in-order sequence into a list,
+    //       then wire the neighbours up in a simple linear sweep. Separates the
+    //       traversal from the pointer surgery at the cost of O(n) extra space.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public NodeX treeToDoublyList_2(NodeX root) {
+        if (root == null) {
+            return null;
+        }
+
+        java.util.List<NodeX> order = new java.util.ArrayList<>();
+        collectInorder_2(root, order);
+
+        int n = order.size();
+        for (int i = 0; i < n; i++) {
+            NodeX cur = order.get(i);
+            // NOTE !!! circular -> wrap around with modulo
+            cur.right = order.get((i + 1) % n);
+            cur.left = order.get((i - 1 + n) % n);
+        }
+        return order.get(0);
+    }
+
+    private void collectInorder_2(NodeX node, java.util.List<NodeX> out) {
+        if (node == null) {
+            return;
+        }
+        collectInorder_2(node.left, out);
+        out.add(node);
+        collectInorder_2(node.right, out);
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/SumOfRootToLeafBinaryNumbers.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/SumOfRootToLeafBinaryNumbers.java
@@ -2,6 +2,9 @@ package LeetCodeJava.BinarySearchTree;
 
 // https://leetcode.com/problems/sum-of-root-to-leaf-binary-numbers/
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import LeetCodeJava.DataStructure.TreeNode;
 
 /**
@@ -52,5 +55,92 @@ public class SumOfRootToLeafBinaryNumbers {
             return cur;
         }
         return dfs(node.left, cur) + dfs(node.right, cur);
+    }
+
+    // V1
+    // IDEA: same DFS, but iterative -- an explicit stack holds (node, partial
+    //       number) pairs, so there is no recursion depth limit on skewed trees.
+    /**
+     * time = O(n)
+     * space = O(h)
+     */
+    public int sumRootToLeaf_1(TreeNode root) {
+        if (root == null) {
+            return 0;
+        }
+        Deque<TreeNode> nodes = new ArrayDeque<>();
+        Deque<Integer> partials = new ArrayDeque<>();
+        nodes.push(root);
+        partials.push(root.val);
+
+        int res = 0;
+        while (!nodes.isEmpty()) {
+            TreeNode node = nodes.pop();
+            int cur = partials.pop();
+
+            if (node.left == null && node.right == null) {
+                res += cur;
+                continue;
+            }
+            if (node.left != null) {
+                nodes.push(node.left);
+                partials.push((cur << 1) | node.left.val);
+            }
+            if (node.right != null) {
+                nodes.push(node.right);
+                partials.push((cur << 1) | node.right.val);
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: Morris pre-order traversal -- temporarily thread each node's
+    //       in-order predecessor's right pointer back to it, so the whole tree is
+    //       walked with NO stack and NO recursion (O(1) extra space). The number
+    //       of steps to the predecessor tells us how many bits to unwind.
+    /**
+     * time = O(n)
+     * space = O(1)
+     */
+    public int sumRootToLeaf_2(TreeNode root) {
+        int res = 0;
+        int cur = 0;
+        TreeNode node = root;
+
+        while (node != null) {
+            if (node.left != null) {
+                // find the in-order predecessor of `node` inside its left subtree
+                TreeNode pred = node.left;
+                int steps = 1;
+                while (pred.right != null && pred.right != node) {
+                    pred = pred.right;
+                    steps++;
+                }
+
+                if (pred.right == null) {
+                    // first visit -> take the bit and thread the link
+                    cur = (cur << 1) | node.val;
+                    pred.right = node;
+                    node = node.left;
+                } else {
+                    // second visit -> pred is the last node of the left subtree
+                    if (pred.left == null) {
+                        res += cur;              // pred is a leaf
+                    }
+                    // NOTE !!! unwind the bits contributed by the left subtree path
+                    cur >>= steps;
+                    pred.right = null;           // restore the tree
+                    node = node.right;
+                }
+            } else {
+                cur = (cur << 1) | node.val;
+                if (node.right == null) {
+                    res += cur;                  // node is a leaf
+                }
+                node = node.right;
+            }
+        }
+        return res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryGap.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryGap.java
@@ -54,4 +54,50 @@ public class BinaryGap {
         }
         return res;
     }
+
+    // V1
+    // IDEA: hop directly from set bit to set bit -- numberOfTrailingZeros gives
+    //       the index of the lowest 1, and n &= (n - 1) clears it. Costs one
+    //       iteration per SET bit instead of one per bit position.
+    /**
+     * time = O(popcount(n)) <= O(32) = O(1)
+     * space = O(1)
+     */
+    public int binaryGap_1(int n) {
+        int prev = -1;
+        int res = 0;
+        while (n != 0) {
+            int idx = Integer.numberOfTrailingZeros(n);
+            if (prev != -1) {
+                res = Math.max(res, idx - prev);
+            }
+            prev = idx;
+            // NOTE !!! n & (n - 1) drops the lowest set bit
+            n &= (n - 1);
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: work on the binary STRING instead of on bits -- the answer is the max
+    //       distance between consecutive '1' characters. Kept as a readable
+    //       reference version.
+    /**
+     * time = O(32) = O(1)
+     * space = O(32) = O(1)   // the string
+     */
+    public int binaryGap_2(int n) {
+        String bits = Integer.toBinaryString(n);
+        int prev = -1;
+        int res = 0;
+        for (int i = 0; i < bits.length(); i++) {
+            if (bits.charAt(i) == '1') {
+                if (prev != -1) {
+                    res = Math.max(res, i - prev);
+                }
+                prev = i;
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryNumberWithAlternatingBits.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryNumberWithAlternatingBits.java
@@ -60,4 +60,25 @@ public class BinaryNumberWithAlternatingBits {
         }
         return true;
     }
+
+    // V2
+    // IDEA: enumerate instead of inspect -- there are only ~31 positive ints with
+    //       alternating bits (1, 10, 101, 1010, ... in binary). Generate them all
+    //       (each one extends the previous by the opposite bit) and test
+    //       membership.
+    /**
+     * time = O(31) = O(1)
+     * space = O(1)
+     */
+    public boolean hasAlternatingBits_2(int n) {
+        long x = 1L;   // "1"
+        while (x <= Integer.MAX_VALUE) {
+            if (x == n) {
+                return true;
+            }
+            // NOTE !!! append the bit OPPOSITE to the current lowest one
+            x = (x << 1) | (1L - (x & 1L));
+        }
+        return false;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BitwiseANDOfNumbersRange.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BitwiseANDOfNumbersRange.java
@@ -57,4 +57,23 @@ public class BitwiseANDOfNumbersRange {
         }
         return right;
     }
+
+
+    // V2
+    // IDEA: same "common prefix" observation as V0, but computed in O(1) with no
+    //       loop: the highest differing bit of left/right tells us how many low
+    //       bits get wiped out, so mask them off in one step.
+    /**
+     * time = O(1)
+     * space = O(1)
+     */
+    public int rangeBitwiseAnd_2(int left, int right) {
+        int diff = left ^ right;
+        if (diff == 0) {
+            return left;
+        }
+        // number of low bits that differ somewhere in the range
+        int shift = 32 - Integer.numberOfLeadingZeros(diff);
+        return left & (~0 << shift);
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BitwiseORsOfSubarrays.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BitwiseORsOfSubarrays.java
@@ -61,4 +61,67 @@ public class BitwiseORsOfSubarrays {
         }
         return res.size();
     }
+
+
+    // V1
+    // IDEA: brute force O(n^2) - OR every subarray explicitly.
+    //       Kept as a readable correctness reference (TLE on the real limits).
+    /**
+     * time = O(n^2)
+     * space = O(n^2) worst case for the result set (bounded by distinct ORs)
+     */
+    public int subarrayBitwiseORs_1(int[] arr) {
+        Set<Integer> res = new HashSet<>();
+        for (int i = 0; i < arr.length; i++) {
+            int cur = 0;
+            for (int j = i; j < arr.length; j++) {
+                cur |= arr[j];
+                res.add(cur);
+            }
+        }
+        return res.size();
+    }
+
+    // V2
+    // IDEA: "next set bit" jump table. Fixing a start i, the OR over [i, j] only
+    //       changes when some arr[j] contributes a bit the running OR lacks.
+    //       nxt[i][b] = first index >= i whose bit b is set, so from the current
+    //       OR we jump straight to the next index that changes it - at most 32
+    //       jumps per start, and no per-index set merging like V0.
+    /**
+     * time = O(32 * 32 * n)
+     * space = O(32 * n)
+     */
+    public int subarrayBitwiseORs_2(int[] arr) {
+        int n = arr.length;
+        final int B = 32;
+        int[][] nxt = new int[n + 1][B];
+        for (int b = 0; b < B; b++) {
+            nxt[n][b] = n;
+        }
+        for (int i = n - 1; i >= 0; i--) {
+            for (int b = 0; b < B; b++) {
+                nxt[i][b] = (((arr[i] >>> b) & 1) == 1) ? i : nxt[i + 1][b];
+            }
+        }
+
+        Set<Integer> res = new HashSet<>();
+        for (int i = 0; i < n; i++) {
+            int cur = 0;
+            int j = i;
+            while (j < n) {
+                cur |= arr[j];
+                res.add(cur);
+                // jump to the next index that actually adds a new bit
+                int j2 = n;
+                for (int b = 0; b < B; b++) {
+                    if (((cur >>> b) & 1) == 0) {
+                        j2 = Math.min(j2, nxt[j + 1][b]);
+                    }
+                }
+                j = j2;
+            }
+        }
+        return res.size();
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/FindTheDifference.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/FindTheDifference.java
@@ -65,4 +65,28 @@ public class FindTheDifference {
         }
         return (char) sum;
     }
+
+
+    // V2
+    // IDEA: counting array over the 26 lowercase letters - tally t, untally s,
+    //       the single leftover count marks the added letter
+    /**
+     * time = O(n)
+     * space = O(26) = O(1)
+     */
+    public char findTheDifference_2(String s, String t) {
+        int[] cnt = new int[26];
+        for (int i = 0; i < t.length(); i++) {
+            cnt[t.charAt(i) - 'a']++;
+        }
+        for (int i = 0; i < s.length(); i++) {
+            cnt[s.charAt(i) - 'a']--;
+        }
+        for (int i = 0; i < 26; i++) {
+            if (cnt[i] > 0) {
+                return (char) ('a' + i);
+            }
+        }
+        return ' '; // unreachable given the constraints
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/HammingDistance.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/HammingDistance.java
@@ -43,4 +43,37 @@ public class HammingDistance {
         }
         return cnt;
     }
+
+
+    // V1
+    // IDEA: compare the two numbers bit position by bit position (no XOR trick,
+    //       no popcount) - the literal reading of the definition
+    /**
+     * time = O(32) = O(1)
+     * space = O(1)
+     */
+    public int hammingDistance_1(int x, int y) {
+        int cnt = 0;
+        for (int i = 0; i < 32; i++) {
+            if (((x >>> i) & 1) != ((y >>> i) & 1)) {
+                cnt++;
+            }
+        }
+        return cnt;
+    }
+
+    // V2
+    // IDEA: branchless SWAR popcount of x ^ y - count bits pairwise, then in
+    //       nibbles, then in bytes, then sum the bytes with one multiply
+    /**
+     * time = O(1) (no loop at all)
+     * space = O(1)
+     */
+    public int hammingDistance_2(int x, int y) {
+        int z = x ^ y;
+        z = z - ((z >>> 1) & 0x55555555);
+        z = (z & 0x33333333) + ((z >>> 2) & 0x33333333);
+        z = (z + (z >>> 4)) & 0x0f0f0f0f;
+        return (z * 0x01010101) >>> 24;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/PrimeNumberOfSetBitsInBinaryRepresentation.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/PrimeNumberOfSetBitsInBinaryRepresentation.java
@@ -76,4 +76,40 @@ public class PrimeNumberOfSetBitsInBinaryRepresentation {
         }
         return res;
     }
+
+    // V2
+    // IDEA: no lookup table at all - count the set bits with Brian Kernighan's
+    //       trick (v &= v - 1 clears the lowest set bit), then decide primality
+    //       of that count by trial division
+    /**
+     * time = O(n * (popcount + sqrt(popcount)))
+     * space = O(1)
+     */
+    public int countPrimeSetBits_2(int left, int right) {
+        int res = 0;
+        for (int i = left; i <= right; i++) {
+            int bits = 0;
+            int v = i;
+            while (v != 0) {
+                v &= (v - 1);
+                bits++;
+            }
+            if (isPrime_2(bits)) {
+                res++;
+            }
+        }
+        return res;
+    }
+
+    private boolean isPrime_2(int x) {
+        if (x < 2) {
+            return false;
+        }
+        for (int d = 2; (long) d * d <= x; d++) {
+            if (x % d == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SetMismatch.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SetMismatch.java
@@ -83,4 +83,50 @@ public class SetMismatch {
         }
         return new int[] { dup, missing };
     }
+
+    // V2
+    // IDEA: XOR the array with 1..n -> dup ^ missing. The lowest set bit of that XOR
+    //       is a bit where the two differ, so bucket BOTH the array and 1..n by that
+    //       bit; each bucket XORs down to one candidate. A final scan says which of
+    //       the two candidates actually occurs in nums (that one is the duplicate).
+    /**
+     * time = O(n)
+     * space = O(1)
+     */
+    public int[] findErrorNums_2(int[] nums) {
+        int n = nums.length;
+        int xorAll = 0;
+        for (int num : nums) {
+            xorAll ^= num;
+        }
+        for (int v = 1; v <= n; v++) {
+            xorAll ^= v;
+        }
+
+        int diffBit = xorAll & (-xorAll);
+
+        int a = 0;
+        int b = 0;
+        for (int num : nums) {
+            if ((num & diffBit) != 0) {
+                a ^= num;
+            } else {
+                b ^= num;
+            }
+        }
+        for (int v = 1; v <= n; v++) {
+            if ((v & diffBit) != 0) {
+                a ^= v;
+            } else {
+                b ^= v;
+            }
+        }
+
+        for (int num : nums) {
+            if (num == a) {
+                return new int[] { a, b };
+            }
+        }
+        return new int[] { b, a };
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SingleNumber.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SingleNumber.java
@@ -1,5 +1,9 @@
 package LeetCodeJava.BitManipulation;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 // https://leetcode.com/problems/single-number/
 
 /**
@@ -44,5 +48,40 @@ public class SingleNumber {
             res ^= num;
         }
         return res;
+    }
+
+    // V1
+    // IDEA: hash set toggle - insert on first sight, delete on the second; the only
+    //       element left in the set is the unique one
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int singleNumber_1(int[] nums) {
+        Set<Integer> seen = new HashSet<>();
+        for (int num : nums) {
+            if (!seen.add(num)) {
+                seen.remove(num);
+            }
+        }
+        return seen.iterator().next();
+    }
+
+    // V2
+    // IDEA: sort first - the duplicated values then sit side by side, so walking in
+    //       steps of 2 finds the first index whose neighbour differs
+    /**
+     * time = O(n log n)
+     * space = O(n) for the defensive copy
+     */
+    public int singleNumber_2(int[] nums) {
+        int[] arr = nums.clone();
+        Arrays.sort(arr);
+        for (int i = 0; i + 1 < arr.length; i += 2) {
+            if (arr[i] != arr[i + 1]) {
+                return arr[i];
+            }
+        }
+        return arr[arr.length - 1];
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SingleNumberIII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SingleNumberIII.java
@@ -1,5 +1,9 @@
 package LeetCodeJava.BitManipulation;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 // https://leetcode.com/problems/single-number-iii/
 
 /**
@@ -59,5 +63,51 @@ public class SingleNumberIII {
             }
         }
         return new int[]{a, b};
+    }
+
+    // V1
+    // IDEA: hash set toggle - insert on first sight, delete on the second; the two
+    //       survivors in the set are the answer
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int[] singleNumber_1(int[] nums) {
+        Set<Integer> seen = new HashSet<>();
+        for (int num : nums) {
+            if (!seen.add(num)) {
+                seen.remove(num);
+            }
+        }
+        int[] res = new int[2];
+        int i = 0;
+        for (Integer v : seen) {
+            res[i++] = v;
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: sort first - equal values become adjacent, so scan and pick up every value
+    //       that is NOT followed by a copy of itself
+    /**
+     * time = O(n log n)
+     * space = O(n) for the defensive copy
+     */
+    public int[] singleNumber_2(int[] nums) {
+        int[] arr = nums.clone();
+        Arrays.sort(arr);
+        int[] res = new int[2];
+        int k = 0;
+        int i = 0;
+        while (i < arr.length) {
+            if (i + 1 < arr.length && arr[i] == arr[i + 1]) {
+                i += 2;
+            } else {
+                res[k++] = arr[i];
+                i++;
+            }
+        }
+        return res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/TotalHammingDistance.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/TotalHammingDistance.java
@@ -1,5 +1,10 @@
 package LeetCodeJava.BitManipulation;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 // https://leetcode.com/problems/total-hamming-distance/
 
 /**
@@ -48,5 +53,47 @@ public class TotalHammingDistance {
             res += ones * (n - ones);
         }
         return res;
+    }
+
+    // V1
+    // IDEA: brute force O(n^2) - kept as a readable correctness reference: sum
+    //       popcount(a ^ b) over every unordered pair
+    /**
+     * time = O(n^2)
+     * space = O(1)
+     */
+    public int totalHammingDistance_1(int[] nums) {
+        int res = 0;
+        for (int i = 0; i < nums.length; i++) {
+            for (int j = i + 1; j < nums.length; j++) {
+                res += Integer.bitCount(nums[i] ^ nums[j]);
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: collapse duplicates with a HashMap<value, count>. Equal values contribute 0,
+    //       so only pairs of DISTINCT values matter, each weighted by cnt[a] * cnt[b].
+    //       Much cheaper than V1 when the array has few distinct values.
+    /**
+     * time = O(n + d^2) with d = number of distinct values
+     * space = O(d)
+     */
+    public int totalHammingDistance_2(int[] nums) {
+        Map<Integer, Integer> freq = new HashMap<>();
+        for (int num : nums) {
+            freq.put(num, freq.getOrDefault(num, 0) + 1);
+        }
+        List<Integer> vals = new ArrayList<>(freq.keySet());
+        long res = 0;
+        for (int i = 0; i < vals.size(); i++) {
+            for (int j = i + 1; j < vals.size(); j++) {
+                int a = vals.get(i);
+                int b = vals.get(j);
+                res += (long) Integer.bitCount(a ^ b) * freq.get(a) * freq.get(b);
+            }
+        }
+        return (int) res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/UTF8Validation.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/BitManipulation/UTF8Validation.java
@@ -75,4 +75,84 @@ public class UTF8Validation {
         }
         return true;
     }
+
+    // V1
+    // IDEA: single pass state machine - carry a counter of how many continuation bytes
+    //       are still expected. A leading byte is only legal when that counter is 0,
+    //       and the stream is valid only if the counter ends at 0.
+    /**
+     * time = O(n)
+     * space = O(1)
+     */
+    public boolean validUtf8_1(int[] data) {
+        int remaining = 0;
+        for (int d : data) {
+            int b = d & 0xFF;
+            if (remaining == 0) {
+                if ((b & 0b10000000) == 0) {
+                    remaining = 0;
+                } else if ((b & 0b11100000) == 0b11000000) {
+                    remaining = 1;
+                } else if ((b & 0b11110000) == 0b11100000) {
+                    remaining = 2;
+                } else if ((b & 0b11111000) == 0b11110000) {
+                    remaining = 3;
+                } else {
+                    return false;
+                }
+            } else {
+                if ((b & 0b11000000) != 0b10000000) {
+                    return false;
+                }
+                remaining--;
+            }
+        }
+        return remaining == 0;
+    }
+
+    // V2
+    // IDEA: readable reference - render each byte as a zero padded 8 char binary string
+    //       and validate the spec with plain string prefix checks instead of bit masks
+    /**
+     * time = O(n)
+     * space = O(1) (8 char scratch string per byte)
+     */
+    public boolean validUtf8_2(int[] data) {
+        int i = 0;
+        int n = data.length;
+        while (i < n) {
+            String s = toBinary_2(data[i]);
+            int cnt;
+            if (s.startsWith("0")) {
+                cnt = 0;
+            } else if (s.startsWith("110")) {
+                cnt = 1;
+            } else if (s.startsWith("1110")) {
+                cnt = 2;
+            } else if (s.startsWith("11110")) {
+                cnt = 3;
+            } else {
+                return false;
+            }
+            if (i + cnt >= n) {
+                return false;
+            }
+            for (int j = i + 1; j <= i + cnt; j++) {
+                if (!toBinary_2(data[j]).startsWith("10")) {
+                    return false;
+                }
+            }
+            i += cnt + 1;
+        }
+        return true;
+    }
+
+    private String toBinary_2(int x) {
+        String s = Integer.toBinaryString(x & 0xFF);
+        StringBuilder sb = new StringBuilder();
+        for (int k = s.length(); k < 8; k++) {
+            sb.append('0');
+        }
+        return sb.append(s).toString();
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DFS/FindLargestValueInEachTreeRow.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DFS/FindLargestValueInEachTreeRow.java
@@ -85,4 +85,40 @@ public class FindLargestValueInEachTreeRow {
         dfs(node.left, depth + 1, res);
         dfs(node.right, depth + 1, res);
     }
+
+    // V2
+    // IDEA: ITERATIVE pre-order DFS with an explicit (node, depth) stack - no recursion,
+    //       so an extremely skewed tree can not blow the JVM call stack
+    /**
+     * time = O(n)
+     * space = O(h)
+     */
+    public List<Integer> largestValues_2(TreeNode root) {
+        List<Integer> res = new ArrayList<>();
+        if (root == null) {
+            return res;
+        }
+        Deque<TreeNode> nodeStack = new ArrayDeque<>();
+        Deque<Integer> depthStack = new ArrayDeque<>();
+        nodeStack.push(root);
+        depthStack.push(0);
+        while (!nodeStack.isEmpty()) {
+            TreeNode node = nodeStack.pop();
+            int depth = depthStack.pop();
+            if (depth == res.size()) {
+                res.add(node.val);
+            } else {
+                res.set(depth, Math.max(res.get(depth), node.val));
+            }
+            if (node.left != null) {
+                nodeStack.push(node.left);
+                depthStack.push(depth + 1);
+            }
+            if (node.right != null) {
+                nodeStack.push(node.right);
+                depthStack.push(depth + 1);
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DFS/FindLeavesOfBinaryTree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DFS/FindLeavesOfBinaryTree.java
@@ -4,8 +4,12 @@ package LeetCodeJava.DFS;
 
 import LeetCodeJava.DataStructure.TreeNode;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  *  366. Find Leaves of Binary Tree
@@ -58,5 +62,105 @@ public class FindLeavesOfBinaryTree {
         }
         res.get(height - 1).add(node.val);
         return height;
+    }
+
+    // V1
+    // IDEA: brute force simulation - literally do what the statement says: strip every leaf,
+    //       repeat on what is left. Kept as a readable correctness reference. The tree is
+    //       cloned first so the caller's tree is not destroyed.
+    /**
+     * time = O(n * h)   // one full pass per removed layer
+     * space = O(n)
+     */
+    public List<List<Integer>> findLeaves_1(TreeNode root) {
+        List<List<Integer>> res = new ArrayList<>();
+        TreeNode cur = cloneTree_1(root);
+        while (cur != null) {
+            List<Integer> level = new ArrayList<>();
+            cur = prune_1(cur, level);
+            res.add(level);
+        }
+        return res;
+    }
+
+    private TreeNode cloneTree_1(TreeNode node) {
+        if (node == null) {
+            return null;
+        }
+        return new TreeNode(node.val, cloneTree_1(node.left), cloneTree_1(node.right));
+    }
+
+    // removes every current leaf, returns the remaining subtree (null if it vanished)
+    private TreeNode prune_1(TreeNode node, List<Integer> collected) {
+        if (node == null) {
+            return null;
+        }
+        if (node.left == null && node.right == null) {
+            collected.add(node.val);
+            return null;
+        }
+        node.left = prune_1(node.left, collected);
+        node.right = prune_1(node.right, collected);
+        return node;
+    }
+
+    // V2
+    // IDEA: KAHN style peeling (topological, bottom-up) - build parent pointers + a
+    //       "children still attached" counter, start from the leaf frontier and release a
+    //       parent only once all of its children have been peeled. No recursion at all.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public List<List<Integer>> findLeaves_2(TreeNode root) {
+        List<List<Integer>> res = new ArrayList<>();
+        if (root == null) {
+            return res;
+        }
+
+        Map<TreeNode, TreeNode> parent = new HashMap<>();
+        Map<TreeNode, Integer> remainingChildren = new HashMap<>();
+        List<TreeNode> frontier = new ArrayList<>();
+
+        Deque<TreeNode> stack = new ArrayDeque<>();
+        stack.push(root);
+        parent.put(root, null);
+        while (!stack.isEmpty()) {
+            TreeNode cur = stack.pop();
+            int cnt = 0;
+            if (cur.left != null) {
+                cnt++;
+                parent.put(cur.left, cur);
+                stack.push(cur.left);
+            }
+            if (cur.right != null) {
+                cnt++;
+                parent.put(cur.right, cur);
+                stack.push(cur.right);
+            }
+            remainingChildren.put(cur, cnt);
+            if (cnt == 0) {
+                frontier.add(cur);
+            }
+        }
+
+        while (!frontier.isEmpty()) {
+            List<Integer> level = new ArrayList<>();
+            List<TreeNode> next = new ArrayList<>();
+            for (TreeNode node : frontier) {
+                level.add(node.val);
+                TreeNode p = parent.get(node);
+                if (p != null) {
+                    int left = remainingChildren.get(p) - 1;
+                    remainingChildren.put(p, left);
+                    if (left == 0) {
+                        next.add(p);
+                    }
+                }
+            }
+            res.add(level);
+            frontier = next;
+        }
+        return res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DFS/FinishTimeOfTasksI.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DFS/FinishTimeOfTasksI.java
@@ -3,7 +3,10 @@ package LeetCodeJava.DFS;
 // https://leetcode.com/problems/finish-time-of-tasks-i/
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
+import java.util.List;
 
 /**
  *  3965. Finish Time of Tasks I
@@ -98,6 +101,93 @@ public class FinishTimeOfTasksI {
 
             long ownDuration = (latest - earliest) + baseTime[cur];
             finish[cur] = latest + ownDuration;
+        }
+
+        return finish[0];
+    }
+
+    // V1
+    // IDEA: plain RECURSIVE post-order over adjacency lists - the direct transcription of the
+    //       definition, kept as the readable reference. NOTE: on a 1e5-long chain this can
+    //       overflow the JVM stack, which is exactly why V0 is iterative.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public long finishTime_1(int n, int[][] edges, int[] baseTime) {
+        List<List<Integer>> children = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            children.add(new ArrayList<Integer>());
+        }
+        for (int[] e : edges) {
+            children.get(e[0]).add(e[1]);
+        }
+        return dfs_1(0, children, baseTime);
+    }
+
+    private long dfs_1(int cur, List<List<Integer>> children, int[] baseTime) {
+        List<Integer> kids = children.get(cur);
+        if (kids.isEmpty()) {
+            return baseTime[cur];
+        }
+        long earliest = Long.MAX_VALUE;
+        long latest = Long.MIN_VALUE;
+        for (Integer c : kids) {
+            long val = dfs_1(c, children, baseTime);
+            earliest = Math.min(earliest, val);
+            latest = Math.max(latest, val);
+        }
+        long ownDuration = (latest - earliest) + baseTime[cur];
+        return latest + ownDuration;
+    }
+
+    // V2
+    // IDEA: KAHN style bottom-up BFS - no traversal order is materialised at all. Keep a
+    //       "children not finished yet" counter plus a running min/max of the children's
+    //       finish times; a node is resolved the moment its counter drops to 0.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public long finishTime_2(int n, int[][] edges, int[] baseTime) {
+        int[] childCount = new int[n];
+        int[] parent = new int[n];
+        Arrays.fill(parent, -1);
+        for (int[] e : edges) {
+            childCount[e[0]]++;
+            parent[e[1]] = e[0];
+        }
+
+        int[] remaining = childCount.clone();
+        long[] minChild = new long[n];
+        long[] maxChild = new long[n];
+        Arrays.fill(minChild, Long.MAX_VALUE);
+        Arrays.fill(maxChild, Long.MIN_VALUE);
+        long[] finish = new long[n];
+
+        Deque<Integer> queue = new ArrayDeque<>();
+        for (int i = 0; i < n; i++) {
+            if (childCount[i] == 0) {
+                queue.offer(i);
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+            if (childCount[cur] == 0) {
+                finish[cur] = baseTime[cur];
+            } else {
+                long ownDuration = (maxChild[cur] - minChild[cur]) + baseTime[cur];
+                finish[cur] = maxChild[cur] + ownDuration;
+            }
+            int p = parent[cur];
+            if (p != -1) {
+                minChild[p] = Math.min(minChild[p], finish[cur]);
+                maxChild[p] = Math.max(maxChild[p], finish[cur]);
+                if (--remaining[p] == 0) {
+                    queue.offer(p);
+                }
+            }
         }
 
         return finish[0];

--- a/leetcode_java/src/main/java/LeetCodeJava/DFS/IncreasingSubsequences.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DFS/IncreasingSubsequences.java
@@ -92,4 +92,41 @@ public class IncreasingSubsequences {
             path.remove(path.size() - 1);
         }
     }
+
+    // V2
+    // IDEA: BITMASK enumeration - n <= 15, so just walk all 2^n subsets, keep the ones that
+    //       are non-decreasing and have >= 2 elements, dedup with a HashSet. No recursion.
+    /**
+     * time = O(2^n * n)
+     * space = O(2^n * n)
+     */
+    public List<List<Integer>> findSubsequences_2(int[] nums) {
+        List<List<Integer>> res = new ArrayList<>();
+        if (nums == null || nums.length < 2) {
+            return res;
+        }
+        int n = nums.length;
+        Set<List<Integer>> seen = new HashSet<>();
+        for (int mask = 0; mask < (1 << n); mask++) {
+            if (Integer.bitCount(mask) < 2) {
+                continue;
+            }
+            List<Integer> cand = new ArrayList<>();
+            boolean nonDecreasing = true;
+            for (int i = 0; i < n; i++) {
+                if ((mask & (1 << i)) == 0) {
+                    continue;
+                }
+                if (!cand.isEmpty() && nums[i] < cand.get(cand.size() - 1)) {
+                    nonDecreasing = false;
+                    break;
+                }
+                cand.add(nums[i]);
+            }
+            if (nonDecreasing && seen.add(cand)) {
+                res.add(cand);
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DFS/ShoppingOffers.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DFS/ShoppingOffers.java
@@ -92,4 +92,101 @@ public class ShoppingOffers {
         memo.put(key, best);
         return best;
     }
+
+    // V1
+    // IDEA: BOTTOM-UP DP over the WHOLE `needs` state space, mixed-radix encoded.
+    //       Every state (n0, n1, ..., nk) is packed into a single int index; a state is
+    //       relaxed only from strictly smaller states, so a plain increasing sweep works
+    //       and no recursion / memo map is needed.
+    /**
+     * time = O(m * n * S), S = product of (needs[i] + 1), m = #offers
+     * space = O(S)
+     */
+    public int shoppingOffers_1(List<Integer> price, List<List<Integer>> special, List<Integer> needs) {
+
+        int n = needs.size();
+        int[] radix = new int[n];  // needs[i] + 1 possible counts for item i
+        int[] weight = new int[n]; // positional weight of item i in the encoding
+        int total = 1;
+        for (int i = 0; i < n; i++) {
+            radix[i] = needs.get(i) + 1;
+            weight[i] = total;
+            total *= radix[i];
+        }
+
+        int[] dp = new int[total];
+        int[] cur = new int[n];
+
+        for (int state = 0; state < total; state++) {
+            // decode the state + compute the "no offer" baseline
+            int rest = state;
+            int best = 0;
+            for (int i = 0; i < n; i++) {
+                cur[i] = rest % radix[i];
+                rest /= radix[i];
+                best += cur[i] * price.get(i);
+            }
+
+            for (List<Integer> offer : special) {
+                boolean valid = true;
+                int taken = 0;
+                int prev = state;
+                for (int i = 0; i < n; i++) {
+                    int cnt = offer.get(i);
+                    if (cnt > cur[i]) {
+                        valid = false;
+                        break;
+                    }
+                    taken += cnt;
+                    prev -= cnt * weight[i];
+                }
+                // NOTE: an offer that takes nothing would point back at the same state
+                if (valid && taken > 0) {
+                    best = Math.min(best, offer.get(offer.size() - 1) + dp[prev]);
+                }
+            }
+            dp[state] = best;
+        }
+
+        return dp[total - 1];
+    }
+
+    // V2
+    // IDEA: brute force DFS with NO memoization - kept as a readable correctness reference.
+    //       At each state, either pay the unit price for everything left, or apply one
+    //       affordable offer and recurse on the leftover needs. Exponential, small inputs only.
+    /**
+     * time = O(m^(sum of needs))  // exponential, no state reuse
+     * space = O(sum of needs)     // recursion depth
+     */
+    public int shoppingOffers_2(List<Integer> price, List<List<Integer>> special, List<Integer> needs) {
+        return dfs_2(price, special, needs);
+    }
+
+    private int dfs_2(List<Integer> price, List<List<Integer>> special, List<Integer> needs) {
+        int best = 0;
+        for (int i = 0; i < needs.size(); i++) {
+            best += price.get(i) * needs.get(i);
+        }
+
+        for (List<Integer> offer : special) {
+            List<Integer> remain = new ArrayList<>();
+            boolean valid = true;
+            int taken = 0;
+            for (int j = 0; j < needs.size(); j++) {
+                int left = needs.get(j) - offer.get(j);
+                if (left < 0) {
+                    valid = false;
+                    break;
+                }
+                taken += offer.get(j);
+                remain.add(left);
+            }
+            if (valid && taken > 0) {
+                best = Math.min(best, offer.get(offer.size() - 1) + dfs_2(price, special, remain));
+            }
+        }
+
+        return best;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DFS/WeightedSumOfATree.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DFS/WeightedSumOfATree.java
@@ -2,6 +2,11 @@ package LeetCodeJava.DFS;
 
 // https://leetcode.com/problems/weighted-sum-of-a-tree/
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
 /**
  *  4015. Weighted Sum of a Tree
  *  Medium
@@ -81,6 +86,78 @@ public class WeightedSumOfATree {
             res += (long) nums[i] * (height - depth[i] + 1);
         }
 
+        return res;
+    }
+
+    // V1
+    // IDEA: BFS LEVEL ORDER on an explicit children adjacency list rebuilt from `parent`.
+    //       Depth comes from the BFS level, height is the deepest level reached.
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public long weightedSum_1(int[] parent, int[] nums) {
+
+        int n = parent.length;
+        List<List<Integer>> children = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            children.add(new ArrayList<>());
+        }
+        for (int i = 1; i < n; i++) {
+            children.get(parent[i]).add(i);
+        }
+
+        int[] depth = new int[n];
+        depth[0] = 1;
+        int height = 1;
+
+        Deque<Integer> q = new ArrayDeque<>();
+        q.add(0);
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            height = Math.max(height, depth[cur]);
+            for (Integer child : children.get(cur)) {
+                depth[child] = depth[cur] + 1;
+                q.add(child);
+            }
+        }
+
+        long res = 0L;
+        for (int i = 0; i < n; i++) {
+            res += (long) nums[i] * (height - depth[i] + 1);
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n * h) - kept as a readable correctness reference.
+    //       For every node, walk the parent chain all the way up to the root and count the
+    //       steps. No caching at all, so a long chain re-walks the same ancestors.
+    /**
+     * time = O(n * h), h = tree height (O(n^2) on a path-shaped tree)
+     * space = O(n)
+     */
+    public long weightedSum_2(int[] parent, int[] nums) {
+
+        int n = parent.length;
+        int[] depth = new int[n];
+        int height = 0;
+
+        for (int i = 0; i < n; i++) {
+            int d = 1;
+            int cur = i;
+            while (parent[cur] != -1) {
+                cur = parent[cur];
+                d++;
+            }
+            depth[i] = d;
+            height = Math.max(height, d);
+        }
+
+        long res = 0L;
+        for (int i = 0; i < n; i++) {
+            res += (long) nums[i] * (height - depth[i] + 1);
+        }
         return res;
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumDifficultyOfAJobSchedule.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumDifficultyOfAJobSchedule.java
@@ -103,4 +103,52 @@ public class MinimumDifficultyOfAJobSchedule {
         memo[i][days] = res;
         return res;
     }
+
+    // V2
+    // IDEA: MONOTONIC STACK DP - O(n * d) instead of O(n^2 * d).
+    //       dp[i] = min difficulty of splitting jobs[0..i] into k days; when moving to a
+    //       new day, a decreasing stack lets us discard dominated split points, so each
+    //       index is pushed / popped once per day.
+    /**
+     * time = O(n * d)
+     * space = O(n)
+     */
+    public int minDifficulty_2(int[] jobDifficulty, int d) {
+        int n = jobDifficulty.length;
+        if (n < d) {
+            return -1;
+        }
+        final int INF = Integer.MAX_VALUE / 2;
+
+        // k = 1 day -> prefix max
+        int[] dp = new int[n];
+        int mx = 0;
+        for (int i = 0; i < n; i++) {
+            mx = Math.max(mx, jobDifficulty[i]);
+            dp[i] = mx;
+        }
+
+        int[] stack = new int[n]; // indices, jobDifficulty strictly decreasing
+        for (int k = 2; k <= d; k++) {
+            int[] ndp = new int[n];
+            Arrays.fill(ndp, INF);
+            int top = -1;
+            for (int i = k - 1; i < n; i++) {
+                // the last day holds only job i
+                ndp[i] = dp[i - 1] + jobDifficulty[i];
+                while (top >= 0 && jobDifficulty[stack[top]] <= jobDifficulty[i]) {
+                    int j = stack[top--];
+                    // job i becomes the max of the last day that used to end at j
+                    ndp[i] = Math.min(ndp[i], ndp[j] - jobDifficulty[j] + jobDifficulty[i]);
+                }
+                if (top >= 0) {
+                    // a bigger job is still the max of the last day -> nothing changes
+                    ndp[i] = Math.min(ndp[i], ndp[stack[top]]);
+                }
+                stack[++top] = i;
+            }
+            dp = ndp;
+        }
+        return dp[n - 1];
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumInsertionStepsToMakeAStringPalindrome.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumInsertionStepsToMakeAStringPalindrome.java
@@ -82,4 +82,36 @@ public class MinimumInsertionStepsToMakeAStringPalindrome {
         }
         return n - prev[n];
     }
+
+    // V2
+    // IDEA: TOP-DOWN MEMOIZATION over the interval (i, j) - the recursive twin of V0
+    /**
+     * time = O(n^2)
+     * space = O(n^2)
+     */
+    public int minInsertions_2(String s) {
+        int n = s.length();
+        if (n <= 1) {
+            return 0;
+        }
+        Integer[][] memo = new Integer[n][n];
+        return helper_2(s, 0, n - 1, memo);
+    }
+
+    private int helper_2(String s, int i, int j, Integer[][] memo) {
+        if (i >= j) {
+            return 0;
+        }
+        if (memo[i][j] != null) {
+            return memo[i][j];
+        }
+        int res;
+        if (s.charAt(i) == s.charAt(j)) {
+            res = helper_2(s, i + 1, j - 1, memo);
+        } else {
+            res = 1 + Math.min(helper_2(s, i + 1, j, memo), helper_2(s, i, j - 1, memo));
+        }
+        memo[i][j] = res;
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/NumberOfCornerRectangles.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/NumberOfCornerRectangles.java
@@ -95,4 +95,41 @@ public class NumberOfCornerRectangles {
         }
         return res;
     }
+
+    // V2
+    // IDEA: BITSET - pack every row into a long[] bitmap, then AND each row pair and
+    //       popcount the overlap, so the inner column scan runs 64 columns at a time
+    /**
+     * time = O(M^2 * N / 64)
+     * space = O(M * N / 64)
+     */
+    public int countCornerRectangles_2(int[][] grid) {
+        if (grid == null || grid.length == 0 || grid[0].length == 0) {
+            return 0;
+        }
+        int m = grid.length;
+        int n = grid[0].length;
+        int words = (n + 63) / 64;
+
+        long[][] bits = new long[m][words];
+        for (int r = 0; r < m; r++) {
+            for (int c = 0; c < n; c++) {
+                if (grid[r][c] == 1) {
+                    bits[r][c >> 6] |= 1L << (c & 63);
+                }
+            }
+        }
+
+        int res = 0;
+        for (int r1 = 0; r1 < m; r1++) {
+            for (int r2 = r1 + 1; r2 < m; r2++) {
+                int cnt = 0;
+                for (int w = 0; w < words; w++) {
+                    cnt += Long.bitCount(bits[r1][w] & bits[r2][w]);
+                }
+                res += cnt * (cnt - 1) / 2;
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/NumberOfLongestIncreasingSubsequence.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/NumberOfLongestIncreasingSubsequence.java
@@ -68,4 +68,139 @@ public class NumberOfLongestIncreasingSubsequence {
         }
         return res;
     }
+
+    // V1
+    // IDEA: FENWICK (BIT) over compressed values, every node keeping (bestLen, ways).
+    //       A prefix query gives the best LIS among strictly smaller values in O(log N).
+    /**
+     * time = O(N log N)
+     * space = O(N)
+     */
+    public int findNumberOfLIS_1(int[] nums) {
+        if (nums == null || nums.length == 0) {
+            return 0;
+        }
+        int n = nums.length;
+
+        // coordinate compression
+        int[] sorted = nums.clone();
+        Arrays.sort(sorted);
+        int sz = 0;
+        for (int i = 0; i < n; i++) {
+            if (i == 0 || sorted[i] != sorted[i - 1]) {
+                sorted[sz++] = sorted[i];
+            }
+        }
+
+        int[] treeLen = new int[sz + 1];
+        int[] treeCnt = new int[sz + 1];
+
+        int bestLen = 0;
+        int bestCnt = 0;
+        for (int x : nums) {
+            int pos = lowerBound_1(sorted, sz, x) + 1; // 1-indexed rank
+            int[] q = query_1(treeLen, treeCnt, pos - 1); // strictly smaller values only
+            int curLen = q[0] + 1;
+            int curCnt = (q[0] == 0) ? 1 : q[1];
+            update_1(treeLen, treeCnt, sz, pos, curLen, curCnt);
+
+            if (curLen > bestLen) {
+                bestLen = curLen;
+                bestCnt = curCnt;
+            } else if (curLen == bestLen) {
+                bestCnt += curCnt;
+            }
+        }
+        return bestCnt;
+    }
+
+    private int lowerBound_1(int[] arr, int sz, int target) {
+        int lo = 0;
+        int hi = sz;
+        while (lo < hi) {
+            int mid = (lo + hi) >>> 1;
+            if (arr[mid] < target) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+
+    private void update_1(int[] treeLen, int[] treeCnt, int sz, int pos, int len, int cnt) {
+        for (int i = pos; i <= sz; i += i & (-i)) {
+            if (treeLen[i] < len) {
+                treeLen[i] = len;
+                treeCnt[i] = cnt;
+            } else if (treeLen[i] == len) {
+                treeCnt[i] += cnt;
+            }
+        }
+    }
+
+    private int[] query_1(int[] treeLen, int[] treeCnt, int pos) {
+        int len = 0;
+        int cnt = 0;
+        for (int i = pos; i > 0; i -= i & (-i)) {
+            if (treeLen[i] > len) {
+                len = treeLen[i];
+                cnt = treeCnt[i];
+            } else if (treeLen[i] == len && len > 0) {
+                cnt += treeCnt[i];
+            }
+        }
+        return new int[] { len, cnt };
+    }
+
+    // V2
+    // IDEA: TOP-DOWN MEMOIZATION - solve(i) returns the LIS length ending at i and
+    //       caches, alongside it, how many such subsequences exist
+    /**
+     * time = O(N^2)
+     * space = O(N)
+     */
+    public int findNumberOfLIS_2(int[] nums) {
+        if (nums == null || nums.length == 0) {
+            return 0;
+        }
+        int n = nums.length;
+        int[] memoLen = new int[n];
+        int[] memoCnt = new int[n];
+
+        int best = 0;
+        for (int i = 0; i < n; i++) {
+            best = Math.max(best, solve_2(nums, i, memoLen, memoCnt));
+        }
+
+        int res = 0;
+        for (int i = 0; i < n; i++) {
+            if (memoLen[i] == best) {
+                res += memoCnt[i];
+            }
+        }
+        return res;
+    }
+
+    private int solve_2(int[] nums, int i, int[] memoLen, int[] memoCnt) {
+        if (memoLen[i] != 0) {
+            return memoLen[i];
+        }
+        int len = 1;
+        int cnt = 1;
+        for (int j = 0; j < i; j++) {
+            if (nums[j] < nums[i]) {
+                int sub = solve_2(nums, j, memoLen, memoCnt);
+                if (sub + 1 > len) {
+                    len = sub + 1;
+                    cnt = memoCnt[j];
+                } else if (sub + 1 == len) {
+                    cnt += memoCnt[j];
+                }
+            }
+        }
+        memoLen[i] = len;
+        memoCnt[i] = cnt;
+        return len;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/OnesAndZeroes.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/OnesAndZeroes.java
@@ -65,4 +65,74 @@ public class OnesAndZeroes {
         }
         return dp[m][n];
     }
+
+    // V1
+    // IDEA: TOP-DOWN MEMOIZATION - dfs(idx, zerosLeft, onesLeft) = best subset size
+    //       reachable from string idx onward (take / skip)
+    /**
+     * time = O(s * m * n)
+     * space = O(s * m * n)
+     */
+    public int findMaxForm_1(String[] strs, int m, int n) {
+        int s = strs.length;
+        int[][] cost = countZerosOnes(strs);
+        Integer[][][] memo = new Integer[Math.max(s, 1)][m + 1][n + 1];
+        return dfs_1(cost, 0, m, n, memo);
+    }
+
+    private int dfs_1(int[][] cost, int idx, int zeros, int ones, Integer[][][] memo) {
+        if (idx == cost.length) {
+            return 0;
+        }
+        if (memo[idx][zeros][ones] != null) {
+            return memo[idx][zeros][ones];
+        }
+        // skip
+        int res = dfs_1(cost, idx + 1, zeros, ones, memo);
+        // take
+        if (cost[idx][0] <= zeros && cost[idx][1] <= ones) {
+            res = Math.max(res,
+                    1 + dfs_1(cost, idx + 1, zeros - cost[idx][0], ones - cost[idx][1], memo));
+        }
+        memo[idx][zeros][ones] = res;
+        return res;
+    }
+
+    // V2
+    // IDEA: EXPLICIT 3D TABULATION over the item index - the un-rolled textbook
+    //       knapsack table that V0 compresses into 2 dimensions
+    /**
+     * time = O(s * m * n)
+     * space = O(s * m * n)
+     */
+    public int findMaxForm_2(String[] strs, int m, int n) {
+        int s = strs.length;
+        int[][] cost = countZerosOnes(strs);
+        int[][][] dp = new int[s + 1][m + 1][n + 1];
+
+        for (int i = 1; i <= s; i++) {
+            int zeros = cost[i - 1][0];
+            int ones = cost[i - 1][1];
+            for (int j = 0; j <= m; j++) {
+                for (int k = 0; k <= n; k++) {
+                    dp[i][j][k] = dp[i - 1][j][k]; // skip
+                    if (j >= zeros && k >= ones) {
+                        dp[i][j][k] = Math.max(dp[i][j][k], dp[i - 1][j - zeros][k - ones] + 1);
+                    }
+                }
+            }
+        }
+        return dp[s][m][n];
+    }
+
+    // shared by V1 / V2 : cost[i] = { #zeros, #ones } of strs[i]
+    private int[][] countZerosOnes(String[] strs) {
+        int[][] cost = new int[strs.length][2];
+        for (int i = 0; i < strs.length; i++) {
+            for (int k = 0; k < strs[i].length(); k++) {
+                cost[i][strs[i].charAt(k) == '0' ? 0 : 1]++;
+            }
+        }
+        return cost;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/OutOfBoundaryPaths.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/OutOfBoundaryPaths.java
@@ -98,4 +98,42 @@ public class OutOfBoundaryPaths {
         memo[moveLeft][x][y] = (int) (res % MOD);
         return memo[moveLeft][x][y];
     }
+
+    // V2
+    // IDEA: FORWARD PROPAGATION - instead of asking "how many ways out from every cell"
+    //       (V0 / V1), push the ball's ways FORWARD from the start cell one move at a
+    //       time; every step that leaves the grid is harvested into the answer directly
+    /**
+     * time = O(maxMove * m * n)
+     * space = O(m * n)
+     */
+    public int findPaths_2(int m, int n, int maxMove, int startRow, int startColumn) {
+        long res = 0;
+        long[][] cur = new long[m][n];
+        cur[startRow][startColumn] = 1;
+        int[][] dirs = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };
+
+        for (int s = 0; s < maxMove; s++) {
+            long[][] nxt = new long[m][n];
+            for (int x = 0; x < m; x++) {
+                for (int y = 0; y < n; y++) {
+                    long ways = cur[x][y];
+                    if (ways == 0) {
+                        continue;
+                    }
+                    for (int[] dir : dirs) {
+                        int nx = x + dir[0];
+                        int ny = y + dir[1];
+                        if (nx < 0 || nx >= m || ny < 0 || ny >= n) {
+                            res = (res + ways) % MOD;
+                        } else {
+                            nxt[nx][ny] = (nxt[nx][ny] + ways) % MOD;
+                        }
+                    }
+                }
+            }
+            cur = nxt;
+        }
+        return (int) res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/PaintFence.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/PaintFence.java
@@ -63,4 +63,86 @@ public class PaintFence {
         }
         return (int) (same + diff);
     }
+
+    // V1
+    // IDEA: TOP-DOWN MEMOIZATION on the merged recurrence
+    //       f(n) = (k-1) * (f(n-1) + f(n-2))
+    //       (post n differs from post n-1  ->  f(n-1) choices;
+    //        post n equals post n-1, which then had to differ from n-2 -> f(n-2) choices)
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int numWays_1(int n, int k) {
+        if (n == 0 || k == 0) {
+            return 0;
+        }
+        long[] memo = new long[n + 1];
+        Arrays.fill(memo, -1);
+        return (int) helper_1(n, k, memo);
+    }
+
+    private long helper_1(int n, int k, long[] memo) {
+        if (n == 1) {
+            return k;
+        }
+        if (n == 2) {
+            return (long) k * k;
+        }
+        if (memo[n] >= 0) {
+            return memo[n];
+        }
+        memo[n] = (long) (k - 1) * (helper_1(n - 1, k, memo) + helper_1(n - 2, k, memo));
+        return memo[n];
+    }
+
+    // V2
+    // IDEA: MATRIX EXPONENTIATION of the same linear recurrence
+    //       [f(n), f(n-1)]^T = [[k-1, k-1], [1, 0]]^(n-2) * [f(2), f(1)]^T
+    //       -> O(log n) instead of O(n)
+    /**
+     * time = O(log n)
+     * space = O(1)
+     */
+    public int numWays_2(int n, int k) {
+        if (n == 0 || k == 0) {
+            return 0;
+        }
+        if (n == 1) {
+            return k;
+        }
+        if (n == 2) {
+            return (int) ((long) k * k);
+        }
+        long[][] pow = matPow_2(new long[][] { { k - 1, k - 1 }, { 1, 0 } }, n - 2);
+        long f2 = (long) k * k;
+        long f1 = k;
+        return (int) (pow[0][0] * f2 + pow[0][1] * f1);
+    }
+
+    private long[][] matPow_2(long[][] m, int p) {
+        long[][] res = { { 1, 0 }, { 0, 1 } };
+        while (p > 0) {
+            if ((p & 1) == 1) {
+                res = matMul_2(res, m);
+            }
+            m = matMul_2(m, m);
+            p >>= 1;
+        }
+        return res;
+    }
+
+    private long[][] matMul_2(long[][] a, long[][] b) {
+        long[][] c = new long[2][2];
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < 2; j++) {
+                long v = 0;
+                for (int t = 0; t < 2; t++) {
+                    v += a[i][t] * b[t][j];
+                }
+                c[i][j] = v;
+            }
+        }
+        return c;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/PushDominoes.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/PushDominoes.java
@@ -131,4 +131,42 @@ public class PushDominoes {
         }
         return sb.toString();
     }
+
+    // V2
+    // IDEA: brute force simultaneous simulation - one "second" per round, applying the
+    //       physics literally until nothing changes; kept as a readable correctness
+    //       reference (O(N^2) worst case)
+    /**
+     * time = O(N^2)
+     * space = O(N)
+     */
+    public String pushDominoes_2(String dominoes) {
+        char[] cur = dominoes.toCharArray();
+        int n = cur.length;
+
+        while (true) {
+            char[] next = cur.clone();
+            boolean changed = false;
+            for (int i = 0; i < n; i++) {
+                if (cur[i] != '.') {
+                    continue;
+                }
+                boolean pushedRight = (i > 0) && cur[i - 1] == 'R';
+                boolean pushedLeft = (i < n - 1) && cur[i + 1] == 'L';
+                if (pushedRight && !pushedLeft) {
+                    next[i] = 'R';
+                    changed = true;
+                } else if (pushedLeft && !pushedRight) {
+                    next[i] = 'L';
+                    changed = true;
+                }
+                // pushed from both sides -> stays upright
+            }
+            if (!changed) {
+                break;
+            }
+            cur = next;
+        }
+        return new String(cur);
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/RotatedDigits.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/RotatedDigits.java
@@ -102,4 +102,77 @@ public class RotatedDigits {
         }
         return changed;
     }
+
+    // V2
+    // IDEA: DIGIT COUNTING (no per-number scan) -
+    //       good(n) = #(x in [1,n] whose digits all lie in {0,1,2,5,6,8,9})
+    //               - #(x in [1,n] whose digits all lie in {0,1,8})
+    //       the subtracted set is exactly the "valid but unchanged" numbers.
+    /**
+     * time = O(log n)
+     * space = O(1)
+     */
+    public int rotatedDigits_2(int n) {
+        boolean[] rotatable = new boolean[10];
+        for (int d : new int[] { 0, 1, 2, 5, 6, 8, 9 }) {
+            rotatable[d] = true;
+        }
+        boolean[] selfMapping = new boolean[10];
+        for (int d : new int[] { 0, 1, 8 }) {
+            selfMapping[d] = true;
+        }
+        return countOnlyDigits_2(n, rotatable) - countOnlyDigits_2(n, selfMapping);
+    }
+
+    // count x in [1, n] such that every digit of x is in the allowed set
+    private int countOnlyDigits_2(int n, boolean[] ok) {
+        if (n <= 0) {
+            return 0;
+        }
+        String s = String.valueOf(n);
+        int len = s.length();
+
+        int all = 0;
+        int nonZero = 0;
+        for (int d = 0; d < 10; d++) {
+            if (ok[d]) {
+                all++;
+                if (d > 0) {
+                    nonZero++;
+                }
+            }
+        }
+
+        long res = 0;
+        // strictly shorter numbers
+        for (int l = 1; l < len; l++) {
+            res += nonZero * pow_2(all, l - 1);
+        }
+        // same length, digit by digit
+        boolean tight = true;
+        for (int i = 0; i < len; i++) {
+            int di = s.charAt(i) - '0';
+            for (int d = (i == 0 ? 1 : 0); d < di; d++) {
+                if (ok[d]) {
+                    res += pow_2(all, len - 1 - i);
+                }
+            }
+            if (!ok[di]) {
+                tight = false;
+                break;
+            }
+        }
+        if (tight) {
+            res++; // n itself
+        }
+        return (int) res;
+    }
+
+    private long pow_2(int base, int exp) {
+        long r = 1;
+        for (int i = 0; i < exp; i++) {
+            r *= base;
+        }
+        return r;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/SentenceScreenFitting.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/SentenceScreenFitting.java
@@ -101,4 +101,28 @@ public class SentenceScreenFitting {
         }
         return total / n;
     }
+
+    // V2
+    // IDEA: brute force greedy simulation - literally fill row after row, word by word,
+    //       and divide the placed-word count by the sentence length; kept as a readable
+    //       correctness reference (no precomputed jump table, no pointer arithmetic)
+    /**
+     * time = O(rows * cols)
+     * space = O(1)
+     */
+    public int wordsTyping_2(String[] sentence, int rows, int cols) {
+        int n = sentence.length;
+        int wordIdx = 0;
+        int placed = 0;
+
+        for (int r = 0; r < rows; r++) {
+            int remain = cols;
+            while (remain >= sentence[wordIdx].length()) {
+                remain -= sentence[wordIdx].length() + 1; // the word plus its trailing space
+                placed++;
+                wordIdx = (wordIdx + 1) % n;
+            }
+        }
+        return placed / n;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/SoupServings.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/SoupServings.java
@@ -78,4 +78,93 @@ public class SoupServings {
         memo[a][b] = res;
         return res;
     }
+
+    // V1
+    // IDEA: BOTTOM-UP TABULATION of the same recurrence - no recursion stack.
+    //       dp[a][b] = answer when a units of A and b units of B remain (1 unit = 25 ml).
+    /**
+     * time = O(M^2) where M = ceil(n / 25), capped at 200
+     * space = O(M^2)
+     */
+    public double soupServings_1(int n) {
+        if (n >= 4800) {
+            return 1.0;
+        }
+        int m = (n + 24) / 25;   // ceil(n / 25)
+        if (m == 0) {
+            return 0.5;         // both are already empty
+        }
+        double[][] dp = new double[m + 1][m + 1];
+        // every predecessor has a strictly smaller "a", so ascending a is a valid order
+        for (int a = 1; a <= m; a++) {
+            for (int b = 1; b <= m; b++) {
+                dp[a][b] = 0.25 * (
+                        read_1(dp, a - 4, b)
+                                + read_1(dp, a - 3, b - 1)
+                                + read_1(dp, a - 2, b - 2)
+                                + read_1(dp, a - 1, b - 3));
+            }
+        }
+        return dp[m][m];
+    }
+
+    private double read_1(double[][] dp, int a, int b) {
+        if (a <= 0 && b <= 0) {
+            return 0.5;
+        }
+        if (a <= 0) {
+            return 1.0;
+        }
+        if (b <= 0) {
+            return 0.0;
+        }
+        return dp[a][b];
+    }
+
+    // V2
+    // IDEA: FORWARD probability propagation - push the probability MASS out of the start
+    //       state (m, m) toward the terminal states, instead of pulling answers back.
+    //       Each operation strictly decreases "a", so one descending sweep over a suffices.
+    /**
+     * time = O(M^2) where M = ceil(n / 25), capped at 200
+     * space = O(M^2)
+     */
+    public double soupServings_2(int n) {
+        if (n >= 4800) {
+            return 1.0;
+        }
+        int m = (n + 24) / 25;
+        if (m == 0) {
+            return 0.5;
+        }
+        double[][] prob = new double[m + 1][m + 1];
+        prob[m][m] = 1.0;
+
+        int[][] moves = new int[][]{{4, 0}, {3, 1}, {2, 2}, {1, 3}};
+        double res = 0.0;
+
+        for (int a = m; a >= 1; a--) {
+            for (int b = m; b >= 1; b--) {
+                double p = prob[a][b];
+                if (p == 0.0) {
+                    continue;
+                }
+                for (int[] mv : moves) {
+                    int na = a - mv[0];
+                    int nb = b - mv[1];
+                    double q = 0.25 * p;
+                    if (na <= 0 && nb <= 0) {
+                        res += 0.5 * q;      // both empty at the same time
+                    } else if (na <= 0) {
+                        res += q;            // A empty first
+                    } else if (nb <= 0) {
+                        // B empty first -> contributes 0
+                    } else {
+                        prob[na][nb] += q;
+                    }
+                }
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/TwoKeysKeyboard.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/TwoKeysKeyboard.java
@@ -2,6 +2,9 @@ package LeetCodeJava.DynamicProgramming;
 
 // https://leetcode.com/problems/2-keys-keyboard/
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 /**
  *  650. 2 Keys Keyboard
  *  Medium
@@ -74,5 +77,51 @@ public class TwoKeysKeyboard {
             res += n;
         }
         return res;
+    }
+
+    // V2
+    // IDEA: BFS over the raw state space (charsOnScreen, charsInClipboard).
+    //       Makes no divisor/prime assumption at all, so it is the readable reference
+    //       that V0's DP and V1's math shortcut are checked against.
+    /**
+     * time = O(n^2)
+     * space = O(n^2)
+     */
+    public int minSteps_2(int n) {
+        if (n <= 1) {
+            return 0;
+        }
+        boolean[][] visited = new boolean[n + 1][n + 1];
+        Deque<int[]> q = new ArrayDeque<>();
+        q.offer(new int[]{1, 0});          // {screen, clipboard}
+        visited[1][0] = true;
+
+        int steps = 0;
+        while (!q.isEmpty()) {
+            steps++;
+            int size = q.size();
+            for (int i = 0; i < size; i++) {
+                int[] cur = q.poll();
+                int screen = cur[0];
+                int clip = cur[1];
+
+                // op 1: copy all
+                if (!visited[screen][screen]) {
+                    visited[screen][screen] = true;
+                    q.offer(new int[]{screen, screen});
+                }
+                // op 2: paste
+                if (clip > 0 && screen + clip <= n) {
+                    if (screen + clip == n) {
+                        return steps;
+                    }
+                    if (!visited[screen + clip][clip]) {
+                        visited[screen + clip][clip] = true;
+                        q.offer(new int[]{screen + clip, clip});
+                    }
+                }
+            }
+        }
+        return -1;   // unreachable for n >= 1
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/UniqueBinarySearchTrees.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/UniqueBinarySearchTrees.java
@@ -58,4 +58,31 @@ public class UniqueBinarySearchTrees {
         }
         return (int) res;
     }
+
+    // V2
+    // IDEA: TOP-DOWN MEMOIZATION of the same "pick a root" recurrence
+    //       (the recursive mirror of V0's bottom-up table).
+    /**
+     * time = O(n^2)
+     * space = O(n)  // memo + recursion depth
+     */
+    public int numTrees_2(int n) {
+        return count_2(n, new int[n + 1], new boolean[n + 1]);
+    }
+
+    private int count_2(int nodes, int[] memo, boolean[] seen) {
+        if (nodes <= 1) {
+            return 1;   // empty tree and single node both have exactly one shape
+        }
+        if (seen[nodes]) {
+            return memo[nodes];
+        }
+        int res = 0;
+        for (int root = 1; root <= nodes; root++) {
+            res += count_2(root - 1, memo, seen) * count_2(nodes - root, memo, seen);
+        }
+        seen[nodes] = true;
+        memo[nodes] = res;
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/UniqueSubstringsInWraparoundString.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/UniqueSubstringsInWraparoundString.java
@@ -2,6 +2,9 @@ package LeetCodeJava.DynamicProgramming;
 
 // https://leetcode.com/problems/unique-substrings-in-wraparound-string/
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  *  467. Unique Substrings in Wraparound String
  *  Medium
@@ -70,6 +73,74 @@ public class UniqueSubstringsInWraparoundString {
 
         int res = 0;
         for (int v : maxLen) {
+            res += v;
+        }
+        return res;
+    }
+
+    // V1
+    // IDEA: brute force - enumerate every substring that is a wraparound run and let a
+    //       HashSet do the de-duplication. Kept as a readable correctness reference
+    //       (far too slow / memory hungry for n = 10^5).
+    /**
+     * time = O(n^2) substrings, O(n^3) counting the string building/hashing
+     * space = O(n^2)
+     */
+    public int findSubstringInWraproundString_1(String s) {
+        if (s == null || s.length() == 0) {
+            return 0;
+        }
+        Set<String> seen = new HashSet<>();
+        int n = s.length();
+        for (int i = 0; i < n; i++) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(s.charAt(i));
+            seen.add(sb.toString());
+            for (int j = i + 1; j < n; j++) {
+                int prev = s.charAt(j - 1) - 'a';
+                int cur = s.charAt(j) - 'a';
+                if ((prev + 1) % 26 != cur) {
+                    break;   // the run stops here, so does every longer substring from i
+                }
+                sb.append(s.charAt(j));
+                seen.add(sb.toString());
+            }
+        }
+        return seen.size();
+    }
+
+    // V2
+    // IDEA: SEGMENT DECOMPOSITION - cut s into maximal wraparound segments, then identify
+    //       each valid substring by (STARTING letter, length), the mirror bijection of V0's
+    //       (ending letter, length). Inside a segment of length L the substring starting at
+    //       offset k can be at most L - k long, so one pass per segment fills the 26 maxima.
+    /**
+     * time = O(n)
+     * space = O(1)  // fixed 26-size array
+     */
+    public int findSubstringInWraproundString_2(String s) {
+        if (s == null || s.length() == 0) {
+            return 0;
+        }
+        int n = s.length();
+        int[] maxStart = new int[26];   // maxStart[c] = longest valid substring starting with c
+
+        int i = 0;
+        while (i < n) {
+            int j = i + 1;
+            while (j < n && (s.charAt(j - 1) - 'a' + 1) % 26 == s.charAt(j) - 'a') {
+                j++;
+            }
+            int len = j - i;            // maximal wraparound segment s[i, j)
+            for (int k = i; k < j; k++) {
+                int c = s.charAt(k) - 'a';
+                maxStart[c] = Math.max(maxStart[c], len - (k - i));
+            }
+            i = j;
+        }
+
+        int res = 0;
+        for (int v : maxStart) {
             res += v;
         }
         return res;

--- a/leetcode_java/src/main/java/LeetCodeJava/Graph/PathWithMaximumProbability.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Graph/PathWithMaximumProbability.java
@@ -2,7 +2,9 @@ package LeetCodeJava.Graph;
 
 // https://leetcode.com/problems/path-with-maximum-probability/
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -116,6 +118,53 @@ public class PathWithMaximumProbability {
             }
             if (!updated) {
                 break;
+            }
+        }
+        return best[end_node];
+    }
+
+    // V2
+    // IDEA: SPFA (queue based relaxation) - like V1's Bellman-Ford, but a node is only
+    //       re-expanded when its own best probability actually improved, so no full
+    //       passes over the whole edge list and no priority queue at all.
+    /**
+     * time = O(V * E) worst case, close to O(V + E) in practice
+     * space = O(V + E)
+     */
+    public double maxProbability_2(int n, int[][] edges, double[] succProb, int start_node, int end_node) {
+        List<List<double[]>> graph = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            graph.add(new ArrayList<>());
+        }
+        for (int i = 0; i < edges.length; i++) {
+            int u = edges[i][0];
+            int v = edges[i][1];
+            graph.get(u).add(new double[]{v, succProb[i]});
+            graph.get(v).add(new double[]{u, succProb[i]});
+        }
+
+        double[] best = new double[n];
+        best[start_node] = 1.0;
+
+        boolean[] inQueue = new boolean[n];
+        Deque<Integer> q = new ArrayDeque<>();
+        q.offer(start_node);
+        inQueue[start_node] = true;
+
+        while (!q.isEmpty()) {
+            int node = q.poll();
+            inQueue[node] = false;
+            double p = best[node];
+            for (double[] nxt : graph.get(node)) {
+                int to = (int) nxt[0];
+                double np = p * nxt[1];
+                if (np > best[to]) {
+                    best[to] = np;
+                    if (!inQueue[to]) {
+                        inQueue[to] = true;
+                        q.offer(to);
+                    }
+                }
             }
         }
         return best[end_node];

--- a/leetcode_java/src/main/java/LeetCodeJava/Greedy/AdvantageShuffle.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Greedy/AdvantageShuffle.java
@@ -4,6 +4,7 @@ package LeetCodeJava.Greedy;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.TreeMap;
 
 /**
  *  870. Advantage Shuffle
@@ -69,6 +70,73 @@ public class AdvantageShuffle {
                 res[i] = sorted[lo];
                 lo++;
             }
+        }
+        return res;
+    }
+
+    // V1
+    // IDEA: TreeMap as a MULTISET of the nums1 values - walk nums2 in its ORIGINAL order
+    //       and take the cheapest value that still beats it (higherKey); if nothing beats
+    //       it, burn the globally smallest value there (it is the least useful one).
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int[] advantageCount_1(int[] nums1, int[] nums2) {
+        TreeMap<Integer, Integer> pool = new TreeMap<>();
+        for (int x : nums1) {
+            pool.put(x, pool.getOrDefault(x, 0) + 1);
+        }
+
+        int n = nums2.length;
+        int[] res = new int[n];
+        for (int i = 0; i < n; i++) {
+            Integer pick = pool.higherKey(nums2[i]);
+            if (pick == null) {
+                pick = pool.firstKey();
+            }
+            res[i] = pick;
+            int cnt = pool.get(pick);
+            if (cnt == 1) {
+                pool.remove(pick);
+            } else {
+                pool.put(pick, cnt - 1);
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) - the same greedy as V1 but with a linear scan over a
+    //       "used" flag array instead of any ordered structure. Kept as a readable
+    //       correctness reference (no sorting, no comparator, nothing to get subtly wrong).
+    /**
+     * time = O(n^2)
+     * space = O(n)
+     */
+    public int[] advantageCount_2(int[] nums1, int[] nums2) {
+        int n = nums1.length;
+        boolean[] used = new boolean[n];
+        int[] res = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            int best = -1;
+            // smallest unused value strictly greater than nums2[i]
+            for (int j = 0; j < n; j++) {
+                if (!used[j] && nums1[j] > nums2[i] && (best == -1 || nums1[j] < nums1[best])) {
+                    best = j;
+                }
+            }
+            if (best == -1) {
+                // nothing beats it -> sacrifice the smallest unused value
+                for (int j = 0; j < n; j++) {
+                    if (!used[j] && (best == -1 || nums1[j] < nums1[best])) {
+                        best = j;
+                    }
+                }
+            }
+            used[best] = true;
+            res[i] = nums1[best];
         }
         return res;
     }

--- a/leetcode_java/src/main/java/LeetCodeJava/Greedy/BulbSwitcherIII.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Greedy/BulbSwitcherIII.java
@@ -55,4 +55,58 @@ public class BulbSwitcherIII {
 
         return res;
     }
+
+    // V1
+    // IDEA: MATH - flips is a permutation of [1, n], so after step i the i flipped indices
+    //       are exactly {1..i} iff their SUM is i*(i+1)/2 (any other i distinct values from
+    //       [1, n] sum to strictly more).
+    /**
+     * time = O(n), space = O(1)
+     */
+    public int numTimesAllBlue_1(int[] flips) {
+        if (flips == null || flips.length == 0) {
+            return 0;
+        }
+        int res = 0;
+        long sum = 0;
+        for (int i = 0; i < flips.length; i++) {
+            sum += flips[i];
+            long expected = (long) (i + 1) * (i + 2) / 2;   // 1 + 2 + ... + (i + 1)
+            if (sum == expected) {
+                res++;
+            }
+        }
+        return res;
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) - literally keep the bulb array and re-scan the prefix
+    //       [1, i + 1] after every step. Kept as a readable correctness reference.
+    //       (Only i + 1 bulbs are on in total, so a full prefix implies the rest are off.)
+    /**
+     * time = O(n^2), space = O(n)
+     */
+    public int numTimesAllBlue_2(int[] flips) {
+        if (flips == null || flips.length == 0) {
+            return 0;
+        }
+        int n = flips.length;
+        boolean[] on = new boolean[n + 2];
+        int res = 0;
+
+        for (int i = 0; i < n; i++) {
+            on[flips[i]] = true;
+            boolean aligned = true;
+            for (int k = 1; k <= i + 1; k++) {
+                if (!on[k]) {
+                    aligned = false;
+                    break;
+                }
+            }
+            if (aligned) {
+                res++;
+            }
+        }
+        return res;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Greedy/IntegerReplacement.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Greedy/IntegerReplacement.java
@@ -2,7 +2,11 @@ package LeetCodeJava.Greedy;
 
 // https://leetcode.com/problems/integer-replacement/
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Map;
 
 /**
@@ -85,5 +89,44 @@ public class IntegerReplacement {
         }
         memo.put(n, res);
         return res;
+    }
+
+    // V2
+    // IDEA: BFS - the answer is the shortest path from n down to 1 in the
+    //       "halve / +-1" state graph, so expand level by level and stop at the first 1.
+    //       Assumes nothing about bit patterns, so it is the reference for V0's greedy.
+    /**
+     * time = O(log^2 n) reachable states
+     * space = O(log^2 n)
+     */
+    public int integerReplacement_2(int n) {
+        if (n <= 1) {
+            return 0;
+        }
+        Set<Long> visited = new HashSet<>();
+        Deque<Long> q = new ArrayDeque<>();
+        q.offer((long) n);
+        visited.add((long) n);
+
+        int steps = 0;
+        while (!q.isEmpty()) {
+            steps++;
+            int size = q.size();
+            for (int i = 0; i < size; i++) {
+                long cur = q.poll();
+                long[] nexts = ((cur & 1L) == 0L)
+                        ? new long[]{cur / 2}
+                        : new long[]{cur + 1, cur - 1};
+                for (long nx : nexts) {
+                    if (nx == 1L) {
+                        return steps;
+                    }
+                    if (visited.add(nx)) {
+                        q.offer(nx);
+                    }
+                }
+            }
+        }
+        return steps;   // unreachable
     }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumLengthOfPairChain.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumLengthOfPairChain.java
@@ -87,4 +87,44 @@ public class MaximumLengthOfPairChain {
         }
         return res;
     }
+
+    // V2
+    // IDEA: PATIENCE / BINARY SEARCH DP (the O(n log n) LIS trick applied to V1's DP).
+    //       Sort by start, keep tails[k] = the smallest achievable END of a chain of
+    //       length k + 1 (tails is increasing), and binary search where each pair lands.
+    /**
+     * time = O(n log n)
+     * space = O(n)
+     */
+    public int findLongestChain_2(int[][] pairs) {
+        Arrays.sort(pairs, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] a, int[] b) {
+                return Integer.compare(a[0], b[0]);
+            }
+        });
+
+        int[] tails = new int[pairs.length];
+        int size = 0;
+
+        for (int[] p : pairs) {
+            // first chain length whose tail can NOT be followed by p (tails[idx] >= p[0])
+            int lo = 0;
+            int hi = size;
+            while (lo < hi) {
+                int mid = (lo + hi) >>> 1;
+                if (tails[mid] < p[0]) {
+                    lo = mid + 1;
+                } else {
+                    hi = mid;
+                }
+            }
+            if (lo == size) {
+                tails[size++] = p[1];          // extends the longest chain so far
+            } else if (p[1] < tails[lo]) {
+                tails[lo] = p[1];              // same length, but a smaller (better) end
+            }
+        }
+        return size;
+    }
 }

--- a/leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumNumberOfNonOverlappingSubarraysWithSumEqualsTarget.java
+++ b/leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumNumberOfNonOverlappingSubarraysWithSumEqualsTarget.java
@@ -71,4 +71,63 @@ public class MaximumNumberOfNonOverlappingSubarraysWithSumEqualsTarget {
 
         return res;
     }
+
+    // V1
+    // IDEA: DP OVER PREFIXES (no greedy cut/reset argument needed).
+    //       dp[i] = best answer for nums[0..i-1];
+    //       dp[i] = max(dp[i-1], dp[j] + 1) where j is the LATEST index with
+    //       prefix[j] == prefix[i] - target (dp is non decreasing, so latest is best).
+    /**
+     * time = O(n)
+     * space = O(n)
+     */
+    public int maxNonOverlapping_1(int[] nums, int target) {
+        if (nums == null || nums.length == 0) {
+            return 0;
+        }
+        int n = nums.length;
+        int[] dp = new int[n + 1];
+
+        Map<Long, Integer> lastIdx = new HashMap<>();   // prefix sum -> largest i with that prefix
+        lastIdx.put(0L, 0);
+
+        long prefix = 0;
+        for (int i = 1; i <= n; i++) {
+            prefix += nums[i - 1];
+            dp[i] = dp[i - 1];
+            Integer j = lastIdx.get(prefix - target);
+            if (j != null) {
+                dp[i] = Math.max(dp[i], dp[j] + 1);
+            }
+            lastIdx.put(prefix, i);
+        }
+        return dp[n];
+    }
+
+    // V2
+    // IDEA: brute force O(n^2) DP - for every end, scan backwards for a subarray summing
+    //       to target. Kept as a readable correctness reference for the two O(n) versions.
+    /**
+     * time = O(n^2)
+     * space = O(n)
+     */
+    public int maxNonOverlapping_2(int[] nums, int target) {
+        if (nums == null || nums.length == 0) {
+            return 0;
+        }
+        int n = nums.length;
+        int[] dp = new int[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            dp[i] = dp[i - 1];
+            long sum = 0;
+            for (int j = i; j >= 1; j--) {
+                sum += nums[j - 1];
+                if (sum == target) {
+                    dp[i] = Math.max(dp[i], dp[j - 1] + 1);
+                }
+            }
+        }
+        return dp[n];
+    }
 }

--- a/vbatches/vbatch_01.md
+++ b/vbatches/vbatch_01.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/AddToArrayFormOfInteger.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ArrayNesting.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ArrayOfDoubledPairs.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/BattleshipsInABoard.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/BeautifulArrangementII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/BestSightseeingPair.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/CanPlaceFlowers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/CandyCrush.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/CyclicallyRotatingAGrid.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/DegreeOfAnArray.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_02.md
+++ b/vbatches/vbatch_02.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/EmployeeFreeTime.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FairCandySwap.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FindAllNumbersDisappearedInAnArray.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FindWinnerOnATicTacToeGame.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FizzBuzz.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FlipGame.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FlippingAnImage.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/FourSum.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/GameOfLife.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ImageOverlap.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_03.md
+++ b/vbatches/vbatch_03.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/ImageSmoother.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/LargestNumberAtLeastTwiceOfOthers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/LargestTimeForGivenDigits.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/LemonadeChange.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/LonelyPixelI.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/LonelyPixelII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MagicSquaresInGrid.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MaxIncreaseToKeepCitySkyline.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MaximumAverageSubarrayI.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MaximumDistanceInArrays.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_04.md
+++ b/vbatches/vbatch_04.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/MaximumLengthOfSubarrayWithPositiveProduct.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MinimumIncrementToMakeArrayUnique.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MinimumLightsToIlluminateARoad.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/MonotonicArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/NRepeatedElementInSize2NArray.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/NonDecreasingArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/NumberOfSubarraysWithBoundedMaximum.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/OneBitAnd2BitCharacters.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/PartitionArrayIntoDisjointIntervals.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/PascalSTriangle.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_05.md
+++ b/vbatches/vbatch_05.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/PascalSTriangleII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/PositionsOfLargeGroups.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/PourWater.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ReadNCharactersGivenRead4.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ReshapeTheMatrix.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/RobotReturnToOrigin.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/RotateFunction.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/SearchA2DMatrixII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ShortestDistanceToACharacter.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ShortestUnsortedContinuousSubarray.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_06.md
+++ b/vbatches/vbatch_06.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/ShortestWordDistanceIII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ShuffleAnArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/SortArrayByParityII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/SpiralMatrixII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/SpiralMatrixIII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/SplitArrayIntoFibonacciSequence.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/SubarrayProductLessThanK.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ThreeSumWithMultiplicity.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ToeplitzMatrix.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ValidMountainArray.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_07.md
+++ b/vbatches/vbatch_07.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Array/ValidTicTacToeState.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Array/ValidWordSquare.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/MinimumGeneticMutation.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/NumberOfGoodLeafNodesPairs.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/NumbersWithSameConsecutiveDifferences.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/PathSumIV.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/ShortestPathToGetFood.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/TheMaze.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BFS/TheMazeII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/BeautifulArrangement.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_08.md
+++ b/vbatches/vbatch_08.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/CombinationSumIII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/FactorCombinations.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/FlipGameII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/GeneralizedAbbreviation.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/ImplementMagicDictionary.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/LetterCasePermutation.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/MaximumLengthOfRepeatedSubarray.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/PalindromePermutationII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/RestoreIPAddresses.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/RobotRoomCleaner.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_09.md
+++ b/vbatches/vbatch_09.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/BackTrack/SudokuSolver.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/AllPossibleFullBinaryTrees.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/FindRightInterval.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/FindSmallestLetterGreaterThanTarget.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/HIndexII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/Heaters.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimizeMaxDistanceToGasStation.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumInitialStrengthToDefeatAllMonsters.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumNumberOfOperationsToMakeArrayContinuous.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/MinimumSpaceWastedFromPackaging.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_10.md
+++ b/vbatches/vbatch_10.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/OnlineElection.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearch/SqrtX.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/BuildBinaryExpressionTreeFromInfixExpression.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ClosestBinarySearchTreeValue.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ContainsDuplicateIII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/ConvertBinarySearchTreeToSortedDoublyLinkedList.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BinarySearchTree/SumOfRootToLeafBinaryNumbers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryGap.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryNumberWithAlternatingBits.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BinaryWatch.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_11.md
+++ b/vbatches/vbatch_11.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BitwiseANDOfNumbersRange.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/BitwiseORsOfSubarrays.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/FindTheDifference.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/HammingDistance.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/MaximumProductOfWordLengths.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/MaximumXOROfTwoNumbersInAnArray.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/MinimumMovesToEqualArrayElementsII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/NumberOfWaysToSplitAString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/PowerOfFour.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/PowerOfTwo.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_12.md
+++ b/vbatches/vbatch_12.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/PrimeNumberOfSetBitsInBinaryRepresentation.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SetMismatch.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SingleNumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/SingleNumberIII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/TotalHammingDistance.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/BitManipulation/UTF8Validation.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/CountDominantNodesInABinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/CountNodesWithTheHighestScore.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/CriticalConnectionsInANetwork.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/EmployeeImportance.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_13.md
+++ b/vbatches/vbatch_13.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/DFS/FindLargestValueInEachTreeRow.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/FindLeavesOfBinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/FinishTimeOfTasksI.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/IncreasingSubsequences.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/LoudAndRich.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/LowestCommonAncestorOfABinaryTreeIV.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/NestedListWeightSum.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/NestedListWeightSumII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/PyramidTransitionMatrix.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/SatisfiabilityOfEqualityEquations.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_14.md
+++ b/vbatches/vbatch_14.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/DFS/ShoppingOffers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DFS/WeightedSumOfATree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignAFileSharingSystem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignAnExpressionTreeWithEvaluateFunction.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignAnOrderedStream.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignAuthenticationManager.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignBrowserHistory.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignFileSystem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignFrontMiddleBackQueue.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignLogStorageSystem.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_15.md
+++ b/vbatches/vbatch_15.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignParkingSystem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignRecentUsedQueue.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignSearchAutocompleteSystem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignSkiplist.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DesignTicTacToe.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/DinnerPlateStacks.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/FirstUniqueNumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/MaxStack.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/NumberOfWaysToArriveAtDestination.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Design/PeekingIterator.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_16.md
+++ b/vbatches/vbatch_16.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/AndroidUnlockPatterns.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/BestTimeToBuyAndSellStockIII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/BinaryTreesWithFactors.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/BombEnemy.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/ChampagneTower.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/ConcatenatedWords.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/CountNumbersWithUniqueDigits.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/DeleteOperationForTwoStrings.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/DominoAndTrominoTiling.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/EncodeStringWithShortestLength.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_17.md
+++ b/vbatches/vbatch_17.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/GuessNumberHigherOrLowerII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/KnightDialer.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/KnightProbabilityInChessboard.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/LargestDivisibleSubset.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/LargestPlusSign.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/LargestSumOfAverages.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/LongestLineOfConsecutiveOneInMatrix.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MaximizeScoreAfterNOperations.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumASCIIDeleteSumForTwoStrings.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumCostToMergeStones.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_18.md
+++ b/vbatches/vbatch_18.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumDifficultyOfAJobSchedule.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/MinimumInsertionStepsToMakeAStringPalindrome.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/NumberOfCornerRectangles.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/NumberOfLongestIncreasingSubsequence.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/OnesAndZeroes.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/OutOfBoundaryPaths.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/PaintFence.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/PushDominoes.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/RotatedDigits.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/SentenceScreenFitting.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_19.md
+++ b/vbatches/vbatch_19.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/SoupServings.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/TwoKeysKeyboard.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/UniqueBinarySearchTrees.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/DynamicProgramming/UniqueSubstringsInWraparoundString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Graph/PathWithMaximumProbability.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/AdvantageShuffle.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/BulbSwitcherIII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/IntegerReplacement.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumLengthOfPairChain.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumNumberOfNonOverlappingSubarraysWithSumEqualsTarget.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_20.md
+++ b/vbatches/vbatch_20.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumUnitsOnATruck.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/MaximumWidthRamp.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/MinimumAdjacentSwapsToPartitionArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/PatchingArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/PathWithMaximumMinimumValue.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/ScoreAfterFlippingMatrix.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/SellDiminishingValuedColoredBalls.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/TheSkylineProblem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/TransformBinaryStringUsingSubsequenceSort.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Greedy/VideoStitching.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_21.md
+++ b/vbatches/vbatch_21.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/ArrayPartitionI.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/BullsAndCows.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/CardFlippingGame.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/CountPrimes.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/DistributeCandies.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/FindAnagramMappings.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/FindDuplicateFileInSystem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/FourSumII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/FriendsOfAppropriateAges.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/ImplementRand10UsingRand7.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_22.md
+++ b/vbatches/vbatch_22.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/JewelsAndStones.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/KDiffPairsInAnArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/LengthOfLongestFibonacciSubsequence.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/LongestAbsoluteFilePath.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/LongestCommonSubpath.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/LongestPalindrome.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/MinimumIndexSumOfTwoLists.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/NumberOfBoomerangs.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/PairsOfSongsWithTotalDurationsDivisibleBy60.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/PalindromePermutation.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_23.md
+++ b/vbatches/vbatch_23.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/PrisonCellsAfterNDays.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/RankTransformOfAnArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/ReorderedPowerOf2.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/ShortestCompletingWord.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/ShortestWordDistanceII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/SubdomainVisitCount.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/TwoSumIIIDataStructureDesign.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/VowelSpellchecker.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/HashTable/WordPattern.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Heap/MinimumCostTreeFromLeafValues.java
+  has: V0, V1
+  add: V2

--- a/vbatches/vbatch_24.md
+++ b/vbatches/vbatch_24.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Heap/SuperUglyNumber.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/LinkedList/OddEvenLinkedList.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/LinkedList/SplitLinkedListInParts.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/AddDigits.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ArithmeticSlices.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ArrangingCoins.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/Base7.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/BulbSwitcher.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/BulbSwitcherII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ComplexNumberMultiplication.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_25.md
+++ b/vbatches/vbatch_25.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Math/ConsecutiveNumbersSum.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ConvexPolygon.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/DivideTwoIntegers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/EliminationGame.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ErectTheFence.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/EscapeTheGhosts.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ExcelSheetColumnNumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/FactorialTrailingZeroes.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/FindGreatestCommonDivisorOfArray.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/FindTheDerangementOfAnArray.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_26.md
+++ b/vbatches/vbatch_26.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Math/FourKeysKeyboard.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/FractionAdditionAndSubtraction.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/FractionToRecurringDecimal.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/GenerateRandomPointInACircle.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/GlobalAndLocalInversions.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/GrayCode.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/IntegerToEnglishWords.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/IntegerToRoman.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/KThSymbolInGrammar.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/LargestTriangleArea.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_27.md
+++ b/vbatches/vbatch_27.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Math/LexicographicalNumbers.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/LinkedListRandomNode.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/MaximumProductOfThreeNumbers.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/MaximumValueOfAnAlternatingSequence.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/MinimumAreaRectangleII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/MinimumFactorization.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/MinimumMovesToEqualArrayElements.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/MirrorReflection.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/NimGame.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/NthDigit.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_28.md
+++ b/vbatches/vbatch_28.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Math/NumberOfStepsToReduceANumberToZero.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/OptimalDivision.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/PalindromeNumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/PermutationSequence.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/PoorPigs.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/PowerOfThree.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/PowerfulIntegers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ProjectionAreaOf3DShapes.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/RabbitsInForest.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/RandomFlipMatrix.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_29.md
+++ b/vbatches/vbatch_29.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Math/RandomPickIndex.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/RandomPointInNonOverlappingRectangles.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ReachANumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ReconstructOriginalDigitsFromEnglish.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/RectangleArea.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/RectangleOverlap.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/ReverseInteger.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SelfDividingNumbers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SimilarRGBColor.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SmallestRangeI.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_30.md
+++ b/vbatches/vbatch_30.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Math/SmallestRangeII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SquirrelSimulation.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SumOfSquareNumbers.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SumOfSubarrayMinimums.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SumOfSubsequenceWidths.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SuperPow.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/SuperWashingMachines.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/UglyNumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/WaterAndJugProblem.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Math/XOfAKindInADeckOfCards.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_31.md
+++ b/vbatches/vbatch_31.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Queue/NumberOfRecentCalls.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Queue/ZigzagIterator.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Recursion/BinaryTreeLongestConsecutiveSequenceII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Recursion/BinaryTreeUpsideDown.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Recursion/OutputContestMatches.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Recursion/SecondMinimumNodeInABinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/SlideWindow/LongestSubstringOfAllVowelsInOrder.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Sort/AnalyzeUserWebsiteVisitPattern.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Sort/BrightestPositionOnStreet.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Sort/InsertionSortList.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_32.md
+++ b/vbatches/vbatch_32.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Sort/PancakeSorting.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Sort/SortList.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Sort/WiggleSort.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/AsteroidCollision.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/ExclusiveTimeOfFunctions.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/FlattenNestedListIterator.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/MiniParser.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumAdjacentSwapsForKConsecutiveOnes.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/MinimumCostToChangeTheFinalValueOfExpression.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/TernaryExpressionParser.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_33.md
+++ b/vbatches/vbatch_33.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Stack/ValidateStackSequences.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/VerifyPreorderSequenceInBinarySearchTree.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/Stack/VerifyPreorderSerializationOfABinaryTree.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/AddBoldTagInString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/AddictiveNumber.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/AmbiguousCoordinates.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/BoldWordsInString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/BuddyStrings.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ConvertANumberToHexadecimal.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/CountBinarySubstrings.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_34.md
+++ b/vbatches/vbatch_34.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/String/CountUniqueCharactersOfAllSubstringsOfAGivenString.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/CountValidPrefixes.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/CustomSortString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/DIStringMatch.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/DecodedStringAtIndex.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/DeleteColumnsToMakeSorted.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/DeleteColumnsToMakeSortedII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/DetectCapital.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/GoatLatin.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/GroupsOfSpecialEquivalentStrings.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_35.md
+++ b/vbatches/vbatch_35.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/String/IPToCIDR.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/LongPressedName.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/LongestUncommonSubsequenceI.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/LongestUncommonSubsequenceII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/MaskingPersonalInformation.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/MostCommonWord.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/NextClosestTime.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/NextGreaterElementIII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/NumberOfLinesToWriteString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/NumberOfSegmentsInAString.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_36.md
+++ b/vbatches/vbatch_36.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/String/RemoveVowelsFromAString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/RepeatedSubstringPattern.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ReverseWordsInAStringII.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ReverseWordsInAStringIII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/RotateString.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ShiftingLetters.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ShortEncodingOfWords.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/String/StringCompression.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/StringToIntegerAtoi.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/UncommonWordsFromTwoSentences.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_37.md
+++ b/vbatches/vbatch_37.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/String/UniqueEmailAddresses.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/UniqueMorseCodeWords.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ValidWordAbbreviation.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/ValidateIPAddress.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/String/WordSubsets.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/BinaryTreeTilt.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/BoundaryOfBinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/CheckCompletenessOfABinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/CompleteBinaryTreeInserter.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/ConstructStringFromBinaryTree.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_38.md
+++ b/vbatches/vbatch_38.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Tree/DistributeCoinsInBinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/EqualTreePartition.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/FlipBinaryTreeToMatchPreorderTraversal.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/IncreasingOrderSearchTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/KEmptySlots.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/LongestZigZagPathInABinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumProductOfSplittedBinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/MaximumWidthOfBinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/PrintBinaryTree.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/Tree/SplitArrayWithEqualSum.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_39.md
+++ b/vbatches/vbatch_39.md
@@ -1,0 +1,32 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/Tree/UnivaluedBinaryTree.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/BinarySubarraysWithSum.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/CircularArrayLoop.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/IntersectionOfTwoArrays.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/IntersectionOfTwoArraysII.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/MinimumNumberOfSwapsToMakeTheStringBalanced.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/MinimumSwapsToGroupAll1STogether.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/MostProfitAssigningWork.java
+  has: V0, V1
+  add: V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/ReverseString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/SortTransformedArray.java
+  has: V0
+  add: V1, V2

--- a/vbatches/vbatch_40.md
+++ b/vbatches/vbatch_40.md
@@ -1,0 +1,11 @@
+Files to bring up to >=3 versions:
+
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/SwapAdjacentInLRString.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/ThreeSumSmaller.java
+  has: V0
+  add: V1, V2
+- leetcode_java/src/main/java/LeetCodeJava/TwoPointer/ValidTriangleNumber.java
+  has: V0
+  add: V1, V2


### PR DESCRIPTION
In-flight work from the feat/java-multi-version task: bring each listed Java LC solution up to at least three versions (V0, V1, V2), keeping the existing V0 untouched. 79 files gained alternate approaches (+4524 lines), each with the repo's `// V<n>` + `// IDEA:` + time/space javadoc format.

Also includes the task scaffolding it was driven from — CONV_V3.md (the instructions) and vbatches/*.md (40 per-batch file lists). Those are working notes, not repo content, and can be dropped when the task is finished.

Committed to preserve the work while removing the CS_basics_wt_v3 worktree; the task is NOT complete (only 79 of the listed files were processed).