### PR TITLE
feat(leetcode_python): add missing solution versions, wave 2 (54 files)

### DIFF
--- a/leetcode_python/Array/create-target-array-in-the-given-order.py
+++ b/leetcode_python/Array/create-target-array-in-the-given-order.py
@@ -73,3 +73,72 @@ class Solution(object):
         for i in range(len(nums)):
             target.insert(index[i], nums[i])
         return target
+
+
+# V0-1
+# IDEA : REPLAY THE INSERTIONS BACKWARDS (free-slot picking)
+#
+#   the pair read LAST is never shifted again, so index[n-1] is already the
+#   FINAL position of nums[n-1]. drop that slot and the still-free slots,
+#   in increasing order, are exactly the array as it looked one step earlier
+#   -> index[i] then means "the index[i]-th still-free slot".
+#
+#   so : walk i from n-1 down to 0 and pop the index[i]-th free position.
+#        no element is ever moved, each one is written straight to its
+#        final home.
+#
+# time = O(n^2)     (list.pop from the middle is O(n))
+# space = O(n)
+class Solution(object):
+    def createTargetArray(self, nums, index):
+        n = len(nums)
+        free = list(range(n))
+        res = [0] * n
+        for i in range(n - 1, -1, -1):
+            pos = free.pop(index[i])
+            res[pos] = nums[i]
+        return res
+
+
+# V0-2
+# IDEA : BACKWARDS REPLAY + BINARY INDEXED TREE  (O(n log n))
+#
+#   same "walk the pairs backwards" observation as V0-1, but the query
+#   "give me the k-th still-free slot" is served by a Fenwick tree that
+#   stores 1 for every free position. binary lifting down the tree finds
+#   the k-th one in O(log n), and marking it used is another O(log n),
+#   which removes the O(n) list.pop of V0-1.
+#
+# time = O(n log n)
+# space = O(n)
+class Solution(object):
+    def createTargetArray(self, nums, index):
+        n = len(nums)
+        tree = [0] * (n + 1)
+
+        def add(i, delta):
+            while i <= n:
+                tree[i] += delta
+                i += i & (-i)
+
+        def kth_free(k):
+            # smallest 1-based pos whose prefix sum reaches k
+            pos, step = 0, 1
+            while step * 2 <= n:
+                step *= 2
+            while step:
+                if pos + step <= n and tree[pos + step] < k:
+                    pos += step
+                    k -= tree[pos]
+                step //= 2
+            return pos + 1
+
+        for i in range(1, n + 1):
+            add(i, 1)
+
+        res = [0] * n
+        for i in range(n - 1, -1, -1):
+            pos = kth_free(index[i] + 1)
+            res[pos - 1] = nums[i]
+            add(pos, -1)
+        return res

--- a/leetcode_python/Array/decode-the-slanted-ciphertext.py
+++ b/leetcode_python/Array/decode-the-slanted-ciphertext.py
@@ -80,3 +80,60 @@ class Solution(object):
                 r += 1
                 cc += 1
         return ''.join(out).rstrip()
+
+
+# V0-1
+# IDEA : INVERSE INDEX MAP (SCATTER) + PREFIX SUMS
+#
+#   instead of GATHERING the answer diagonal by diagonal, push every
+#   encoded character straight to the slot it occupies in originalText.
+#
+#   the diagonal starting at column d holds min(rows, cols - d) characters,
+#   so start[d] = sum of the earlier diagonal lengths tells where diagonal d
+#   begins inside originalText.
+#   encoded position p sits at (r, c) = divmod(p, cols) and belongs to
+#   diagonal d = c - r at offset r  ->  originalText[start[c - r] + r] = ch.
+#   cells with c < r are the padding the encoder wrote, so they are skipped.
+#
+# time = O(len(encodedText)), space = O(len(encodedText))
+class Solution(object):
+    def decodeCiphertext(self, encodedText, rows):
+        if rows == 0 or not encodedText:
+            return ""
+        cols = len(encodedText) // rows
+        start = [0] * cols
+        total = 0
+        for d in range(cols):
+            start[d] = total
+            total += min(rows, cols - d)
+
+        out = [' '] * total
+        for p, ch in enumerate(encodedText):
+            r, c = divmod(p, cols)
+            if c >= r:
+                out[start[c - r] + r] = ch
+        return ''.join(out).rstrip()
+
+
+# V0-2
+# IDEA : A DIAGONAL IS AN ARITHMETIC PROGRESSION -> STRIDED SLICING
+#
+#   moving one step down-right in the matrix moves cols + 1 characters
+#   forward in the flat encodedText, so the whole diagonal starting at
+#   column c is just the slice encodedText[c :: cols + 1].
+#   that slice runs off the bottom of the matrix (it wraps into later rows'
+#   earlier columns), so cut it at its true length min(rows, cols - c).
+#
+#   no per-character indexing at all: cols slices, then one join.
+#
+# time = O(len(encodedText)), space = O(len(encodedText))
+class Solution(object):
+    def decodeCiphertext(self, encodedText, rows):
+        if rows == 0 or not encodedText:
+            return ""
+        cols = len(encodedText) // rows
+        step = cols + 1
+        out = []
+        for c in range(cols):
+            out.append(encodedText[c::step][:min(rows, cols - c)])
+        return ''.join(out).rstrip()

--- a/leetcode_python/Array/decompress-run-length-encoded-list.py
+++ b/leetcode_python/Array/decompress-run-length-encoded-list.py
@@ -48,3 +48,53 @@ class Solution(object):
             freq, val = nums[i], nums[i + 1]
             res += [val] * freq
         return res
+
+
+# V0-1
+# IDEA : TWO PASS, PRE-ALLOCATE THE OUTPUT
+#
+#   pass 1 : the total output length is just the sum of the freq entries
+#            (the even indices), so it is known before writing anything.
+#   pass 2 : allocate that list once and fill it through a write pointer.
+#
+#   this trades the repeated list growth / temporary [val] * freq blocks of
+#   V0 for a single allocation, which is what you would have to do in a
+#   language without a growable list.
+#
+# time = O(n + k), k = total output length
+# space = O(1) extra, excluding the output list
+class Solution(object):
+    def decompressRLElist(self, nums):
+        total = 0
+        for i in range(0, len(nums), 2):
+            total += nums[i]
+
+        res = [0] * total
+        w = 0
+        for i in range(0, len(nums), 2):
+            freq, val = nums[i], nums[i + 1]
+            for _ in range(freq):
+                res[w] = val
+                w += 1
+        return res
+
+
+# V0-2
+# IDEA : LAZY ITERATORS - PAIR UP WITH STRIDED SLICES, EXPAND WITH repeat
+#
+#   nums[0::2] / nums[1::2] split the array into the freq stream and the val
+#   stream, zip pairs them, itertools.repeat turns one pair into a lazy run
+#   and chain.from_iterable concatenates the runs.
+#
+#   nothing is materialised per pair: the runs are consumed straight into
+#   the final list by list(), instead of building a temporary list per pair.
+#
+# time = O(n + k), k = total output length
+# space = O(n) for the two strided slices, plus the output list
+from itertools import chain, repeat
+
+
+class Solution(object):
+    def decompressRLElist(self, nums):
+        pairs = zip(nums[0::2], nums[1::2])
+        return list(chain.from_iterable(repeat(val, freq) for freq, val in pairs))

--- a/leetcode_python/Array/decrease-elements-to-make-array-zigzag.py
+++ b/leetcode_python/Array/decrease-elements-to-make-array-zigzag.py
@@ -60,3 +60,85 @@ class Solution(object):
                 if nb != float('inf') and nums[j] >= nb:
                     res[i] += nums[j] - nb + 1
         return min(res)
+
+
+# V0-1
+# IDEA : DP OVER THE VALUE DOMAIN (no greedy insight needed)
+#
+#   fix which parity carries the peaks, then let
+#       dp[i][v] = min moves so that nums[0..i] is a valid zigzag prefix
+#                  AND nums[i] ends up equal to v
+#   dp[i][v] = (nums[i] - v) + min over allowed u of dp[i-1][u], where
+#       "i is a peak"   -> u < v   (running PREFIX min of dp[i-1])
+#       "i is a valley" -> u > v   (running SUFFIX min of dp[i-1])
+#   only v <= nums[i] is reachable because moves may only DECREASE.
+#
+#   the running prefix / suffix minimum keeps each row linear in the value
+#   range, so this stays O(n * max(nums)) instead of O(n * max(nums)^2).
+#
+# time = O(n * max(nums))
+# space = O(max(nums))
+class Solution(object):
+    def movesToMakeZigzag(self, nums):
+        n = len(nums)
+        if n == 1:
+            return 0
+
+        INF = float('inf')
+        V = max(nums) + 1
+        best = INF
+        for pat in range(2):        # pat = parity of the PEAK indices
+            dp = [INF] * V
+            for v in range(nums[0] + 1):
+                dp[v] = nums[0] - v
+
+            for i in range(1, n):
+                nxt = [INF] * V
+                run = INF
+                if i % 2 == pat:            # nums[i] must beat nums[i-1]
+                    for v in range(V):
+                        if v > 0 and dp[v - 1] < run:
+                            run = dp[v - 1]
+                        if v <= nums[i] and run < INF:
+                            nxt[v] = run + nums[i] - v
+                else:                       # nums[i] must be below nums[i-1]
+                    for v in range(V - 1, -1, -1):
+                        if v + 1 < V and dp[v + 1] < run:
+                            run = dp[v + 1]
+                        if v <= nums[i] and run < INF:
+                            nxt[v] = run + nums[i] - v
+                dp = nxt
+
+            best = min(best, min(dp))
+        return best
+
+
+# V0-2
+# IDEA : BRUTE FORCE - ACTUALLY PERFORM THE MOVES, ONE DECREMENT AT A TIME
+#
+#   pick the parity that becomes the valleys, copy the array, then for every
+#   valley keep subtracting 1 and counting the move until it is strictly
+#   below both of its (never touched) neighbours.
+#
+#   no closed-form cost is used, the moves are simulated literally, which is
+#   a handy way to sanity check the greedy formula of V0.
+#
+# time = O(n * max(nums))
+# space = O(n) for the working copy
+class Solution(object):
+    def movesToMakeZigzag(self, nums):
+        n = len(nums)
+        res = float('inf')
+        for start in range(2):          # start = parity of the VALLEYS
+            arr = list(nums)
+            moves = 0
+            for j in range(start, n, 2):
+                while True:
+                    left_ok = (j - 1 < 0) or (arr[j] < arr[j - 1])
+                    right_ok = (j + 1 >= n) or (arr[j] < arr[j + 1])
+                    if left_ok and right_ok:
+                        break
+                    arr[j] -= 1
+                    moves += 1
+            res = min(res, moves)
+        return res

--- a/leetcode_python/Array/defuse-the-bomb.py
+++ b/leetcode_python/Array/defuse-the-bomb.py
@@ -81,3 +81,67 @@ class Solution(object):
             total += code[(hi + i) % n]
             res[i] = total
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE, RE-SUM THE |k| NEIGHBOURS FOR EVERY INDEX
+#
+#   straight transcription of the statement: for each i add up the next k
+#   (or previous -k) entries, wrapping with % n. no window is reused, so
+#   the same values are added over and over.
+#
+#   fine here because n <= 100, and it is the baseline the sliding window of
+#   V0 optimises.
+#
+# time = O(n * |k|), space = O(n) for the output
+class Solution(object):
+    def decrypt(self, code, k):
+        n = len(code)
+        res = [0] * n
+        if k == 0:
+            return res
+        for i in range(n):
+            total = 0
+            if k > 0:
+                for j in range(1, k + 1):
+                    total += code[(i + j) % n]
+            else:
+                for j in range(1, -k + 1):
+                    total += code[(i - j) % n]
+            res[i] = total
+        return res
+
+
+# V0-2
+# IDEA : DOUBLE THE ARRAY + PREFIX SUMS (kill the modulo)
+#
+#   concatenating code with itself turns every wrap-around window into a
+#   plain contiguous range, so one prefix sum table answers each entry with
+#   a single subtraction:
+#       k > 0 : range [i + 1, i + k]
+#       k < 0 : range [i + n + k, i + n - 1]
+#   both ranges always live inside [0, 2n - 1], so no % is needed at all.
+#
+#   unlike the sliding window this gives random access - any window length
+#   could be answered afterwards without re-scanning.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def decrypt(self, code, k):
+        n = len(code)
+        if k == 0:
+            return [0] * n
+
+        doubled = code + code
+        pre = [0] * (2 * n + 1)
+        for i in range(2 * n):
+            pre[i + 1] = pre[i] + doubled[i]
+
+        res = [0] * n
+        for i in range(n):
+            if k > 0:
+                lo, hi = i + 1, i + k
+            else:
+                lo, hi = i + n + k, i + n - 1
+            res[i] = pre[hi + 1] - pre[lo]
+        return res

--- a/leetcode_python/Array/delete-greatest-value-in-each-row.py
+++ b/leetcode_python/Array/delete-greatest-value-in-each-row.py
@@ -61,3 +61,64 @@ class Solution(object):
     def deleteGreatestValue(self, grid):
         rows = [sorted(row) for row in grid]
         return sum(max(col) for col in zip(*rows))
+
+
+# V0-1
+# IDEA : ONE MAX-HEAP PER ROW, POP ONE ROUND AT A TIME
+#
+#   run the operations exactly as described instead of pre-sorting: keep a
+#   max-heap per row (python only has min-heaps, so store negated values),
+#   and each round pop one element from every row and add the largest of
+#   them to the answer.
+#
+#   heapify is O(n) per row and each round costs O(log n) per row, so this
+#   never fully orders a row - it only ever extracts the current maximum.
+#
+# time = O(m * n * log n), space = O(m * n) for the heaps
+import heapq
+
+
+class Solution(object):
+    def deleteGreatestValue(self, grid):
+        heaps = [[-v for v in row] for row in grid]
+        for h in heaps:
+            heapq.heapify(h)
+
+        res = 0
+        for _ in range(len(grid[0])):
+            res += -min(heapq.heappop(h) for h in heaps)
+        return res
+
+
+# V0-2
+# IDEA : COUNTING SORT PER ROW (values are bounded by 100)
+#
+#   same "k-th largest of every row are removed together" observation as V0,
+#   but the ordering is done by bucket counting rather than comparison
+#   sorting: tally each row into 101 buckets, then read the buckets from 100
+#   down to 1 to get the row in descending order.
+#
+#   that drops the log n factor - column j of the descending rows is exactly
+#   the group removed by operation j, so the answer is the sum of the column
+#   maxima.
+#
+# time = O(m * (n + V)), V = 100 the value bound
+# space = O(m * n + V)
+class Solution(object):
+    def deleteGreatestValue(self, grid):
+        MAXV = 100
+        desc_rows = []
+        for row in grid:
+            cnt = [0] * (MAXV + 1)
+            for v in row:
+                cnt[v] += 1
+            desc = []
+            for v in range(MAXV, 0, -1):
+                if cnt[v]:
+                    desc += [v] * cnt[v]
+            desc_rows.append(desc)
+
+        res = 0
+        for j in range(len(grid[0])):
+            res += max(row[j] for row in desc_rows)
+        return res

--- a/leetcode_python/Array/detect-cycles-in-2d-grid.py
+++ b/leetcode_python/Array/detect-cycles-in-2d-grid.py
@@ -69,3 +69,87 @@ class Solution(object):
                             return True
                         par[ra] = rb
         return False
+
+
+# V0-1
+# IDEA : ITERATIVE DFS + PARENT TRACKING
+#
+#   flood fill every same-letter component with an explicit stack, pushing
+#   (cell, the cell we came from). if a neighbour is already visited and it is
+#   NOT the cell we came from, we have reached it by a second route -> cycle.
+#
+#   NOTE : the "came from" test is exactly the problem's "you cannot move back
+#          to the cell of your last move" rule; and a grid graph is bipartite
+#          so it has no triangles -> every cycle it contains is already of
+#          length >= 4.
+#
+#   NOTE : written iteratively on purpose -- a 500 x 500 single-letter grid is
+#          250_000 cells deep and would blow python's recursion limit.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def containsCycle(self, grid):
+        m, n = len(grid), len(grid[0])
+        seen = [[False] * n for _ in range(m)]
+        for si in range(m):
+            for sj in range(n):
+                if seen[si][sj]:
+                    continue
+                val = grid[si][sj]
+                seen[si][sj] = True
+                stack = [(si, sj, -1, -1)]
+                while stack:
+                    i, j, pi, pj = stack.pop()
+                    for di, dj in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                        x, y = i + di, j + dj
+                        if not (0 <= x < m and 0 <= y < n):
+                            continue
+                        if grid[x][y] != val or (x == pi and y == pj):
+                            continue
+                        if seen[x][y]:
+                            return True
+                        seen[x][y] = True
+                        stack.append((x, y, i, j))
+        return False
+
+
+# V0-2
+# IDEA : FLOOD FILL + EULER COUNT (a connected component is a tree iff E == V - 1)
+#
+#   BFS each same-letter component and count its vertices V and its edges E
+#   (each edge counted exactly once, by letting every cell report only its
+#   right / down same-letter neighbours).
+#   a connected graph always has E >= V - 1, with equality only for a tree,
+#   so E >= V proves the component holds a cycle -- no parent bookkeeping and
+#   no union-find needed.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def containsCycle(self, grid):
+        import collections
+        m, n = len(grid), len(grid[0])
+        seen = [[False] * n for _ in range(m)]
+        for si in range(m):
+            for sj in range(n):
+                if seen[si][sj]:
+                    continue
+                val = grid[si][sj]
+                seen[si][sj] = True
+                q = collections.deque([(si, sj)])
+                verts = edges = 0
+                while q:
+                    i, j = q.popleft()
+                    verts += 1
+                    for di, dj in ((0, 1), (1, 0)):
+                        x, y = i + di, j + dj
+                        if x < m and y < n and grid[x][y] == val:
+                            edges += 1
+                    for di, dj in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                        x, y = i + di, j + dj
+                        if 0 <= x < m and 0 <= y < n and not seen[x][y] \
+                                and grid[x][y] == val:
+                            seen[x][y] = True
+                            q.append((x, y))
+                if edges >= verts:
+                    return True
+        return False

--- a/leetcode_python/Array/detect-pattern-of-length-m-repeated-k-or-more-times.py
+++ b/leetcode_python/Array/detect-pattern-of-length-m-repeated-k-or-more-times.py
@@ -56,3 +56,49 @@ class Solution(object):
             else:
                 run = 0
         return False
+
+
+# V0-1
+# IDEA : BRUTE FORCE SLICE COMPARISON
+#
+#   try every possible window start i and compare the candidate pattern
+#   arr[i:i+m], repeated k times, against the m*k cells that actually sit
+#   there. list multiplication builds the expected block for us.
+#
+# time = O(n * m * k), space = O(m * k)
+class Solution(object):
+    def containsPattern(self, arr, m, k):
+        n = len(arr)
+        for i in range(n - m * k + 1):
+            if arr[i:i + m] * k == arr[i:i + m * k]:
+                return True
+        return False
+
+
+# V0-2
+# IDEA : PREFIX SUM OVER THE PERIOD-m MATCH ARRAY
+#
+#   b[i] = 1 when arr[i] == arr[i + m], i.e. "period m holds at i".
+#   the answer is yes iff b contains m*(k-1) CONSECUTIVE ones, so build the
+#   prefix sums of b once and then every window of that width is an O(1) test.
+#   (V0 does the same count with a running streak; here the counting is
+#   decoupled from the scan, which is the shape you need when several
+#   different k values must be answered over the same arr.)
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def containsPattern(self, arr, m, k):
+        n = len(arr)
+        need = m * (k - 1)
+        if need == 0:
+            return n >= m
+        b = [1 if arr[i] == arr[i + m] else 0 for i in range(n - m)]
+        if len(b) < need:
+            return False
+        pre = [0] * (len(b) + 1)
+        for i, v in enumerate(b):
+            pre[i + 1] = pre[i] + v
+        for i in range(len(b) - need + 1):
+            if pre[i + need] - pre[i] == need:
+                return True
+        return False

--- a/leetcode_python/Array/determine-if-a-cell-is-reachable-at-a-given-time.py
+++ b/leetcode_python/Array/determine-if-a-cell-is-reachable-at-a-given-time.py
@@ -58,3 +58,51 @@ class Solution(object):
         dx = abs(sx - fx)
         dy = abs(sy - fy)
         return max(dx, dy) <= t
+
+
+# V0-1
+# IDEA : REACHABLE-REGION CONTAINMENT (the exactly-t reachable set is a square)
+#
+#   a king move may change x and y at the SAME time, so the two coordinates are
+#   completely decoupled: in t seconds x can land anywhere in [sx-t, sx+t] and,
+#   independently, y anywhere in [sy-t, sy+t]. so the set of cells reachable in
+#   exactly t seconds is that axis-aligned square -- with a single hole at its
+#   own centre when t == 1, since we are forced to move every second.
+#
+#   that turns the whole problem into a bounding-box membership test, with no
+#   distance to compute at all.
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def isReachableAtTime(self, sx, sy, fx, fy, t):
+        if t == 1 and sx == fx and sy == fy:
+            return False
+        return sx - t <= fx <= sx + t and sy - t <= fy <= sy + t
+
+
+# V0-2
+# IDEA : GREEDY STEP-BY-STEP SIMULATION (why the closed form is max(|dx|, |dy|))
+#
+#   actually walk the king: each second nudge x toward fx and y toward fy at
+#   the same time, which is a diagonal move while both coordinates are off and
+#   a straight move once one of them has landed. count the seconds.
+#   abort as soon as the count passes t, so the loop runs at most t + 1 times.
+#
+#   NOTE : (fx > x) - (fx < x) is the sign of the remaining x gap, i.e. +1 / 0 / -1.
+#   NOTE : steps == 0 means we never moved (start == finish) -- reachable for
+#          t == 0 and for t >= 2 (step away and back), but not for t == 1.
+#
+# time = O(min(t, max(|dx|, |dy|))), space = O(1)
+class Solution(object):
+    def isReachableAtTime(self, sx, sy, fx, fy, t):
+        x, y = sx, sy
+        steps = 0
+        while x != fx or y != fy:
+            if steps > t:
+                return False
+            x += (fx > x) - (fx < x)
+            y += (fy > y) - (fy < y)
+            steps += 1
+        if steps == 0:
+            return t != 1
+        return steps <= t

--- a/leetcode_python/Array/determine-if-two-events-have-conflict.py
+++ b/leetcode_python/Array/determine-if-two-events-have-conflict.py
@@ -57,3 +57,46 @@ All the event times follow the HH:MM format.
 class Solution(object):
     def haveConflict(self, event1, event2):
         return event1[0] <= event2[1] and event2[0] <= event1[1]
+
+
+# V0-1
+# IDEA : PARSE TO MINUTES, THEN COMPARE INTEGERS
+#
+#   map "HH:MM" to minutes since midnight and run the same closed-interval
+#   overlap test on plain integers.
+#   NOTE : this is the version that survives a format change -- the string
+#          comparison in V0 only works because HH and MM are zero padded, so
+#          it would silently break on "9:30" vs "10:00".
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def haveConflict(self, event1, event2):
+        def to_min(hhmm):
+            h, m = hhmm.split(":")
+            return int(h) * 60 + int(m)
+
+        s1, e1 = to_min(event1[0]), to_min(event1[1])
+        s2, e2 = to_min(event2[0]), to_min(event2[1])
+        return s1 <= e2 and s2 <= e1
+
+
+# V0-2
+# IDEA : MATERIALISE THE MINUTES AND INTERSECT THE TWO SETS
+#
+#   a day holds only 1440 minutes, so we can literally build the set of minutes
+#   each event occupies (inclusive on both ends) and ask whether the two sets
+#   share anything. this is the definition of "conflict" transcribed as-is,
+#   which makes it the brute-force oracle the two O(1) formulas can be tested
+#   against.
+#
+# time = O(1440) = O(1), space = O(1440) = O(1)
+class Solution(object):
+    def haveConflict(self, event1, event2):
+        def slots(ev):
+            sh, sm = ev[0].split(":")
+            eh, em = ev[1].split(":")
+            start = int(sh) * 60 + int(sm)
+            end = int(eh) * 60 + int(em)
+            return set(range(start, end + 1))
+
+        return len(slots(event1) & slots(event2)) > 0

--- a/leetcode_python/Array/determine-the-minimum-sum-of-a-k-avoiding-array.py
+++ b/leetcode_python/Array/determine-the-minimum-sum-of-a-k-avoiding-array.py
@@ -64,3 +64,74 @@ class Solution(object):
             banned.add(k - i)
             i += 1
         return total
+
+
+# V0-1
+# IDEA : CLOSED FORM (two arithmetic series, no loop at all)
+#
+#   the greedy answer always has the same shape, so it can be summed directly:
+#     - 1, 2, ..., k//2 are ALL safe together (the largest pair among them sums
+#       to at most k - 1), so take as many of them as we still need
+#     - every number from k//2 + 1 to k - 1 is the banned partner of one of
+#       those, so nothing in that band is usable
+#     - from k upward everything is free (a pair summing to k needs both
+#       members below k)
+#
+#   head = min(n, k // 2) numbers -> 1 + 2 + ... + head
+#   tail = n - head numbers       -> k + (k + 1) + ... + (k + tail - 1)
+#
+# time = O(1), space = O(1)
+class Solution(object):
+    def minimumSum(self, n, k):
+        head = min(n, k // 2)
+        total = head * (head + 1) // 2
+        tail = n - head
+        if tail > 0:
+            total += tail * k + tail * (tail - 1) // 2
+        return total
+
+
+# V0-2
+# IDEA : DP / EXACT-COUNT KNAPSACK OVER THE CONFLICT GROUPS
+#
+#   this one proves nothing about greedy -- it just lets a DP choose, which is
+#   the approach to fall back on if the greedy exchange argument is not obvious
+#   under interview pressure.
+#
+#   only the numbers 1 .. n + k can ever be needed (that window already holds
+#   n usable numbers in the worst case). partition that window into groups:
+#     - {i, k - i} when both sides exist and differ -> at most ONE may be taken
+#     - anything else (i >= k, or i == k - i)       -> a free singleton
+#   the task is then "take exactly n items, at most one per group, minimum
+#   sum", a tiny knapsack over dp[c] = cheapest way to have taken c numbers.
+#
+# time = O((n + k) * n), space = O(n + k)
+class Solution(object):
+    def minimumSum(self, n, k):
+        limit = n + k
+        taken = [False] * (limit + 2)
+        groups = []
+        for i in range(1, limit + 1):
+            if taken[i]:
+                continue
+            j = k - i
+            taken[i] = True
+            if 1 <= j <= limit and j != i:
+                taken[j] = True
+                groups.append((i, j))
+            else:
+                groups.append((i,))
+
+        INF = float("inf")
+        dp = [INF] * (n + 1)
+        dp[0] = 0
+        for g in groups:
+            nxt = dp[:]
+            for c in range(n):
+                if dp[c] == INF:
+                    continue
+                for v in g:
+                    if dp[c] + v < nxt[c + 1]:
+                        nxt[c + 1] = dp[c] + v
+            dp = nxt
+        return dp[n]

--- a/leetcode_python/Array/determine-the-winner-of-a-bowling-game.py
+++ b/leetcode_python/Array/determine-the-winner-of-a-bowling-game.py
@@ -97,3 +97,58 @@ class Solution(object):
         if b > a:
             return 2
         return 0
+
+
+# V0-1
+# IDEA : FORWARD MARKING (push the bonus forward instead of looking backward)
+#
+#   the block above asks, at every turn, "was one of my two previous turns
+#   a strike?".
+#   flip the direction: walk once and, on each strike at turn i, stamp a x2
+#   multiplier onto turns i + 1 and i + 2. a second pass multiplies and sums.
+#
+#   NOTE : stamping the value 2 (rather than doubling in place) is what keeps
+#          the bonus from stacking when two strikes both point at the same turn.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def isWinner(self, player1, player2):
+        def score(arr):
+            n = len(arr)
+            mult = [1] * n
+            for i, x in enumerate(arr):
+                if x == 10:
+                    for j in (i + 1, i + 2):
+                        if j < n:
+                            mult[j] = 2
+            return sum(x * m for x, m in zip(arr, mult))
+
+        a, b = score(player1), score(player2)
+        return 1 if a > b else (2 if b > a else 0)
+
+
+# V0-2
+# IDEA : BASE SUM + BONUS SUM (2*x is x + x)
+#
+#   split the score into a part that needs no rules and a correction:
+#     score = sum(arr) + one EXTRA copy of every turn that follows a strike
+#             within two turns
+#   collecting those positions in a SET is what removes the double counting
+#   when two strikes cover the same turn, so the bonus is added at most once.
+#   comparing the two scores then reduces to the sign of their difference.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def isWinner(self, player1, player2):
+        def score(arr):
+            n = len(arr)
+            bonus = {j for i, x in enumerate(arr) if x == 10
+                     for j in (i + 1, i + 2) if j < n}
+            return sum(arr) + sum(arr[j] for j in bonus)
+
+        diff = score(player1) - score(player2)
+        if diff > 0:
+            return 1
+        if diff < 0:
+            return 2
+        return 0

--- a/leetcode_python/Array/determine-whether-matrix-can-be-obtained-by-rotation.py
+++ b/leetcode_python/Array/determine-whether-matrix-can-be-obtained-by-rotation.py
@@ -57,3 +57,67 @@ class Solution(object):
             cur = [[cur[n - 1 - j][i] for j in range(n)] for i in range(n)]
 
         return False
+
+
+# V0-1
+# IDEA : INDEX-MAPPED COMPARISON (no rotated matrix is ever built)
+#
+#   instead of materialising each rotation, compare cell-by-cell through the
+#   index map that a k-times-90-degrees-clockwise rotation induces :
+#
+#     k = 0 : target[i][j] == mat[i][j]
+#     k = 1 : target[i][j] == mat[n-1-j][i]
+#     k = 2 : target[i][j] == mat[n-1-i][n-1-j]
+#     k = 3 : target[i][j] == mat[j][n-1-i]
+#
+#   all() short-circuits on the first mismatch, and nothing is allocated, so
+#   this trades the O(n^2) scratch matrix of V0 for O(1) extra space.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def findRotation(self, mat, target):
+        n = len(mat)
+        maps = [
+            lambda i, j: (i, j),
+            lambda i, j: (n - 1 - j, i),
+            lambda i, j: (n - 1 - i, n - 1 - j),
+            lambda i, j: (j, n - 1 - i),
+        ]
+
+        for f in maps:
+            if all(
+                target[i][j] == mat[f(i, j)[0]][f(i, j)[1]]
+                for i in range(n)
+                for j in range(n)
+            ):
+                return True
+        return False
+
+
+# V0-2
+# IDEA : CANONICAL FORM OF THE ROTATION ORBIT
+#
+#   "mat is reachable from target by rotation" is an equivalence relation :
+#   both matrices sit in the same 4-element rotation orbit. So pick ONE
+#   representative of an orbit - the lexicographically smallest of its 4
+#   rotations, flattened to a tuple - and just compare representatives.
+#
+#   this needs no pairwise loop over the two inputs at all; it is the standard
+#   canonicalisation trick that also lets you bucket many matrices by orbit
+#   (e.g. group / dedup a whole list) in one pass each.
+#
+# time = O(n^2), space = O(n^2)
+class Solution(object):
+    def findRotation(self, mat, target):
+        def canonical(m):
+            n = len(m)
+            cur = m
+            best = None
+            for _ in range(4):
+                flat = tuple(v for row in cur for v in row)
+                if best is None or flat < best:
+                    best = flat
+                cur = [[cur[n - 1 - j][i] for j in range(n)] for i in range(n)]
+            return best
+
+        return canonical(mat) == canonical(target)

--- a/leetcode_python/Array/difference-between-element-sum-and-digit-sum-of-an-array.py
+++ b/leetcode_python/Array/difference-between-element-sum-and-digit-sum-of-an-array.py
@@ -60,3 +60,40 @@ class Solution(object):
                 digit_sum += v % 10
                 v //= 10
         return abs(elem_sum - digit_sum)
+
+
+# V0-1
+# IDEA : DECIMAL STRING SCAN (str() does the digit split, not % / //)
+#
+#   the digit sum of v is just the sum of the characters of its decimal
+#   spelling, so one flat generator over str(v) replaces the divmod loop.
+#   no arithmetic peeling at all - the base-10 decomposition is delegated to
+#   int -> str conversion.
+#
+# time = O(n * log10(M)), space = O(log10(M)) for the temporary strings
+class Solution(object):
+    def differenceOfSum(self, nums):
+        elem_sum = sum(nums)
+        digit_sum = sum(int(ch) for v in nums for ch in str(v))
+        return abs(elem_sum - digit_sum)
+
+
+# V0-2
+# IDEA : DP LOOKUP TABLE OF DIGIT SUMS (tabulation, digits reused)
+#
+#   digit_sum(v) = digit_sum(v // 10) + v % 10, so a bottom-up table over
+#   0..max(nums) fills every digit sum in O(1) each. Then the answer is two
+#   O(n) sums with NO per-element digit work.
+#
+#   this wins when the array is long relative to the value range (here
+#   nums[i] <= 2000 while n can be 2000) and it is the shape you want if the
+#   same digit sums get queried repeatedly.
+#
+# time = O(M + n), space = O(M)  where M = max(nums)
+class Solution(object):
+    def differenceOfSum(self, nums):
+        top = max(nums)
+        ds = [0] * (top + 1)
+        for v in range(1, top + 1):
+            ds[v] = ds[v // 10] + v % 10
+        return abs(sum(nums) - sum(ds[v] for v in nums))

--- a/leetcode_python/Array/difference-between-ones-and-zeros-in-row-and-column.py
+++ b/leetcode_python/Array/difference-between-ones-and-zeros-in-row-and-column.py
@@ -83,3 +83,59 @@ class Solution(object):
             for j in range(n):
                 out[j] = base + 2 * cols[j]
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE (re-count row i and column j for every cell)
+#
+#   read the statement literally : for each of the m * n cells, walk its whole
+#   row and its whole column tallying ones and zeros, then plug the four
+#   numbers into diff[i][j] = onesRow + onesCol - zerosRow - zerosCol.
+#
+#   no precomputation and no algebra, so it is the easiest version to trust -
+#   but each row is re-scanned n times and each column m times, which blows up
+#   at the m * n <= 10^5 limit. Kept as the reference/oracle version.
+#
+# time = O(m * n * (m + n)), space = O(1) besides the output
+class Solution(object):
+    def onesMinusZeros(self, grid):
+        m, n = len(grid), len(grid[0])
+        res = [[0] * n for _ in range(m)]
+        for i in range(m):
+            for j in range(n):
+                ones_row = zeros_row = 0
+                for y in range(n):
+                    if grid[i][y]:
+                        ones_row += 1
+                    else:
+                        zeros_row += 1
+                ones_col = zeros_col = 0
+                for x in range(m):
+                    if grid[x][j]:
+                        ones_col += 1
+                    else:
+                        zeros_col += 1
+                res[i][j] = ones_row + ones_col - zeros_row - zeros_col
+        return res
+
+
+# V0-2
+# IDEA : SEPARABLE MATRIX = OUTER SUM OF TWO VECTORS (transpose via zip)
+#
+#   diff[i][j] = (2 * onesRow_i - n) + (2 * onesCol_j - m), i.e. it is
+#   f(i) + g(j) - a rank-1 / separable matrix. So the answer never needs a
+#   2-D scan : build the row vector f with sum() per row, build the column
+#   vector g by transposing the grid with zip(*grid) and sum()-ing the tuples,
+#   then emit the outer sum with one comprehension.
+#
+#   the counting is pushed into C-level sum()/zip() instead of a hand-written
+#   double loop, and the "answer = f(i) + g(j)" framing is what generalises to
+#   any separable-formula grid problem.
+#
+# time = O(m * n), space = O(m + n) besides the output
+class Solution(object):
+    def onesMinusZeros(self, grid):
+        m, n = len(grid), len(grid[0])
+        f = [2 * sum(row) - n for row in grid]
+        g = [2 * sum(col) - m for col in zip(*grid)]
+        return [[fi + gj for gj in g] for fi in f]

--- a/leetcode_python/Array/difference-of-number-of-distinct-values-on-diagonals.py
+++ b/leetcode_python/Array/difference-of-number-of-distinct-values-on-diagonals.py
@@ -99,3 +99,81 @@ class Solution(object):
                 seen.add(grid[x][y])
 
         return ans
+
+
+# V0-1
+# IDEA : BRUTE FORCE (walk both diagonal rays out of every cell)
+#
+#   for each cell, step up-left collecting values into a set until falling off
+#   the grid, then step down-right into a second set, and take the absolute
+#   difference of the two set sizes. The cell itself is never added, which is
+#   exactly the "not including grid[r][c]" clause.
+#
+#   each cell walks up to min(m, n) steps in each direction, so this is the
+#   O(m * n * min(m, n)) version - fine at m, n <= 50, and the obvious oracle
+#   for the linear sweeps.
+#
+# time = O(m * n * min(m, n)), space = O(min(m, n))
+class Solution(object):
+    def differenceOfDistinctValues(self, grid):
+        m, n = len(grid), len(grid[0])
+        ans = [[0] * n for _ in range(m)]
+
+        for r in range(m):
+            for c in range(n):
+                left_above = set()
+                x, y = r - 1, c - 1
+                while x >= 0 and y >= 0:
+                    left_above.add(grid[x][y])
+                    x, y = x - 1, y - 1
+
+                right_below = set()
+                x, y = r + 1, c + 1
+                while x < m and y < n:
+                    right_below.add(grid[x][y])
+                    x, y = x + 1, y + 1
+
+                ans[r][c] = abs(len(left_above) - len(right_below))
+        return ans
+
+
+# V0-2
+# IDEA : GROUP BY (r - c) + SHRINKING MULTISET, ONE PASS PER DIAGONAL
+#
+#   cells on the same top-left -> bottom-right diagonal all share the key
+#   r - c, so a defaultdict keyed on r - c collects the diagonals without any
+#   "find the starting cell" logic.
+#
+#   then a single forward pass per diagonal, carrying TWO structures :
+#     - `left`  : a set that GROWS behind the cursor
+#     - `right` : a Counter (multiset) of everything ahead, seeded with the
+#                 whole diagonal, from which the current cell is removed
+#                 before it is read
+#   len(right) is the number of distinct values still ahead, so no prefix
+#   array and no backward pass are needed - the multiset is what makes the
+#   "distinct count of a shrinking suffix" query O(1).
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def differenceOfDistinctValues(self, grid):
+        from collections import Counter, defaultdict
+
+        m, n = len(grid), len(grid[0])
+        ans = [[0] * n for _ in range(m)]
+
+        diag = defaultdict(list)
+        for r in range(m):
+            for c in range(n):
+                diag[r - c].append((r, c))
+
+        for cells in diag.values():
+            right = Counter(grid[x][y] for x, y in cells)
+            left = set()
+            for x, y in cells:
+                v = grid[x][y]
+                right[v] -= 1
+                if right[v] == 0:
+                    del right[v]
+                ans[x][y] = abs(len(left) - len(right))
+                left.add(v)
+        return ans

--- a/leetcode_python/Array/distance-between-bus-stops.py
+++ b/leetcode_python/Array/distance-between-bus-stops.py
@@ -64,3 +64,59 @@ class Solution(object):
         total = sum(distance)
         clockwise = sum(distance[lo:hi])
         return min(clockwise, total - clockwise)
+
+
+# V0-1
+# IDEA : EXPLICIT PREFIX-SUM TABLE (O(1) per query afterwards)
+#
+#   precompute P where P[k] = distance[0] + ... + distance[k-1] (P[0] = 0).
+#   then ANY forward arc [lo, hi) is P[hi] - P[lo] in constant time, and the
+#   whole ring is P[n], so :
+#     clockwise = P[hi] - P[lo],  counter = P[n] - clockwise
+#
+#   V0 re-sums a slice each time; the table makes the summation a one-off, so
+#   answering q different (start, destination) pairs costs O(n + q) instead of
+#   O(n * q). itertools.accumulate builds it in one C-level pass.
+#
+# time = O(n) to build then O(1) per query, space = O(n)
+class Solution(object):
+    def distanceBetweenBusStops(self, distance, start, destination):
+        from itertools import accumulate
+
+        pre = [0] + list(accumulate(distance))
+        lo, hi = min(start, destination), max(start, destination)
+        clockwise = pre[hi] - pre[lo]
+        return min(clockwise, pre[-1] - clockwise)
+
+
+# V0-2
+# IDEA : SIMULATE THE BUS IN BOTH DIRECTIONS WITH MODULAR STEPS
+#
+#   actually ride the ring. going clockwise from i you pay distance[i] and
+#   land on (i + 1) % n; going counterclockwise from i you step back to
+#   (i - 1) % n and pay distance[(i - 1) % n] (the edge you just crossed).
+#
+#   walk each direction from start until destination is reached, accumulating,
+#   and take the smaller total. No min/max normalisation and no total sum are
+#   needed - the wrap-around is handled by the modulus itself, which is the
+#   version that still works if the ring were directed or edge costs differed
+#   per direction.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def distanceBetweenBusStops(self, distance, start, destination):
+        n = len(distance)
+
+        cw = 0
+        i = start
+        while i != destination:
+            cw += distance[i]
+            i = (i + 1) % n
+
+        ccw = 0
+        i = start
+        while i != destination:
+            i = (i - 1) % n
+            ccw += distance[i]
+
+        return min(cw, ccw)

--- a/leetcode_python/Array/distribute-elements-into-two-arrays-i.py
+++ b/leetcode_python/Array/distribute-elements-into-two-arrays-i.py
@@ -62,3 +62,64 @@ class Solution(object):
             else:
                 arr2.append(x)
         return arr1 + arr2
+
+
+# V0-1
+# IDEA : RECURSION (carry the two arrays down the index)
+#
+#   the same rule expressed as a recurrence over the remaining suffix :
+#     go(i, a, b) = go(i+1, a + [nums[i]], b)   if a[-1] > b[-1]
+#                 = go(i+1, a, b + [nums[i]])   otherwise
+#   with the base case i == n returning a + b.
+#
+#   NOTE : the state is threaded through the call instead of being mutated, so
+#          there is nothing to undo on the way back up; depth is n (n <= 50,
+#          so no recursion-limit worry).
+#
+# time = O(n), space = O(n) for the frames plus the carried lists
+class Solution(object):
+    def resultArray(self, nums):
+        n = len(nums)
+
+        def go(i, a, b):
+            if i == n:
+                return a + b
+            if a[-1] > b[-1]:
+                return go(i + 1, a + [nums[i]], b)
+            return go(i + 1, a, b + [nums[i]])
+
+        return go(2, [nums[0]], [nums[1]])
+
+
+# V0-2
+# IDEA : TWO PASS - RECORD THE ROUTING BITS FIRST, BUILD THE ANSWER AFTER
+#
+#   the decision at step i depends ONLY on the two current tail values, so the
+#   simulation does not need the arrays at all : keep `t1` / `t2` as scalars,
+#   and write a 0/1 bit per element saying where it went.
+#
+#   pass 2 then materialises the answer by filtering nums on that bit list
+#   (all the 0s in order, then all the 1s), which is a stable partition.
+#
+#   the point : the routing decision is decoupled from the container growth,
+#   so pass 1 is O(1) auxiliary state per step and the ordering is recovered
+#   purely from the recorded bits.
+#
+# time = O(n), space = O(n) for the bit list plus the output
+class Solution(object):
+    def resultArray(self, nums):
+        n = len(nums)
+        where = [0] * n
+        where[1] = 1
+        t1, t2 = nums[0], nums[1]
+
+        for i in range(2, n):
+            if t1 > t2:
+                t1 = nums[i]
+                where[i] = 0
+            else:
+                t2 = nums[i]
+                where[i] = 1
+
+        return ([nums[i] for i in range(n) if where[i] == 0]
+                + [nums[i] for i in range(n) if where[i] == 1])

--- a/leetcode_python/Array/divide-an-array-into-subarrays-with-minimum-cost-i.py
+++ b/leetcode_python/Array/divide-an-array-into-subarrays-with-minimum-cost-i.py
@@ -58,3 +58,48 @@ class Solution(object):
     def minimumCost(self, nums):
         rest = sorted(nums[1:])
         return nums[0] + rest[0] + rest[1]
+
+
+# V0-1
+# IDEA : BRUTE FORCE OVER EVERY PAIR OF CUT POSITIONS
+#
+#   a division is fully described by the two indices i < j at which the 2nd and
+#   3rd subarrays begin (1 <= i < j <= n-1), and its cost is then simply
+#   nums[0] + nums[i] + nums[j]. n <= 50, so all O(n^2) pairs can be tried.
+#
+#   this is the "no insight needed" baseline that the V0 observation replaces.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def minimumCost(self, nums):
+        n = len(nums)
+        best = float('inf')
+        for i in range(1, n - 1):
+            for j in range(i + 1, n):
+                cost = nums[0] + nums[i] + nums[j]
+                if cost < best:
+                    best = cost
+        return best
+
+
+# V0-2
+# IDEA : ONE PASS SELECTION OF THE TWO SMALLEST STARTS (NO SORTING)
+#
+#   same insight as V0 (pay nums[0], then the two cheapest of nums[1:]), but the
+#   two minima are tracked with a pair of running variables instead of being read
+#   off a sorted copy -- selection instead of a full sort, so O(n) / O(1).
+#
+#   `first` holds the smallest seen so far, `second` the runner up; a new value
+#   either displaces `first` (pushing it down into `second`) or only `second`.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minimumCost(self, nums):
+        first = second = float('inf')
+        for i in range(1, len(nums)):
+            v = nums[i]
+            if v < first:
+                first, second = v, first
+            elif v < second:
+                second = v
+        return nums[0] + first + second

--- a/leetcode_python/Array/drop-duplicate-rows.py
+++ b/leetcode_python/Array/drop-duplicate-rows.py
@@ -73,3 +73,44 @@ class Solution(object):
 
 def dropDuplicateEmails(customers):
     return Solution().dropDuplicateEmails(customers)
+
+
+# V0-1
+# IDEA : GROUPBY THE KEY COLUMN AND TAKE THE FIRST ROW OF EACH GROUP
+#
+#   instead of asking pandas to de-duplicate, group the rows by `email` and keep
+#   the head of every group. `groupby(...).head(1)` is applied as a per-group
+#   row mask, so the surviving rows come back in the ORIGINAL frame order with
+#   their original index labels -- unlike `groupby(...).first()`, which
+#   aggregates and re-indexes by the (sorted) group key.
+#
+#   `sort=False` only saves the needless ordering of group keys; the output
+#   order is already fixed by the mask.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def dropDuplicateEmails(self, customers):
+        return customers.groupby("email", sort=False).head(1)
+
+
+# V0-2
+# IDEA : EXPLICIT SET SCAN OVER THE KEY COLUMN, THEN SELECT BY LABEL
+#
+#   no pandas de-duplication primitive at all : walk the `email` column in row
+#   order, remember every email already seen in a set, and record the index
+#   label of each row whose email is new. One `.loc[keep]` then materialises the
+#   result. This is what drop_duplicates does internally, spelled out.
+#
+#   useful when the "first occurrence" rule is more complex than a plain key
+#   match (e.g. case-insensitive emails -> add `email.lower()` to the set).
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def dropDuplicateEmails(self, customers):
+        seen = set()
+        keep = []
+        for label, email in customers["email"].items():
+            if email not in seen:
+                seen.add(email)
+                keep.append(label)
+        return customers.loc[keep]

--- a/leetcode_python/Array/drop-missing-data.py
+++ b/leetcode_python/Array/drop-missing-data.py
@@ -67,3 +67,41 @@ class Solution(object):
 
 def dropMissingData(students):
     return Solution().dropMissingData(students)
+
+
+# V0-1
+# IDEA : BUILD THE SET OF BAD LABELS WITH isna(), THEN DROP THEM BY LABEL
+#
+#   the inverse framing of V0 : instead of SELECTING the rows to keep, compute
+#   the index labels of the offending rows (`index[...isna()]`) and hand them to
+#   `DataFrame.drop`, which removes rows by label.
+#
+#   worth knowing because it composes : the same label set can be reused (e.g.
+#   logged, or dropped from a second frame that shares the index), which a
+#   boolean-mask selection cannot hand you.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def dropMissingData(self, students):
+        bad = students.index[students["name"].isna()]
+        return students.drop(index=bad)
+
+
+# V0-2
+# IDEA : EXPLICIT PYTHON SCAN OVER THE COLUMN, THEN SELECT BY LABEL
+#
+#   no pandas null-handling primitive : iterate the `name` column, test each
+#   value with `pd.isna` (which catches both the `None` of an object column and
+#   float `NaN`), collect the labels that survive, and materialise once via
+#   `.loc`.
+#
+#   NOTE : the explicit predicate is the point -- swap `pd.isna(v)` for
+#          `pd.isna(v) or v == ""` and empty strings drop too, something
+#          `dropna` will never do for you.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def dropMissingData(self, students):
+        keep = [label for label, v in students["name"].items()
+                if not pd.isna(v)]
+        return students.loc[keep]

--- a/leetcode_python/Array/earliest-finish-time-for-land-and-water-rides-i.py
+++ b/leetcode_python/Array/earliest-finish-time-for-land-and-water-rides-i.py
@@ -114,3 +114,78 @@ class Solution(object):
                 if fin < best:
                     best = fin
         return best
+
+
+# V0-1
+# IDEA : ONLY THE EARLIEST-FINISHING FIRST RIDE MATTERS -- O(n + m)
+#
+#   fix the order (say land first). the finish time is
+#       max(landFinish_i, ws_j) + wd_j
+#   which is NON-DECREASING in landFinish_i, so for EVERY choice of j the best
+#   partner i is the same one : the land ride with the smallest ls_i + ld_i.
+#
+#   that collapses the double loop of V0 into "one min over the first category,
+#   then one min over the second", done once per order.
+#
+# time = O(n + m), space = O(1)
+class Solution(object):
+    def earliestFinishTime(self, landStartTime, landDuration, waterStartTime, waterDuration):
+        def best(firstStart, firstDur, secondStart, secondDur):
+            t = min(s + d for s, d in zip(firstStart, firstDur))
+            return min(max(t, s) + d for s, d in zip(secondStart, secondDur))
+
+        return min(
+            best(landStartTime, landDuration, waterStartTime, waterDuration),
+            best(waterStartTime, waterDuration, landStartTime, landDuration),
+        )
+
+
+# V0-2
+# IDEA : BUCKET THE SECOND CATEGORY BY OPENING TIME (PREFIX / SUFFIX MINIMA)
+#
+#   answer the query "given I am free at time t, when can I finish a ride of the
+#   second category?" for EVERY t in O(1), by splitting the rides in two:
+#     - already open (ss_j <= t)  -> finish t + sd_j   -> want min duration,
+#       so openBy[T] = prefix-min of sd_j over ss_j <= T
+#     - not open yet (ss_j >  t)  -> finish ss_j + sd_j -> want min of that sum,
+#       so fromT[T] = suffix-min of (ss_j + sd_j) over ss_j >= T
+#   then f(t) = min(t + openBy[t], fromT[t + 1]).
+#
+#   times are bounded (start, duration <= 1000 => any finish <= 2000), so both
+#   tables are plain arrays indexed by time -- a counting/bucket table rather
+#   than a sort or a scan. Unlike V0-1 this handles every first ride cheaply,
+#   which is what you would need if a first ride could be forbidden per query.
+#
+# time = O(n + m + MAX_T), space = O(MAX_T)
+class Solution(object):
+    def earliestFinishTime(self, landStartTime, landDuration, waterStartTime, waterDuration):
+        INF = float('inf')
+        LIM = 2001          # every reachable time index, inclusive
+
+        def best(firstStart, firstDur, secondStart, secondDur):
+            openBy = [INF] * (LIM + 2)
+            fromT = [INF] * (LIM + 2)
+            for s, d in zip(secondStart, secondDur):
+                if d < openBy[s]:
+                    openBy[s] = d
+                if s + d < fromT[s]:
+                    fromT[s] = s + d
+            for T in range(1, LIM + 1):
+                if openBy[T - 1] < openBy[T]:
+                    openBy[T] = openBy[T - 1]
+            for T in range(LIM - 1, -1, -1):
+                if fromT[T + 1] < fromT[T]:
+                    fromT[T] = fromT[T + 1]
+
+            res = INF
+            for s, d in zip(firstStart, firstDur):
+                t = s + d
+                cand = min(t + openBy[t], fromT[t + 1])
+                if cand < res:
+                    res = cand
+            return res
+
+        return min(
+            best(landStartTime, landDuration, waterStartTime, waterDuration),
+            best(waterStartTime, waterDuration, landStartTime, landDuration),
+        )

--- a/leetcode_python/Array/earliest-time-to-finish-one-task.py
+++ b/leetcode_python/Array/earliest-time-to-finish-one-task.py
@@ -47,3 +47,43 @@ tasks[i] = [si, ti]
 class Solution(object):
     def earliestTime(self, tasks):
         return min(s + t for s, t in tasks)
+
+
+# V0-1
+# IDEA : SORT THE FINISH TIMES AND TAKE THE FIRST
+#
+#   build the list of independent finish times s_i + t_i, sort it, read index 0.
+#   strictly more work than the single min-scan of V0 (a full ordering is
+#   computed when only its smallest element is used), but it is the shape you
+#   want the moment the question becomes "the k-th earliest task to finish"
+#   instead of "the earliest" -- then the answer is just `finish[k - 1]`.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def earliestTime(self, tasks):
+        finish = sorted(s + t for s, t in tasks)
+        return finish[0]
+
+
+# V0-2
+# IDEA : COUNTING / BUCKET SCAN OVER THE BOUNDED TIME RANGE
+#
+#   s_i, t_i <= 100, so every finish time falls in 0..200. Mark each achieved
+#   finish time in a flat boolean table, then walk the table upward and return
+#   the first marked slot -- no comparison between tasks is ever made, the
+#   ordering comes from the array indices themselves (counting sort).
+#
+#   this is the version that stays O(1) per extra task when the same table is
+#   queried repeatedly (e.g. streaming tasks, or "how many finish by time T").
+#
+# time = O(n + MAX_T), space = O(MAX_T)
+class Solution(object):
+    def earliestTime(self, tasks):
+        LIM = 200           # max s_i + t_i under the constraints
+        seen = [False] * (LIM + 1)
+        for s, t in tasks:
+            seen[s + t] = True
+        for v in range(LIM + 1):
+            if seen[v]:
+                return v
+        return -1

--- a/leetcode_python/Array/elements-in-array-after-removing-and-replacing-elements.py
+++ b/leetcode_python/Array/elements-in-array-after-removing-and-replacing-elements.py
@@ -80,3 +80,78 @@ class Solution(object):
             else:
                 res.append(nums[index] if index < t - n else -1)
         return res
+
+
+# V0-1
+# IDEA : SIMULATE ONE FULL CYCLE AND SNAPSHOT EVERY STATE, THEN LOOK UP
+#
+#   rather than deriving the index formula, just run the process for the 2n
+#   minutes of one period with a deque -- popleft during the shrinking half,
+#   append the removed values back (in removal order) during the growing half --
+#   and store a copy of the array at each minute.
+#
+#   every query is then `states[time % (2n)]`, an O(1) lookup plus a length test.
+#   n <= 100, so the 2n snapshots cost at most ~10^4 cells.
+#
+# time = O(n^2 + q), space = O(n^2 + q)
+from collections import deque
+
+class Solution(object):
+    def elementInNums(self, nums, queries):
+        n = len(nums)
+        cur = deque(nums)
+        removed = deque()
+        states = []
+        for _ in range(n):                 # minutes 0 .. n-1 : shrinking
+            states.append(list(cur))
+            removed.append(cur.popleft())
+        for _ in range(n):                 # minutes n .. 2n-1 : growing back
+            states.append(list(cur))
+            cur.append(removed.popleft())
+
+        res = []
+        for t, index in queries:
+            state = states[t % (2 * n)]
+            res.append(state[index] if index < len(state) else -1)
+        return res
+
+
+# V0-2
+# IDEA : OFFLINE SWEEP -- BUCKET THE QUERIES BY time % 2n, SIMULATE ONCE
+#
+#   the queries are answered out of order : first bucket each query index under
+#   `time % (2n)`, then walk the single cycle once and, at each minute, answer
+#   only the queries parked on that minute. Nothing but the current array is
+#   ever kept, so no 2n snapshots are stored (unlike V0-1) -- the classic
+#   offline-query trade of "answer in a convenient order" for memory.
+#
+#   the deque is materialised into a list only on minutes that actually carry
+#   queries, which is what keeps the per-answer cost O(1).
+#
+# time = O(n^2 + q), space = O(n + q)
+from collections import defaultdict, deque
+
+class Solution(object):
+    def elementInNums(self, nums, queries):
+        n = len(nums)
+        cycle = 2 * n
+        buckets = defaultdict(list)
+        for qi, (t, _) in enumerate(queries):
+            buckets[t % cycle].append(qi)
+
+        res = [-1] * len(queries)
+        cur = deque(nums)
+        removed = deque()
+        for minute in range(cycle):
+            todo = buckets.get(minute)
+            if todo:
+                snap = list(cur)
+                for qi in todo:
+                    index = queries[qi][1]
+                    if index < len(snap):
+                        res[qi] = snap[index]
+            if minute < n:
+                removed.append(cur.popleft())
+            else:
+                cur.append(removed.popleft())
+        return res

--- a/leetcode_python/Array/equal-sum-grid-partition-i.py
+++ b/leetcode_python/Array/equal-sum-grid-partition-i.py
@@ -88,3 +88,84 @@ class Solution(object):
             if run == half:
                 return True
         return False
+
+
+# V0-1
+# IDEA : TWO POINTERS -- GROW THE LIGHTER SIDE UNTIL THE TWO SIDES BALANCE
+#
+#   collapse the grid to its row sums (and separately its column sums).  every
+#   cell is positive, so the prefix grows and the suffix shrinks monotonically
+#   as the cut slides right -- the two curves can cross at most once.
+#
+#   that lets a pair of pointers walk toward each other instead of scanning:
+#   whichever side is currently lighter absorbs the next line, because the
+#   lighter side can never be fixed by making the heavier side heavier.  when
+#   the pointers become adjacent the only candidate cut left is between them,
+#   so one equality test finishes it.  no total / 2 division is needed, which
+#   also removes the "odd total" special case.
+#
+# time = O(m * n), space = O(m + n)
+class Solution(object):
+    def canPartitionGrid(self, grid):
+        m, n = len(grid), len(grid[0])
+        rows = [sum(r) for r in grid]
+        if self._meet(rows):
+            return True
+
+        cols = [0] * n
+        for r in grid:
+            for j, v in enumerate(r):
+                cols[j] += v
+        return self._meet(cols)
+
+    def _meet(self, arr):
+        if len(arr) < 2:                  # a cut needs two non-empty sides
+            return False
+        lo, hi = 0, len(arr) - 1
+        left, right = arr[lo], arr[hi]
+        while lo + 1 < hi:
+            if left < right:
+                lo += 1
+                left += arr[lo]
+            else:
+                hi -= 1
+                right += arr[hi]
+        return left == right
+
+
+# V0-2
+# IDEA : 2D PREFIX SUM MATRIX -- EVERY CUT BECOMES AN O(1) RECTANGLE QUERY
+#
+#   build pre[i][j] = sum of the sub-rectangle [0..i) x [0..j).  then the top
+#   part of a horizontal cut after row i-1 is pre[i][n] and the left part of a
+#   vertical cut after column j-1 is pre[m][j], both read in constant time, so
+#   the cut scan is decoupled from how the sums were accumulated.
+#
+#   heavier on memory than the running-total version, but it is the shape to
+#   reach for when the follow-up asks for arbitrary sub-rectangles (two cuts,
+#   a cut plus a hole, ...) rather than only full-width splits.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def canPartitionGrid(self, grid):
+        m, n = len(grid), len(grid[0])
+        pre = [[0] * (n + 1) for _ in range(m + 1)]
+        for i in range(m):
+            row, up, cur = grid[i], pre[i], pre[i + 1]
+            run = 0
+            for j in range(n):
+                run += row[j]
+                cur[j + 1] = up[j + 1] + run
+
+        total = pre[m][n]
+        if total % 2:
+            return False
+        half = total // 2
+
+        for i in range(1, m):             # horizontal cut below row i-1
+            if pre[i][n] == half:
+                return True
+        for j in range(1, n):             # vertical cut right of column j-1
+            if pre[m][j] == half:
+                return True
+        return False

--- a/leetcode_python/Array/equal-sum-grid-partition-ii.py
+++ b/leetcode_python/Array/equal-sum-grid-partition-ii.py
@@ -144,3 +144,117 @@ class Solution(object):
                 elif need == g[i + 1][0] or need == g[rows - 1][cols - 1]:
                     return True
         return False
+
+
+# V0-1
+# IDEA : BRUTE FORCE -- REBUILD BOTH PIECES AT EVERY CUT AND HUNT THE CELL
+#
+#   the reference version of the sweep, written so the rule being tested is
+#   visible: for each of the m-1 + n-1 cuts, add up the two pieces from
+#   scratch, and if they differ by d then look for a cell worth exactly d in
+#   the heavier piece that may be punched out without breaking it.
+#
+#   removability is the whole subtlety, so it lives in one helper.  a piece is
+#   always a full-width band of rows, so it is a rectangle: with at least two
+#   rows AND at least two columns any single cell can go and the rest is still
+#   connected, but a one-cell-wide strip only survives losing one of its two
+#   end cells.
+#
+#   O((m + n) * m * n) -- too slow for the real limits, kept as the statement
+#   of intent that the hash-map sweep above optimises.
+#
+# time = O((m + n) * m * n), space = O(m * n)
+class Solution(object):
+    def canPartitionGrid(self, grid):
+        if self._brute(grid):
+            return True
+        m, n = len(grid), len(grid[0])
+        return self._brute([[grid[i][j] for i in range(m)] for j in range(n)])
+
+    def _brute(self, g):
+        rows, cols = len(g), len(g[0])
+        for i in range(rows - 1):
+            s_top = sum(sum(g[r]) for r in range(i + 1))
+            s_bot = sum(sum(g[r]) for r in range(i + 1, rows))
+            if s_top == s_bot:
+                return True
+            if s_top > s_bot:
+                if self._removable(g, 0, i, cols, s_top - s_bot):
+                    return True
+            elif self._removable(g, i + 1, rows - 1, cols, s_bot - s_top):
+                return True
+        return False
+
+    def _removable(self, g, r0, r1, cols, need):
+        # rows r0..r1 x every column: is there a cell == need whose removal
+        # leaves the rest of that rectangle connected?
+        if r1 > r0 and cols >= 2:                 # both sides >= 2 : any cell
+            for r in range(r0, r1 + 1):
+                for v in g[r]:
+                    if v == need:
+                        return True
+            return False
+        # a strip (one row, or one column) : only its two ends can be dropped
+        return need == g[r0][0] or need == g[r1][cols - 1]
+
+
+# V0-2
+# IDEA : BIG-INT BITMASK MEMBERSHIP + ONE FORWARD AND ONE BACKWARD PASS
+#
+#   the sweep only ever asks "does this piece contain the value d", and cell
+#   values are bounded by 10^5, so the value set fits in a single Python
+#   integer used as a bitset: bit v is on iff v is present.  membership is then
+#   a shift and a mask instead of a dict probe, and no per-cut bookkeeping of
+#   *removals* is needed at all.
+#
+#   that is the point of splitting the walk in two: the forward pass grows the
+#   top piece and answers only the cuts where the top is heavier, the backward
+#   pass grows the bottom piece and answers only the cuts where the bottom is
+#   heavier.  each pass adds bits and never clears them, so no complement
+#   structure has to be maintained.
+#
+#   V = 10^5 is the value ceiling; the bitset holds V bits, i.e. V / 64 words.
+#
+# time = O(m * n * V / 64), space = O(V / 64 + m + n)
+class Solution(object):
+    def canPartitionGrid(self, grid):
+        if self._sweep(grid):
+            return True
+        m, n = len(grid), len(grid[0])
+        return self._sweep([[grid[i][j] for i in range(m)] for j in range(n)])
+
+    def _sweep(self, g):
+        rows, cols = len(g), len(g[0])
+        rs = [sum(r) for r in g]
+        total = sum(rs)
+
+        # forward : discount one cell of the top piece (rows 0..i)
+        mask, s = 0, 0
+        for i in range(rows - 1):
+            for v in g[i]:
+                mask |= 1 << v
+            s += rs[i]
+            diff = 2 * s - total
+            if diff == 0:
+                return True
+            if diff > 0:
+                if i >= 1 and cols >= 2:
+                    if (mask >> diff) & 1:
+                        return True
+                elif diff == g[0][0] or diff == g[i][cols - 1]:
+                    return True
+
+        # backward : discount one cell of the bottom piece (rows i+1..rows-1)
+        mask, s = 0, 0
+        for i in range(rows - 2, -1, -1):
+            for v in g[i + 1]:
+                mask |= 1 << v
+            s += rs[i + 1]
+            need = 2 * s - total                  # bottom - top
+            if need > 0:
+                if rows - i >= 3 and cols >= 2:
+                    if (mask >> need) & 1:
+                        return True
+                elif need == g[i + 1][0] or need == g[rows - 1][cols - 1]:
+                    return True
+        return False

--- a/leetcode_python/Array/faulty-sensor.py
+++ b/leetcode_python/Array/faulty-sensor.py
@@ -84,3 +84,72 @@ class Solution(object):
         if ok2 and not ok1:
             return 2
         return -1
+
+
+# V0-1
+# IDEA : BRUTE FORCE -- SIMULATE EVERY POSSIBLE DROP AND SEE WHICH ONE FITS
+#
+#   "sensor1 is the broken one" says exactly this: the truth is sensor2, and
+#   sensor1 is sensor2 with one entry deleted, the tail shifted left, and the
+#   final slot filled with garbage.  the garbage slot carries no information,
+#   so the claim is testable by construction --
+#
+#       exists k :  sensor2 without index k  ==  sensor1[:-1]
+#
+#   and symmetrically for sensor2.  so just try all n deletions on each side.
+#   whichever claim holds alone names the faulty sensor; if both hold the data
+#   is ambiguous and if neither holds nothing is provably broken -> -1.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def badSensor(self, sensor1, sensor2):
+        ok1 = self._can_drop(sensor2, sensor1)   # sensor1 lost a data point
+        ok2 = self._can_drop(sensor1, sensor2)   # sensor2 lost a data point
+        if ok1 and not ok2:
+            return 1
+        if ok2 and not ok1:
+            return 2
+        return -1
+
+    def _can_drop(self, truth, broken):
+        target = broken[:-1]
+        for k in range(len(truth)):
+            if truth[:k] + truth[k + 1:] == target:
+                return True
+        return False
+
+
+# V0-2
+# IDEA : SUBSEQUENCE TEST -- GREEDY TWO POINTERS, NO INDEX ARITHMETIC
+#
+#   deleting one entry from a length-n list is the same statement as "the
+#   length n-1 result is a subsequence of the original".  so the whole problem
+#   collapses to two greedy scans:
+#
+#       sensor1 faulty  <=>  sensor1[:-1] is a subsequence of sensor2
+#       sensor2 faulty  <=>  sensor2[:-1] is a subsequence of sensor1
+#
+#   (the dropped-last-slot garbage is excluded on the left of each test, which
+#   is why the lengths differ by one and the greedy match is forced.)
+#
+#   this needs no "first mismatch" index and no shift offsets -- one pointer
+#   per list, advance the short one on every match.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def badSensor(self, sensor1, sensor2):
+        ok1 = self._is_subseq(sensor1, sensor2)
+        ok2 = self._is_subseq(sensor2, sensor1)
+        if ok1 and not ok2:
+            return 1
+        if ok2 and not ok1:
+            return 2
+        return -1
+
+    def _is_subseq(self, short, full):
+        # is short[:-1] a subsequence of full ?
+        i, m = 0, len(short) - 1
+        for v in full:
+            if i < m and v == short[i]:
+                i += 1
+        return i == m

--- a/leetcode_python/Array/fill-a-special-grid.py
+++ b/leetcode_python/Array/fill-a-special-grid.py
@@ -114,3 +114,75 @@ class Solution(object):
             grid = top + bottom
             s <<= 1
         return grid
+
+
+# V0-1
+# IDEA : TOP-DOWN DIVIDE AND CONQUER -- PAINT EACH QUADRANT WITH ITS OFFSET
+#
+#   read the four constraints as an ordering of the quadrants: top-right gets
+#   the lowest block of values, then bottom-right, then bottom-left, then
+#   top-left.  a quadrant of side h owns exactly h*h consecutive values, so its
+#   starting value is forced -- base + 0, base + h*h, base + 2h*h, base + 3h*h
+#   in that order.
+#
+#   "each quadrant is also special" is then literally the recursive call, so
+#   allocate the 2^n x 2^n board once and paint into it, splitting until a
+#   single cell is left and it can only hold `base`.
+#
+#   the mirror image of the bottom-up doubling above: same recursion tree, but
+#   walked from the whole board down instead of from [[0]] up, so it never
+#   re-copies an intermediate grid (at the cost of ~4^n Python frames).
+#
+# time = O(4^n), space = O(4^n)
+class Solution(object):
+    def specialGrid(self, n):
+        side = 1 << n
+        grid = [[0] * side for _ in range(side)]
+
+        def fill(r, c, size, base):
+            if size == 1:
+                grid[r][c] = base
+                return
+            h = size >> 1
+            q = h * h
+            fill(r, c + h, h, base)               # top-right    : smallest
+            fill(r + h, c + h, h, base + q)       # bottom-right
+            fill(r + h, c, h, base + 2 * q)       # bottom-left
+            fill(r, c, h, base + 3 * q)           # top-left     : largest
+
+        fill(0, 0, side, 0)
+        return grid
+
+
+# V0-2
+# IDEA : CLOSED FORM FROM THE BITS OF (i, j) -- NO RECURSION, NO SHARED STATE
+#
+#   the recursion above chooses a quadrant at every level purely from one bit
+#   of the row index and one bit of the column index, and each choice
+#   contributes a fixed base-4 digit:
+#
+#       (top bit of i, top bit of j) ->  (0,0) top-left     -> digit 3
+#                                        (0,1) top-right    -> digit 0
+#                                        (1,0) bottom-left  -> digit 2
+#                                        (1,1) bottom-right -> digit 1
+#
+#   which is exactly the n = 1 answer [[3,0],[2,1]] used as a 2x2 lookup table.
+#   so grid[i][j] is the base-4 number whose k-th digit is Q[bit_k(i)][bit_k(j)]
+#   -- an interleave of the two indices' bits, computable per cell on its own
+#   with no recursion and no intermediate grid.
+#
+# time = O(4^n * n), space = O(4^n)
+class Solution(object):
+    def specialGrid(self, n):
+        Q = ((3, 0), (2, 1))
+        side = 1 << n
+        out = []
+        for i in range(side):
+            row = []
+            for j in range(side):
+                v = 0
+                for k in range(n - 1, -1, -1):
+                    v = v * 4 + Q[(i >> k) & 1][(j >> k) & 1]
+                row.append(v)
+            out.append(row)
+        return out

--- a/leetcode_python/Array/filter-restaurants-by-vegan-friendly-price-and-distance.py
+++ b/leetcode_python/Array/filter-restaurants-by-vegan-friendly-price-and-distance.py
@@ -78,3 +78,81 @@ class Solution(object):
         # sort by rating desc, then id desc
         res.sort(key=lambda x: (-x[0], -x[1]))
         return [_id for _, _id in res]
+
+
+# V0-1
+# IDEA : MAX-HEAP -- HEAPIFY THE SURVIVORS, THEN DRAIN THEM IN ORDER
+#
+#   the ranking key is (rating desc, id desc), so negating both fields turns it
+#   into a min-heap key and heapq can do the ordering.  building the heap is
+#   O(k) and each pop is O(log k), so the total is the same O(k log k) as a
+#   sort -- the reason to reach for it here is that it generalises: if the
+#   follow-up only wants the top few, stop popping early and the log factor is
+#   paid only for those.
+#
+# time = O(n + k log k), space = O(k)   (k = number of survivors)
+import heapq
+
+class Solution(object):
+    def filterRestaurants(self, restaurants, veganFriendly, maxPrice, maxDistance):
+        h = []
+        for _id, rating, vegan, price, dist in restaurants:
+            if veganFriendly and not vegan:
+                continue
+            if price <= maxPrice and dist <= maxDistance:
+                h.append((-rating, -_id))
+
+        heapq.heapify(h)
+        res = []
+        while h:
+            _, neg_id = heapq.heappop(h)
+            res.append(-neg_id)
+        return res
+
+
+# V0-2
+# IDEA : BUCKET / COUNTING SORT -- BOTH KEYS ARE BOUNDED, SO NO COMPARISONS
+#
+#   ratings and ids are both <= 10^5 and the ids are distinct, so the ordering
+#   can be produced by two counting passes instead of a comparison sort:
+#
+#     pass 1 : park each survivor's rating in slot rate_of[id] -- one slot per
+#              id, which IS the sort by id (distinctness makes it collision
+#              free, no counts or offsets needed).
+#     pass 2 : walk ids from high to low and drop each into the bucket of its
+#              rating.  because the feed is already descending by id, every
+#              bucket comes out descending by id for free.
+#
+#   concatenating the buckets from the highest rating down then gives exactly
+#   (rating desc, id desc).  this is the stable-radix trick: sort by the minor
+#   key first, then bucket by the major key.
+#
+# time = O(n + A + R), space = O(n + A + R)   (A = max id, R = max rating)
+class Solution(object):
+    def filterRestaurants(self, restaurants, veganFriendly, maxPrice, maxDistance):
+        keep = []
+        for _id, rating, vegan, price, dist in restaurants:
+            if veganFriendly and not vegan:
+                continue
+            if price <= maxPrice and dist <= maxDistance:
+                keep.append((_id, rating))
+        if not keep:
+            return []
+
+        max_id = max(x[0] for x in keep)
+        max_rate = max(x[1] for x in keep)
+
+        rate_of = [-1] * (max_id + 1)
+        for _id, rating in keep:
+            rate_of[_id] = rating
+
+        buckets = [[] for _ in range(max_rate + 1)]
+        for _id in range(max_id, -1, -1):
+            r = rate_of[_id]
+            if r >= 0:
+                buckets[r].append(_id)
+
+        res = []
+        for r in range(max_rate, -1, -1):
+            res.extend(buckets[r])
+        return res

--- a/leetcode_python/Array/final-value-of-variable-after-performing-operations.py
+++ b/leetcode_python/Array/final-value-of-variable-after-performing-operations.py
@@ -69,3 +69,37 @@ class Solution(object):
             else:
                 res -= 1
         return res
+
+
+# V0-1
+# IDEA : TALLY THE FOUR TOKENS WITH A COUNTER, THEN COMBINE THE COUNTS
+#
+#   the input alphabet is only four strings, so hash the whole tokens once and
+#   read the four tallies off the map instead of inspecting characters:
+#   (# "++X" + # "X++") - (# "--X" + # "X--").
+#
+#   the loop moves into Counter's C level and the arithmetic becomes a single
+#   expression -- useful shape when the token set is later extended (a new
+#   operation is one more term, not a new branch in the scan).
+#
+# time = O(n), space = O(1)   (at most 4 distinct keys)
+import collections
+
+class Solution(object):
+    def finalValueAfterOperations(self, operations):
+        cnt = collections.Counter(operations)
+        return (cnt["++X"] + cnt["X++"]) - (cnt["--X"] + cnt["X--"])
+
+
+# V0-2
+# IDEA : ARITHMETIC -- COUNT ONLY THE DECREMENTS AND DERIVE THE REST
+#
+#   every operation moves X by exactly +1 or -1, so with n operations of which
+#   d are decrements the answer is (n - d) - d = n - 2 * d.  no running total
+#   and no per-op branch: count one class and let arithmetic supply the other.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def finalValueAfterOperations(self, operations):
+        d = sum(1 for op in operations if "-" in op)
+        return len(operations) - 2 * d

--- a/leetcode_python/Array/find-a-good-subset-of-the-matrix.py
+++ b/leetcode_python/Array/find-a-good-subset-of-the-matrix.py
@@ -99,3 +99,69 @@ class Solution(object):
                     i, j = seen[masks[p]], seen[masks[q]]
                     return [min(i, j), max(i, j)]
         return []
+
+
+# V0-1
+# IDEA : BRUTE FORCE - TEST EVERY SINGLE ROW, THEN EVERY PAIR OF ROWS
+#
+#   same "only k in {1, 2} can ever win" argument as V0, but with no bitmask
+#   encoding at all: compare two candidate rows column by column and reject as
+#   soon as some column holds a 1 in both (that column would sum to
+#   2 > floor(2/2) = 1).
+#
+#   NOTE : quadratic in the number of rows, so this is the reference-correctness
+#          version rather than the one to ship for m = 10^4.
+#
+# time = O(m^2 * n)
+# space = O(1)
+class Solution(object):
+    def goodSubsetofBinaryMatrix(self, grid):
+        m, n = len(grid), len(grid[0])
+        for i in range(m):
+            if not any(grid[i]):
+                return [i]
+        for i in range(m):
+            for j in range(i + 1, m):
+                if all(grid[i][c] + grid[j][c] <= 1 for c in range(n)):
+                    return [i, j]
+        return []
+
+
+# V0-2
+# IDEA : ONE PASS + SUBMASK ENUMERATION OF THE COMPLEMENT
+#
+#   walk the rows once keeping seen[mask] = first row index with that mask.
+#   a partner for the current mask must share no 1-column with it, i.e. it must
+#   be a SUBSET of comp = full ^ mask, so enumerate the submasks of comp with
+#   the standard sub = (sub - 1) & comp trick and take the first one already
+#   stored. no second pass over pairs of masks.
+#
+#   NOTE : any partner found is an EARLIER row, so [seen[sub], i] already comes
+#          out in ascending order.
+#   NOTE : an all-zero row (mask == 0) is the k = 1 answer and is returned
+#          before the enumeration, so sub == mask can never happen.
+#
+# time = O(m * 2^n)
+# space = O(2^n)
+class Solution(object):
+    def goodSubsetofBinaryMatrix(self, grid):
+        n = len(grid[0])
+        full = (1 << n) - 1
+        seen = {}
+        for i, row in enumerate(grid):
+            mask = 0
+            for j, v in enumerate(row):
+                if v:
+                    mask |= 1 << j
+            if mask == 0:
+                return [i]
+            comp = full ^ mask
+            sub = comp
+            while True:
+                if sub in seen:
+                    return [seen[sub], i]
+                if sub == 0:
+                    break
+                sub = (sub - 1) & comp
+            seen.setdefault(mask, i)
+        return []

--- a/leetcode_python/Array/find-all-groups-of-farmland.py
+++ b/leetcode_python/Array/find-all-groups-of-farmland.py
@@ -78,3 +78,94 @@ class Solution(object):
                     y += 1
                 res.append([i, j, x, y])
         return res
+
+
+# V0-1
+# IDEA : BFS FLOOD FILL, TRACKING THE BOUNDING BOX OF EACH COMPONENT
+#
+#   ignore the "every group is a rectangle" guarantee entirely: treat the 1s as
+#   a 4-directional graph, BFS out of every unvisited 1, and record the min/max
+#   row and column reached. for a solid rectangle that bounding box IS the
+#   group, so the same answer falls out of a generic connected-component walk.
+#
+#   NOTE : a cell is marked visited when it is PUSHED, so nothing can enter the
+#          queue twice.
+#
+# time = O(m * n)
+# space = O(m * n)
+import collections
+class Solution(object):
+    def findFarmland(self, land):
+        m, n = len(land), len(land[0])
+        seen = [[False] * n for _ in range(m)]
+        res = []
+        for i in range(m):
+            for j in range(n):
+                if land[i][j] == 0 or seen[i][j]:
+                    continue
+                seen[i][j] = True
+                q = collections.deque([(i, j)])
+                r1 = r2 = i
+                c1 = c2 = j
+                while q:
+                    x, y = q.popleft()
+                    r1, r2 = min(r1, x), max(r2, x)
+                    c1, c2 = min(c1, y), max(c2, y)
+                    for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                        a, b = x + dx, y + dy
+                        if 0 <= a < m and 0 <= b < n and \
+                                land[a][b] == 1 and not seen[a][b]:
+                            seen[a][b] = True
+                            q.append((a, b))
+                res.append([r1, c1, r2, c2])
+        return res
+
+
+# V0-2
+# IDEA : UNION-FIND OVER THE 1 CELLS, THEN ONE BOUNDING BOX PER ROOT
+#
+#   flatten (i, j) to i * n + j, union each 1 with its RIGHT and DOWN neighbour
+#   when that neighbour is also a 1 (left/up are the same edges seen from the
+#   other end), then bucket the cells by root and reduce each bucket to
+#   [min row, min col, max row, max col].
+#
+#   NOTE : no recursion and no queue - the grouping is done by the disjoint-set
+#          structure instead of by a traversal order.
+#
+# time = O(m * n * alpha(m * n))
+# space = O(m * n)
+class Solution(object):
+    def findFarmland(self, land):
+        m, n = len(land), len(land[0])
+        par = list(range(m * n))
+
+        def find(x):
+            while par[x] != x:
+                par[x] = par[par[x]]
+                x = par[x]
+            return x
+
+        for i in range(m):
+            for j in range(n):
+                if land[i][j] == 0:
+                    continue
+                for a, b in ((i + 1, j), (i, j + 1)):
+                    if a < m and b < n and land[a][b] == 1:
+                        ra, rb = find(i * n + j), find(a * n + b)
+                        if ra != rb:
+                            par[ra] = rb
+        box = {}
+        for i in range(m):
+            for j in range(n):
+                if land[i][j] == 0:
+                    continue
+                r = find(i * n + j)
+                if r not in box:
+                    box[r] = [i, j, i, j]
+                else:
+                    cur = box[r]
+                    cur[0] = min(cur[0], i)
+                    cur[1] = min(cur[1], j)
+                    cur[2] = max(cur[2], i)
+                    cur[3] = max(cur[3], j)
+        return list(box.values())

--- a/leetcode_python/Array/find-closest-number-to-zero.py
+++ b/leetcode_python/Array/find-closest-number-to-zero.py
@@ -44,3 +44,55 @@ Constraints:
 class Solution(object):
     def findClosestNumber(self, nums):
         return min(nums, key=lambda x: (abs(x), -x))
+
+
+# V0-1
+# IDEA : SORT + BINARY SEARCH FOR THE INSERTION POINT OF 0
+#
+#   once the array is sorted, the value closest to 0 has to be one of the two
+#   neighbours of the slot where 0 would be inserted: the last negative and the
+#   first non-negative. compare just those two.
+#
+#   NOTE : the tie-break "return the larger value" is exactly "prefer the
+#          non-negative side", so the test is hi <= -lo (abs(lo) == -lo since
+#          lo < 0).
+#
+# time = O(n log n)
+# space = O(n)
+import bisect
+class Solution(object):
+    def findClosestNumber(self, nums):
+        arr = sorted(nums)
+        k = bisect.bisect_left(arr, 0)
+        lo = arr[k - 1] if k > 0 else None
+        hi = arr[k] if k < len(arr) else None
+        if lo is None:
+            return hi
+        if hi is None:
+            return lo
+        return hi if hi <= -lo else lo
+
+
+# V0-2
+# IDEA : MEMBERSHIP SET + SWEEP THE DISTANCE OUTWARD FROM 0
+#
+#   search the VALUE space instead of ranking the elements: drop the numbers in
+#   a set, then try distances d = 0, 1, 2, ... and ask whether +d or -d is
+#   present. the first hit is the answer, and probing +d before -d hands us the
+#   "larger value wins" tie-break for free.
+#
+#   NOTE : the loop is bounded by max(abs(x)), which the constraints cap at
+#          10^5, so this trades element comparisons for value-range steps.
+#
+# time = O(n + M) with M = max abs value
+# space = O(n)
+class Solution(object):
+    def findClosestNumber(self, nums):
+        s = set(nums)
+        limit = max(abs(x) for x in nums)
+        for d in range(limit + 1):
+            if d in s:
+                return d
+            if -d in s:
+                return -d
+        return 0

--- a/leetcode_python/Array/find-good-days-to-rob-the-bank.py
+++ b/leetcode_python/Array/find-good-days-to-rob-the-bank.py
@@ -74,3 +74,71 @@ class Solution(object):
             if security[i] <= security[i + 1]:
                 inc[i] = inc[i + 1] + 1
         return [i for i in range(n) if dec[i] >= time and inc[i] >= time]
+
+
+# V0-1
+# IDEA : PREFIX COUNTS OF MONOTONICITY VIOLATIONS + RANGE QUERIES
+#
+#   up[i]   = how many k <= i have security[k] > security[k-1]  (a rise)
+#   down[i] = how many k <= i have security[k] < security[k-1]  (a fall)
+#
+#   the block [i - time, i] is non-increasing  <=>  it contains no rise
+#       <=>  up[i] - up[i - time] == 0
+#   the block [i, i + time] is non-decreasing  <=>  it contains no fall
+#       <=>  down[i + time] - down[i] == 0
+#
+#   so each day becomes two O(1) prefix-sum range queries; no run lengths are
+#   tracked at all.
+#
+#   NOTE : time == 0 makes both queries compare a cell with itself, so every
+#          day passes, as required.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def goodDaysToRobBank(self, security, time):
+        n = len(security)
+        up = [0] * n
+        down = [0] * n
+        for i in range(1, n):
+            up[i] = up[i - 1] + (1 if security[i] > security[i - 1] else 0)
+            down[i] = down[i - 1] + (1 if security[i] < security[i - 1] else 0)
+        res = []
+        for i in range(time, n - time):
+            if up[i] - up[i - time] == 0 and down[i + time] - down[i] == 0:
+                res.append(i)
+        return res
+
+
+# V0-2
+# IDEA : BRUTE FORCE - VERIFY THE 2 * time NEIGHBOURS OF EVERY CANDIDATE DAY
+#
+#   straight from the definition: for every day that has room on both sides,
+#   walk the "time" steps before it demanding non-increasing values and the
+#   "time" steps after it demanding non-decreasing values, bailing out at the
+#   first violation.
+#
+#   NOTE : O(n * time) - the definition-level reference, too slow for the
+#          n = time = 10^5 upper bound but useful to check the fast versions
+#          against.
+#
+# time = O(n * time)
+# space = O(1) besides the output
+class Solution(object):
+    def goodDaysToRobBank(self, security, time):
+        n = len(security)
+        res = []
+        for i in range(time, n - time):
+            ok = True
+            for k in range(i - time, i):
+                if security[k] < security[k + 1]:
+                    ok = False
+                    break
+            if ok:
+                for k in range(i, i + time):
+                    if security[k] > security[k + 1]:
+                        ok = False
+                        break
+            if ok:
+                res.append(i)
+        return res

--- a/leetcode_python/Array/find-indices-of-stable-mountains.py
+++ b/leetcode_python/Array/find-indices-of-stable-mountains.py
@@ -48,3 +48,57 @@ Constraints:
 class Solution(object):
     def stableMountains(self, height, threshold):
         return [i for i in range(1, len(height)) if height[i - 1] > threshold]
+
+
+# V0-1
+# IDEA : STREAMING ONE PASS, CARRYING THE PREVIOUS HEIGHT
+#
+#   never index backwards: consume the heights in order, keep the last one seen
+#   in a variable, and emit the current position whenever that remembered
+#   height cleared the threshold. this works over any iterable (a generator, a
+#   stream) and not just over a list that supports height[i - 1].
+#
+#   NOTE : prev is None only on the very first element, which is how mountain 0
+#          gets excluded.
+#
+# time = O(n)
+# space = O(1) besides the output
+class Solution(object):
+    def stableMountains(self, height, threshold):
+        res = []
+        prev = None
+        for i, h in enumerate(height):
+            if prev is not None and prev > threshold:
+                res.append(i)
+            prev = h
+        return res
+
+
+# V0-2
+# IDEA : BITMASK OF THE TALL POSITIONS, SHIFTED LEFT BY ONE
+#
+#   set bit i when height[i] > threshold. shifting that whole mask left by one
+#   slides every tall position onto its SUCCESSOR, so the set bits of
+#   (mask << 1) that are still inside [0, n) are exactly the stable indices -
+#   and bit 0 can never survive the shift, which drops mountain 0 for free.
+#
+#   the bits are then read off with the low-bit trick low = m & -m, so the
+#   whole predicate is evaluated by integer arithmetic rather than by per-index
+#   comparisons.
+#
+# time = O(n)
+# space = O(n) for the n-bit mask
+class Solution(object):
+    def stableMountains(self, height, threshold):
+        n = len(height)
+        mask = 0
+        for i, h in enumerate(height):
+            if h > threshold:
+                mask |= 1 << i
+        mask = (mask << 1) & ((1 << n) - 1)
+        res = []
+        while mask:
+            low = mask & -mask
+            res.append(low.bit_length() - 1)
+            mask ^= low
+        return res

--- a/leetcode_python/Array/find-indices-with-index-and-value-difference-i.py
+++ b/leetcode_python/Array/find-indices-with-index-and-value-difference-i.py
@@ -82,3 +82,56 @@ class Solution(object):
             if nums[mx] - nums[i] >= valueDifference:
                 return [mx, i]
         return [-1, -1]
+
+
+# V0-1
+# IDEA : BRUTE FORCE - TEST EVERY PAIR OF INDICES
+#
+#   n <= 100, so just check both conditions directly for every i <= j. taking
+#   j from i (not i + 1) keeps the i == j case that the problem explicitly
+#   allows, which is what makes indexDifference == 0 answer [0, 0].
+#
+# time = O(n^2)
+# space = O(1)
+class Solution(object):
+    def findIndices(self, nums, indexDifference, valueDifference):
+        n = len(nums)
+        for i in range(n):
+            for j in range(i, n):
+                if j - i >= indexDifference and \
+                        abs(nums[i] - nums[j]) >= valueDifference:
+                    return [i, j]
+        return [-1, -1]
+
+
+# V0-2
+# IDEA : BUCKET BY VALUE - FIRST / LAST INDEX PER VALUE, THEN ALL VALUE PAIRS
+#
+#   nums[i] <= 50, so at most 51 distinct values exist. for a FIXED pair of
+#   values (a, b) the widest possible index gap is obtained by pairing the
+#   first occurrence of one with the last occurrence of the other, so storing
+#   first[v] and last[v] and then scanning the value pairs is enough:
+#   if any valid (i, j) with nums[i] = a, nums[j] = b exists then
+#   last[b] - first[a] >= j - i >= indexDifference.
+#
+#   NOTE : a == b must be allowed - that is the valueDifference == 0 case - and
+#          first[v] == last[v] then gives i == j, which the problem permits.
+#   NOTE : the search is over the value range, so its cost is independent of n
+#          once the buckets are built.
+#
+# time = O(n + V^2) with V = 51 distinct values
+# space = O(V)
+class Solution(object):
+    def findIndices(self, nums, indexDifference, valueDifference):
+        first, last = {}, {}
+        for i, v in enumerate(nums):
+            first.setdefault(v, i)
+            last[v] = i
+        for a in first:
+            for b in first:
+                if abs(a - b) < valueDifference:
+                    continue
+                for i, j in ((first[a], last[b]), (last[a], first[b])):
+                    if abs(i - j) >= indexDifference:
+                        return [min(i, j), max(i, j)]
+        return [-1, -1]

--- a/leetcode_python/Array/find-indices-with-index-and-value-difference-ii.py
+++ b/leetcode_python/Array/find-indices-with-index-and-value-difference-ii.py
@@ -85,3 +85,65 @@ class Solution(object):
             if nums[mx] - nums[i] >= valueDifference:
                 return [mx, i]
         return [-1, -1]
+
+
+# V0-1
+# IDEA : BRUTE FORCE — CHECK EVERY PAIR
+#
+#   the literal transcription of the definition : try all pairs (i, j) with
+#   j >= i and return the first one that satisfies both conditions.
+#   i and j may be EQUAL, so the inner loop starts at i, not at i + 1.
+#   this is what passes LC 2903 (n <= 100) and TLEs here (n <= 10^5); it is
+#   kept as the baseline the single pass above is derived from.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def findIndices(self, nums, indexDifference, valueDifference):
+        n = len(nums)
+        for i in range(n):
+            for j in range(i, n):
+                if j - i < indexDifference:
+                    continue
+                if abs(nums[i] - nums[j]) >= valueDifference:
+                    return [i, j]
+        return [-1, -1]
+
+
+# V0-2
+# IDEA : SORT BY VALUE + MONOTONE POINTER OVER PREFIX INDEX EXTREMES
+#
+#   attack the VALUE condition first : sort the (value, index) pairs. walking
+#   q through that sorted order, every legal partner of q (value at most
+#   nums[q] - valueDifference) forms a PREFIX of the sorted array, and that
+#   prefix only grows as the value of q grows -> one monotone pointer p.
+#
+#   inside the prefix only two entries can ever matter for the INDEX
+#   condition : the smallest and the largest original index, because
+#   max |i - idx| over the prefix is max(i - minIdx, maxIdx - i). so a running
+#   min / max of the prefix indices replaces the whole prefix.
+#
+#   NOTE : with valueDifference == 0 the threshold is nums[q] itself, so q and
+#          its value-ties enter their own prefix -> the i == j case is handled
+#          without a special branch.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def findIndices(self, nums, indexDifference, valueDifference):
+        order = sorted((v, i) for i, v in enumerate(nums))
+        p = 0
+        lo = hi = -1                    # min / max original index in prefix
+        for v, i in order:
+            while p < len(order) and order[p][0] <= v - valueDifference:
+                idx = order[p][1]
+                if lo == -1 or idx < lo:
+                    lo = idx
+                if idx > hi:
+                    hi = idx
+                p += 1
+            if lo == -1:
+                continue
+            if i - lo >= indexDifference:
+                return [lo, i]
+            if hi - i >= indexDifference:
+                return [i, hi]
+        return [-1, -1]

--- a/leetcode_python/Array/find-kth-largest-xor-coordinate-value.py
+++ b/leetcode_python/Array/find-kth-largest-xor-coordinate-value.py
@@ -72,3 +72,89 @@ class Solution(object):
 
         vals.sort()
         return vals[len(vals) - k]
+
+
+# V0-1
+# IDEA : ROW PREFIX XOR + RUNNING COLUMN XOR + MIN-HEAP OF SIZE K
+#
+#   the 2D prefix XOR does not need the inclusion-exclusion recurrence at all:
+#   it factors into two independent 1D passes. XOR-prefix each row on its own
+#   (`run`), then fold every row into the column accumulator (`col`), so after
+#   visiting row i the cell col[j] already holds the value of coordinate
+#   (i, j) = XOR of the whole top-left rectangle.
+#
+#   and we never need every value ordered, only the kth largest -> keep a
+#   MIN-heap capped at k. its root is the kth largest seen so far, which is
+#   exactly the answer once all m*n values have been offered.
+#
+# time = O(m * n * log k), space = O(n + k)
+import heapq
+class Solution(object):
+    def kthLargestValue(self, matrix, k):
+        m, n = len(matrix), len(matrix[0])
+        col = [0] * n                       # XOR of the rows above, per column
+        heap = []
+        for i in range(m):
+            run = 0
+            row = matrix[i]
+            for j in range(n):
+                run ^= row[j]               # prefix XOR inside this row
+                col[j] ^= run               # fold in all rows seen so far
+                v = col[j]
+                if len(heap) < k:
+                    heapq.heappush(heap, v)
+                elif v > heap[0]:
+                    heapq.heapreplace(heap, v)
+        return heap[0]
+
+
+# V0-2
+# IDEA : IN-PLACE PREFIX XOR + QUICKSELECT (no sort, no heap)
+#
+#   overwrite the matrix itself with its 2D prefix XOR — in row-major order
+#   the three cells the recurrence reads (up, left, up-left) are already
+#   finalised, so no extra table is needed (the input is mutated).
+#
+#   then pick the kth largest by SELECTION instead of sorting: quickselect
+#   with a random pivot and a 3-way (Dutch-flag) partition, which is O(N)
+#   expected. the 3-way split matters here because XOR values repeat a lot,
+#   and a 2-way partition degrades to O(N^2) on heavy duplicates.
+#   kth largest == index N - k of the ascending order.
+#
+# time = O(m * n) expected, space = O(m * n) for the flattened values
+import random
+class Solution(object):
+    def kthLargestValue(self, matrix, k):
+        m, n = len(matrix), len(matrix[0])
+        for i in range(m):
+            for j in range(n):
+                if i:
+                    matrix[i][j] ^= matrix[i - 1][j]
+                if j:
+                    matrix[i][j] ^= matrix[i][j - 1]
+                if i and j:
+                    matrix[i][j] ^= matrix[i - 1][j - 1]
+
+        vals = [v for row in matrix for v in row]
+        target = len(vals) - k              # 0-based rank in ASCENDING order
+        lo, hi = 0, len(vals) - 1
+        while lo < hi:
+            pivot = vals[random.randint(lo, hi)]
+            i, j, t = lo, hi, lo
+            while t <= j:                   # [lo,i) < pivot, (j,hi] > pivot
+                if vals[t] < pivot:
+                    vals[i], vals[t] = vals[t], vals[i]
+                    i += 1
+                    t += 1
+                elif vals[t] > pivot:
+                    vals[t], vals[j] = vals[j], vals[t]
+                    j -= 1
+                else:
+                    t += 1
+            if target < i:
+                hi = i - 1
+            elif target > j:
+                lo = j + 1
+            else:
+                return pivot
+        return vals[lo]

--- a/leetcode_python/Array/find-latest-group-of-size-m.py
+++ b/leetcode_python/Array/find-latest-group-of-size-m.py
@@ -74,3 +74,87 @@ class Solution(object):
             if cnt[m] > 0:
                 res = step
         return res
+
+
+# V0-1
+# IDEA : UNION-FIND OVER THE BITS TURNED ON + LIVE COUNT OF SIZE-M GROUPS
+#
+#   model each group of ones as a DSU component instead of an interval:
+#   turning on bit x creates a singleton, then unions it with whichever of
+#   x-1 / x+1 is already on.
+#   `cnt` = how many components currently have size exactly m. every event
+#   changes at most 3 sizes (the new singleton, and the two operands of a
+#   union), so cnt is patched in O(1) each time and never rescanned.
+#   answer = the last step at which cnt > 0.
+#
+#   NOTE : sizes are only meaningful at a ROOT, so always compare
+#          size[find(v)], never size[v].
+#
+# time = O(n * alpha(n)) ~ O(n), space = O(n)
+class Solution(object):
+    def findLatestStep(self, arr, m):
+        n = len(arr)
+        parent = list(range(n + 2))
+        size = [1] * (n + 2)
+        on = [False] * (n + 2)
+
+        def find(a):
+            while parent[a] != a:
+                parent[a] = parent[parent[a]]     # path halving
+                a = parent[a]
+            return a
+
+        cnt = 0                                   # components of size == m
+        res = -1
+        for step, x in enumerate(arr, 1):
+            on[x] = True
+            if m == 1:
+                cnt += 1
+            for y in (x - 1, x + 1):
+                if 1 <= y <= n and on[y]:
+                    rx, ry = find(x), find(y)
+                    if rx != ry:
+                        if size[rx] == m:
+                            cnt -= 1
+                        if size[ry] == m:
+                            cnt -= 1
+                        parent[ry] = rx
+                        size[rx] += size[ry]
+                        if size[rx] == m:
+                            cnt += 1
+            if cnt > 0:
+                res = step
+        return res
+
+
+# V0-2
+# IDEA : BRUTE FORCE — REBUILD THE BIT ARRAY AND RESCAN AFTER EVERY STEP
+#
+#   the definition itself : keep the bit array, and after each step walk it
+#   once measuring every maximal run of ones, recording the step whenever some
+#   run has length exactly m.
+#   O(n^2) so it TLEs at n = 10^5, but it needs no invariant to be believed
+#   and makes a convenient oracle for the two linear solutions above.
+#
+#   NOTE : the run that touches the right border must be checked after the
+#          loop, it is never closed by a zero.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def findLatestStep(self, arr, m):
+        n = len(arr)
+        bits = [0] * (n + 1)
+        res = -1
+        for step, x in enumerate(arr, 1):
+            bits[x] = 1
+            run = 0
+            for i in range(1, n + 1):
+                if bits[i]:
+                    run += 1
+                else:
+                    if run == m:
+                        res = step
+                    run = 0
+            if run == m:
+                res = step
+        return res

--- a/leetcode_python/Array/find-lucky-integer-in-an-array.py
+++ b/leetcode_python/Array/find-lucky-integer-in-an-array.py
@@ -51,3 +51,47 @@ class Solution(object):
             if x == v and x > res:
                 res = x
         return res
+
+
+# V0-1
+# IDEA : FIXED BUCKET ARRAY + SCAN FROM THE LARGEST VALUE DOWN
+#
+#   the constraints cap arr[i] at 500, so a 501-slot tally replaces the hash
+#   map entirely, and because the buckets are already in value order we can
+#   walk them DOWNWARDS and return on the first hit instead of comparing every
+#   candidate against a running maximum.
+#   the tally size does not depend on n, so the extra space is constant.
+#
+# time = O(n + 500), space = O(1)
+class Solution(object):
+    def findLucky(self, arr):
+        freq = [0] * 501
+        for x in arr:
+            freq[x] += 1
+        for x in range(500, 0, -1):
+            if freq[x] == x:
+                return x
+        return -1
+
+
+# V0-2
+# IDEA : SORT, THEN MEASURE THE EQUAL-VALUE RUNS FROM THE RIGHT
+#
+#   sorting puts equal values next to each other, so a run's LENGTH is that
+#   value's frequency — no counting structure at all. scanning the runs from
+#   the right visits the candidates in decreasing order, so the first run
+#   whose length equals its value is already the answer.
+#
+# time = O(n log n), space = O(n) for the sorted copy (O(1) if sorted in place)
+class Solution(object):
+    def findLucky(self, arr):
+        vals = sorted(arr)
+        i = len(vals) - 1
+        while i >= 0:
+            j = i
+            while j >= 0 and vals[j] == vals[i]:
+                j -= 1
+            if i - j == vals[i]:
+                return vals[i]
+            i = j
+        return -1

--- a/leetcode_python/Array/find-maximal-uncovered-ranges.py
+++ b/leetcode_python/Array/find-maximal-uncovered-ranges.py
@@ -90,3 +90,77 @@ class Solution(object):
         if last + 1 < n:
             res.append([last + 1, n - 1])
         return res
+
+
+# V0-1
+# IDEA : +1 / -1 BOUNDARY EVENTS, GAPS ARE WHERE THE COUNTER SITS AT 0
+#
+#   turn every interval into two events, (l, +1) and (r + 1, -1), sort them by
+#   position and sweep. the running counter is how many intervals cover the
+#   current position, so an uncovered stretch is exactly the span between the
+#   position where the counter FELL to 0 and the next position where it leaves
+#   0 again. no interval-nesting special case is needed — nesting just makes
+#   the counter go to 2 and back.
+#
+#   NOTE : at one shared position every +1 must be applied BEFORE the -1s
+#          there, otherwise touching intervals such as [0,3] and [4,6] would
+#          momentarily show counter 0 and fake a gap. sorting on (pos, -delta)
+#          gives that ordering.
+#
+#   NOTE : the tail [gap, n-1] is emitted after the loop, which also produces
+#          the whole array when ranges == [].
+#
+# time = O(m log m), space = O(m)  (m = len(ranges))
+class Solution(object):
+    def findMaximalUncoveredRanges(self, n, ranges):
+        events = []
+        for l, r in ranges:
+            events.append((l, 1))
+            events.append((r + 1, -1))
+        events.sort(key=lambda e: (e[0], -e[1]))
+
+        res = []
+        active = 0
+        gap = 0                      # start of the current uncovered stretch
+        for pos, d in events:
+            if active == 0 and d == 1 and pos > gap:
+                res.append([gap, pos - 1])
+            active += d
+            if active == 0:
+                gap = pos
+        if gap < n:
+            res.append([gap, n - 1])
+        return res
+
+
+# V0-2
+# IDEA : BRUTE FORCE — PAINT THE COVERED FLAGS, THEN REPORT RUNS OF ZEROS
+#
+#   the literal reading of the statement : build the binary array the examples
+#   describe, paint every interval into it, then emit each maximal run of
+#   zeros. maximality and the sorted order come for free from scanning left to
+#   right.
+#   unusable on the real constraints (n <= 10^9, and painting costs the total
+#   interval length), but it is the definition, so it doubles as the oracle
+#   for the two interval solutions above.
+#
+# time = O(n + total interval length), space = O(n)
+class Solution(object):
+    def findMaximalUncoveredRanges(self, n, ranges):
+        covered = [False] * n
+        for l, r in ranges:
+            for i in range(l, r + 1):
+                covered[i] = True
+
+        res = []
+        i = 0
+        while i < n:
+            if covered[i]:
+                i += 1
+                continue
+            j = i
+            while j < n and not covered[j]:
+                j += 1
+            res.append([i, j - 1])
+            i = j
+        return res

--- a/leetcode_python/Array/find-mirror-score-of-a-string.py
+++ b/leetcode_python/Array/find-mirror-score-of-a-string.py
@@ -84,3 +84,60 @@ class Solution(object):
             else:
                 stacks[c].append(i)
         return score
+
+
+# V0-1
+# IDEA : BRUTE FORCE — MARK ARRAY + BACKWARD SCAN FOR THE PARTNER
+#
+#   the literal transcription of the process : for each i, walk j from i - 1
+#   down to 0 and stop at the first unmarked position holding the mirror
+#   letter, then mark both and add i - j.
+#   no auxiliary structure beyond the marks, but a string with few matches
+#   rescans the whole prefix every time -> O(n^2), which TLEs at n = 10^5.
+#   kept as the oracle the stack solutions are checked against.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def calculateScore(self, s):
+        n = len(s)
+        marked = [False] * n
+        score = 0
+        for i in range(n):
+            target = chr(ord('a') + ord('z') - ord(s[i]))
+            for j in range(i - 1, -1, -1):
+                if not marked[j] and s[j] == target:
+                    marked[j] = marked[i] = True
+                    score += i - j
+                    break
+        return score
+
+
+# V0-2
+# IDEA : PARTITION BY MIRROR PAIR — ONE STACK PER PAIR, NOT PER LETTER
+#
+#   the 26 letters split into 13 mirror PAIRS ((a,z), (b,y), ..., (m,n)) and no
+#   letter is its own mirror, so indices belonging to different pairs can never
+#   interact. the whole process is therefore 13 disjoint two-letter matchings,
+#   with every index living in exactly one of them (pair id = min(c, 25 - c)).
+#
+#   inside one pair a SINGLE stack is enough : a match is taken as soon as the
+#   top carries the other letter, so a pair's stack can only ever hold copies
+#   of one and the same letter. "is the top my mirror?" then collapses to "is
+#   the stack holding the other side?", one bit per pair.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def calculateScore(self, s):
+        pend = [[] for _ in range(13)]     # unmatched indices, per mirror pair
+        side = [0] * 13                    # which side of the pair they hold
+        score = 0
+        for i, ch in enumerate(s):
+            c = ord(ch) - 97
+            p = c if c < 13 else 25 - c    # pair id 0..12
+            cur = 0 if c < 13 else 1       # 0 = low letter, 1 = high letter
+            if pend[p] and side[p] != cur:
+                score += i - pend[p].pop()
+            else:
+                side[p] = cur
+                pend[p].append(i)
+        return score

--- a/leetcode_python/Array/find-n-unique-integers-sum-up-to-zero.py
+++ b/leetcode_python/Array/find-n-unique-integers-sum-up-to-zero.py
@@ -47,3 +47,36 @@ class Solution(object):
         if n % 2 == 1:
             res.append(0)
         return res
+
+
+# V0-1
+# IDEA : FILL 1..n-1, THEN CANCEL EVERYTHING WITH ONE COMPENSATING VALUE
+#
+#   any n-1 distinct numbers can be freely chosen; the last slot is then
+#   forced to be -(sum of the others). picking 1, 2, ..., n-1 makes that
+#   last value -(n-1)*n/2, which is <= 0 and therefore can never collide
+#   with the positive prefix (for n >= 2 it is strictly negative).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def sumZero(self, n):
+        res = list(range(1, n))
+        res.append(-sum(res))
+        return res
+
+
+# V0-2
+# IDEA : ARITHMETIC PROGRESSION CENTERED ON 0 (STEP 2)
+#
+#   instead of building pairs, emit the n-term progression
+#   -(n-1), -(n-3), ..., (n-3), (n-1) i.e. range(1 - n, n, 2).
+#   it is symmetric about 0, so the terms cancel term-by-term and the sum is
+#   0; the step of 2 keeps every term distinct and automatically includes 0
+#   exactly when n is odd (no parity branch needed).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def sumZero(self, n):
+        return list(range(1 - n, n, 2))

--- a/leetcode_python/Array/find-nearest-point-that-has-the-same-x-or-y-coordinate.py
+++ b/leetcode_python/Array/find-nearest-point-that-has-the-same-x-or-y-coordinate.py
@@ -55,3 +55,53 @@ class Solution(object):
                 if d < best:
                     res, best = i, d
         return res
+
+
+# V0-1
+# IDEA : MATERIALIZE (DISTANCE, INDEX) PAIRS AND LET min() DO THE TIE-BREAK
+#
+#   instead of hand-rolling "update only on a strictly smaller distance", pack
+#   each valid point into the tuple (distance, index). tuples compare
+#   lexicographically, so min() picks the smallest distance and, among equal
+#   distances, the smallest index — the required tie-break falls out for free.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def nearestValidPoint(self, x, y, points):
+        cand = [(abs(a - x) + abs(b - y), i)
+                for i, (a, b) in enumerate(points)
+                if a == x or b == y]
+        return min(cand)[1] if cand else -1
+
+
+# V0-2
+# IDEA : EXPANDING MANHATTAN RADIUS OVER THE TWO LINES THROUGH (x, y)
+#
+#   every valid point sits on the vertical line X = x or the horizontal line
+#   Y = y, so the only cells at distance r are (x, y-r), (x, y+r), (x-r, y)
+#   and (x+r, y). index the input by coordinate pair, keeping the SMALLEST
+#   index per pair, then grow r from 0 upwards and stop at the first radius
+#   that hits any of those four cells.
+#
+#   this trades the scan over points for a scan over radii, so it wins when
+#   the coordinate range is small relative to the number of points.
+#
+# time = O(n + C) where C is the coordinate span
+# space = O(n)
+class Solution(object):
+    def nearestValidPoint(self, x, y, points):
+        best_idx = {}
+        limit = 0
+        for i, (a, b) in enumerate(points):
+            if (a, b) not in best_idx:
+                best_idx[(a, b)] = i
+            limit = max(limit, abs(a - x), abs(b - y))
+
+        for r in range(limit + 1):
+            hits = [best_idx[c] for c in
+                    ((x, y - r), (x, y + r), (x - r, y), (x + r, y))
+                    if c in best_idx]
+            if hits:
+                return min(hits)
+        return -1

--- a/leetcode_python/Array/find-original-array-from-doubled-array.py
+++ b/leetcode_python/Array/find-original-array-from-doubled-array.py
@@ -69,3 +69,95 @@ class Solution(object):
             res.append(x)
 
         return res
+
+
+# V0-1
+# IDEA : GREEDY FROM THE TOP WITH A MAX-HEAP (MIRROR OF THE SORTED SCAN)
+#
+#   run the same exchange argument from the other end : the LARGEST remaining
+#   value can never be an `original` (nothing bigger is left to be its double),
+#   so it MUST be a double and has to consume one copy of half itself.
+#   a max-heap (negated min-heap) hands the values back largest-first without
+#   materialising a sorted copy.
+#
+#   NOTE : an odd largest value has no half -> impossible immediately.
+#   NOTE : 0 is its own double; popping 0 decrements cnt[0] before asking for
+#          cnt[0] again, so an odd number of zeros is rejected for free.
+#
+# time = O(n log n)
+# space = O(n)
+import heapq
+from collections import Counter
+class Solution(object):
+    def findOriginalArray(self, changed):
+        if len(changed) % 2 == 1:
+            return []
+
+        cnt = Counter(changed)
+        heap = [-v for v in changed]
+        heapq.heapify(heap)
+
+        res = []
+        while heap:
+            x = -heapq.heappop(heap)
+            if cnt[x] == 0:
+                continue
+            if x % 2 == 1:
+                return []
+            cnt[x] -= 1
+            half = x // 2
+            if cnt[half] == 0:
+                return []
+            cnt[half] -= 1
+            res.append(half)
+
+        return res
+
+
+# V0-2
+# IDEA : CHAIN DECOMPOSITION — SOLVE EACH DOUBLING CHAIN s, 2s, 4s, ... AT ONCE
+#
+#   values only ever pair up along a doubling chain rooted at an ODD number:
+#   1,2,4,8...  /  3,6,12...  /  5,10,20...  Different chains never interact,
+#   so the whole problem splits into independent 1-D problems.
+#
+#   walk one chain bottom-up carrying `pending` = how many doubles the previous
+#   level still needs. the root is odd, so nothing at the root can be a double
+#   -> every root copy is an original. at each level:
+#       o = cnt[v] - pending      (leftovers are forced to be originals)
+#   a negative o means the previous level cannot be paired -> impossible.
+#   after the chain leaves the value range, `pending` must be 0.
+#
+#   NOTE : 0 is handled on its own — it is its own double, so the count of
+#          zeros must be even and contributes cnt[0] // 2 zeros.
+#
+# time = O(n + M log M) with M = max(changed)
+# space = O(n)
+from collections import Counter
+class Solution(object):
+    def findOriginalArray(self, changed):
+        if len(changed) % 2 == 1:
+            return []
+
+        cnt = Counter(changed)
+        res = []
+
+        if cnt[0] % 2 == 1:
+            return []
+        res.extend([0] * (cnt[0] // 2))
+
+        top = max(changed)
+        for s in range(1, top + 1, 2):
+            pending = 0
+            v = s
+            while v <= top:
+                o = cnt[v] - pending
+                if o < 0:
+                    return []
+                res.extend([v] * o)
+                pending = o
+                v *= 2
+            if pending != 0:
+                return []
+
+        return res

--- a/leetcode_python/Array/find-subsequence-of-length-k-with-the-largest-sum.py
+++ b/leetcode_python/Array/find-subsequence-of-length-k-with-the-largest-sum.py
@@ -57,3 +57,56 @@ class Solution(object):
         idx = sorted(range(len(nums)), key=lambda i: nums[i], reverse=True)[:k]
         idx.sort()
         return [nums[i] for i in idx]
+
+
+# V0-1
+# IDEA : STREAM THROUGH A SIZE-k MIN-HEAP OF (VALUE, INDEX)
+#
+#   keep a min-heap holding the best k pairs seen so far. push every element
+#   and, whenever the heap exceeds k entries, evict its smallest — the value
+#   that can no longer belong to the top k. the heap therefore never grows
+#   past k, which matters when k << n.
+#
+#   the heap loses the ordering, so sort the k survivors by index at the end
+#   to hand back a real subsequence.
+#
+# time = O(n log k)
+# space = O(k)
+import heapq
+class Solution(object):
+    def maxSubsequence(self, nums, k):
+        heap = []
+        for i, v in enumerate(nums):
+            heapq.heappush(heap, (v, i))
+            if len(heap) > k:
+                heapq.heappop(heap)
+        heap.sort(key=lambda p: p[1])
+        return [v for v, _ in heap]
+
+
+# V0-2
+# IDEA : VALUE THRESHOLD + ONE LEFT-TO-RIGHT PASS (NO INDEX BOOKKEEPING)
+#
+#   let t be the k-th largest VALUE. every element strictly greater than t is
+#   certainly in the answer; the remaining slots are filled with copies of t
+#   itself. so count how many copies of t are needed:
+#       need = k - (how many values are > t)
+#   then sweep the array once in order, emitting anything > t and at most
+#   `need` copies of t. the output is in original order by construction — no
+#   index array and no second sort.
+#
+# time = O(n log n) for the k-th largest, then O(n)
+# space = O(n)
+class Solution(object):
+    def maxSubsequence(self, nums, k):
+        t = sorted(nums)[len(nums) - k]
+        need = k - sum(1 for v in nums if v > t)
+
+        res = []
+        for v in nums:
+            if v > t:
+                res.append(v)
+            elif v == t and need > 0:
+                res.append(v)
+                need -= 1
+        return res

--- a/leetcode_python/Array/find-the-first-player-to-win-k-games-in-a-row.py
+++ b/leetcode_python/Array/find-the-first-player-to-win-k-games-in-a-row.py
@@ -78,3 +78,80 @@ class Solution(object):
             if streak == k:
                 return champ
         return champ
+
+
+# V0-1
+# IDEA : LITERAL QUEUE SIMULATION (WITH THE ONLY BOUND THAT MAKES IT FINITE)
+#
+#   play the games exactly as described with a deque : the two front players
+#   meet, the winner stays at the front, the loser is pushed to the back.
+#
+#   the one thing that has to be reasoned about is termination : a streak of
+#   n - 1 wins means having beaten EVERY other player, i.e. being the strongest
+#   player, and the strongest player then wins forever. so any k >= n can be
+#   answered straight away with argmax(skills), and for k < n the simulation
+#   provably ends within O(n) games.
+#
+# time = O(n)
+# space = O(n)
+from collections import deque
+class Solution(object):
+    def findWinningPlayer(self, skills, k):
+        n = len(skills)
+        if k >= n:
+            return skills.index(max(skills))
+
+        q = deque(range(n))
+        champ = q.popleft()
+        streak = 0
+        while True:
+            other = q.popleft()
+            if skills[champ] > skills[other]:
+                q.append(other)
+                streak += 1
+            else:
+                q.append(champ)
+                champ = other
+                streak = 1
+            if streak == k:
+                return champ
+
+
+# V0-2
+# IDEA : NEXT GREATER ELEMENT (MONOTONIC STACK) OVER THE PREFIX MAXIMA
+#
+#   turn the process into a closed formula instead of stepping through it.
+#
+#   1) only a PREFIX MAXIMUM ever reaches the front : player i takes over
+#      exactly when skills[i] beats everything before it.
+#   2) once at the front, player i keeps winning against i+1, i+2, ... until
+#      the first j > i with skills[j] > skills[i]. so with nge[i] = that j
+#      (or n when there is none), its streak is nge[i] - i wins — one less for
+#      player 0, which starts at the front without having won anything.
+#   3) champions appear in increasing index order, so the first prefix maximum
+#      whose streak reaches k is the answer; a prefix maximum with nge == n is
+#      the global maximum and wins arbitrarily many games, so it always ends
+#      the competition.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def findWinningPlayer(self, skills, k):
+        n = len(skills)
+        nge = [n] * n
+        stack = []
+        for i in range(n):
+            while stack and skills[stack[-1]] < skills[i]:
+                nge[stack.pop()] = i
+            stack.append(i)
+
+        mx = -1
+        for i in range(n):
+            if skills[i] > mx:
+                if nge[i] == n:
+                    return i
+                wins = nge[i] - i - (1 if i == 0 else 0)
+                if wins >= k:
+                    return i
+                mx = skills[i]
+        return n - 1

--- a/leetcode_python/Array/find-the-grid-of-region-average.py
+++ b/leetcode_python/Array/find-the-grid-of-region-average.py
@@ -92,3 +92,125 @@ class Solution(object):
 
         return [[total[i][j] // count[i][j] if count[i][j] else image[i][j]
                  for j in range(n)] for i in range(m)]
+
+
+# V0-1
+# IDEA : PREFIX SUMS OF VIOLATIONS + 2D PREFIX SUM, SO EACH WINDOW IS O(1)
+#
+#   the brute force re-reads the same 12 adjacencies and the same 9 values for
+#   overlapping windows. precompute instead :
+#     hbad[i][j] = 1 when the horizontal pair (i,j)-(i,j+1) breaks threshold
+#     vbad[i][j] = 1 when the vertical   pair (i,j)-(i+1,j) breaks threshold
+#   a 3x3 window at (i,j) is a region iff the rectangle rows i..i+2 /
+#   cols j..j+1 of hbad AND rows i..i+1 / cols j..j+2 of vbad both sum to 0.
+#   a third prefix sum over the pixels themselves gives the window total.
+#
+#   every window then costs a constant number of table lookups instead of a
+#   nested rescan — same asymptotics, but the constant drops from ~21 reads to
+#   3 rectangle queries.
+#
+# time = O(m * n)
+# space = O(m * n)
+class Solution(object):
+    def resultGrid(self, image, threshold):
+        m, n = len(image), len(image[0])
+
+        def build(grid, rows, cols):
+            p = [[0] * (cols + 1) for _ in range(rows + 1)]
+            for i in range(rows):
+                for j in range(cols):
+                    p[i + 1][j + 1] = (p[i][j + 1] + p[i + 1][j]
+                                       - p[i][j] + grid[i][j])
+            return p
+
+        def query(p, r1, c1, r2, c2):
+            return (p[r2 + 1][c2 + 1] - p[r1][c2 + 1]
+                    - p[r2 + 1][c1] + p[r1][c1])
+
+        hbad = [[1 if abs(image[i][j] - image[i][j + 1]) > threshold else 0
+                 for j in range(n - 1)] for i in range(m)]
+        vbad = [[1 if abs(image[i][j] - image[i + 1][j]) > threshold else 0
+                 for j in range(n)] for i in range(m - 1)]
+
+        ph = build(hbad, m, n - 1)
+        pv = build(vbad, m - 1, n)
+        pi = build(image, m, n)
+
+        total = [[0] * n for _ in range(m)]
+        count = [[0] * n for _ in range(m)]
+
+        for i in range(m - 2):
+            for j in range(n - 2):
+                if query(ph, i, j, i + 2, j + 1):
+                    continue
+                if query(pv, i, j, i + 1, j + 2):
+                    continue
+                avg = query(pi, i, j, i + 2, j + 2) // 9
+                for a in range(i, i + 3):
+                    for b in range(j, j + 3):
+                        total[a][b] += avg
+                        count[a][b] += 1
+
+        return [[total[i][j] // count[i][j] if count[i][j] else image[i][j]
+                 for j in range(n)] for i in range(m)]
+
+
+# V0-2
+# IDEA : RUN LENGTHS FOR VALIDITY + SEPARABLE (ROW-TRIPLE) SUMS
+#
+#   validity : hrun[i][j] = how many cells of row i, ending at column j, form
+#   an unbroken chain of within-threshold horizontal neighbours (reset to 1 on
+#   a break). row i covers columns j..j+2 iff hrun[i][j + 2] >= 3. vrun does
+#   the same downwards for columns. a window is a region iff its 3 rows and
+#   3 columns all have a run of at least 3 — 6 comparisons, no rectangle math.
+#
+#   sums : a 3x3 total is separable, so first collapse each row to
+#   rows3[i][j] = image[i][j] + image[i][j+1] + image[i][j+2] with a rolling
+#   window, then the window total is just rows3[i][j] + rows3[i+1][j] +
+#   rows3[i+2][j] — three additions, and only 1D tables are needed.
+#
+# time = O(m * n)
+# space = O(m * n)
+class Solution(object):
+    def resultGrid(self, image, threshold):
+        m, n = len(image), len(image[0])
+
+        hrun = [[1] * n for _ in range(m)]
+        for i in range(m):
+            for j in range(1, n):
+                if abs(image[i][j] - image[i][j - 1]) <= threshold:
+                    hrun[i][j] = hrun[i][j - 1] + 1
+
+        vrun = [[1] * n for _ in range(m)]
+        for i in range(1, m):
+            for j in range(n):
+                if abs(image[i][j] - image[i - 1][j]) <= threshold:
+                    vrun[i][j] = vrun[i - 1][j] + 1
+
+        rows3 = [[0] * (n - 2) for _ in range(m)]
+        for i in range(m):
+            w = sum(image[i][:3])
+            rows3[i][0] = w
+            for j in range(1, n - 2):
+                w += image[i][j + 2] - image[i][j - 1]
+                rows3[i][j] = w
+
+        total = [[0] * n for _ in range(m)]
+        count = [[0] * n for _ in range(m)]
+
+        for i in range(m - 2):
+            for j in range(n - 2):
+                if min(hrun[i][j + 2], hrun[i + 1][j + 2],
+                       hrun[i + 2][j + 2]) < 3:
+                    continue
+                if min(vrun[i + 2][j], vrun[i + 2][j + 1],
+                       vrun[i + 2][j + 2]) < 3:
+                    continue
+                avg = (rows3[i][j] + rows3[i + 1][j] + rows3[i + 2][j]) // 9
+                for a in range(i, i + 3):
+                    for b in range(j, j + 3):
+                        total[a][b] += avg
+                        count[a][b] += 1
+
+        return [[total[i][j] // count[i][j] if count[i][j] else image[i][j]
+                 for j in range(n)] for i in range(m)]

--- a/leetcode_python/Array/find-the-highest-altitude.py
+++ b/leetcode_python/Array/find-the-highest-altitude.py
@@ -49,3 +49,45 @@ class Solution(object):
             h += g
             res = max(res, h)
         return res
+
+
+# V0-1
+# IDEA : MATERIALISE THE ALTITUDE ARRAY WITH itertools.accumulate
+#
+#   accumulate(gain, initial=0) yields the whole altitude list
+#       [0, gain[0], gain[0]+gain[1], ...]
+#   i.e. exactly the points described in the statement, so max() over it is
+#   the answer. useful when the altitudes themselves are wanted (plotting,
+#   "which point is highest"), at the cost of O(n) memory.
+#
+# time = O(n), space = O(n)
+from itertools import accumulate
+
+
+class Solution(object):
+    def largestAltitude(self, gain):
+        altitudes = list(accumulate(gain, initial=0))
+        return max(altitudes)
+
+
+# V0-2
+# IDEA : BRUTE FORCE — RE-SUM THE PREFIX FOR EVERY POINT
+#
+#   translate the definition literally : the altitude of point i is
+#   sum(gain[:i]), so evaluate that sum from scratch for every i in 0..n and
+#   keep the largest. no carried state at all, which makes it the easiest
+#   version to trust, and O(n^2) is still nothing at n <= 100.
+#
+#   included as the baseline that V0's single carried `h` optimises.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def largestAltitude(self, gain):
+        n = len(gain)
+        res = float('-inf')
+        for i in range(n + 1):
+            h = 0
+            for j in range(i):
+                h += gain[j]
+            res = max(res, h)
+        return res

--- a/leetcode_python/Array/find-the-integer-added-to-array-i.py
+++ b/leetcode_python/Array/find-the-integer-added-to-array-i.py
@@ -56,3 +56,44 @@ The test cases are generated in a way that there is an integer x such that nums1
 class Solution(object):
     def addedInteger(self, nums1, nums2):
         return min(nums2) - min(nums1)
+
+
+# V0-1
+# IDEA : COMPARE THE SUMS — EVERY ELEMENT GAINED x, SO THE SUM GAINED n * x
+#
+#       sum(nums2) - sum(nums1) = n * x   =>   x = (sum2 - sum1) / n
+#
+#   an aggregate argument rather than an order-statistic one : it never looks
+#   at any single element, so it is immune to how the two arrays are permuted
+#   relative to each other. use exact integer division (the problem promises
+#   a valid x, so the difference is divisible by n).
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def addedInteger(self, nums1, nums2):
+        n = len(nums1)
+        return (sum(nums2) - sum(nums1)) // n
+
+
+# V0-2
+# IDEA : BRUTE FORCE OVER EVERY CANDIDATE x, VALIDATED AS A MULTISET
+#
+#   values are bounded by 1000, so x can only lie in [-1000, 1000]. try each
+#   candidate and check the definition directly : shifting nums1 by x must
+#   produce the same multiset as nums2 (Counter equality, which is what
+#   "same integers with the same frequencies" means).
+#
+#   slower, but it is the only version that VERIFIES rather than deduces —
+#   handy as an oracle when random-testing the O(n) formulas above.
+#
+# time = O(V * n) with V = 2001 candidates, space = O(n)
+from collections import Counter
+
+
+class Solution(object):
+    def addedInteger(self, nums1, nums2):
+        target = Counter(nums2)
+        for x in range(-1000, 1001):
+            if Counter(v + x for v in nums1) == target:
+                return x
+        return 0

--- a/leetcode_python/Array/find-the-minimum-area-to-cover-all-ones-ii.py
+++ b/leetcode_python/Array/find-the-minimum-area-to-cover-all-ones-ii.py
@@ -111,3 +111,177 @@ class Solution(object):
                 best = min(best, area(0, m, 0, c) + area(0, a, c, n) + area(a, m, c, n))
 
         return best
+
+
+# V0-1
+# IDEA : RECURSIVE GUILLOTINE DP — dfs(region, k) INSTEAD OF 6 HAND-WRITTEN CASES
+#
+#   the same guillotine insight as V0, but expressed as a recurrence over
+#   (region, number of rectangles left) :
+#
+#       f(R, 1) = bounding-box area of the 1s in R
+#       f(R, k) = min over every horizontal / vertical cut of R into A|B
+#                 and every split k = i + (k - i) of  f(A, i) + f(B, k - i)
+#
+#   the six layouts of V0 fall out automatically as the six ways the two cuts
+#   can be nested, and the recurrence generalises to any k (LC 3195 is k = 2)
+#   without writing new cases. memoised on (r1, r2, c1, c2, k).
+#
+#   a region that cannot be cut into k >= 2 pieces (a single row for a
+#   horizontal split, etc.) returns inf, so infeasible layouts drop out of
+#   the min on their own.
+#
+# time = O((m + n)^2 * m * n) worst case, space = O((m + n)^2 + m * n)
+class Solution(object):
+    def minimumSum(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        bbox_memo = {}
+
+        def bbox_area(r1, r2, c1, c2):
+            key = (r1, r2, c1, c2)
+            if key in bbox_memo:
+                return bbox_memo[key]
+            top, bot, left, right = m, -1, n, -1
+            for i in range(r1, r2):
+                row = grid[i]
+                for j in range(c1, c2):
+                    if row[j]:
+                        top = min(top, i)
+                        bot = max(bot, i)
+                        left = min(left, j)
+                        right = max(right, j)
+            res = 0 if bot < 0 else (bot - top + 1) * (right - left + 1)
+            bbox_memo[key] = res
+            return res
+
+        INF = float('inf')
+        dp_memo = {}
+
+        def dfs(r1, r2, c1, c2, k):
+            if k == 1:
+                return bbox_area(r1, r2, c1, c2)
+            key = (r1, r2, c1, c2, k)
+            if key in dp_memo:
+                return dp_memo[key]
+            best = INF
+            for i in range(1, k):
+                for a in range(r1 + 1, r2):
+                    best = min(best, dfs(r1, a, c1, c2, i)
+                                     + dfs(a, r2, c1, c2, k - i))
+                for b in range(c1 + 1, c2):
+                    best = min(best, dfs(r1, r2, c1, b, i)
+                                     + dfs(r1, r2, b, c2, k - i))
+            dp_memo[key] = best
+            return best
+
+        return dfs(0, m, 0, n, 3)
+
+
+# V0-2
+# IDEA : PRECOMPUTED PREFIX BOUNDING-BOX TABLES — O(1) PER REGION LOOKUP
+#
+#   V0 / V0-1 both RESCAN a region to find its bounding box. but only six
+#   families of regions are ever asked about, and each family can be built up
+#   incrementally, merging one row (or column) at a time :
+#
+#       row_pre[r][c]  = bbox of row r restricted to cols [0, c)
+#       row_suf[r][c]  = bbox of row r restricted to cols [c, n)
+#       TL[a][c] = bbox of rows [0, a) x cols [0, c)  = TL[a-1][c] + row_pre[a-1][c]
+#       TR[a][c] = bbox of rows [0, a) x cols [c, n)  = TR[a-1][c] + row_suf[a-1][c]
+#       BL[a][c] = bbox of rows [a, m) x cols [0, c)  = BL[a+1][c] + row_pre[a][c]
+#       BR[a][c] = bbox of rows [a, m) x cols [c, n)  = BR[a+1][c] + row_suf[a][c]
+#       band[r1][r2]   = bbox of rows [r1, r2) x all cols
+#       strip[c1][c2]  = bbox of cols [c1, c2) x all rows
+#
+#   merging two bounding boxes is min/min/max/max, so every table entry costs
+#   O(1) and the whole enumeration of the six layouts becomes table lookups.
+#   that drops the m*n rescan factor entirely.
+#
+#   empty bbox is represented as None and contributes area 0.
+#
+# time = O(m * n + m^2 + n^2), space = O(m * n + m^2 + n^2)
+class Solution(object):
+    def minimumSum(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        def merge(a, b):
+            if a is None:
+                return b
+            if b is None:
+                return a
+            return (min(a[0], b[0]), max(a[1], b[1]),
+                    min(a[2], b[2]), max(a[3], b[3]))
+
+        def area(b):
+            if b is None:
+                return 0
+            return (b[1] - b[0] + 1) * (b[3] - b[2] + 1)
+
+        # per-row prefix / suffix boxes
+        row_pre = [[None] * (n + 1) for _ in range(m)]
+        row_suf = [[None] * (n + 1) for _ in range(m)]
+        for r in range(m):
+            for c in range(1, n + 1):
+                cell = (r, r, c - 1, c - 1) if grid[r][c - 1] else None
+                row_pre[r][c] = merge(row_pre[r][c - 1], cell)
+            for c in range(n - 1, -1, -1):
+                cell = (r, r, c, c) if grid[r][c] else None
+                row_suf[r][c] = merge(row_suf[r][c + 1], cell)
+
+        # quadrant tables
+        TL = [[None] * (n + 1) for _ in range(m + 1)]
+        TR = [[None] * (n + 1) for _ in range(m + 1)]
+        BL = [[None] * (n + 1) for _ in range(m + 1)]
+        BR = [[None] * (n + 1) for _ in range(m + 1)]
+        for a in range(1, m + 1):
+            for c in range(n + 1):
+                TL[a][c] = merge(TL[a - 1][c], row_pre[a - 1][c])
+                TR[a][c] = merge(TR[a - 1][c], row_suf[a - 1][c])
+        for a in range(m - 1, -1, -1):
+            for c in range(n + 1):
+                BL[a][c] = merge(BL[a + 1][c], row_pre[a][c])
+                BR[a][c] = merge(BR[a + 1][c], row_suf[a][c])
+
+        # full-width bands and full-height strips
+        band = [[0] * (m + 1) for _ in range(m + 1)]
+        for r1 in range(m):
+            box = None
+            for r2 in range(r1 + 1, m + 1):
+                box = merge(box, row_pre[r2 - 1][n])
+                band[r1][r2] = area(box)
+
+        col_box = []
+        for c in range(n):
+            box = None
+            for r in range(m):
+                if grid[r][c]:
+                    box = merge(box, (r, r, c, c))
+            col_box.append(box)
+        strip = [[0] * (n + 1) for _ in range(n + 1)]
+        for c1 in range(n):
+            box = None
+            for c2 in range(c1 + 1, n + 1):
+                box = merge(box, col_box[c2 - 1])
+                strip[c1][c2] = area(box)
+
+        best = float('inf')
+
+        for a in range(1, m):
+            for b in range(a + 1, m):
+                best = min(best, band[0][a] + band[a][b] + band[b][m])
+
+        for a in range(1, n):
+            for b in range(a + 1, n):
+                best = min(best, strip[0][a] + strip[a][b] + strip[b][n])
+
+        for a in range(1, m):
+            for c in range(1, n):
+                tl, tr = area(TL[a][c]), area(TR[a][c])
+                bl, br = area(BL[a][c]), area(BR[a][c])
+                best = min(best, tl + tr + band[a][m])       # cut rows, split top
+                best = min(best, band[0][a] + bl + br)       # cut rows, split bottom
+                best = min(best, tl + bl + strip[c][n])      # cut cols, split left
+                best = min(best, strip[0][c] + tr + br)      # cut cols, split right
+
+        return best

--- a/leetcode_python/Array/find-the-minimum-possible-sum-of-a-beautiful-array.py
+++ b/leetcode_python/Array/find-the-minimum-possible-sum-of-a-beautiful-array.py
@@ -85,3 +85,68 @@ class Solution(object):
         rest = n - m
         total = m * (m + 1) // 2 + rest * target + rest * (rest - 1) // 2
         return total % MOD
+
+
+# V0-1
+# IDEA : GREEDY SIMULATION WITH AN EXPLICIT BANNED SET
+#
+#   walk the candidates 1, 2, 3, ... in increasing order and take each one
+#   unless it has already been banned by a partner we picked ; picking x bans
+#   target - x. stop once n values are collected.
+#
+#   this is the version to reason with (and the oracle to test the closed
+#   forms against) : it makes no claim about WHERE the boundary is, it just
+#   applies the rule. it is O(n) time and memory though, so at n = 10^9 it
+#   only serves as a reference implementation for small inputs.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def minimumPossibleSum(self, n, target):
+        MOD = 10 ** 9 + 7
+        banned = set()
+        total = 0
+        taken = 0
+        x = 1
+        while taken < n:
+            if x not in banned:
+                total += x
+                taken += 1
+                if target - x != x:
+                    banned.add(target - x)
+            x += 1
+        return total % MOD
+
+
+# V0-2
+# IDEA : COMPLEMENT COUNTING — SUM ONE CONTIGUOUS RUN, SUBTRACT THE BANNED BLOCK
+#
+#   the chosen set is  {1..m}  U  {target..hi}  with m = target // 2 and
+#   hi = target + (n - m) - 1. instead of adding the two pieces (V0), note
+#   that together they are the single run 1..hi with the middle block
+#   [m + 1, target - 1] punched out :
+#
+#       sum = tri(hi) - ( tri(target - 1) - tri(m) )
+#
+#   so the whole answer is three triangular numbers, and the only formula
+#   needed is tri(k) = k(k+1)/2.
+#
+#   every step is taken modulo 10^9 + 7 using the modular inverse of 2
+#   (Fermat : 2^(MOD-2)), so nothing ever exceeds the modulus — the shape a
+#   fixed-width language (Java/C++ long) has to use to stay overflow-free.
+#
+# time = O(log MOD) for the one modular inverse, space = O(1)
+class Solution(object):
+    def minimumPossibleSum(self, n, target):
+        MOD = 10 ** 9 + 7
+        inv2 = pow(2, MOD - 2, MOD)
+
+        def tri(k):
+            if k <= 0:
+                return 0
+            return (k % MOD) * ((k + 1) % MOD) % MOD * inv2 % MOD
+
+        m = target // 2
+        if n <= m:
+            return tri(n)
+        hi = target + (n - m) - 1
+        return (tri(hi) - tri(target - 1) + tri(m)) % MOD

--- a/leetcode_python/Array/find-the-number-of-good-pairs-i.py
+++ b/leetcode_python/Array/find-the-number-of-good-pairs-i.py
@@ -47,3 +47,65 @@ class Solution(object):
                    for a in nums1
                    for b in nums2
                    if a % (b * k) == 0)
+
+
+# V0-1
+# IDEA : COUNT MULTIPLES — FREQUENCY TABLE OVER THE VALUE RANGE (HARMONIC SUM)
+#
+#   group nums1 by value once. then for each b in nums2 the divisor is
+#   d = b * k, and every good partner is a MULTIPLE of d, so walk
+#   d, 2d, 3d, ... up to max(nums1) and add the frequencies.
+#
+#   the walk costs V / d steps, and summing V / d over the distinct divisors
+#   is the harmonic sum ~ V log V — independent of how long nums1 is. this is
+#   the version that scales to the sequel (LC 3164, arrays of 10^5).
+#
+# time = O(n + m + V log V) with V = max(nums1), space = O(V)
+from collections import Counter
+
+
+class Solution(object):
+    def numberOfPairs(self, nums1, nums2, k):
+        cnt1 = Counter(nums1)
+        top = max(nums1)
+        res = 0
+        for b in nums2:
+            d = b * k
+            if d > top:
+                continue
+            for mult in range(d, top + 1, d):
+                res += cnt1[mult]
+        return res
+
+
+# V0-2
+# IDEA : ENUMERATE THE DIVISORS OF EACH nums1[i] IN O(sqrt(a))
+#
+#   the mirror image of V0-1 : group nums2 instead, then for each a in nums1
+#   list its divisors by trial division up to sqrt(a). a divisor d is usable
+#   only when d is itself a multiple of k, and it then corresponds to the
+#   nums2 value b = d // k — so add cnt2[d // k].
+#
+#   watch the perfect-square case (d == a // d) so the divisor is not counted
+#   twice.
+#
+#   preferable to V0-1 when the values are large but the arrays are short,
+#   since it never touches the value range as a whole.
+#
+# time = O(m + n * sqrt(V)), space = O(m)
+from collections import Counter
+
+
+class Solution(object):
+    def numberOfPairs(self, nums1, nums2, k):
+        cnt2 = Counter(nums2)
+        res = 0
+        for a in nums1:
+            d = 1
+            while d * d <= a:
+                if a % d == 0:
+                    for div in {d, a // d}:
+                        if div % k == 0:
+                            res += cnt2[div // k]
+                d += 1
+        return res

--- a/leetcode_python/Array/find-the-original-array-of-prefix-xor.py
+++ b/leetcode_python/Array/find-the-original-array-of-prefix-xor.py
@@ -49,3 +49,56 @@ Constraints:
 class Solution(object):
     def findArray(self, pref):
         return [pref[0]] + [pref[i] ^ pref[i - 1] for i in range(1, len(pref))]
+
+
+# V0-1
+# IDEA : IN-PLACE BACKWARD PASS — O(1) EXTRA SPACE
+#
+#   walking FORWARD in place would destroy pref[i-1] before it is needed, so
+#   walk backward instead : at index i, both pref[i] and pref[i-1] are still
+#   untouched, so pref[i] ^= pref[i-1] overwrites the slot with the answer
+#   and never corrupts a value still to be read.
+#
+#   pref[0] already equals arr[0], so the loop stops at i == 1.
+#
+#   NOTE : this mutates the caller's list (LeetCode accepts that, and it is
+#          the version to use when memory is tight).
+#
+# time = O(n), space = O(1) beyond the input
+class Solution(object):
+    def findArray(self, pref):
+        for i in range(len(pref) - 1, 0, -1):
+            pref[i] ^= pref[i - 1]
+        return pref
+
+
+# V0-2
+# IDEA : BITWISE — EACH BIT COLUMN IS AN INDEPENDENT PARITY STREAM
+#
+#   xor acts on every bit position independently, so bit b of pref is just
+#   the running PARITY of bit b of arr :
+#
+#       bit b of arr[i] = 1  <=>  bit b flips between pref[i-1] and pref[i]
+#
+#   so reconstruct one bit column at a time : scan the column, remember the
+#   previous bit (0 before the array starts), and set the bit in the answer
+#   wherever it changes. this is the "difference of a parity prefix" view, and
+#   it is what makes the O(1)-space trick above believable.
+#
+#   values are <= 10^6 < 2^20, so at most 20 columns.
+#
+# time = O(n * B) with B = bit width, space = O(n) for the output
+class Solution(object):
+    def findArray(self, pref):
+        n = len(pref)
+        arr = [0] * n
+        bits = max(pref).bit_length() if n else 0
+        for b in range(bits):
+            mask = 1 << b
+            prev = 0
+            for i in range(n):
+                cur = (pref[i] >> b) & 1
+                if cur != prev:
+                    arr[i] |= mask
+                prev = cur
+        return arr

--- a/leetcode_python/Array/find-the-power-of-k-size-subarrays-i.py
+++ b/leetcode_python/Array/find-the-power-of-k-size-subarrays-i.py
@@ -64,3 +64,53 @@ class Solution(object):
             ok = all(nums[t + 1] == nums[t] + 1 for t in range(i, i + k - 1))
             res.append(nums[i + k - 1] if ok else -1)
         return res
+
+
+# V0-1
+# IDEA : PREFIX SUM OVER THE "+1 STEP" FLAGS
+#
+#   step[t] = 1 when nums[t] == nums[t - 1] + 1. a window [i, i + k - 1]
+#   qualifies iff ALL k - 1 steps strictly inside it are 1, i.e. their sum
+#   is k - 1. one prefix-sum array then answers every window in O(1)
+#   instead of re-walking it, which is what makes this scale to the larger
+#   n of the sequel (LC 3255).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def resultsArray(self, nums, k):
+        n = len(nums)
+        pre = [0] * n
+        for t in range(1, n):
+            pre[t] = pre[t - 1] + (1 if nums[t] == nums[t - 1] + 1 else 0)
+        res = []
+        for i in range(n - k + 1):
+            j = i + k - 1
+            res.append(nums[j] if pre[j] - pre[i] == k - 1 else -1)
+        return res
+
+
+# V0-2
+# IDEA : CUT INTO MAXIMAL +1 RUNS, THEN STAMP A WHOLE RUN AT A TIME
+#
+#   a window is powerful exactly when it lies entirely inside one maximal
+#   run of consecutive +1 steps. so stop asking a question per window :
+#   walk the runs, and for a run spanning [l, r] fill in every start index
+#   from l to r - k + 1 at once, each answered by its own last element.
+#   everything else keeps the -1 it was initialised with.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def resultsArray(self, nums, k):
+        n = len(nums)
+        res = [-1] * (n - k + 1)
+        l = 0
+        while l < n:
+            r = l
+            while r + 1 < n and nums[r + 1] == nums[r] + 1:
+                r += 1
+            for i in range(l, r - k + 2):
+                res[i] = nums[i + k - 1]
+            l = r + 1
+        return res

--- a/leetcode_python/Array/find-the-winner-of-an-array-game.py
+++ b/leetcode_python/Array/find-the-winner-of-an-array-game.py
@@ -69,3 +69,63 @@ class Solution(object):
             if streak == k:
                 break
         return champ
+
+
+# V0-1
+# IDEA : LITERAL SIMULATION WITH A DEQUE
+#
+#   play the game exactly as written : take the two front elements, the
+#   loser is pushed to the back, the winner stays at the front. the only
+#   extra ingredient needed to make it terminate is a stop condition --
+#   once the champion is the array maximum nothing can ever beat it, so it
+#   is the answer no matter how big k is (k can be 10^9).
+#
+# time = O(n)
+# space = O(n)
+from collections import deque
+class Solution(object):
+    def getWinner(self, arr, k):
+        top = max(arr)
+        dq = deque(arr)
+        champ = dq.popleft()
+        streak = 0
+        while champ != top and streak < k:
+            other = dq.popleft()
+            if other > champ:
+                dq.append(champ)
+                champ, streak = other, 1
+            else:
+                dq.append(other)
+                streak += 1
+        return champ
+
+
+# V0-2
+# IDEA : TWO PASSES -- PREFIX MAXIMA, THEN A CLOSED-FORM TEST PER CANDIDATE
+#
+#   arr[i] can only ever hold the crown if it beats everybody before it,
+#   i.e. arr[i] == max(arr[:i + 1]) (a prefix record). such a record wins
+#   round i and then needs k - 1 more wins, against arr[i + 1 .. i + k - 1];
+#   since it already dominates the whole prefix, "it beats them all"
+#   collapses to arr[i] == max(arr[:i + k]) -- a single lookup in the
+#   prefix-maximum table, no streak counter at all.
+#   arr[0] is the exception : it has not won a round when the game starts,
+#   so it must survive k opponents, arr[0] == max(arr[:k + 1]).
+#   the global maximum always passes the test, so the scan always returns.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def getWinner(self, arr, k):
+        n = len(arr)
+        pmax = [0] * n
+        run = arr[0]
+        for i in range(n):
+            run = max(run, arr[i])
+            pmax[i] = run
+        if pmax[min(n - 1, k)] == arr[0]:
+            return arr[0]
+        for i in range(1, n):
+            if arr[i] == pmax[i] and arr[i] == pmax[min(n - 1, i + k - 1)]:
+                return arr[i]
+        return pmax[n - 1]

--- a/leetcode_python/Array/flip-columns-for-maximum-number-of-equal-rows.py
+++ b/leetcode_python/Array/flip-columns-for-maximum-number-of-equal-rows.py
@@ -59,3 +59,50 @@ class Solution(object):
             key = tuple(x ^ row[0] for x in row)
             cnt[key] += 1
         return max(cnt.values())
+
+
+# V0-1
+# IDEA : BRUTE FORCE -- TRY EVERY ROW AS THE ROW WE INSIST ON MAKING UNIFORM
+#
+#  the flip set is fully determined once we decide WHICH row must come out
+#  all-equal (flip exactly the columns where that row holds 1), so only m
+#  candidate flip sets are worth trying. under a candidate, another row
+#  becomes uniform iff it matches the chosen row in every column or
+#  disagrees with it in every column.
+# time = O(m^2 * n)
+# space = O(1)
+class Solution(object):
+    def maxEqualRowsAfterFlips(self, matrix):
+        n = len(matrix[0])
+        best = 0
+        for base in matrix:
+            cnt = 0
+            for row in matrix:
+                same = all(row[j] == base[j] for j in range(n))
+                opp = all(row[j] != base[j] for j in range(n))
+                if same or opp:
+                    cnt += 1
+            best = max(best, cnt)
+        return best
+
+
+# V0-2
+# IDEA : PACK EACH ROW INTO AN INTEGER, PAIR A MASK WITH ITS COMPLEMENT
+#
+#  with n <= 300 a row is just a (big) python int bitmask. equal rows share
+#  a mask and complementary rows have masks that XOR to the all-ones value,
+#  so no normalisation pass is needed : count the masks, then read off
+#  cnt[mask] + cnt[full ^ mask] and keep the biggest.
+# time = O(m * n)
+# space = O(m)
+class Solution(object):
+    def maxEqualRowsAfterFlips(self, matrix):
+        n = len(matrix[0])
+        full = (1 << n) - 1
+        cnt = {}
+        for row in matrix:
+            mask = 0
+            for v in row:
+                mask = (mask << 1) | v
+            cnt[mask] = cnt.get(mask, 0) + 1
+        return max(c + cnt.get(full ^ mask, 0) for mask, c in cnt.items())

--- a/leetcode_python/Array/flip-square-submatrix-vertically.py
+++ b/leetcode_python/Array/flip-square-submatrix-vertically.py
@@ -58,3 +58,47 @@ class Solution(object):
             for j in range(y, y + k):
                 grid[top][j], grid[bot][j] = grid[bot][j], grid[top][j]
         return grid
+
+
+# V0-1
+# IDEA : COPY THE WINDOW OUT, REVERSE IT, PASTE IT BACK
+#
+#   lift the k x k window out as its own list of row slices. a vertical
+#   flip IS a reversal of that list, so reverse it and write the rows back
+#   with slice assignment -- no mirrored-index arithmetic anywhere.
+#
+# time = O(k^2)
+# space = O(k^2)
+class Solution(object):
+    def reverseSubmatrix(self, grid, x, y, k):
+        block = [grid[r][y:y + k] for r in range(x, x + k)]
+        block.reverse()
+        for i in range(k):
+            grid[x + i][y:y + k] = block[i]
+        return grid
+
+
+# V0-2
+# IDEA : REBUILD THE GRID FROM A COORDINATE MAP (NO MUTATION AT ALL)
+#
+#   state the answer as a pure function of the source cell : a cell inside
+#   the window reads from its mirror row 2*x + k - 1 - r (same column), and
+#   every cell outside reads from itself. materialising that map builds a
+#   fresh matrix and leaves the input untouched, which is what you want when
+#   the caller still needs the original grid.
+#
+# time = O(m * n)
+# space = O(m * n)
+class Solution(object):
+    def reverseSubmatrix(self, grid, x, y, k):
+        m, n = len(grid), len(grid[0])
+        res = []
+        for r in range(m):
+            row = []
+            for c in range(n):
+                if x <= r < x + k and y <= c < y + k:
+                    row.append(grid[2 * x + k - 1 - r][c])
+                else:
+                    row.append(grid[r][c])
+            res.append(row)
+        return res

--- a/leetcode_python/Array/gcd-sort-of-an-array.py
+++ b/leetcode_python/Array/gcd-sort-of-an-array.py
@@ -103,3 +103,109 @@ class Solution(object):
             if nums[i] != target[i] and find(nums[i]) != find(target[i]):
                 return False
         return True
+
+
+# V0-1
+# IDEA : UNION EACH PRIME'S MULTIPLES DIRECTLY (NO PER-VALUE FACTORIZATION)
+#
+#   flip the loops around. instead of factorizing every value, mark which
+#   values are PRESENT, then for each prime p walk p, 2p, 3p, ... and union
+#   every present multiple into the first present one seen. that produces
+#   exactly the same components (values sharing a prime) in one
+#   harmonic-series sweep, and the sweep doubles as the sieve : p is prime
+#   iff no smaller number ever crossed it out.
+#
+#   NOTE : no gcd call and no factorization anywhere - the "share a prime"
+#          relation is read straight off the multiples table.
+#
+# time = O(M log log M + n * alpha(M)), M = max(nums)
+# space = O(M)
+class Solution(object):
+    def gcdSort(self, nums):
+        mx = max(nums)
+        present = [False] * (mx + 1)
+        for v in nums:
+            present[v] = True
+
+        parent = list(range(mx + 1))
+
+        def find(x):
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]     # path halving
+                x = parent[x]
+            return x
+
+        composite = [False] * (mx + 1)
+        for p in range(2, mx + 1):
+            if composite[p]:
+                continue
+            anchor = -1
+            for m in range(p, mx + 1, p):
+                if m > p:
+                    composite[m] = True
+                if present[m]:
+                    if anchor < 0:
+                        anchor = m
+                    else:
+                        ra, rb = find(anchor), find(m)
+                        if ra != rb:
+                            parent[rb] = ra
+
+        return all(a == b or find(a) == find(b)
+                   for a, b in zip(nums, sorted(nums)))
+
+
+# V0-2
+# IDEA : VALUE <-> PRIME BIPARTITE GRAPH + BFS COMPONENT LABELLING
+#
+#   drop union-find entirely and make the swap relation an explicit graph :
+#   nodes are the distinct values plus the primes, with an edge v -- p for
+#   every prime p dividing v. two values can be swapped (possibly through
+#   intermediaries) exactly when they sit in the same connected component,
+#   so one BFS per unlabelled value stamps component ids, and the
+#   original-vs-sorted comparison just compares ids.
+#
+#   NOTE : each prime bucket is popped the first time it is expanded, so a
+#          prime shared by many values is scanned once, not once per value.
+#
+# time = O(n * sqrt(M) + E), M = max(nums)
+# space = O(n * log M)
+class Solution(object):
+    def gcdSort(self, nums):
+        from collections import defaultdict, deque
+
+        factors = {}
+        by_prime = defaultdict(list)
+        for v in set(nums):
+            fs = []
+            x, d = v, 2
+            while d * d <= x:
+                if x % d == 0:
+                    fs.append(d)
+                    while x % d == 0:
+                        x //= d
+                d += 1 if d == 2 else 2
+            if x > 1:
+                fs.append(x)
+            factors[v] = fs
+            for p in fs:
+                by_prime[p].append(v)
+
+        comp = {}
+        cid = 0
+        for start in factors:
+            if start in comp:
+                continue
+            comp[start] = cid
+            q = deque([start])
+            while q:
+                v = q.popleft()
+                for p in factors[v]:
+                    for u in by_prime.pop(p, ()):
+                        if u not in comp:
+                            comp[u] = cid
+                            q.append(u)
+            cid += 1
+
+        return all(a == b or comp[a] == comp[b]
+                   for a, b in zip(nums, sorted(nums)))

--- a/leetcode_python/Array/generate-schedule.py
+++ b/leetcode_python/Array/generate-schedule.py
@@ -113,3 +113,134 @@ class Solution(object):
             for i in range(start, start + n):
                 res.append([i % n, (i + g) % n])
         return res
+
+
+# V0-1
+# IDEA : DAY-BY-DAY GREEDY -- ALWAYS SERVE THE BUSIEST PAIR STILL OWED
+#
+#   forget the algebra and fill the days one at a time. keep owed[i][j] = 1
+#   while "i at home vs j" has not been played, and rem[t] = how many
+#   matches team t still owes in total. each day, among the pairs touching
+#   neither of yesterday's two teams, play the one whose two teams owe the
+#   most matches between them (tie-break: a pair that still owes both
+#   orientations goes before a half-finished one).
+#
+#   why it does not paint itself into a corner: the team that runs out of
+#   legal days is always the one with the most matches left, so spending
+#   every day on the currently busiest teams keeps the remaining demand
+#   flat. verified to produce a legal schedule for every n in 5..50, the
+#   whole input range.
+#
+#   n <= 4 is impossible, exactly as in V0.
+#
+# time = O(n^4)  (n*(n-1) days x an O(n^2) scan for the best pair)
+# space = O(n^2)
+class Solution(object):
+    def generateSchedule(self, n):
+        if n <= 4:
+            return []
+
+        owed = [[1] * n for _ in range(n)]
+        for i in range(n):
+            owed[i][i] = 0
+        rem = [2 * (n - 1)] * n
+
+        res = []
+        prev = (-1, -1)
+        for _ in range(n * (n - 1)):
+            pick, key = None, None
+            for i in range(n):
+                if i in prev:
+                    continue
+                for j in range(n):
+                    if j in prev or not owed[i][j]:
+                        continue
+                    cand = (rem[i] + rem[j], owed[j][i], -i, -j)
+                    if key is None or cand > key:
+                        pick, key = (i, j), cand
+            if pick is None:
+                return []
+            i, j = pick
+            owed[i][j] = 0
+            rem[i] -= 1
+            rem[j] -= 1
+            res.append([i, j])
+            prev = (i, j)
+        return res
+
+
+# V0-2
+# IDEA : 1-FACTORIZE K_n INTO ROUNDS, THEN ONLY FIX THE SEAMS
+#
+#   the classic circle method splits all C(n, 2) pairs into rounds of
+#   pairwise-disjoint matches (n-1 rounds of n/2 for even n; for odd n add a
+#   dummy team, so each of the n rounds has (n-1)/2 real matches and one
+#   resting team). inside a round no two matches share a team, so the days
+#   of a round may be emitted in ANY order -- and emitting the round's
+#   matches once as [a, b] and then again in the same order as [b, a] covers
+#   both legs while keeping the middle seam clean (the last home match and
+#   the first away match are different, hence disjoint, pairs).
+#
+#   that leaves only the joins between rounds. a round with m >= 3 matches
+#   always contains a match avoiding the two teams that just played (two
+#   teams can block at most two matches), so for n >= 6 a single left-to-right
+#   pass never gets stuck; n = 5 has m = 2 and is the only case where the
+#   search actually has to try another (first, last) choice, and its state
+#   space is a handful of options.
+#
+# time = O(n^2)  (each round emitted in O(n); backtracking only for n = 5)
+# space = O(n^2)
+class Solution(object):
+    def generateSchedule(self, n):
+        if n <= 4:
+            return []
+
+        # ---- circle method : rounds of disjoint matches
+        m = n if n % 2 == 0 else n + 1          # dummy team n when n is odd
+        rounds = []
+        for r in range(m - 1):
+            rnd = []
+            if r < n and m - 1 < n:             # the fixed seat vs the rotator
+                rnd.append((r, m - 1))
+            for i in range(1, m // 2):
+                u, v = (r + i) % (m - 1), (r - i) % (m - 1)
+                if u < n and v < n:
+                    rnd.append((u, v))
+            rounds.append(rnd)
+
+        # ---- order the rounds, and inside each one the first / last match,
+        #      so that consecutive days never share a team
+        plan = []
+
+        def walk(used, last):
+            if len(used) == len(rounds):
+                return True
+            for ri, edges in enumerate(rounds):
+                if ri in used:
+                    continue
+                for f in range(len(edges)):
+                    if last and (edges[f][0] in last or edges[f][1] in last):
+                        continue
+                    for l in range(len(edges)):
+                        if l == f:
+                            continue
+                        mid = [e for t, e in enumerate(edges) if t != f and t != l]
+                        seq = [edges[f]] + mid + [edges[l]]
+                        used.add(ri)
+                        plan.append(seq)
+                        if walk(used, set(edges[l])):
+                            return True
+                        plan.pop()
+                        used.discard(ri)
+            return False
+
+        if not walk(set(), None):
+            return []
+
+        res = []
+        for seq in plan:
+            for a, b in seq:
+                res.append([a, b])
+            for a, b in seq:
+                res.append([b, a])
+        return res


### PR DESCRIPTION
Batches 011-019 of task 3: every LC problem should carry at least 3 genuinely distinct, tested solution versions. All 54 files are Array problems that had a single implementation.

Batch 020 is still running and is deliberately left out of this commit rather than captured half-written.

The added versions are real algorithmic alternatives, not respelled loops — union-find vs BFS flood fill, Fenwick tree vs merge-sort inversion counting, closed-form arithmetic vs exact-count knapsack DP, guillotine-recursion DP vs precomputed quadrant prefix tables, monotonic stack vs deque simulation, counting sort vs heap. Where a brute force was added it is labelled as the teaching contrast to the optimal block, with its own honest complexity.

Every block carries the house 4-line header, and existing blocks were left byte-for-byte unchanged: the diff has zero deletions.

Each new solution was run against its problem's docstring examples plus randomized differential testing against an independent oracle, and the pandas problems were exercised in a local venv since pandas is not in the system python. All 54 files pass script/py_multi_version/verify.py.