### PR TITLE
feat(leetcode_python): add missing solution versions, wave 3 (60 files)

### DIFF
--- a/leetcode_python/Array/get-biggest-three-rhombus-sums-in-a-grid.py
+++ b/leetcode_python/Array/get-biggest-three-rhombus-sums-in-a-grid.py
@@ -86,3 +86,110 @@ class Solution(object):
                     k += 1
 
         return sorted(sums, reverse=True)[:3]
+
+
+# V0-1
+# IDEA : DIAGONAL PREFIX SUMS -> EACH RHOMBUS BORDER IN O(1)
+#
+#   the four edges of a rhombus are DIAGONAL segments, so precompute a prefix
+#   sum along each of the two diagonal directions (1-indexed, padded) :
+#
+#       dr[i][j] = grid[i][j] + dr[i - 1][j - 1]   ("\" ray ending at (i, j))
+#       dl[i][j] = grid[i][j] + dl[i - 1][j + 1]   ("/" ray ending at (i, j))
+#
+#   then any diagonal segment is a single subtraction :
+#
+#       "\" from (r1, c1) to (r2, c2) = dr[r2][c2] - dr[r1 - 1][c1 - 1]
+#       "/" from (r1, c1) to (r2, c2) = dl[r2][c2] - dl[r1 - 1][c1 + 1]
+#
+#   a border = 4 such segments, and summing them counts each of the 4 CORNERS
+#   twice, so subtract the four corner cells once.
+#
+#   NOTE : this removes the inner O(k) walk, so the enumeration drops from
+#          O(m * n * K^2) to O(m * n * K).
+#   NOTE : dl needs a column n + 1 sentinel, hence the width n + 2 padding.
+#
+# time = O(m * n * K), K = min(m, n) / 2
+# space = O(m * n)
+class Solution(object):
+    def getBiggestThree(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        dr = [[0] * (n + 2) for _ in range(m + 1)]
+        dl = [[0] * (n + 2) for _ in range(m + 1)]
+        for i in range(1, m + 1):
+            for j in range(1, n + 1):
+                dr[i][j] = grid[i - 1][j - 1] + dr[i - 1][j - 1]
+                dl[i][j] = grid[i - 1][j - 1] + dl[i - 1][j + 1]
+
+        def down_right(r1, c1, r2, c2):
+            return dr[r2][c2] - dr[r1 - 1][c1 - 1]
+
+        def down_left(r1, c1, r2, c2):
+            return dl[r2][c2] - dl[r1 - 1][c1 + 1]
+
+        sums = set()
+        for i in range(m):
+            for j in range(n):
+                sums.add(grid[i][j])                      # k = 0
+                k = 1
+                while i + 2 * k < m and j - k >= 0 and j + k < n:
+                    r, c = i + 1, j + 1                   # 1-indexed top corner
+                    total = (down_right(r, c, r + k, c + k)
+                             + down_left(r + k, c + k, r + 2 * k, c)
+                             + down_left(r, c, r + k, c - k)
+                             + down_right(r + k, c - k, r + 2 * k, c))
+                    total -= (grid[i][j] + grid[i + k][j + k]
+                              + grid[i + 2 * k][j] + grid[i + k][j - k])
+                    sums.add(total)
+                    k += 1
+
+        return sorted(sums, reverse=True)[:3]
+
+
+# V0-2
+# IDEA : BRUTE FORCE BY (CENTER, RADIUS) + MANHATTAN MEMBERSHIP TEST
+#
+#   describe the rhombus by its CENTER (cy, cx) and radius k instead of its top
+#   corner: the border is exactly the cells with
+#
+#       |r - cy| + |c - cx| == k
+#
+#   so scan the (2k + 1) x (2k + 1) bounding box around the center and add up
+#   whatever satisfies that test -- no edge-walking geometry to get right, at
+#   the cost of touching O(k^2) cells per rhombus instead of O(k).
+#
+#   the top-3 are kept in a 3-slot list rather than a set of every sum, so the
+#   extra space is O(1) -- useful when the grid is far larger than 50 x 50.
+#
+#   NOTE : k = 0 makes the box a single cell, so the degenerate rhombus is
+#          handled by the same loop with no special case.
+#
+# time = O(m * n * K^3), K = min(m, n) / 2
+# space = O(1)
+class Solution(object):
+    def getBiggestThree(self, grid):
+        m, n = len(grid), len(grid[0])
+        top = []
+
+        def offer(v):
+            if v in top:
+                return
+            top.append(v)
+            top.sort(reverse=True)
+            del top[3:]
+
+        for cy in range(m):
+            for cx in range(n):
+                k = 0
+                while cy - k >= 0 and cy + k < m and cx - k >= 0 and cx + k < n:
+                    total = 0
+                    for r in range(cy - k, cy + k + 1):
+                        rest = k - abs(r - cy)
+                        for c in range(cx - k, cx + k + 1):
+                            if abs(c - cx) == rest:
+                                total += grid[r][c]
+                    offer(total)
+                    k += 1
+
+        return top

--- a/leetcode_python/Array/get-maximum-in-generated-array.py
+++ b/leetcode_python/Array/get-maximum-in-generated-array.py
@@ -73,3 +73,85 @@ class Solution(object):
             else:
                 nums[i] = nums[half] + nums[half + 1]
         return max(nums)
+
+
+# V0-1
+# IDEA : TOP-DOWN RECURSION + MEMOIZATION
+#
+#   same two rules, but read as a recursive definition instead of a forward
+#   pass :
+#     val(0) = 0, val(1) = 1
+#     val(i) = val(i // 2)                       if i is even
+#     val(i) = val(i // 2) + val(i // 2 + 1)     if i is odd
+#   the memo dict turns the (exponentially branching) recursion into one
+#   evaluation per index, and the recursion depth is only O(log n) because
+#   every call halves the argument.
+#
+#   NOTE : we still have to ASK for every index 0..n to know the maximum --
+#          the largest value is not always at the end (nums[7] == nums[5] == 3
+#          for n = 7), so there is no shortcut to a single call.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def getMaximumGenerated(self, n):
+        if n < 2:
+            return n
+
+        memo = {0: 0, 1: 1}
+
+        def val(i):
+            if i in memo:
+                return memo[i]
+            half = i // 2
+            if i % 2 == 0:
+                res = val(half)
+            else:
+                res = val(half) + val(half + 1)
+            memo[i] = res
+            return res
+
+        return max(val(i) for i in range(n + 1))
+
+
+# V0-2
+# IDEA : BIT WALK (STERN'S DIATOMIC SERIES CLOSED FORM), O(1) SPACE
+#
+#   nums is exactly Stern's diatomic series (fusc) :
+#     s(0) = 0, s(1) = 1, s(2i) = s(i), s(2i + 1) = s(i) + s(i + 1)
+#   fusc has a classic O(log i) evaluation that walks the BINARY DIGITS of i
+#   from the least significant end while carrying a pair (a, b) :
+#
+#       a, b = 1, 0
+#       for each bit of i, low -> high:
+#           bit 1 -> b += a
+#           bit 0 -> a += b
+#       answer = b
+#
+#   the pair (a, b) is the running 2x2-matrix product of the two branch
+#   transforms, so no array of previous values is needed at all -- each index
+#   is evaluated completely on its own.
+#
+#   NOTE : this trades the O(n) table for O(1) memory at the price of an extra
+#          log factor in time; with n <= 100 both are trivial, but the point is
+#          that a single nums[i] can be answered without building the array.
+#
+# time = O(n * log n)
+# space = O(1)
+class Solution(object):
+    def getMaximumGenerated(self, n):
+        if n < 2:
+            return n
+
+        best = 0
+        for i in range(n + 1):
+            a, b = 1, 0
+            x = i
+            while x:
+                if x & 1:
+                    b += a
+                else:
+                    a += b
+                x >>= 1
+            best = max(best, b)
+        return best

--- a/leetcode_python/Array/grumpy-bookstore-owner.py
+++ b/leetcode_python/Array/grumpy-bookstore-owner.py
@@ -75,3 +75,68 @@ class Solution(object):
             best = max(best, cur)
 
         return base + best
+
+
+# V0-1
+# IDEA : PREFIX SUM OVER THE "RESCUABLE" ARRAY
+#
+#   build lost[i] = customers[i] if grumpy[i] else 0  -- the customers a
+#   technique window would RESCUE at minute i -- and take its prefix sum:
+#
+#       pre[i] = lost[0] + ... + lost[i - 1]
+#
+#   then the gain of the window starting at s is the O(1) range query
+#   pre[s + minutes] - pre[s], and the answer is
+#   base + max over all s.
+#
+#   same O(n) as the sliding window, but the window total is looked up from a
+#   precomputed table instead of being carried incrementally -- which also
+#   makes it trivial to answer for SEVERAL different `minutes` values.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def maxSatisfied(self, customers, grumpy, minutes):
+        n = len(customers)
+
+        pre = [0] * (n + 1)
+        base = 0
+        for i in range(n):
+            if grumpy[i]:
+                pre[i + 1] = pre[i] + customers[i]
+            else:
+                pre[i + 1] = pre[i]
+                base += customers[i]
+
+        best = 0
+        for s in range(n - minutes + 1):
+            best = max(best, pre[s + minutes] - pre[s])
+
+        return base + best
+
+
+# V0-2
+# IDEA : BRUTE FORCE -- REPLAY THE WHOLE DAY FOR EVERY WINDOW CHOICE
+#
+#   there are only n - minutes + 1 possible placements of the technique, so
+#   just try each one and count the satisfied customers of the whole day from
+#   scratch: minute i is satisfied iff the owner is not grumpy there OR the
+#   chosen window covers it.
+#
+#   no prefix table, no incremental total -- it recomputes everything, which is
+#   the straightforward O(n^2) baseline the two O(n) versions above optimise.
+#
+# time = O(n^2)
+# space = O(1)
+class Solution(object):
+    def maxSatisfied(self, customers, grumpy, minutes):
+        n = len(customers)
+
+        best = 0
+        for s in range(n - minutes + 1):
+            cur = 0
+            for i in range(n):
+                if grumpy[i] == 0 or s <= i < s + minutes:
+                    cur += customers[i]
+            best = max(best, cur)
+        return best

--- a/leetcode_python/Array/guess-the-majority-in-a-hidden-array.py
+++ b/leetcode_python/Array/guess-the-majority-in-a-hidden-array.py
@@ -109,3 +109,136 @@ class Solution(object):
         if a == b:
             return -1
         return 3 if a > b else k
+
+
+# V0-1
+# IDEA : SLIDING WINDOW OF CONSECUTIVE QUADRUPLES -> 4 CHAINS MOD 4
+#
+#   query the n - 3 CONSECUTIVE quadruples
+#       Q[i] = query(i, i + 1, i + 2, i + 3)
+#   two neighbouring windows share the trio (i+1, i+2, i+3) and differ only in
+#   the free slot (i vs i + 4), so
+#       Q[i] == Q[i + 1]   <=>   nums[i] == nums[i + 4]
+#
+#   that is a relation with STRIDE 4, so the single sweep resolves each of the
+#   4 residue classes mod 4 internally (labels propagate by XOR along the
+#   chain) but says nothing across classes.
+#
+#   the classes are then stitched together with 4 more queries, all sharing
+#   the quadruple {1,2,3,4} as the right-hand side :
+#       {0,2,3,4} vs {1,2,3,4}  (trio 2,3,4)  ->  nums[0] ?= nums[1]
+#       {0,1,3,4} vs {1,2,3,4}  (trio 1,3,4)  ->  nums[0] ?= nums[2]
+#       {0,1,2,4} vs {1,2,3,4}  (trio 1,2,4)  ->  nums[0] ?= nums[3]
+#
+#   NOTE : total calls = (n - 3) + 4 = n + 1, same budget as the star version,
+#          but the information comes from OVERLAPPING windows instead of one
+#          fixed reference trio.
+#   NOTE : all labels are relative to nums[0]; the absolute values are
+#          unknowable (complementing the whole array leaves every query
+#          unchanged) which is fine -- only the group SIZES matter.
+#
+# time = O(n) calls, space = O(n)
+class Solution(object):
+    def guessMajority(self, reader):
+        n = reader.length()
+
+        window = [reader.query(i, i + 1, i + 2, i + 3) for i in range(n - 3)]
+
+        lab = [0] * n                       # 0 == "same value as nums[0]"
+        base = reader.query(1, 2, 3, 4)
+        lab[1] = 0 if reader.query(0, 2, 3, 4) == base else 1
+        lab[2] = 0 if reader.query(0, 1, 3, 4) == base else 1
+        lab[3] = 0 if reader.query(0, 1, 2, 4) == base else 1
+
+        for i in range(n - 4):
+            if window[i] == window[i + 1]:
+                lab[i + 4] = lab[i]
+            else:
+                lab[i + 4] = lab[i] ^ 1
+
+        zeros = lab.count(0)
+        ones = n - zeros
+        if zeros == ones:
+            return -1
+        return lab.index(0) if zeros > ones else lab.index(1)
+
+
+# V0-2
+# IDEA : KNOWN-EQUAL ANCHOR PAIR -> TWO INDICES PER QUERY (~n / 2 CALLS)
+#
+#   answers the follow-up (fewer calls) by putting a pair of indices KNOWN TO
+#   BE EQUAL into the query instead of a trio.
+#
+#   step 1 -- find such a pair among 0, 1, 2. By pigeonhole two of three bits
+#   are equal, so at most two comparisons are needed: if nums[0] != nums[1] and
+#   nums[0] != nums[2] then nums[1] == nums[2]. This also labels 0, 1, 2.
+#   A comparison of i and j is "same trio, swap the 4th slot", and the shared
+#   quadruple {1,2,3,4} is reused, so step 1 costs only 3 calls.
+#
+#   step 2 -- with the anchor pair (a, b), nums[a] == nums[b] == v, a single
+#   query on {a, b, i, j} reads off HOW MANY of nums[i], nums[j] equal v :
+#       4  ->  both equal v            (v, v, v, v)
+#       2  ->  exactly one equals v    (v, v, v, x)
+#       0  ->  neither equals v        (v, v, x, x)
+#   so one call classifies TWO fresh indices.
+#
+#   the ambiguous "2" case never needs resolving: such a pair contributes
+#   exactly +1 to each side of the count, and if the majority turns out to be
+#   the non-v group then known-1 labels must already outnumber the known-0
+#   labels (a and b are both 0), so a representative index is already in hand.
+#
+#   NOTE : calls = 3 + ceil((n - 3) / 2) (+2 for an odd leftover index),
+#          roughly n / 2 -- half of the star / sliding-window versions.
+#
+# time = O(n) calls (~n / 2), space = O(n)
+class Solution(object):
+    def guessMajority(self, reader):
+        n = reader.length()
+        memo = {}
+
+        def ask(quad):
+            key = tuple(sorted(quad))
+            if key not in memo:
+                memo[key] = reader.query(*key)
+            return memo[key]
+
+        def same(i, j):
+            # 3 fixed slots + swap the 4th -> equal answers iff equal values
+            trio = [t for t in range(n) if t != i and t != j][:3]
+            return ask(trio + [i]) == ask(trio + [j])
+
+        lab = [None] * n                    # 0 == "equals the anchor value v"
+        if same(0, 1):
+            lab[0] = lab[1] = 0
+            lab[2] = 0 if same(0, 2) else 1
+            anchor = (0, 1)
+        elif same(0, 2):
+            lab[0] = lab[2] = 0
+            lab[1] = 1
+            anchor = (0, 2)
+        else:
+            # nums[0] differs from both -> nums[1] == nums[2], anchor on them
+            lab[1] = lab[2] = 0
+            lab[0] = 1
+            anchor = (1, 2)
+
+        a, b = anchor
+        split = 0                           # pairs known to be one-of-each
+        i = 3
+        while i + 1 < n:
+            got = ask([a, b, i, i + 1])
+            if got == 4:
+                lab[i] = lab[i + 1] = 0
+            elif got == 0:
+                lab[i] = lab[i + 1] = 1
+            else:
+                split += 1
+            i += 2
+        if i < n:                           # odd number of remaining indices
+            lab[i] = 0 if same(i, a) else 1
+
+        zeros = sum(1 for x in lab if x == 0) + split
+        ones = sum(1 for x in lab if x == 1) + split
+        if zeros == ones:
+            return -1
+        return lab.index(0) if zeros > ones else lab.index(1)

--- a/leetcode_python/Array/handling-sum-queries-after-update.py
+++ b/leetcode_python/Array/handling-sum-queries-after-update.py
@@ -128,3 +128,130 @@ class Solution(object):
             else:
                 res.append(total)
         return res
+
+
+# V0-1
+# IDEA : SQRT DECOMPOSITION (BLOCK FLIP TAGS) + RUNNING TOTAL
+#
+#   same key observation as V0 (nums2 is never materialised, we only need the
+#   COUNT OF ONES in nums1), but the range flip is served by a block
+#   decomposition instead of a segment tree.
+#
+#   split nums1 into blocks of ~sqrt(n). per block keep
+#     cnt[b]  = ones stored in arr for that block
+#     flip[b] = pending "whole block is inverted" tag
+#   so the live count of the block is
+#     ones(b) = blen[b] - cnt[b] if flip[b] else cnt[b]
+#
+#   a flip of [l, r] touches at most 2 PARTIAL blocks -- materialise their tag
+#   into arr, then toggle the individual cells -- and the FULL blocks in
+#   between, where only the tag is toggled and the running total is corrected
+#   by (blen - 2 * ones) in O(1) each.
+#
+#   NOTE : materialising a block does not change ones(b), so `total_ones` needs
+#          no adjustment there -- only the per-cell toggles and the whole-block
+#          tags move it.
+#   NOTE : O(sqrt(n)) per flip is slower than the tree's O(log n) but the
+#          constant factor is much smaller and there is no recursion at all,
+#          which matters in Python for 10^5 queries.
+#
+# time = O(n + q * sqrt(n)), space = O(n)
+class Solution(object):
+    def handleQuery(self, nums1, nums2, queries):
+        n = len(nums1)
+        bsize = max(1, int(n ** 0.5))
+        nblock = (n + bsize - 1) // bsize
+
+        arr = list(nums1)
+        blen = [min(bsize, n - b * bsize) for b in range(nblock)]
+        cnt = [0] * nblock
+        flip = [0] * nblock
+        for i in range(n):
+            cnt[i // bsize] += arr[i]
+        total_ones = sum(nums1)
+
+        def live_ones(b):
+            return blen[b] - cnt[b] if flip[b] else cnt[b]
+
+        def materialize(b):
+            if not flip[b]:
+                return
+            start = b * bsize
+            for i in range(start, start + blen[b]):
+                arr[i] ^= 1
+            cnt[b] = blen[b] - cnt[b]
+            flip[b] = 0
+
+        def toggle_cells(lo, hi):
+            # inclusive [lo, hi], all inside one already-materialised block
+            delta = 0
+            b = lo // bsize
+            for i in range(lo, hi + 1):
+                if arr[i]:
+                    arr[i] = 0
+                    delta -= 1
+                else:
+                    arr[i] = 1
+                    delta += 1
+            cnt[b] += delta
+            return delta
+
+        def flip_range(l, r):
+            bl, br = l // bsize, r // bsize
+            moved = 0
+            if bl == br:
+                materialize(bl)
+                moved += toggle_cells(l, r)
+            else:
+                materialize(bl)
+                moved += toggle_cells(l, (bl + 1) * bsize - 1)
+                materialize(br)
+                moved += toggle_cells(br * bsize, r)
+                for b in range(bl + 1, br):
+                    before = live_ones(b)
+                    flip[b] ^= 1
+                    moved += blen[b] - 2 * before
+            return moved
+
+        total = sum(nums2)
+        res = []
+        for op, a, b in queries:
+            if op == 1:
+                total_ones += flip_range(a, b)
+            elif op == 2:
+                total += a * total_ones
+            else:
+                res.append(total)
+        return res
+
+
+# V0-2
+# IDEA : BRUTE FORCE -- MATERIALISE BOTH ARRAYS AND DO EXACTLY WHAT IS ASKED
+#
+#   no algebraic shortcut at all: keep nums1 and nums2 as real lists,
+#     type 1 -> toggle every cell of [l, r]
+#     type 2 -> add p * nums1[i] to nums2[i] for every i
+#     type 3 -> sum(nums2)
+#
+#   O(n) per query, so O(n * q) = 10^10 at the constraint limit -- far too slow
+#   to submit, but it is the definition of the problem written out and hence the
+#   reference the two fast versions are validated against.
+#
+# time = O(n * q), space = O(n)
+class Solution(object):
+    def handleQuery(self, nums1, nums2, queries):
+        a1 = list(nums1)
+        a2 = list(nums2)
+        n = len(a1)
+
+        res = []
+        for op, x, y in queries:
+            if op == 1:
+                for i in range(x, y + 1):
+                    a1[i] ^= 1
+            elif op == 2:
+                for i in range(n):
+                    a2[i] += a1[i] * x
+            else:
+                res.append(sum(a2))
+        return res

--- a/leetcode_python/Array/increment-submatrices-by-one.py
+++ b/leetcode_python/Array/increment-submatrices-by-one.py
@@ -78,3 +78,66 @@ class Solution(object):
                 if i > 0 and j > 0:
                     mat[i][j] -= mat[i - 1][j - 1]
         return mat
+
+
+# V0-1
+# IDEA : ONE 1D DIFFERENCE ARRAY PER ROW
+#
+#   instead of the 4-corner 2D trick, treat every query as x2 - x1 + 1
+#   independent 1D range updates -- one per covered row :
+#
+#       for r in [x1, x2] :  diff[r][y1] += 1 ,  diff[r][y2 + 1] -= 1
+#
+#   then a single left-to-right running sum per row rebuilds that row. Only
+#   ONE prefix direction is needed (columns), because the rows were already
+#   expanded explicitly.
+#
+#   NOTE : the sentinel column n makes the "-1" stamp always in range, so no
+#          boundary test is needed at all.
+#   NOTE : this is slower than the 2D version (O(n) stamps per query instead
+#          of O(1)) but it needs no inclusion-exclusion reasoning, and it is
+#          the natural shape when the queries arrive row-by-row.
+#
+# time = O(q * n + n^2)
+# space = O(n^2)
+class Solution(object):
+    def rangeAddQueries(self, n, queries):
+        diff = [[0] * (n + 1) for _ in range(n)]
+        for x1, y1, x2, y2 in queries:
+            for r in range(x1, x2 + 1):
+                diff[r][y1] += 1
+                diff[r][y2 + 1] -= 1
+
+        mat = []
+        for r in range(n):
+            row = [0] * n
+            cur = 0
+            for c in range(n):
+                cur += diff[r][c]
+                row[c] = cur
+            mat.append(row)
+        return mat
+
+
+# V0-2
+# IDEA : BRUTE FORCE -- STAMP EVERY CELL OF EVERY SUBMATRIX
+#
+#   literally do what the statement says: walk the rectangle of each query and
+#   add 1 to each cell. No difference array, no prefix sum.
+#
+#   With q up to 10^4 and n up to 500 this is up to 2.5 * 10^9 cell writes in
+#   the worst case, so it is the baseline that MOTIVATES the difference array
+#   rather than a submission-ready solution -- but it is the ground truth the
+#   other two versions are checked against.
+#
+# time = O(q * n^2)
+# space = O(1) beyond the output
+class Solution(object):
+    def rangeAddQueries(self, n, queries):
+        mat = [[0] * n for _ in range(n)]
+        for x1, y1, x2, y2 in queries:
+            for r in range(x1, x2 + 1):
+                row = mat[r]
+                for c in range(y1, y2 + 1):
+                    row[c] += 1
+        return mat

--- a/leetcode_python/Array/intervals-between-identical-elements.py
+++ b/leetcode_python/Array/intervals-between-identical-elements.py
@@ -76,3 +76,80 @@ class Solution(object):
                 cur += (t + 1) * gap - (m - t - 1) * gap
                 res[idx[t + 1]] = cur
         return res
+
+
+# V0-1
+# IDEA : PREFIX SUMS INSIDE EACH VALUE GROUP
+#
+#   for one group of (already sorted) indices idx[0 .. m-1] and a position t :
+#       left  part = sum_{j<t} (idx[t] - idx[j]) = t * idx[t] - pre[t]
+#       right part = sum_{j>t} (idx[j] - idx[t]) = (tot - pre[t+1])
+#                                                 - (m - 1 - t) * idx[t]
+#   with pre[t] = idx[0] + ... + idx[t-1] and tot = pre[m].
+#
+#   so every answer is read off the prefix-sum table directly, instead of
+#   being carried forward incrementally as in V0.
+#
+# time = O(n)
+# space = O(n)
+from collections import defaultdict
+
+
+class Solution(object):
+    def getDistances(self, arr):
+        pos = defaultdict(list)
+        for i, x in enumerate(arr):
+            pos[x].append(i)
+
+        res = [0] * len(arr)
+        for idx in pos.values():
+            m = len(idx)
+            pre = [0] * (m + 1)
+            for t in range(m):
+                pre[t + 1] = pre[t] + idx[t]
+            tot = pre[m]
+            for t in range(m):
+                left = t * idx[t] - pre[t]
+                right = (tot - pre[t + 1]) - (m - 1 - t) * idx[t]
+                res[idx[t]] = left + right
+        return res
+
+
+# V0-2
+# IDEA : TWO STREAMING SWEEPS, ONLY (COUNT, SUM OF INDICES) PER VALUE
+#
+#   left -> right : every already seen index j of the same value contributes
+#                   (i - j), i.e. cnt[v] * i - tot[v]
+#   right -> left : every already seen index j of the same value contributes
+#                   (j - i), i.e. tot[v] - cnt[v] * i
+#
+#   no per-value index list is ever materialised - two integers per distinct
+#   value are enough, so this is the low-memory variant.
+#
+# time = O(n)
+# space = O(u), u = number of distinct values
+from collections import defaultdict
+
+
+class Solution(object):
+    def getDistances(self, arr):
+        n = len(arr)
+        res = [0] * n
+
+        cnt = defaultdict(int)
+        tot = defaultdict(int)
+        for i in range(n):
+            v = arr[i]
+            res[i] += cnt[v] * i - tot[v]
+            cnt[v] += 1
+            tot[v] += i
+
+        cnt.clear()
+        tot.clear()
+        for i in range(n - 1, -1, -1):
+            v = arr[i]
+            res[i] += tot[v] - cnt[v] * i
+            cnt[v] += 1
+            tot[v] += i
+
+        return res

--- a/leetcode_python/Array/largest-component-size-by-common-factor.py
+++ b/leetcode_python/Array/largest-component-size-by-common-factor.py
@@ -81,3 +81,120 @@ class Solution(object):
         # only the actual numbers count towards component size, not the prime nodes
         cnt = Counter(find(v) for v in nums)
         return max(cnt.values())
+
+
+# V0-1
+# IDEA : SMALLEST-PRIME-FACTOR SIEVE + UNION FIND OVER THE INDICES
+#
+#  - sieve spf[x] = smallest prime factor of x once, up to max(nums).
+#    factorising a number is then O(log v) divisions instead of O(sqrt(v))
+#    trial divisions.
+#  - the DSU nodes are the INDICES of nums (not the values), so no shared
+#    label space with the primes is needed. For each prime p we remember the
+#    first index that owned it and union every later owner with that index.
+#  - component sizes come straight out of the DSU size array.
+#
+# time = O(M log log M + n log M), n = len(nums), M = max(nums)
+# space = O(M)
+class Solution(object):
+    def largestComponentSize(self, nums):
+        M = max(nums)
+        spf = list(range(M + 1))
+        i = 2
+        while i * i <= M:
+            if spf[i] == i:
+                for j in range(i * i, M + 1, i):
+                    if spf[j] == j:
+                        spf[j] = i
+            i += 1
+
+        n = len(nums)
+        parent = list(range(n))
+        size = [1] * n
+
+        def find(x):
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        def union(a, b):
+            ra, rb = find(a), find(b)
+            if ra == rb:
+                return
+            if size[ra] < size[rb]:
+                ra, rb = rb, ra
+            parent[rb] = ra
+            size[ra] += size[rb]
+
+        owner = {}          # prime -> index of the first number carrying it
+        for k, v in enumerate(nums):
+            x = v
+            while x > 1:
+                p = spf[x]
+                if p in owner:
+                    union(k, owner[p])
+                else:
+                    owner[p] = k
+                while x % p == 0:
+                    x //= p
+
+        return max(size[find(k)] for k in range(n))
+
+
+# V0-2
+# IDEA : PRIME BUCKETS -> EXPLICIT GRAPH -> ITERATIVE DFS (no union find)
+#
+#  - bucket[p] = every index whose number is divisible by prime p, and
+#    primes_of[k] = the prime factors of nums[k]. Together they encode the
+#    graph without ever writing down its O(n^2) edges.
+#  - flood fill from each unvisited index : from index k hop to every index
+#    in bucket[p] for each p in primes_of[k].
+#  - each bucket is expanded at most ONCE globally (a prime lives in exactly
+#    one component), which is what keeps the traversal linear in the total
+#    bucket size instead of quadratic.
+#
+# time = O(n * sqrt(M) + n log M), space = O(n log M)
+from collections import defaultdict
+class Solution(object):
+    def largestComponentSize(self, nums):
+        n = len(nums)
+        bucket = defaultdict(list)
+        primes_of = [[] for _ in range(n)]
+
+        for k, v in enumerate(nums):
+            x = v
+            f = 2
+            while f * f <= x:
+                if x % f == 0:
+                    bucket[f].append(k)
+                    primes_of[k].append(f)
+                    while x % f == 0:
+                        x //= f
+                f += 1
+            if x > 1:
+                bucket[x].append(k)
+                primes_of[k].append(x)
+
+        seen = [False] * n
+        used_prime = set()
+        res = 0
+        for start in range(n):
+            if seen[start]:
+                continue
+            seen[start] = True
+            stack = [start]
+            cnt = 0
+            while stack:
+                k = stack.pop()
+                cnt += 1
+                for p in primes_of[k]:
+                    if p in used_prime:
+                        continue
+                    used_prime.add(p)
+                    for nb in bucket[p]:
+                        if not seen[nb]:
+                            seen[nb] = True
+                            stack.append(nb)
+            res = max(res, cnt)
+        return res

--- a/leetcode_python/Array/largest-local-values-in-a-matrix.py
+++ b/leetcode_python/Array/largest-local-values-in-a-matrix.py
@@ -52,3 +52,53 @@ class Solution(object):
         return [[max(grid[i + di][j + dj] for di in range(3) for dj in range(3))
                  for j in range(n - 2)]
                 for i in range(n - 2)]
+
+
+# V0-1
+# IDEA : SEPARABLE MAX - SQUEEZE THE ROWS FIRST, THEN THE COLUMNS
+#
+#   max over a 3 x 3 block = max over 3 vertically stacked 1 x 3 strips.
+#   so first collapse every row to its width-3 running maxima
+#     rowMax[i][j] = max(grid[i][j .. j+2])
+#   then collapse vertically
+#     out[i][j] = max(rowMax[i][j], rowMax[i+1][j], rowMax[i+2][j])
+#
+#   each cell is now touched 3 + 3 = 6 times instead of 9, and the same
+#   trick generalises to a k x k window in O(n^2 * k) instead of O(n^2 * k^2).
+#
+# time = O(n^2)
+# space = O(n^2)
+class Solution(object):
+    def largestLocal(self, grid):
+        n = len(grid)
+        rowMax = [[max(row[j], row[j + 1], row[j + 2]) for j in range(n - 2)]
+                  for row in grid]
+        return [[max(rowMax[i][j], rowMax[i + 1][j], rowMax[i + 2][j])
+                 for j in range(n - 2)]
+                for i in range(n - 2)]
+
+
+# V0-2
+# IDEA : SPARSE-TABLE STYLE DOUBLING - BUILD 2 x 2 MAXIMA, THEN OVERLAP FOUR
+#
+#   d[i][j] = max of the 2 x 2 block with top-left (i, j).
+#   the 3 x 3 block at (i, j) is exactly covered by the four (overlapping)
+#   2 x 2 blocks at (i, j), (i, j+1), (i+1, j), (i+1, j+1) - overlap is
+#   harmless for max, so
+#     out[i][j] = max(d[i][j], d[i][j+1], d[i+1][j], d[i+1][j+1])
+#
+#   this is the 2D range-max sparse table idea at one doubling level: 4 + 4
+#   comparisons per cell, and reusing d for other window sizes is free.
+#
+# time = O(n^2)
+# space = O(n^2)
+class Solution(object):
+    def largestLocal(self, grid):
+        n = len(grid)
+        d = [[max(grid[i][j], grid[i][j + 1],
+                  grid[i + 1][j], grid[i + 1][j + 1])
+              for j in range(n - 1)]
+             for i in range(n - 1)]
+        return [[max(d[i][j], d[i][j + 1], d[i + 1][j], d[i + 1][j + 1])
+                 for j in range(n - 2)]
+                for i in range(n - 2)]

--- a/leetcode_python/Array/largest-magic-square.py
+++ b/leetcode_python/Array/largest-magic-square.py
@@ -82,3 +82,103 @@ class Solution(object):
                         return k
 
         return 1
+
+
+# V0-1
+# IDEA : PREFIX SUMS IN ALL FOUR DIRECTIONS + GROW k UPWARDS
+#
+#   on top of the row / column prefix sums, precompute the two DIAGONAL
+#   prefix sums as well :
+#       dg[i][j] = grid[i-1][j-1] + dg[i-1][j-1]      (down-right runs)
+#       ag[i][j] = grid[i-1][j-1] + ag[i-1][j+1]      (down-left  runs)
+#   then for a square of side k at (r, c) :
+#       main diagonal = dg[r+k][c+k] - dg[r][c]
+#       anti diagonal = ag[r+k][c+1] - ag[r][c+k+1]
+#   i.e. BOTH diagonals become O(1) instead of the O(k) walk of V0.
+#
+#   here k grows from 2 upwards and the best k seen is kept, which makes the
+#   diagonal test (the cheapest one now) the first filter of each candidate.
+#
+# time = O(m * n * min(m,n)^2), space = O(m * n)
+class Solution(object):
+    def largestMagicSquare(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        rowPre = [[0] * (n + 1) for _ in range(m + 1)]
+        colPre = [[0] * (n + 1) for _ in range(m + 1)]
+        dg = [[0] * (n + 2) for _ in range(m + 2)]
+        ag = [[0] * (n + 2) for _ in range(m + 2)]
+        for i in range(1, m + 1):
+            for j in range(1, n + 1):
+                v = grid[i - 1][j - 1]
+                rowPre[i][j] = rowPre[i][j - 1] + v
+                colPre[i][j] = colPre[i - 1][j] + v
+                dg[i][j] = dg[i - 1][j - 1] + v
+        for i in range(1, m + 1):
+            for j in range(n, 0, -1):
+                ag[i][j] = ag[i - 1][j + 1] + grid[i - 1][j - 1]
+
+        def ok(r, c, k):
+            # r, c are 0-based top-left of the k x k square
+            target = dg[r + k][c + k] - dg[r][c]
+            if ag[r + k][c + 1] - ag[r][c + k + 1] != target:
+                return False
+            for i in range(r + 1, r + k + 1):
+                if rowPre[i][c + k] - rowPre[i][c] != target:
+                    return False
+            for j in range(c + 1, c + k + 1):
+                if colPre[r + k][j] - colPre[r][j] != target:
+                    return False
+            return True
+
+        best = 1
+        for k in range(2, min(m, n) + 1):
+            found = False
+            for r in range(m - k + 1):
+                for c in range(n - k + 1):
+                    if ok(r, c, k):
+                        found = True
+                        break
+                if found:
+                    break
+            if found:
+                best = k
+        return best
+
+
+# V0-2
+# IDEA : PURE BRUTE FORCE - RE-ADD EVERY CELL OF EVERY CANDIDATE SQUARE
+#
+#   no precomputation at all : for each side k (largest first) and each
+#   top-left corner, sum the k rows, the k columns and the 2 diagonals
+#   directly from grid and compare them. Return on the first hit.
+#
+#   this is the O(k^2)-per-square baseline the prefix-sum versions above
+#   optimise; kept because m, n <= 50 makes it still viable and it needs no
+#   auxiliary memory.
+#
+# time = O(m * n * min(m,n)^3), space = O(1)
+class Solution(object):
+    def largestMagicSquare(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        def ok(r, c, k):
+            target = sum(grid[r][c:c + k])
+            for i in range(r + 1, r + k):
+                if sum(grid[i][c:c + k]) != target:
+                    return False
+            for j in range(c, c + k):
+                if sum(grid[i][j] for i in range(r, r + k)) != target:
+                    return False
+            if sum(grid[r + t][c + t] for t in range(k)) != target:
+                return False
+            if sum(grid[r + t][c + k - 1 - t] for t in range(k)) != target:
+                return False
+            return True
+
+        for k in range(min(m, n), 1, -1):
+            for r in range(m - k + 1):
+                for c in range(n - k + 1):
+                    if ok(r, c, k):
+                        return k
+        return 1

--- a/leetcode_python/Array/last-day-where-you-can-still-cross.py
+++ b/leetcode_python/Array/last-day-where-you-can-still-cross.py
@@ -101,3 +101,112 @@ class Solution(object):
             if find(s) == find(t):
                 return i
         return 0
+
+
+# V0-1
+# IDEA : BINARY SEARCH THE DAY + BFS ON THE LAND OF THAT DAY
+#
+#   "can I still cross after d floods ?" is MONOTONE in d : once a day fails,
+#   every later day fails too (water only ever grows). So binary search the
+#   largest d that still answers yes, and answer each question independently
+#   with a plain top-row -> bottom-row BFS over the land cells.
+#
+#   day 0 is always crossable (the whole grid is land), so the search range
+#   is [0, len(cells)] and the loop always converges.
+#
+# time = O(m * n * log(m * n)), space = O(m * n)
+from collections import deque
+class Solution(object):
+    def latestDayToCross(self, row, col, cells):
+        dirs = ((-1, 0), (1, 0), (0, -1), (0, 1))
+
+        def can(day):
+            water = [[False] * col for _ in range(row)]
+            for i in range(day):
+                water[cells[i][0] - 1][cells[i][1] - 1] = True
+            q = deque()
+            for j in range(col):
+                if not water[0][j]:
+                    water[0][j] = True     # flooding == marking as visited
+                    q.append((0, j))
+            while q:
+                x, y = q.popleft()
+                if x == row - 1:
+                    return True
+                for dx, dy in dirs:
+                    nx, ny = x + dx, y + dy
+                    if 0 <= nx < row and 0 <= ny < col and not water[nx][ny]:
+                        water[nx][ny] = True
+                        q.append((nx, ny))
+            return False
+
+        lo, hi = 0, len(cells)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if can(mid):
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
+
+
+# V0-2
+# IDEA : FORWARD UNION FIND ON THE *WATER*, 8-DIRECTIONALLY
+#
+#   dual / "blocking wall" view : a top-to-bottom land path exists exactly
+#   until the WATER forms a left-wall-to-right-wall barrier - and for a
+#   barrier the water cells may touch DIAGONALLY (a diagonal water pair
+#   already blocks every 4-directional land step through it).
+#
+#   so just flood forward in the given order, unioning each new water cell
+#   with its 8 neighbours plus the virtual nodes L (column 0) and R (last
+#   column). The first index i where L and R meet is the flood that kills the
+#   crossing, i.e. the last good day is i (days are 1-based, cells[i] is the
+#   flood of day i+1).
+#
+#   no reverse replay needed, and it stops as soon as the barrier appears.
+#
+# time = O(m * n * alpha(m * n)), space = O(m * n)
+class Solution(object):
+    def latestDayToCross(self, row, col, cells):
+        n = row * col
+        parent = list(range(n + 2))
+        size = [1] * (n + 2)
+        L, R = n, n + 1
+
+        def find(x):
+            root = x
+            while parent[root] != root:
+                root = parent[root]
+            while parent[x] != root:
+                parent[x], x = root, parent[x]
+            return root
+
+        def union(a, b):
+            pa, pb = find(a), find(b)
+            if pa == pb:
+                return
+            if size[pa] < size[pb]:
+                pa, pb = pb, pa
+            parent[pb] = pa
+            size[pa] += size[pb]
+
+        water = [[False] * col for _ in range(row)]
+        dirs8 = ((-1, -1), (-1, 0), (-1, 1), (0, -1),
+                 (0, 1), (1, -1), (1, 0), (1, 1))
+
+        for i in range(len(cells)):
+            x, y = cells[i][0] - 1, cells[i][1] - 1
+            water[x][y] = True
+            cur = x * col + y
+            for dx, dy in dirs8:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < row and 0 <= ny < col and water[nx][ny]:
+                    union(cur, nx * col + ny)
+            if y == 0:
+                union(cur, L)
+            if y == col - 1:
+                union(cur, R)
+            if find(L) == find(R):
+                return i
+        return len(cells)

--- a/leetcode_python/Array/last-moment-before-all-ants-fall-out-of-a-plank.py
+++ b/leetcode_python/Array/last-moment-before-all-ants-fall-out-of-a-plank.py
@@ -78,3 +78,78 @@ class Solution(object):
         for x in right:
             res = max(res, n - x)
         return res
+
+
+# V0-1
+# IDEA : HONEST SIMULATION, HALF-SECOND TICKS ON DOUBLED COORDINATES
+#         (no "ants pass through each other" insight used at all)
+#
+#   collisions can happen at half-integer points, so double every coordinate:
+#   a half second then becomes an integer step of 1, every meeting lands
+#   exactly on a lattice point, and no pair can slip past one another.
+#   all ants share the parity of the tick counter, so gaps stay even and the
+#   plank ends (0 and 2n) are only ever reached on even ticks.
+#
+#   per tick : move everyone, flip the two ants sitting on a shared point,
+#   drop whoever reached an end and remember when that happened.
+#
+# time = O(n * k), k = len(left) + len(right)
+# space = O(k)
+from collections import defaultdict
+class Solution(object):
+    def getLastMoment(self, n, left, right):
+        end = 2 * n
+        alive = []
+        res = 0
+        for x in left:
+            if x == 0:
+                continue          # already at the left end -> falls at t = 0
+            alive.append([2 * x, -1])
+        for x in right:
+            if x == n:
+                continue          # already at the right end -> falls at t = 0
+            alive.append([2 * x, 1])
+
+        tick = 0
+        while alive:
+            tick += 1
+            spot = defaultdict(list)
+            for a in alive:
+                a[0] += a[1]
+                spot[a[0]].append(a)
+            for same in spot.values():
+                if len(same) > 1:
+                    for a in same:
+                        a[1] = -a[1]          # head-on bounce
+            keep = []
+            for a in alive:
+                if (a[0] == 0 and a[1] == -1) or (a[0] == end and a[1] == 1):
+                    res = tick // 2           # ticks are half seconds
+                else:
+                    keep.append(a)
+            alive = keep
+        return res
+
+
+# V0-2
+# IDEA : SORT - ONLY ONE ANT PER DIRECTION CAN POSSIBLY BE THE LAST
+#
+#   since (by V0's argument) each ant just walks straight to its own end,
+#   the walking distances are monotone in the position :
+#     * among the left-goers the RIGHT-most one walks furthest  -> max(left)
+#     * among the right-goers the LEFT-most one walks furthest  -> n - min(right)
+#   so sorting each list and reading a single endpoint is enough - no scan
+#   over all the distances.
+#
+# time = O(k log k), k = len(left) + len(right)
+# space = O(k) for the sorted copies
+class Solution(object):
+    def getLastMoment(self, n, left, right):
+        l = sorted(left)
+        r = sorted(right)
+        res = 0
+        if l:
+            res = max(res, l[-1])
+        if r:
+            res = max(res, n - r[0])
+        return res

--- a/leetcode_python/Array/left-and-right-sum-differences.py
+++ b/leetcode_python/Array/left-and-right-sum-differences.py
@@ -65,3 +65,46 @@ class Solution(object):
             res.append(abs(l - r))
             l += x           # only now does l absorb the current element
         return res
+
+
+# V0-1
+# IDEA : MATERIALIZE THE TWO PREFIX/SUFFIX ARRAYS (two passes)
+#
+#   the literal reading of the statement: actually build leftSum and rightSum
+#   as arrays, then zip them. `itertools.accumulate` gives the running totals,
+#   and shifting by one index is what turns "sum up to and including i" into
+#   "sum strictly before i".
+#
+#     leftSum  = [0] + accumulate(nums)[:-1]
+#     rightSum = the same trick on the reversed array, reversed back
+#
+#   slower in space than the rolling-scalar version but it is the version you
+#   can read straight off the problem text, and it needs no ordering trick.
+#
+# time = O(n)
+# space = O(n)
+from itertools import accumulate
+
+
+class Solution(object):
+    def leftRightDifference(self, nums):
+        n = len(nums)
+        pre = list(accumulate(nums))              # pre[i] = nums[0..i]
+        left = [0] + pre[:-1]                     # drop the last, shift right
+        right = [pre[-1] - pre[i] for i in range(n)]   # total - nums[0..i]
+        return [abs(left[i] - right[i]) for i in range(n)]
+
+
+# V0-2
+# IDEA : BRUTE FORCE - RE-SUM BOTH SIDES FOR EVERY INDEX
+#
+#   no precomputation at all: for each i, sum the slice to its left and the
+#   slice to its right from scratch. n <= 1000 so ~10^6 additions still runs
+#   instantly, and it is the reference implementation the two fast versions
+#   above are checked against.
+#
+# time = O(n^2)
+# space = O(1) beyond the output
+class Solution(object):
+    def leftRightDifference(self, nums):
+        return [abs(sum(nums[:i]) - sum(nums[i + 1:])) for i in range(len(nums))]

--- a/leetcode_python/Array/library-late-fee-calculator.py
+++ b/leetcode_python/Array/library-late-fee-calculator.py
@@ -64,3 +64,60 @@ class Solution(object):
             else:
                 total += 2 * x
         return total
+
+
+# V0-1
+# IDEA : PRECOMPUTED FEE TABLE + FREQUENCY COUNTING
+#
+#   daysLate[i] <= 100, so the fee schedule can be tabulated ONCE for every
+#   possible lateness and then only looked up. Counter collapses repeated
+#   values, so a book count of n with only d distinct latenesses costs d
+#   multiplications instead of n branches.
+#
+#   the branch is evaluated 100 times regardless of n rather than n times,
+#   which is what makes this a table lookup rather than a re-spelling of V0.
+#
+# time = O(n + M), M = 101 possible day counts
+# space = O(M)
+from collections import Counter
+
+
+class Solution(object):
+    def lateFee(self, daysLate):
+        M = 101
+        fee = [0] * M
+        for d in range(1, M):
+            fee[d] = 1 if d == 1 else (2 * d if d <= 5 else 3 * d)
+        return sum(fee[d] * c for d, c in Counter(daysLate).items())
+
+
+# V0-2
+# IDEA : SORT + BINARY SEARCH THE TIER BOUNDARIES + PREFIX SUMS
+#
+#   the fee is `multiplier(tier) * x` on each tier (with tier 1 being the
+#   degenerate 1 * 1), so within a tier the total is just the multiplier times
+#   the SUM of that tier's values. sorting puts each tier in a contiguous
+#   block, bisect finds the two cut points, and a prefix-sum array gives each
+#   block's sum in O(1):
+#
+#       [ ... 1 ... | ... 2..5 ... | ... >5 ... ]
+#                   i              j
+#
+#       total = 1*count(1) + 2*sum(arr[i:j]) + 3*sum(arr[j:])
+#
+#   no per-element branching at all - the tiers are located, not tested.
+#
+# time = O(n log n)
+# space = O(n)
+import bisect
+
+
+class Solution(object):
+    def lateFee(self, daysLate):
+        arr = sorted(daysLate)
+        pre = [0]
+        for x in arr:
+            pre.append(pre[-1] + x)
+        i = bisect.bisect_left(arr, 2)    # arr[:i] are the 1-day-late books
+        j = bisect.bisect_right(arr, 5)   # arr[i:j] fall in the 2..5 band
+        return i + 2 * (pre[j] - pre[i]) + 3 * (pre[-1] - pre[j])

--- a/leetcode_python/Array/longer-contiguous-segments-of-ones-than-zeros.py
+++ b/leetcode_python/Array/longer-contiguous-segments-of-ones-than-zeros.py
@@ -70,3 +70,49 @@ class Solution(object):
                 best[s[i]] = run
 
         return best['1'] > best['0']
+
+
+# V0-1
+# IDEA : BRUTE FORCE - GROW A CANDIDATE RUN AND ASK "IS IT A SUBSTRING?"
+#
+#   instead of measuring the runs, we TEST them: '111' occurs in s iff s has a
+#   run of 1s of length >= 3. so the longest run of c is the largest L with
+#   c * L in s, and since the predicate is monotone in L (if c*L fits then
+#   c*(L-1) fits) we can simply grow L by one until the test fails.
+#
+#   uses no counters and no grouping at all - only Python's substring search.
+#
+# time = O(n^2), each `in` test scans s and there can be O(n) tests
+# space = O(n) for the candidate string being built
+class Solution(object):
+    def checkZeroOnes(self, s):
+        def longest(ch):
+            L = 0
+            while ch * (L + 1) in s:
+                L += 1
+            return L
+
+        return longest('1') > longest('0')
+
+
+# V0-2
+# IDEA : SPLIT ON THE OPPOSITE CHARACTER
+#
+#   splitting s on '0' cuts it exactly at every zero, so every piece that
+#   survives is a MAXIMAL run of 1s (with empty strings wherever two zeros
+#   were adjacent). the longest piece is therefore the answer for 1s, and the
+#   mirrored split gives the answer for 0s:
+#
+#       "110100010".split('0') -> ['11', '1', '', '', '1', '']  -> 2
+#       "110100010".split('1') -> ['', '', '0', '000', '0']     -> 3
+#
+#   NOTE : the empty pieces are why a character that never appears yields 0
+#          rather than an error - split always returns at least one piece.
+#
+# time = O(n)
+# space = O(n) for the pieces
+class Solution(object):
+    def checkZeroOnes(self, s):
+        ones = max(len(piece) for piece in s.split('0'))
+        zeros = max(len(piece) for piece in s.split('1'))
+        return ones > zeros

--- a/leetcode_python/Array/longest-common-subsequence-between-sorted-arrays.py
+++ b/leetcode_python/Array/longest-common-subsequence-between-sorted-arrays.py
@@ -63,3 +63,65 @@ class Solution(object):
                 cnt[x] += 1
         need = len(arrays)
         return [x for x in range(101) if cnt[x] == need]
+
+
+# V0-1
+# IDEA : FOLD THE ROWS WITH SET INTERSECTION
+#
+#   same observation as V0 (strictly increasing rows -> the LCS is exactly the
+#   values common to every row) but expressed with the operation that IS
+#   "common to every row": intersection. reduce(&) collapses the rows pairwise,
+#   and one final sort restores increasing order.
+#
+#   hashing instead of a bounded counter, so this one does not depend on the
+#   `arrays[i][j] <= 100` constraint - it works for any value range.
+#
+# time = O(N + m log m), N = total elements, m = size of the answer
+# space = O(N) for the sets
+from functools import reduce
+
+
+class Solution(object):
+    def longestCommonSubsequence(self, arrays):
+        common = reduce(lambda a, b: a & b, (set(row) for row in arrays))
+        return sorted(common)
+
+
+# V0-2
+# IDEA : PAIRWISE TWO-POINTER INTERSECTION OF SORTED LISTS
+#
+#   intersection is associative, so fold the rows one at a time, and because
+#   every row (and every partial result) is sorted, each fold step is the
+#   classic sorted-merge walk:
+#
+#       a[i] == b[j] -> keep it, advance BOTH
+#       a[i] <  b[j] -> a[i] can never appear later in b, drop it
+#       a[i] >  b[j] -> symmetric
+#
+#   no hashing and no value bound needed, and the running result only ever
+#   shrinks - so we can bail out the moment it becomes empty.
+#
+# time = O(N), N = total elements across all rows
+# space = O(L), L = length of the first row
+class Solution(object):
+    def longestCommonSubsequence(self, arrays):
+        def intersect(a, b):
+            i = j = 0
+            out = []
+            while i < len(a) and j < len(b):
+                if a[i] == b[j]:
+                    out.append(a[i])
+                    i += 1
+                    j += 1
+                elif a[i] < b[j]:
+                    i += 1
+                else:
+                    j += 1
+            return out
+
+        res = list(arrays[0])
+        for row in arrays[1:]:
+            res = intersect(res, row)
+            if not res:
+                break
+        return res

--- a/leetcode_python/Array/longest-even-odd-subarray-with-threshold.py
+++ b/leetcode_python/Array/longest-even-odd-subarray-with-threshold.py
@@ -80,3 +80,78 @@ class Solution(object):
             res = max(res, r - l)
             l = r
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE - VALIDATE EVERY (l, r) PAIR FROM SCRATCH
+#
+#   the definition, transcribed literally: try every subarray and re-check the
+#   three rules on it. n <= 100, so ~10^6 checks is fine and this is the
+#   reference the smarter versions get compared against.
+#
+#   the only subtlety is that the parity rule is checked between CONSECUTIVE
+#   elements inside [l, r], while the even-start rule applies to nums[l] alone.
+#
+# time = O(n^3)
+# space = O(1)
+class Solution(object):
+    def longestAlternatingSubarray(self, nums, threshold):
+        n = len(nums)
+
+        def valid(l, r):
+            if nums[l] % 2 != 0:
+                return False
+            for i in range(l, r + 1):
+                if nums[i] > threshold:
+                    return False
+                if i > l and nums[i] % 2 == nums[i - 1] % 2:
+                    return False
+            return True
+
+        res = 0
+        for l in range(n):
+            for r in range(l, n):
+                if valid(l, r):
+                    res = max(res, r - l + 1)
+        return res
+
+
+# V0-2
+# IDEA : DP RIGHT-TO-LEFT ON "LONGEST ALTERNATING RUN STARTING HERE"
+#
+#   define, ignoring the even-start rule for a moment,
+#
+#       dp[i] = length of the longest run starting at i where every element is
+#               <= threshold and adjacent parities alternate
+#
+#   the recurrence only needs its right neighbour:
+#
+#       nums[i] > threshold                      -> dp[i] = 0
+#       parity(nums[i+1]) != parity(nums[i])     -> dp[i] = 1 + dp[i+1]
+#       otherwise                                -> dp[i] = 1
+#
+#   NOTE : the middle case is still correct when nums[i+1] > threshold, because
+#          then dp[i+1] == 0 and the run correctly stops at i.
+#
+#   the even-start rule is then just a FILTER on which dp values may be taken,
+#   so the answer is max(dp[i]) over even, in-threshold starts (0 if none).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def longestAlternatingSubarray(self, nums, threshold):
+        n = len(nums)
+        dp = [0] * n
+        for i in range(n - 1, -1, -1):
+            if nums[i] > threshold:
+                dp[i] = 0
+            elif i + 1 < n and nums[i + 1] % 2 != nums[i] % 2:
+                dp[i] = 1 + dp[i + 1]
+            else:
+                dp[i] = 1
+
+        res = 0
+        for i in range(n):
+            if nums[i] % 2 == 0 and nums[i] <= threshold:
+                res = max(res, dp[i])
+        return res

--- a/leetcode_python/Array/longest-increasing-subsequence-ii.py
+++ b/leetcode_python/Array/longest-increasing-subsequence-ii.py
@@ -104,3 +104,91 @@ class Solution(object):
             best = max(best, cur)
             update(v, cur)
         return best
+
+
+# V0-1
+# IDEA : CLASSIC O(n^2) LIS DP INDEXED BY *POSITION*
+#
+#   dp[i] = length of the longest valid subsequence ending AT INDEX i.
+#   every earlier index j is a candidate predecessor, and it is a legal one
+#   exactly when nums[j] < nums[i] (strictly increasing) and the gap
+#   nums[i] - nums[j] <= k. so
+#
+#       dp[i] = 1 + max(dp[j] for legal j),  or 1 if there is none
+#
+#   no data structure at all - the range condition is simply re-tested for
+#   every pair. this is the honest baseline the value-indexed versions
+#   accelerate; at n = 10^5 it is far too slow for the judge, but it is the
+#   reference implementation and the shape worth remembering.
+#
+# time = O(n^2)
+# space = O(n)
+class Solution(object):
+    def lengthOfLIS(self, nums, k):
+        n = len(nums)
+        dp = [1] * n
+        for i in range(n):
+            for j in range(i):
+                if nums[j] < nums[i] and nums[i] - nums[j] <= k:
+                    dp[i] = max(dp[i], dp[j] + 1)
+        return max(dp)
+
+
+# V0-2
+# IDEA : SQRT DECOMPOSITION OF THE VALUE AXIS (block maxima instead of a tree)
+#
+#   same DP as V0 - best[v] = 1 + max(best[u] : v-k <= u <= v-1) - but the
+#   range-maximum structure is a flat two-level one instead of a segment tree:
+#
+#       val[v]  : best subsequence ending with value v
+#       blk[b]  : max of val over the b-th block of B consecutive values
+#
+#   a query walks the partial head block element by element, then whole blocks
+#   through blk, then the partial tail block:
+#
+#       [ head ... ][ block ][ block ][ ... tail ]
+#         O(B)        O(V/B)  O(V/B)     O(B)
+#
+#   choosing B ~ sqrt(V) balances the two halves at O(sqrt V) per query. an
+#   update is O(1): raise one leaf and, if needed, its block max (the maxima
+#   only ever grow, so nothing has to be recomputed).
+#
+#   slower asymptotically than the segment tree but noticeably shorter, and
+#   it is the go-to when you need a range max in a hurry.
+#
+# time = O(n * sqrt(V)), V = max(nums)
+# space = O(V)
+class Solution(object):
+    def lengthOfLIS(self, nums, k):
+        V = max(nums) + 1
+        B = int(V ** 0.5) + 1
+        val = [0] * V
+        blk = [0] * ((V + B - 1) // B)
+
+        def query(lo, hi):
+            """max of val over the inclusive value range [lo, hi]"""
+            if lo > hi:
+                return 0
+            res = 0
+            bl, bh = lo // B, hi // B
+            if bl == bh:
+                for v in range(lo, hi + 1):
+                    res = max(res, val[v])
+                return res
+            for v in range(lo, (bl + 1) * B):
+                res = max(res, val[v])
+            for b in range(bl + 1, bh):
+                res = max(res, blk[b])
+            for v in range(bh * B, hi + 1):
+                res = max(res, val[v])
+            return res
+
+        best = 0
+        for v in nums:
+            cur = 1 + query(max(0, v - k), v - 1)
+            if cur > val[v]:
+                val[v] = cur
+                if cur > blk[v // B]:
+                    blk[v // B] = cur
+            best = max(best, cur)
+        return best

--- a/leetcode_python/Array/longest-strictly-increasing-or-strictly-decreasing-subarray.py
+++ b/leetcode_python/Array/longest-strictly-increasing-or-strictly-decreasing-subarray.py
@@ -59,3 +59,51 @@ class Solution(object):
             dec = dec + 1 if nums[i] < nums[i - 1] else 1
             res = max(res, inc, dec)
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE — EXTEND EVERY START WHILE IT STAYS MONOTONIC
+#
+#   n <= 50, so trying all O(n^2) subarrays is affordable. from each start
+#   walk right while the strict comparison keeps holding, once for the
+#   increasing direction and once for the decreasing one.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def longestMonotonicSubarray(self, nums):
+        n = len(nums)
+        res = 1
+        for i in range(n):
+            j = i + 1
+            while j < n and nums[j] > nums[j - 1]:
+                j += 1
+            res = max(res, j - i)
+            j = i + 1
+            while j < n and nums[j] < nums[j - 1]:
+                j += 1
+            res = max(res, j - i)
+        return res
+
+
+# V0-2
+# IDEA : GROUP THE PAIRWISE COMPARISON SIGNS (itertools.groupby)
+#
+#   compress nums into the n-1 signs of its consecutive differences :
+#       [1,4,3,3,2] -> ['+', '-', '=', '-']
+#   a maximal run of k identical '+' (or '-') signs IS a strictly monotonic
+#   subarray of length k + 1. '=' runs contribute nothing, and an empty sign
+#   list (n == 1) leaves the initial answer 1.
+#
+# time = O(n), space = O(n)
+from itertools import groupby
+class Solution(object):
+    def longestMonotonicSubarray(self, nums):
+        signs = []
+        for a, b in zip(nums, nums[1:]):
+            signs.append('+' if b > a else ('-' if b < a else '='))
+        res = 1
+        for sign, run in groupby(signs):
+            if sign == '=':
+                continue
+            res = max(res, len(list(run)) + 1)
+        return res

--- a/leetcode_python/Array/make-a-square-with-the-same-color.py
+++ b/leetcode_python/Array/make-a-square-with-the-same-color.py
@@ -61,3 +61,66 @@ class Solution(object):
                 if blacks != 2:
                     return True
         return False
+
+
+# V0-1
+# IDEA : BRUTE FORCE — TRY THE 9 SINGLE FLIPS (AND NO FLIP AT ALL)
+#
+#   "at most one change" is small enough to enumerate literally : the grid
+#   as given plus the 9 one-cell mutations, each tested for a uniform 2x2
+#   block. no insight about counts needed.
+#
+# time = O(1), space = O(1)   (10 candidate grids * 4 blocks)
+class Solution(object):
+    def canMakeSquare(self, grid):
+        def has_square(g):
+            for r in range(2):
+                for c in range(2):
+                    cell = g[r][c]
+                    if (g[r][c + 1] == cell and g[r + 1][c] == cell
+                            and g[r + 1][c + 1] == cell):
+                        return True
+            return False
+
+        if has_square(grid):
+            return True
+        for r in range(3):
+            for c in range(3):
+                g = [list(row) for row in grid]
+                g[r][c] = 'W' if g[r][c] == 'B' else 'B'
+                if has_square(g):
+                    return True
+        return False
+
+
+# V0-2
+# IDEA : PRECOMPUTED 4-BIT LOOKUP TABLE OVER THE 16 POSSIBLE BLOCKS
+#
+#   read a 2x2 block as a 4-bit mask (bit set = 'B'). all 16 masks are
+#   enumerated ONCE at import time, and a mask is recorded as fixable when
+#   it is already uniform or becomes uniform after flipping one of its bits.
+#   the grid scan then answers each block with a single set lookup, doing no
+#   counting or reasoning of its own.
+#
+# time = O(1), space = O(1)
+def _build_fixable_masks():
+    good = set()
+    for mask in range(16):
+        for cand in [mask] + [mask ^ (1 << b) for b in range(4)]:
+            if cand == 0b0000 or cand == 0b1111:
+                good.add(mask)
+                break
+    return good
+_FIXABLE_MASKS = _build_fixable_masks()
+class Solution(object):
+    def canMakeSquare(self, grid):
+        offsets = ((0, 0), (0, 1), (1, 0), (1, 1))
+        for r in range(2):
+            for c in range(2):
+                mask = 0
+                for bit, (dr, dc) in enumerate(offsets):
+                    if grid[r + dr][c + dc] == 'B':
+                        mask |= 1 << bit
+                if mask in _FIXABLE_MASKS:
+                    return True
+        return False

--- a/leetcode_python/Array/make-array-elements-equal-to-zero.py
+++ b/leetcode_python/Array/make-array-elements-equal-to-zero.py
@@ -81,3 +81,67 @@ class Solution(object):
                 if all(v == 0 for v in arr):
                     res += 1
         return res
+
+
+# V0-1
+# IDEA : PREFIX SUMS — ONLY THE LEFT/RIGHT TOTALS MATTER
+#
+#   from a zero start the walker bounces between the two sides, and every
+#   bounce spends exactly one unit from the side it is heading into. so the
+#   whole run is "drain the left total and the right total alternately", and
+#   whether it can clear everything depends only on how balanced they are :
+#       left == right          -> both directions work  (+2)
+#       abs(left - right) == 1 -> exactly one works     (+1)
+#       otherwise              -> neither               (+0)
+#   left/right are the sums strictly left/right of the start, so one sweep
+#   with a running prefix and a shrinking suffix answers every zero.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def countValidSelections(self, nums):
+        right = sum(nums)
+        left = 0
+        res = 0
+        for v in nums:
+            right -= v
+            if v == 0:
+                if left == right:
+                    res += 2
+                elif abs(left - right) == 1:
+                    res += 1
+            left += v
+        return res
+
+
+# V0-2
+# IDEA : COLLAPSE THE ZEROS — SIMULATE ON TWO STACKS OF NONZERO VALUES
+#
+#   stepping cell by cell burns time on the zeros, which never do anything.
+#   for a given start, push the nonzero values lying to its left on one
+#   stack (nearest on top) and those to its right on another. the walker
+#   then just decrements the top of the stack it is heading into, flips
+#   side, and a value that reaches 0 is popped for good.
+#   the run ends the moment the side ahead is empty (the walker leaves the
+#   array), and the selection is valid only if the side behind is empty too.
+#
+# time = O(n * (n + sum(nums))), space = O(n)
+class Solution(object):
+    def countValidSelections(self, nums):
+        n = len(nums)
+        res = 0
+        for start in range(n):
+            if nums[start] != 0:
+                continue
+            base_left = [v for v in nums[:start] if v > 0]
+            base_right = [v for v in nums[start + 1:] if v > 0][::-1]
+            for go_right in (True, False):
+                left, right = list(base_left), list(base_right)
+                ahead, behind = (right, left) if go_right else (left, right)
+                while ahead:
+                    ahead[-1] -= 1
+                    if ahead[-1] == 0:
+                        ahead.pop()
+                    ahead, behind = behind, ahead
+                if not behind:
+                    res += 1
+        return res

--- a/leetcode_python/Array/make-two-arrays-equal-by-reversing-subarrays.py
+++ b/leetcode_python/Array/make-two-arrays-equal-by-reversing-subarrays.py
@@ -54,3 +54,39 @@ from collections import Counter
 class Solution(object):
     def canBeEqual(self, target, arr):
         return Counter(target) == Counter(arr)
+
+
+# V0-1
+# IDEA : SORT BOTH AND COMPARE ELEMENTWISE
+#
+#   two multisets are equal exactly when their sorted forms are identical,
+#   so sorting normalises away the order that the reversals are free to
+#   change. no auxiliary counting structure at all.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def canBeEqual(self, target, arr):
+        return sorted(target) == sorted(arr)
+
+
+# V0-2
+# IDEA : GREEDY MATCH-AND-DELETE (no hashing, no sorting)
+#
+#   walk target and consume one equal element from a working copy of arr for
+#   each value. a value with no partner left proves the multisets differ; if
+#   every value finds one the copy ends empty.
+#   the linear search hidden inside list.remove is what makes this the
+#   O(n^2) baseline that the Counter version above optimises away.
+#
+# time = O(n^2), space = O(n)
+class Solution(object):
+    def canBeEqual(self, target, arr):
+        if len(target) != len(arr):
+            return False
+        pool = list(arr)
+        for v in target:
+            try:
+                pool.remove(v)
+            except ValueError:
+                return False
+        return not pool

--- a/leetcode_python/Array/match-alphanumerical-pattern-in-matrix-i.py
+++ b/leetcode_python/Array/match-alphanumerical-pattern-in-matrix-i.py
@@ -99,3 +99,105 @@ class Solution(object):
                 if matches(r0, c0):
                     return [r0, c0]
         return [-1, -1]
+
+
+# V0-1
+# IDEA : PRECOMPUTE THE PATTERN'S CONSTRAINT GROUPS ONCE
+#
+#   the pattern says three separate things, and all three can be prepared
+#   before any anchor is examined :
+#       digit cells    -> (r, c, required digit)
+#       letter groups  -> every cell of one letter must hold the same value
+#       group leaders  -> the leaders' values must be pairwise distinct
+#   an anchor is then validated by checking those three lists, cheapest
+#   first, instead of rebuilding two dictionaries cell by cell. the digit
+#   list usually rejects an anchor immediately.
+#
+# time = O(m * n * pm * pn), space = O(pm * pn)
+class Solution(object):
+    def findPattern(self, board, pattern):
+        m, n = len(board), len(board[0])
+        pm, pn = len(pattern), len(pattern[0])
+
+        digit_cells = []
+        groups = {}
+        for r in range(pm):
+            for c in range(pn):
+                ch = pattern[r][c]
+                if ch.isdigit():
+                    digit_cells.append((r, c, int(ch)))
+                else:
+                    groups.setdefault(ch, []).append((r, c))
+        group_cells = list(groups.values())
+        leaders = [cells[0] for cells in group_cells]
+
+        for r0 in range(m - pm + 1):
+            for c0 in range(n - pn + 1):
+                if any(board[r0 + r][c0 + c] != d for r, c, d in digit_cells):
+                    continue
+                ok = True
+                for cells in group_cells:
+                    lr, lc = cells[0]
+                    v = board[r0 + lr][c0 + lc]
+                    if any(board[r0 + r][c0 + c] != v for r, c in cells[1:]):
+                        ok = False
+                        break
+                if not ok:
+                    continue
+                vals = [board[r0 + r][c0 + c] for r, c in leaders]
+                if len(set(vals)) == len(vals):
+                    return [r0, c0]
+        return [-1, -1]
+
+
+# V0-2
+# IDEA : RECURSIVE ROW-BY-ROW VERIFICATION WITH BACKTRACKING
+#
+#   same anchor sweep, but the per-anchor check is a recursion over pattern
+#   ROWS (depth <= 50, so no recursion-limit trouble even for a 50x50
+#   pattern). it carries ONE shared letter -> digit dict plus a 10-bit mask
+#   of digits already claimed : a letter is bound the first time it is seen
+#   and every binding made inside a row is UNDONE when that row's subtree
+#   fails, so nothing is allocated per anchor.
+#   the taken-digit mask is what enforces injectivity, replacing the reverse
+#   digit -> letter dictionary of V0.
+#
+# time = O(m * n * pm * pn), space = O(pm)   (recursion depth)
+class Solution(object):
+    def findPattern(self, board, pattern):
+        m, n = len(board), len(board[0])
+        pm, pn = len(pattern), len(pattern[0])
+        bound = {}
+
+        def dfs(r, r0, c0, used):
+            if r == pm:
+                return True
+            fresh = []
+            for c in range(pn):
+                ch = pattern[r][c]
+                v = board[r0 + r][c0 + c]
+                if ch.isdigit():
+                    if v != int(ch):
+                        break
+                elif ch in bound:
+                    if bound[ch] != v:
+                        break
+                elif used >> v & 1:
+                    break
+                else:
+                    bound[ch] = v
+                    used |= 1 << v
+                    fresh.append(ch)
+            else:
+                if dfs(r + 1, r0, c0, used):
+                    return True
+            for ch in fresh:
+                del bound[ch]
+            return False
+
+        for r0 in range(m - pm + 1):
+            for c0 in range(n - pn + 1):
+                bound.clear()
+                if dfs(0, r0, c0, 0):
+                    return [r0, c0]
+        return [-1, -1]

--- a/leetcode_python/Array/matrix-diagonal-sum.py
+++ b/leetcode_python/Array/matrix-diagonal-sum.py
@@ -54,3 +54,38 @@ class Solution(object):
         if n % 2:
             res -= mat[n // 2][n // 2]
         return res
+
+
+# V0-1
+# IDEA : FULL O(n^2) SCAN, KEEP THE CELLS THAT SIT ON EITHER DIAGONAL
+#
+#   visit every cell and add it when i == j (primary) OR i + j == n - 1
+#   (secondary). because each cell is visited exactly once, the odd-n centre
+#   — which satisfies both tests — is added once and the parity correction
+#   of V0 is not needed at all.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def diagonalSum(self, mat):
+        n = len(mat)
+        res = 0
+        for i in range(n):
+            for j in range(n):
+                if i == j or i + j == n - 1:
+                    res += mat[i][j]
+        return res
+
+
+# V0-2
+# IDEA : COLLECT THE INDEX PAIRS IN A SET AND LET THE SET DEDUPE
+#
+#   build {(i, i)} | {(i, n-1-i)} : for odd n the shared centre is produced
+#   by both halves and the set keeps one copy, so summing over the set needs
+#   no special case — and only the 2n - 1 relevant cells are touched.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def diagonalSum(self, mat):
+        n = len(mat)
+        cells = {(i, i) for i in range(n)} | {(i, n - 1 - i) for i in range(n)}
+        return sum(mat[i][j] for i, j in cells)

--- a/leetcode_python/Array/max-consecutive-ones.py
+++ b/leetcode_python/Array/max-consecutive-ones.py
@@ -44,3 +44,50 @@ class Solution(object):
             else:
                 cur = 0     # streak broken
         return best
+
+
+# V0-1
+# IDEA : itertools.groupby ON MAXIMAL RUNS
+#
+#  groupby collapses the array into maximal runs of equal values, so the
+#  answer is just the longest run whose key is 1. no manual counter and no
+#  reset branch - the run boundaries come out of the grouping itself.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def findMaxConsecutiveOnes(self, nums):
+        import itertools
+        best = 0
+        for key, grp in itertools.groupby(nums):
+            if key == 1:
+                best = max(best, len(list(grp)))
+        return best
+
+
+# V0-2
+# IDEA : SLIDING WINDOW ALLOWING AT MOST 0 ZEROS
+#
+#  read the task as "longest subarray containing at most k zeros" with k = 0 :
+#  grow the right edge, and while the window holds a zero drag the left edge
+#  past it. the widest legal window is the answer.
+#  the point of writing it this way is that raising k to 1 / 2 / K turns this
+#  same block into LC 487 / LC 1004 - the running-counter form of V0 does not
+#  generalise like that.
+#
+# time = O(n)
+# space = O(1)
+class Solution(object):
+    def findMaxConsecutiveOnes(self, nums):
+        left = 0
+        zeros = 0
+        best = 0
+        for right in range(len(nums)):
+            if nums[right] == 0:
+                zeros += 1
+            while zeros > 0:
+                if nums[left] == 0:
+                    zeros -= 1
+                left += 1
+            best = max(best, right - left + 1)
+        return best

--- a/leetcode_python/Array/maximize-count-of-distinct-primes-after-split.py
+++ b/leetcode_python/Array/maximize-count-of-distinct-primes-after-split.py
@@ -192,3 +192,167 @@ class Solution(object):
                     attach(val, idx)
             res.append(distinct[0] + tree[1])
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE - RECOMPUTE PREFIX / SUFFIX DISTINCT PRIME COUNTS PER QUERY
+#
+#   no reformulation and no data structure : after applying the update, walk
+#   left to right holding a set of the primes already seen to get
+#   pre[k] = # distinct primes in nums[0..k-1], walk right to left the same
+#   way for suf[k] = # distinct primes in nums[k..n-1], then take
+#   max(pre[k] + suf[k]) over k = 1 .. n-1.
+#   O(n) per query, so this is the reference implementation to check the
+#   clever versions against rather than a submission for the real limits.
+#
+# time = O(q * n + V log log V), space = O(n + V)
+class Solution(object):
+    def maximumCount(self, nums, queries):
+        LIMIT = 100001
+        sieve = bytearray([1]) * LIMIT
+        sieve[0] = sieve[1] = 0
+        i = 2
+        while i * i < LIMIT:
+            if sieve[i]:
+                sieve[i * i::i] = bytearray(len(range(i * i, LIMIT, i)))
+            i += 1
+
+        n = len(nums)
+        cur = list(nums)
+        res = []
+        for idx, val in queries:
+            cur[idx] = val
+
+            pre = [0] * (n + 1)
+            seen = set()
+            for i in range(n):
+                if sieve[cur[i]]:
+                    seen.add(cur[i])
+                pre[i + 1] = len(seen)
+
+            suf = [0] * (n + 1)
+            seen = set()
+            for i in range(n - 1, -1, -1):
+                if sieve[cur[i]]:
+                    seen.add(cur[i])
+                suf[i] = len(seen)
+
+            best = 0
+            for k in range(1, n):
+                if pre[k] + suf[k] > best:
+                    best = pre[k] + suf[k]
+            res.append(best)
+        return res
+
+
+# V0-2
+# IDEA : SAME "TOTAL PRIMES + INTERVAL STABBING" REWRITE, BUT SQRT DECOMPOSITION
+#
+#   as in V0 : every distinct prime present scores 1 for free, and scores a
+#   second point exactly for the split points k in [first[p] + 1, last[p]],
+#   so answer = distinct + (max coverage of those intervals over one point).
+#
+#   the difference is the structure holding the coverage profile. instead of a
+#   lazy segment tree the array is cut into blocks of ~sqrt(n) :
+#     * range add - the whole blocks strictly inside take a lazy += delta in
+#       O(1) each, the two partial blocks are patched element-wise and their
+#       block maximum recomputed, so O(sqrt n) per interval
+#     * global max - max over blocks of (block_max + block_lazy), O(sqrt n)
+#   occurrence indices of a prime live in one bisect-sorted list, so first and
+#   last are s[0] / s[-1] and an update is a single insort / pop.
+#   flatter constants and much less code than the segment tree, at the price
+#   of sqrt(n) instead of log(n) per operation.
+#
+# time = O((n + q) * sqrt(n) + V log log V), space = O(n + V)
+class Solution(object):
+    def maximumCount(self, nums, queries):
+        import bisect
+
+        LIMIT = 100001
+        sieve = bytearray([1]) * LIMIT
+        sieve[0] = sieve[1] = 0
+        i = 2
+        while i * i < LIMIT:
+            if sieve[i]:
+                sieve[i * i::i] = bytearray(len(range(i * i, LIMIT, i)))
+            i += 1
+
+        n = len(nums)
+        m = n - 1                    # split points k = 1..n-1 -> slots 0..m-1
+        B = int(m ** 0.5) + 1
+        nb = (m + B - 1) // B
+        cov = [0] * m
+        blk_max = [0] * nb
+        blk_add = [0] * nb
+
+        def add(lo, hi, delta):
+            b_lo, b_hi = lo // B, hi // B
+            if b_lo == b_hi:
+                for j in range(lo, hi + 1):
+                    cov[j] += delta
+                s, e = b_lo * B, min(b_lo * B + B, m)
+                blk_max[b_lo] = max(cov[s:e])
+                return
+            s, e = b_lo * B, min(b_lo * B + B, m)
+            for j in range(lo, e):
+                cov[j] += delta
+            blk_max[b_lo] = max(cov[s:e])
+            for b in range(b_lo + 1, b_hi):
+                blk_add[b] += delta
+            s, e = b_hi * B, min(b_hi * B + B, m)
+            for j in range(s, hi + 1):
+                cov[j] += delta
+            blk_max[b_hi] = max(cov[s:e])
+
+        occ = {}         # prime -> sorted list of indices holding it
+        distinct = [0]
+
+        def span(p):
+            s = occ.get(p)
+            if not s or s[0] == s[-1]:
+                return None
+            return (s[0], s[-1] - 1)
+
+        def relay(before, after):
+            if before == after:
+                return
+            if before is not None:
+                add(before[0], before[1], -1)
+            if after is not None:
+                add(after[0], after[1], 1)
+
+        def attach(p, idx):
+            s = occ.get(p)
+            if s is None:
+                s = occ[p] = []
+            before = span(p)
+            if not s:
+                distinct[0] += 1
+            bisect.insort(s, idx)
+            relay(before, span(p))
+
+        def detach(p, idx):
+            s = occ[p]
+            before = span(p)
+            s.pop(bisect.bisect_left(s, idx))
+            if not s:
+                distinct[0] -= 1
+            relay(before, span(p))
+
+        cur = list(nums)
+        for idx, v in enumerate(cur):
+            if sieve[v]:
+                attach(v, idx)
+
+        res = []
+        for idx, val in queries:
+            old = cur[idx]
+            if old != val:
+                if sieve[old]:
+                    detach(old, idx)
+                cur[idx] = val
+                if sieve[val]:
+                    attach(val, idx)
+            top = max(blk_max[b] + blk_add[b] for b in range(nb))
+            res.append(distinct[0] + top)
+        return res

--- a/leetcode_python/Array/maximize-the-topmost-element-after-k-moves.py
+++ b/leetcode_python/Array/maximize-the-topmost-element-after-k-moves.py
@@ -78,3 +78,66 @@ class Solution(object):
         if k < n:
             best = max(best, nums[k])
         return best
+
+
+# V0-1
+# IDEA : REACHABILITY PREDICATE + SORT THE (VALUE, INDEX) PAIRS
+#
+#   which index can end up on top does not depend on the values at all, so
+#   turn the problem into "pick the largest value sitting on a reachable
+#   index". for k >= 2 on a pile of 2+ elements index i is reachable iff
+#     i <= k - 2   (pop the prefix, burn the spare moves, push nums[i] last)
+#     or i == k    (pop exactly k elements and stop)
+#   so sort the pairs by value descending and return the first one whose
+#   index passes the test - no case analysis on where the maximum lives.
+#   the degenerate k = 0 / k = 1 / single-element piles are still special.
+#
+# time = O(n log n), space = O(n)
+class Solution(object):
+    def maximumTop(self, nums, k):
+        n = len(nums)
+        if k == 0:
+            return nums[0]
+        if n == 1:
+            # the pile just flips between [nums[0]] and empty
+            return nums[0] if k % 2 == 0 else -1
+        if k == 1:
+            return nums[1]
+
+        for v, i in sorted(((v, i) for i, v in enumerate(nums)), reverse=True):
+            if i <= k - 2 or i == k:
+                return v
+        return -1
+
+
+# V0-2
+# IDEA : MAX-HEAP, POP UNTIL A REACHABLE INDEX SURFACES
+#
+#   same reachability test as V0-1, but the candidates are ordered lazily : a
+#   heap of (-value, index) is built in O(n) and only popped until the top is
+#   a usable index. at most (n - number of reachable indices) + 1 pops ever
+#   happen, so when a large value already sits in the reachable prefix - the
+#   common case, since the prefix is nums[0 .. k-2] - the sort of V0-1 is
+#   never paid for.
+#
+# time = O(n) to heapify + O(t log n) for the t pops actually taken
+# space = O(n)
+class Solution(object):
+    def maximumTop(self, nums, k):
+        import heapq
+
+        n = len(nums)
+        if k == 0:
+            return nums[0]
+        if n == 1:
+            return nums[0] if k % 2 == 0 else -1
+        if k == 1:
+            return nums[1]
+
+        heap = [(-v, i) for i, v in enumerate(nums)]
+        heapq.heapify(heap)
+        while heap:
+            v, i = heapq.heappop(heap)
+            if i <= k - 2 or i == k:
+                return -v
+        return -1

--- a/leetcode_python/Array/maximum-area-of-a-piece-of-cake-after-horizontal-and-vertical-cuts.py
+++ b/leetcode_python/Array/maximum-area-of-a-piece-of-cake-after-horizontal-and-vertical-cuts.py
@@ -65,3 +65,75 @@ class Solution(object):
             return best
 
         return (widest(horizontalCuts, h) * widest(verticalCuts, w)) % MOD
+
+
+# V0-1
+# IDEA : LINEAR MAX GAP BY BUCKETING (THE LC 164 "MAXIMUM GAP" TRICK)
+#
+#   the widest gap between the m + 2 boundary points of one axis is at least
+#   the average gap, so if the range [0, size] is split into buckets of width
+#   floor(size / (#points - 1)) the two ends of the widest gap can never fall
+#   in the same bucket. keeping only the min and max of each bucket is then
+#   enough : scan the non-empty buckets in order and measure
+#   bucket_min - previous_bucket_max.
+#   nothing is sorted, so each axis costs O(m) instead of O(m log m).
+#
+# time = O(m + n), space = O(m + n)
+class Solution(object):
+    def maxArea(self, h, w, horizontalCuts, verticalCuts):
+        MOD = 10 ** 9 + 7
+
+        def widest(cuts, size):
+            pts = cuts + [0, size]
+            width = max(1, size // (len(pts) - 1))
+            nb = size // width + 1
+            bmin = [-1] * nb
+            bmax = [-1] * nb
+            for p in pts:
+                b = p // width
+                if bmin[b] < 0 or p < bmin[b]:
+                    bmin[b] = p
+                if p > bmax[b]:
+                    bmax[b] = p
+            best = 0
+            prev = -1
+            for b in range(nb):
+                if bmin[b] < 0:
+                    continue
+                if prev >= 0 and bmin[b] - prev > best:
+                    best = bmin[b] - prev
+                prev = bmax[b]
+            return best
+
+        return (widest(horizontalCuts, h) * widest(verticalCuts, w)) % MOD
+
+
+# V0-2
+# IDEA : HEAP - STREAM THE BOUNDARY POINTS OUT IN INCREASING ORDER
+#
+#   the largest gap only ever compares neighbours in sorted order, and a
+#   binary heap can hand those out one at a time : heapify the boundaries in
+#   O(m), then pop and diff against the previously popped point.
+#   the sorted array of V0 is never materialised, which is the shape you want
+#   when the cuts arrive as a stream or when only the first few gaps matter.
+#
+# time = O(m log m + n log n), space = O(m + n)
+class Solution(object):
+    def maxArea(self, h, w, horizontalCuts, verticalCuts):
+        import heapq
+
+        MOD = 10 ** 9 + 7
+
+        def widest(cuts, size):
+            pq = cuts + [0, size]
+            heapq.heapify(pq)
+            best = 0
+            prev = heapq.heappop(pq)
+            while pq:
+                p = heapq.heappop(pq)
+                if p - prev > best:
+                    best = p - prev
+                prev = p
+            return best
+
+        return (widest(horizontalCuts, h) * widest(verticalCuts, w)) % MOD

--- a/leetcode_python/Array/maximum-area-of-longest-diagonal-rectangle.py
+++ b/leetcode_python/Array/maximum-area-of-longest-diagonal-rectangle.py
@@ -56,3 +56,36 @@ class Solution(object):
                 best_diag = diag
                 best_area = area
         return best_area
+
+
+# V0-1
+# IDEA : SORT ON THE KEY (DIAGONAL^2, AREA) AND READ THE LAST ENTRY
+#
+#   the tie-break rule of the problem *is* the lexicographic order of the
+#   tuple (l*l + w*w, l*w), so building those tuples and sorting them makes
+#   the hand-written comparison branch disappear : the winner is simply the
+#   largest tuple, and its second component is the answer.
+#
+# time = O(n log n)
+# space = O(n)
+class Solution(object):
+    def areaOfMaxDiagonal(self, dimensions):
+        ranked = sorted((l * l + w * w, l * w) for l, w in dimensions)
+        return ranked[-1][1]
+
+
+# V0-2
+# IDEA : TWO PASS - LONGEST DIAGONAL FIRST, THEN BEST AREA AMONG THE TIES
+#
+#   split the two objectives instead of comparing them together : pass 1
+#   maximises the squared diagonal only, pass 2 maximises the area over the
+#   rectangles that attain it. neither pass needs a tie-break, and the same
+#   shape answers "list every rectangle with the longest diagonal", which the
+#   single-pass form of V0 cannot do without extra bookkeeping.
+#
+# time = O(n)
+# space = O(1)
+class Solution(object):
+    def areaOfMaxDiagonal(self, dimensions):
+        top = max(l * l + w * w for l, w in dimensions)
+        return max(l * w for l, w in dimensions if l * l + w * w == top)

--- a/leetcode_python/Array/maximum-ascending-subarray-sum.py
+++ b/leetcode_python/Array/maximum-ascending-subarray-sum.py
@@ -50,3 +50,50 @@ class Solution(object):
                 cur = nums[i]
             res = max(res, cur)
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE - EVERY START, EXTEND WHILE STRICTLY ASCENDING
+#
+#   read the definition literally : for each start i keep adding nums[j] while
+#   the run stays strictly increasing, recording the total after every step,
+#   and stop at the first non-increase. this enumerates every ascending
+#   subarray rather than only the maximal ones.
+#
+# time = O(n^2)
+# space = O(1)
+class Solution(object):
+    def maxAscendingSum(self, nums):
+        n = len(nums)
+        best = 0
+        for i in range(n):
+            total = nums[i]
+            if total > best:
+                best = total
+            j = i + 1
+            while j < n and nums[j] > nums[j - 1]:
+                total += nums[j]
+                if total > best:
+                    best = total
+                j += 1
+        return best
+
+
+# V0-2
+# IDEA : PREFIX SUMS + THE LIST OF RUN BOUNDARIES
+#
+#   index i opens a new run exactly when nums[i] <= nums[i-1], so collect
+#   those cut points (plus the two ends) and the array is described by the
+#   boundary list alone. with a prefix-sum table the total of the run
+#   [a, b) is the single subtraction pre[b] - pre[a], so no value is ever
+#   added twice and any run's sum is an O(1) lookup afterwards.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def maxAscendingSum(self, nums):
+        import itertools
+        n = len(nums)
+        pre = [0] + list(itertools.accumulate(nums))
+        cuts = [0] + [i for i in range(1, n) if nums[i] <= nums[i - 1]] + [n]
+        return max(pre[cuts[i + 1]] - pre[cuts[i]] for i in range(len(cuts) - 1))

--- a/leetcode_python/Array/maximum-average-subarray-ii.py
+++ b/leetcode_python/Array/maximum-average-subarray-ii.py
@@ -91,3 +91,91 @@ class Solution(object):
                 hi = mid
 
         return lo
+
+
+# V0-1
+# IDEA : BRUTE FORCE OVER EVERY SUBARRAY (running sum, no prefix array)
+#
+#   fix the left endpoint i, extend the right endpoint j and keep the running
+#   sum. once the window is long enough (j - i + 1 >= k) its average is a
+#   candidate. no monotonicity is exploited, so every one of the O(n^2)
+#   subarrays is priced explicitly.
+#
+#   too slow for n = 10^4, but it is the definition of the problem and is what
+#   the smarter versions get validated against.
+#
+# time = O(n^2)
+# space = O(1)
+class Solution(object):
+    def findMaxAverage(self, nums, k):
+        n = len(nums)
+        res = float("-inf")
+        for i in range(n):
+            total = 0
+            for j in range(i, n):
+                total += nums[j]
+                length = j - i + 1
+                if length >= k:
+                    res = max(res, total / float(length))
+        return res
+
+
+# V0-2
+# IDEA : CONVEX HULL TRICK (MAX SLOPE BETWEEN PREFIX-SUM POINTS) - EXACT, O(n)
+#
+#   with prefix sums P, the average of nums[i..j-1] is
+#
+#       (P[j] - P[i]) / (j - i)
+#
+#   which is exactly the SLOPE of the line through the plane points
+#   A_i = (i, P[i]) and A_j = (j, P[j]). so the task becomes: maximise the
+#   slope over all pairs with j - i >= k.
+#
+#   for a fixed right point A_j, the left point maximising the slope always
+#   lies on the LOWER convex hull of {A_0 ... A_{j-k}} - any point strictly
+#   above the hull is dominated. so:
+#
+#     * as j advances, the newly legal left index j-k is pushed onto a
+#       monotonic stack that keeps the hull convex (pop while the middle point
+#       sits on/above the segment through its neighbours),
+#     * the best hull vertex for j is found by a pointer that only ever moves
+#       FORWARD, because that optimum is non-decreasing in j.
+#
+#   every index is pushed once, popped at most once, and the pointer advances
+#   at most n times -> linear, and unlike V0 this is exact (no epsilon).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def findMaxAverage(self, nums, k):
+        n = len(nums)
+        pre = [0] * (n + 1)
+        for i, v in enumerate(nums):
+            pre[i + 1] = pre[i] + v
+
+        def slope(a, b):
+            return (pre[b] - pre[a]) / float(b - a)
+
+        def useless(a, b, c):
+            # b is on/above segment (a, c) -> it can never be a hull optimum
+            return (pre[b] - pre[a]) * (c - a) >= (pre[c] - pre[a]) * (b - a)
+
+        hull = []
+        ptr = 0
+        res = float("-inf")
+        for j in range(k, n + 1):
+            # index j - k just became a legal left endpoint
+            new = j - k
+            while len(hull) >= 2 and useless(hull[-2], hull[-1], new):
+                hull.pop()
+            hull.append(new)
+
+            if ptr >= len(hull):
+                ptr = len(hull) - 1
+            while (ptr + 1 < len(hull)
+                   and slope(hull[ptr], j) <= slope(hull[ptr + 1], j)):
+                ptr += 1
+
+            res = max(res, slope(hull[ptr], j))
+
+        return res

--- a/leetcode_python/Array/maximum-consecutive-floors-without-special-floors.py
+++ b/leetcode_python/Array/maximum-consecutive-floors-without-special-floors.py
@@ -54,3 +54,81 @@ class Solution(object):
         for i in range(1, len(special)):
             res = max(res, special[i] - special[i - 1] - 1)
         return res
+
+
+# V0-1
+# IDEA : MIN-HEAP, CONSUMING THE SPECIAL FLOORS IN INCREASING ORDER
+#
+#   the gaps only need the special floors visited in ascending order - a total
+#   sort is more than required, so heapify + repeated pop streams them out
+#   instead. two sentinel tricks remove the edge cases V0 handles by hand :
+#
+#       prev starts at bottom - 1  -> the first gap is cur - (bottom-1) - 1
+#       after the loop, top acts as the closing wall -> top - prev
+#
+#   heapify is O(n) and the n pops are O(log n) each, so the asymptotics match
+#   sorting, but nothing is ever fully ordered in memory and the loop could
+#   stop early if only the first few gaps mattered.
+#
+# time = O(n log n)
+# space = O(n) for the heap
+import heapq
+class Solution(object):
+    def maxConsecutive(self, bottom, top, special):
+        heap = list(special)
+        heapq.heapify(heap)
+
+        res = 0
+        prev = bottom - 1
+        while heap:
+            cur = heapq.heappop(heap)
+            res = max(res, cur - prev - 1)
+            prev = cur
+
+        return max(res, top - prev)
+
+
+# V0-2
+# IDEA : PIGEONHOLE BUCKETS -> MAXIMUM GAP IN LINEAR TIME (LC 164 TRICK)
+#
+#   add the two virtual walls bottom-1 and top+1 to the special floors; the
+#   answer is then simply (max gap between consecutive points) - 1.
+#
+#   sorting is not needed to find a MAX gap. spread the m points over m-1
+#   buckets of equal width w = span / (m - 1). by the pigeonhole principle the
+#   maximum gap is at least w, so it can never sit strictly inside one bucket
+#   - it must run from some bucket's max to the next non-empty bucket's min.
+#   so storing only (min, max) per bucket and scanning the buckets once is
+#   enough, and the points inside a bucket never have to be ordered.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def maxConsecutive(self, bottom, top, special):
+        pts = list(special) + [bottom - 1, top + 1]
+        m = len(pts)
+        lo, hi = min(pts), max(pts)
+        if lo == hi:
+            return 0
+
+        width = max(1, (hi - lo) // (m - 1))
+        nb = (hi - lo) // width + 1
+        bmin = [None] * nb
+        bmax = [None] * nb
+        for p in pts:
+            b = (p - lo) // width
+            if bmin[b] is None or p < bmin[b]:
+                bmin[b] = p
+            if bmax[b] is None or p > bmax[b]:
+                bmax[b] = p
+
+        res = 0
+        prev = None
+        for b in range(nb):
+            if bmin[b] is None:
+                continue
+            if prev is not None:
+                res = max(res, bmin[b] - prev - 1)
+            prev = bmax[b]
+
+        return res

--- a/leetcode_python/Array/maximum-difference-between-adjacent-elements-in-a-circular-array.py
+++ b/leetcode_python/Array/maximum-difference-between-adjacent-elements-in-a-circular-array.py
@@ -49,3 +49,51 @@ class Solution(object):
     def maxAdjacentDistance(self, nums):
         n = len(nums)
         return max(abs(nums[i] - nums[(i + 1) % n]) for i in range(n))
+
+
+# V0-1
+# IDEA : DIVIDE AND CONQUER (RECURSION) OVER THE n CIRCULAR PAIRS
+#
+#   the n adjacent pairs are indexed 0 .. n-1, pair i being
+#   (nums[i], nums[(i+1) % n]).  "max over a range of pairs" splits cleanly :
+#
+#       best(lo, hi) = max( best(lo, mid), best(mid+1, hi) )
+#
+#   with a single pair as the base case.  same n comparisons of work as the
+#   flat scan, but the control flow is a recursion tree instead of a loop -
+#   the shape you need when the same reduction has to be parallelised or run
+#   over a segment tree.
+#
+# time = O(n)
+# space = O(log n) recursion stack
+class Solution(object):
+    def maxAdjacentDistance(self, nums):
+        n = len(nums)
+
+        def solve(lo, hi):
+            if lo == hi:
+                return abs(nums[hi] - nums[(hi + 1) % n])
+            mid = (lo + hi) // 2
+            return max(solve(lo, mid), solve(mid + 1, hi))
+
+        return solve(0, n - 1)
+
+
+# V0-2
+# IDEA : DROP abs() - TWO SIGNED PASSES OVER A ROTATED COPY
+#
+#   abs() can be decomposed :  max |x - y| = max( max (y - x), max (x - y) ),
+#   so the answer is the larger of two plain signed maxima.
+#
+#   pairing is handled by rotating the array by one (nxt[i] is the circular
+#   successor of nums[i]) and zipping, so neither modulo arithmetic nor an
+#   index variable appears - the two passes are pure streaming reductions.
+#
+# time = O(n) (two passes)
+# space = O(n) for the rotated copy
+class Solution(object):
+    def maxAdjacentDistance(self, nums):
+        nxt = nums[1:] + nums[:1]
+        up = max(b - a for a, b in zip(nums, nxt))
+        down = max(a - b for a, b in zip(nums, nxt))
+        return max(up, down)

--- a/leetcode_python/Array/maximum-difference-between-increasing-elements.py
+++ b/leetcode_python/Array/maximum-difference-between-increasing-elements.py
@@ -60,3 +60,56 @@ class Solution(object):
             else:
                 cur_min = x
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE - PRICE EVERY (i, j) PAIR
+#
+#   check all pairs i < j directly and keep the best positive difference.
+#   n <= 1000 so the ~5 * 10^5 pairs are cheap enough to pass, and this is the
+#   literal statement of the problem - useful as the ground truth the O(n)
+#   versions are checked against.
+#
+# time = O(n^2)
+# space = O(1)
+class Solution(object):
+    def maximumDifference(self, nums):
+        n = len(nums)
+        res = -1
+        for i in range(n):
+            for j in range(i + 1, n):
+                if nums[i] < nums[j]:
+                    res = max(res, nums[j] - nums[i])
+        return res
+
+
+# V0-2
+# IDEA : SUFFIX MAXIMUM ARRAY (TWO PASSES, RIGHT -> LEFT THEN LEFT -> RIGHT)
+#
+#   the V0 scan fixes j and keeps the best i so far. flip it: fix i and ask for
+#   the largest value anywhere to its RIGHT.
+#
+#     pass 1 (backwards) : suf[i] = max(nums[i:])
+#     pass 2 (forwards)  : the best partner for i is suf[i+1], so the answer
+#                          is max(suf[i+1] - nums[i]) over the i where that
+#                          difference is strictly positive
+#
+#   this trades O(1) space for an explicit table, but it is the shape that
+#   generalises when the right-hand aggregate is something a running scalar
+#   cannot maintain (e.g. queried repeatedly, or a max over a suffix window).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def maximumDifference(self, nums):
+        n = len(nums)
+        suf = [0] * n
+        suf[n - 1] = nums[n - 1]
+        for i in range(n - 2, -1, -1):
+            suf[i] = max(nums[i], suf[i + 1])
+
+        res = -1
+        for i in range(n - 1):
+            if suf[i + 1] > nums[i]:
+                res = max(res, suf[i + 1] - nums[i])
+        return res

--- a/leetcode_python/Array/maximum-fruits-harvested-after-at-most-k-steps.py
+++ b/leetcode_python/Array/maximum-fruits-harvested-after-at-most-k-steps.py
@@ -89,3 +89,90 @@ class Solution(object):
             if i <= j:
                 res = max(res, prefix[j + 1] - prefix[i])
         return res
+
+
+# V0-1
+# IDEA : ENUMERATE THE BUDGET SPLIT (how far to walk against the turn) + BISECT
+#
+#   an optimal walk turns around AT MOST once, so it is fully described by one
+#   number : how many steps d are spent on the "wrong" side before turning.
+#   walking d left first then turning right leaves k - 2d steps for the right
+#   side, so the harvested interval is
+#
+#       [ startPos - d , startPos + (k - 2d) ]
+#
+#   and the mirror case (right first) is
+#
+#       [ startPos - (k - 2d) , startPos + d ]
+#
+#   d only needs to run over 0 .. k // 2 (beyond that the far side is empty and
+#   the mirror case already covers it). since `fruits` is sorted by position,
+#   the amount inside an interval is one prefix-sum difference located by two
+#   binary searches - no sliding pointer at all.
+#
+# time = O(k log n)
+# space = O(n)
+import bisect
+class Solution(object):
+    def maxTotalFruits(self, fruits, startPos, k):
+        pos = [p for p, _ in fruits]
+        prefix = [0] * (len(fruits) + 1)
+        for i, (_, amt) in enumerate(fruits):
+            prefix[i + 1] = prefix[i] + amt
+
+        def total(lo, hi):
+            a = bisect.bisect_left(pos, lo)
+            b = bisect.bisect_right(pos, hi)
+            return prefix[b] - prefix[a]
+
+        res = 0
+        for d in range(k // 2 + 1):
+            rest = k - 2 * d
+            # left d steps, then turn right
+            res = max(res, total(startPos - d, startPos + rest))
+            # right d steps, then turn left
+            res = max(res, total(startPos - rest, startPos + d))
+        return res
+
+
+# V0-2
+# IDEA : FIX THE LEFT END, BINARY SEARCH THE FURTHEST FEASIBLE RIGHT END
+#
+#   for a FIXED left index i, the walk cost min(2L + R, L + 2R) is monotone
+#   non-decreasing as the right index j grows (R only grows). monotone predicate
+#   -> binary search instead of the amortised two-pointer of V0.
+#
+#   and the best window starting at i is always the widest feasible one, because
+#   amounts are strictly positive - so one binary search per i gives the answer,
+#   with no invariant to maintain between iterations. slower than V0 by a log
+#   factor, but each i is independent, which is what you want if the queries
+#   (different startPos / k) arrive one at a time.
+#
+# time = O(n log n)
+# space = O(n)
+class Solution(object):
+    def maxTotalFruits(self, fruits, startPos, k):
+        n = len(fruits)
+        pos = [p for p, _ in fruits]
+        prefix = [0] * (n + 1)
+        for i, (_, amt) in enumerate(fruits):
+            prefix[i + 1] = prefix[i] + amt
+
+        def cost(i, j):
+            left = max(0, startPos - pos[i])
+            right = max(0, pos[j] - startPos)
+            return min(2 * left + right, left + 2 * right)
+
+        res = 0
+        for i in range(n):
+            if cost(i, i) > k:
+                continue
+            lo, hi = i, n - 1
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if cost(i, mid) <= k:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            res = max(res, prefix[lo + 1] - prefix[i])
+        return res

--- a/leetcode_python/Array/maximum-number-of-balls-in-a-box.py
+++ b/leetcode_python/Array/maximum-number-of-balls-in-a-box.py
@@ -68,3 +68,84 @@ class Solution(object):
             cnt[s] += 1
 
         return max(cnt)
+
+
+# V0-1
+# IDEA : STRING DIGITS + Counter (hash map instead of a fixed array)
+#
+#   the digit sum can be read off the DECIMAL STRING instead of being peeled
+#   with % / // : str(v) hands the digits over directly, and Counter grows the
+#   box space on demand, so no bound on the digit sum has to be known up front
+#   (which matters the moment highLimit stops being 10^5).
+#
+#   the mechanism differs from V0 on both axes - string scan vs modular
+#   arithmetic, hash map vs pre-sized array - but the work is still one pass
+#   per ball.
+#
+# time = O(n * log10(highLimit))
+# space = O(log10(highLimit)) distinct boxes in the map
+import collections
+class Solution(object):
+    def countBalls(self, lowLimit, highLimit):
+        boxes = collections.Counter(
+            sum(int(ch) for ch in str(v))
+            for v in range(lowLimit, highLimit + 1)
+        )
+        return max(boxes.values())
+
+
+# V0-2
+# IDEA : DIGIT DP - COUNT PER DIGIT SUM WITHOUT VISITING A SINGLE BALL
+#
+#   define f(N)[s] = how many x in [0, N] have digit sum s. then the balls of
+#   box s are f(highLimit)[s] - f(lowLimit - 1)[s], and the answer is the max
+#   over s. no loop over the n balls at all - the cost depends only on the
+#   NUMBER OF DIGITS.
+#
+#   f is built the standard digit-DP way :
+#     free[m][s] = # of m-digit strings (leading zeros allowed) with sum s
+#                  -> free[m][s] = sum over d in 0..9 of free[m-1][s-d]
+#     then walk the digits of N left to right; fixing a smaller digit dd < d at
+#     position i leaves the remaining `rest` positions completely free, so it
+#     contributes free[rest][*] shifted by (prefix sum so far + dd). finally add
+#     1 for N itself.
+#
+#   with D = number of digits (D = 6 here) this is O(D^2 * 9D) ~ a few thousand
+#   operations regardless of how wide the range is - it still answers
+#   [1, 10^18] instantly, where V0 and V0-1 cannot even start.
+#
+# time = O(D^3) where D = digits of highLimit (independent of n)
+# space = O(D^2)
+class Solution(object):
+    def countBalls(self, lowLimit, highLimit):
+        def counts_up_to(n):
+            digits = [int(c) for c in str(n)]
+            L = len(digits)
+            top = 9 * L
+
+            free = [[0] * (top + 1) for _ in range(L + 1)]
+            free[0][0] = 1
+            for m in range(1, L + 1):
+                for s in range(9 * m + 1):
+                    free[m][s] = sum(free[m - 1][s - d]
+                                     for d in range(10) if s - d >= 0)
+
+            cnt = [0] * (top + 1)
+            used = 0
+            for i, d in enumerate(digits):
+                rest = L - i - 1
+                for dd in range(d):
+                    for s in range(9 * rest + 1):
+                        if free[rest][s]:
+                            cnt[used + dd + s] += free[rest][s]
+                used += d
+            cnt[used] += 1          # n itself
+            return cnt
+
+        hi = counts_up_to(highLimit)
+        lo = counts_up_to(lowLimit - 1) if lowLimit > 0 else [0]
+        m = max(len(hi), len(lo))
+        hi += [0] * (m - len(hi))
+        lo += [0] * (m - len(lo))
+        # box 0 only ever holds the number 0, which is never a ball
+        return max(hi[s] - lo[s] for s in range(1, m))

--- a/leetcode_python/Array/maximum-number-of-groups-entering-a-competition.py
+++ b/leetcode_python/Array/maximum-number-of-groups-entering-a-competition.py
@@ -60,3 +60,58 @@ class Solution(object):
         while k * (k + 1) // 2 > n:
             k -= 1
         return k
+
+
+# V0-1
+# IDEA : BINARY SEARCH ON THE ANSWER
+#
+#   f(k) = k*(k+1)/2 (students needed for k groups of sizes 1..k) is strictly
+#   increasing, so "can k groups be built?" is monotone and a plain binary
+#   search over k in [0, n] finds the largest feasible k.
+#   this drops the float sqrt of V0 entirely, so there is no rounding to
+#   patch up afterwards.
+#
+# time = O(log n)
+# space = O(1)
+class Solution(object):
+    def maximumGroups(self, grades):
+        n = len(grades)
+        lo, hi = 0, n
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if mid * (mid + 1) // 2 <= n:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
+
+
+# V0-2
+# IDEA : CONSTRUCTIVE GREEDY SIMULATION (actually build the groups)
+#
+#   sort ascending and hand out consecutive blocks of size 1, 2, 3, ...
+#   after sorting, block t is element-wise <= block t+1 and is also shorter,
+#   so the sum condition holds automatically -- it is still checked here so
+#   the code doubles as the proof of V0's formula.
+#   slower than the closed form, but this version can hand back the witness
+#   grouping, not just its size.
+#
+# time = O(n log n)
+# space = O(n)
+class Solution(object):
+    def maximumGroups(self, grades):
+        arr = sorted(grades)
+        n = len(arr)
+        res = 0
+        prev_sum = 0
+        idx = 0
+        size = 1
+        while idx + size <= n:
+            cur = sum(arr[idx: idx + size])
+            if cur <= prev_sum:
+                break
+            res += 1
+            prev_sum = cur
+            idx += size
+            size += 1
+        return res

--- a/leetcode_python/Array/maximum-number-of-matching-indices-after-right-shifts.py
+++ b/leetcode_python/Array/maximum-number-of-matching-indices-after-right-shifts.py
@@ -70,3 +70,72 @@ class Solution(object):
             if c > best:
                 best = c
         return best
+
+
+# V0-1
+# IDEA : LET EVERY EQUAL-VALUE PAIR VOTE FOR THE SHIFT THAT ALIGNS IT
+#
+#   index i of nums1 lands on index (i + s) % n after s right shifts, so a
+#   pair (i, j) can only ever help the single shift s = (j - i) % n, and only
+#   when nums1[i] == nums2[j].
+#   so instead of scoring all n shifts, bucket nums2's indices by value and
+#   cast one vote per matching pair; the fullest bucket is the answer.
+#   with mostly distinct values this is near O(n); the quadratic blow-up only
+#   appears when one value repeats a lot.
+#
+# time = O(n + P), P = number of equal-value pairs (O(n^2) worst case)
+# space = O(n)
+from collections import defaultdict
+
+
+class Solution(object):
+    def maximumMatchingIndices(self, nums1, nums2):
+        n = len(nums1)
+        pos = defaultdict(list)
+        for j, v in enumerate(nums2):
+            pos[v].append(j)
+        votes = [0] * n
+        for i, v in enumerate(nums1):
+            for j in pos.get(v, ()):
+                votes[(j - i) % n] += 1
+        return max(votes)
+
+
+# V0-2
+# IDEA : SORT BOTH ARRAYS BY VALUE, THEN COUNT SHIFTS BLOCK BY BLOCK
+#
+#   same "each equal-value pair votes for one shift" observation as V0-1, but
+#   the value -> indices grouping is built by SORTING instead of hashing:
+#   sort (value, index) for both arrays, sweep them with two pointers, and for
+#   every block sharing a value cross-multiply the two index lists.
+#   no dictionary at all -- the version to use when hashing the values is
+#   expensive or when a flat, cache-friendly layout matters.
+#
+# time = O(n log n + P), P = number of equal-value pairs
+# space = O(n)
+class Solution(object):
+    def maximumMatchingIndices(self, nums1, nums2):
+        n = len(nums1)
+        a = sorted((v, i) for i, v in enumerate(nums1))
+        b = sorted((v, j) for j, v in enumerate(nums2))
+        votes = [0] * n
+        p = q = 0
+        while p < n and q < n:
+            if a[p][0] < b[q][0]:
+                p += 1
+            elif a[p][0] > b[q][0]:
+                q += 1
+            else:
+                v = a[p][0]
+                p2 = p
+                while p2 < n and a[p2][0] == v:
+                    p2 += 1
+                q2 = q
+                while q2 < n and b[q2][0] == v:
+                    q2 += 1
+                for x in range(p, p2):
+                    i = a[x][1]
+                    for y in range(q, q2):
+                        votes[(b[y][1] - i) % n] += 1
+                p, q = p2, q2
+        return max(votes)

--- a/leetcode_python/Array/maximum-number-of-operations-with-the-same-score-i.py
+++ b/leetcode_python/Array/maximum-number-of-operations-with-the-same-score-i.py
@@ -57,3 +57,46 @@ class Solution(object):
                 break
             res += 1
         return res
+
+
+# V0-1
+# IDEA : RECURSION ON THE REMAINING SUFFIX
+#
+#   the score is decided once, up front, by the first pair; after that the
+#   only state is "where does the array start now".
+#     count(i) = 0                      if fewer than 2 elements are left
+#              = 0                      if nums[i] + nums[i+1] != score
+#              = 1 + count(i + 2)       otherwise
+#
+# time = O(n)
+# space = O(n) recursion depth (n/2 frames)
+class Solution(object):
+    def maxOperations(self, nums):
+        score = nums[0] + nums[1]
+
+        def count(i):
+            if i + 1 >= len(nums) or nums[i] + nums[i + 1] != score:
+                return 0
+            return 1 + count(i + 2)
+
+        return count(0)
+
+
+# V0-2
+# IDEA : MATERIALISE THE PAIR SUMS, THEN MEASURE THE LEADING RUN (itertools)
+#
+#   zip(nums[::2], nums[1::2]) IS the sequence of operations, so the answer is
+#   the length of the first constant run of that sum sequence.
+#   itertools.groupby yields that run directly -- no index arithmetic and no
+#   early-exit branch, paid for by building the whole pair-sum list first.
+#
+# time = O(n)
+# space = O(n)
+from itertools import groupby
+
+
+class Solution(object):
+    def maxOperations(self, nums):
+        sums = [a + b for a, b in zip(nums[::2], nums[1::2])]
+        _, run = next(groupby(sums))
+        return len(list(run))

--- a/leetcode_python/Array/maximum-product-of-first-and-last-elements-of-a-subsequence.py
+++ b/leetcode_python/Array/maximum-product-of-first-and-last-elements-of-a-subsequence.py
@@ -72,3 +72,61 @@ class Solution(object):
             if c2 > ans:
                 ans = c2
         return ans
+
+
+# V0-1
+# IDEA : BRUTE FORCE OVER EVERY VALID (first, last) PAIR
+#
+#   a size-m subsequence with endpoints i and j exists exactly when
+#   j - i >= m - 1 (i == j is allowed when m == 1), so score every such pair
+#   directly and keep the best.
+#   quadratic is far too slow at n = 10^5, but it is the literal definition of
+#   the problem and therefore the reference oracle for the linear versions.
+#
+# time = O(n^2)
+# space = O(1)
+class Solution(object):
+    def maximumProduct(self, nums, m):
+        n = len(nums)
+        ans = float('-inf')
+        for i in range(n):
+            for j in range(i + m - 1, n):
+                p = nums[i] * nums[j]
+                if p > ans:
+                    ans = p
+        return ans
+
+
+# V0-2
+# IDEA : TWO PASSES WITH EXPLICIT PREFIX MAX / MIN TABLES
+#
+#   pass 1 tabulates pmax[i] / pmin[i] = max / min of nums[0..i].
+#   pass 2 then answers each right endpoint j in O(1) by reading index
+#   j - m + 1: the best partner is either the largest or the smallest value in
+#   the allowed prefix, since nums[j] may be negative.
+#   same maths as V0, but the prefix statistics are stored instead of streamed
+#   -- the shape to reach for when the table is needed again (other m values,
+#   or reconstructing which indices won).
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def maximumProduct(self, nums, m):
+        n = len(nums)
+        pmax = [0] * n
+        pmin = [0] * n
+        pmax[0] = pmin[0] = nums[0]
+        for i in range(1, n):
+            pmax[i] = pmax[i - 1] if pmax[i - 1] > nums[i] else nums[i]
+            pmin[i] = pmin[i - 1] if pmin[i - 1] < nums[i] else nums[i]
+        ans = float('-inf')
+        for j in range(m - 1, n):
+            i = j - m + 1
+            b = nums[j]
+            c = pmax[i] * b
+            if c > ans:
+                ans = c
+            c = pmin[i] * b
+            if c > ans:
+                ans = c
+        return ans

--- a/leetcode_python/Array/maximum-product-of-two-elements-in-an-array.py
+++ b/leetcode_python/Array/maximum-product-of-two-elements-in-an-array.py
@@ -50,3 +50,46 @@ class Solution(object):
             elif x > b:
                 b = x
         return (a - 1) * (b - 1)
+
+
+# V0-1
+# IDEA : SORT, THEN TAKE THE TWO LARGEST
+#
+#   no case analysis at all : after sorting ascending the two biggest values
+#   sit at the very end. slower than the single pass, but this is the shape to
+#   use when the k-th largest is also wanted, or when negatives are possible
+#   and both ends of the sorted array must be inspected.
+#
+# time = O(n log n)
+# space = O(n)
+class Solution(object):
+    def maxProduct(self, nums):
+        s = sorted(nums)
+        return (s[-1] - 1) * (s[-2] - 1)
+
+
+# V0-2
+# IDEA : COUNTING SORT OVER THE BOUNDED VALUE RANGE (1 <= nums[i] <= 1000)
+#
+#   the values are bounded, so tally them into buckets and walk the buckets
+#   downwards, taking two units of count (a duplicated value can supply both,
+#   since only the INDICES must differ).
+#   the scan length does not depend on n, so this is the win when nums is huge
+#   and the value range is tiny -- the usual counting-sort trade.
+#
+# time = O(n + M), M = 1001 buckets
+# space = O(M)
+class Solution(object):
+    def maxProduct(self, nums):
+        M = 1001
+        cnt = [0] * M
+        for x in nums:
+            cnt[x] += 1
+        picked = []
+        for v in range(M - 1, 0, -1):
+            while cnt[v] > 0 and len(picked) < 2:
+                picked.append(v)
+                cnt[v] -= 1
+            if len(picked) == 2:
+                break
+        return (picked[0] - 1) * (picked[1] - 1)

--- a/leetcode_python/Array/maximum-segment-sum-after-removals.py
+++ b/leetcode_python/Array/maximum-segment-sum-after-removals.py
@@ -90,3 +90,86 @@ class Solution(object):
                         total[ri] += total[rj]
             best = max(best, total[find(i)])
         return res
+
+
+# V0-1
+# IDEA : REVERSE TIME AGAIN, BUT MERGE VIA SEGMENT *BOUNDARIES* (no DSU)
+#
+#   when index i comes back, the segment on its left must END exactly at i - 1
+#   and the one on its right must START exactly at i + 1 -- precisely because
+#   i itself was missing. so keeping, at each endpoint, the opposite endpoint
+#   plus the segment sum is enough to merge in true O(1): no find(), no path
+#   compression, no alpha(n) factor, just list indexing.
+#
+# time = O(n)
+# space = O(n)
+class Solution(object):
+    def maximumSegmentSum(self, nums, removeQueries):
+        n = len(nums)
+        present = [False] * n
+        seg_l = [0] * n            # meaningful at a segment's RIGHT endpoint
+        seg_r = [0] * n            # meaningful at a segment's LEFT endpoint
+        seg_sum = [0] * n          # meaningful at a segment's LEFT endpoint
+        res = [0] * n
+        best = 0
+        for t in range(n - 1, -1, -1):
+            res[t] = best                  # state BEFORE this index returns
+            i = removeQueries[t]
+            l, r, s = i, i, nums[i]
+            if i > 0 and present[i - 1]:
+                l = seg_l[i - 1]
+                s += seg_sum[l]
+            if i + 1 < n and present[i + 1]:
+                r = seg_r[i + 1]
+                s += seg_sum[i + 1]
+            present[i] = True
+            seg_l[r] = l
+            seg_r[l] = r
+            seg_sum[l] = s
+            if s > best:
+                best = s
+        return res
+
+
+# V0-2
+# IDEA : FORWARD IN TIME -- SPLIT SEGMENTS, MAX-HEAP WITH LAZY DELETION
+#
+#   the honest forward simulation. removing i splits the segment [L, R] that
+#   contains it into [L, i-1] and [i+1, R]; a bisect over the sorted list of
+#   already-removed indices supplies L and R, and prefix sums give the two new
+#   sums in O(1).
+#
+#   a heap cannot erase the parent segment, so keep a set of live intervals and
+#   discard dead tops lazily when reading the maximum. every interval is pushed
+#   once and popped at most once.
+#
+# time = O(n log n) heap work, plus O(n) shifting per insert (O(n^2) worst case)
+# space = O(n)
+import bisect
+import heapq
+
+
+class Solution(object):
+    def maximumSegmentSum(self, nums, removeQueries):
+        n = len(nums)
+        pref = [0] * (n + 1)
+        for i, v in enumerate(nums):
+            pref[i + 1] = pref[i] + v
+
+        removed = [-1, n]                  # sentinels
+        alive = set([(0, n - 1)])
+        heap = [(-pref[n], 0, n - 1)]
+        res = [0] * n
+        for t, i in enumerate(removeQueries):
+            p = bisect.bisect_left(removed, i)
+            lo, hi = removed[p - 1] + 1, removed[p] - 1
+            alive.discard((lo, hi))
+            for a, b in ((lo, i - 1), (i + 1, hi)):
+                if a <= b:
+                    alive.add((a, b))
+                    heapq.heappush(heap, (-(pref[b + 1] - pref[a]), a, b))
+            removed.insert(p, i)
+            while heap and (heap[0][1], heap[0][2]) not in alive:
+                heapq.heappop(heap)
+            res[t] = -heap[0][0] if heap else 0
+        return res

--- a/leetcode_python/Array/maximum-sum-of-an-hourglass.py
+++ b/leetcode_python/Array/maximum-sum-of-an-hourglass.py
@@ -56,3 +56,71 @@ class Solution(object):
                          + sum(grid[i + 2][j:j + 3]))
                 res = max(res, total)
         return res
+
+
+# V0-1
+# IDEA : 2D PREFIX SUM — 3 x 3 BLOCK MINUS THE MIDDLE ROW'S SIDE CELLS
+#
+#   an hourglass anchored at (i, j) is the whole 3 x 3 block with two cells
+#   removed :
+#       hourglass = block(i, j) - grid[i + 1][j] - grid[i + 1][j + 2]
+#
+#   with a standard (m+1) x (n+1) prefix table any rectangle is 4 lookups, so
+#   the block costs O(1) no matter how big the shape gets — the same code
+#   generalises to a k x k window by changing one constant.
+#
+# time = O(m * n), space = O(m * n)
+class Solution(object):
+    def maxSum(self, grid):
+        m, n = len(grid), len(grid[0])
+        pre = [[0] * (n + 1) for _ in range(m + 1)]
+        for i in range(m):
+            for j in range(n):
+                pre[i + 1][j + 1] = (grid[i][j] + pre[i][j + 1]
+                                     + pre[i + 1][j] - pre[i][j])
+        res = 0
+        for i in range(m - 2):
+            for j in range(n - 2):
+                block = (pre[i + 3][j + 3] - pre[i][j + 3]
+                         - pre[i + 3][j] + pre[i][j])
+                cur = block - grid[i + 1][j] - grid[i + 1][j + 2]
+                if cur > res:
+                    res = cur
+        return res
+
+
+# V0-2
+# IDEA : ROLLING WIDTH-3 ROW WINDOWS, ONLY THREE ROWS HELD AT A TIME
+#
+#   the top and bottom bars are plain 3-cell row runs, so sweep each row once
+#   with a sliding window (add the entering cell, drop the leaving one) to get
+#       win[j] = grid[i][j] + grid[i][j + 1] + grid[i][j + 2]
+#   then an hourglass is win_top[j] + grid[mid][j + 1] + win_bottom[j].
+#
+#   nothing is ever re-summed and no full table is kept : only the window rows
+#   of the last three grid rows live at once, so the extra memory is O(n)
+#   instead of O(m * n).
+#
+# time = O(m * n), space = O(n)
+class Solution(object):
+    def maxSum(self, grid):
+        m, n = len(grid), len(grid[0])
+        res = 0
+        win = []                          # window sums of the last <= 3 rows
+        for i in range(m):
+            row = grid[i]
+            cur = row[0] + row[1] + row[2]
+            w = [cur]
+            for j in range(3, n):
+                cur += row[j] - row[j - 3]
+                w.append(cur)
+            win.append(w)
+            if len(win) > 3:
+                win.pop(0)
+            if len(win) == 3:
+                mid = grid[i - 1]         # rows i-2, i-1, i -> middle is i-1
+                for j in range(n - 2):
+                    total = win[0][j] + mid[j + 1] + win[2][j]
+                    if total > res:
+                        res = total
+        return res

--- a/leetcode_python/Array/maximum-sum-score-of-array.py
+++ b/leetcode_python/Array/maximum-sum-score-of-array.py
@@ -64,3 +64,50 @@ class Solution(object):
                 res = cur
             r -= x
         return res
+
+
+# V0-1
+# IDEA : PULL THE max APART — TWO INDEPENDENT RUNNING-SUM SCANS
+#
+#       answer = max_i max(prefix_i, suffix_i)
+#              = max( max_i prefix_i , max_i suffix_i )
+#
+#   the two families are independent, so no index pairing is needed at all :
+#   whichever running sum is the largest anywhere IS the answer. that reduces
+#   the problem to "biggest prefix sum" and "biggest suffix sum", and
+#   itertools.accumulate streams both of those lazily (no list is built).
+#
+# time = O(n), space = O(1)
+import itertools
+
+
+class Solution(object):
+    def maximumSumScore(self, nums):
+        return max(max(itertools.accumulate(nums)),
+                   max(itertools.accumulate(reversed(nums))))
+
+
+# V0-2
+# IDEA : BRUTE FORCE — RE-ADD BOTH SIDES AT EVERY SPLIT POINT
+#
+#   direct transcription of the definition : at index i sum nums[0..i] and
+#   nums[i..n-1] from scratch and score = max of the two. O(n^2) so it is
+#   only a reference implementation at n = 10^5, but it is the version to
+#   check the O(n) ones against.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def maximumSumScore(self, nums):
+        n = len(nums)
+        res = float('-inf')
+        for i in range(n):
+            left = 0
+            for j in range(i + 1):
+                left += nums[j]
+            right = 0
+            for j in range(i, n):
+                right += nums[j]
+            cur = left if left > right else right
+            if cur > res:
+                res = cur
+        return res

--- a/leetcode_python/Array/maximum-trailing-zeros-in-a-cornered-path.py
+++ b/leetcode_python/Array/maximum-trailing-zeros-in-a-cornered-path.py
@@ -108,3 +108,135 @@ class Solution(object):
                     for b2, b5 in ((up2, up5), (down2, down5)):
                         res = max(res, min(a2 + b2 - c2, a5 + b5 - c5))
         return res
+
+
+# V0-1
+# IDEA : BRUTE FORCE — WALK THE FOUR ARMS OUT OF EVERY CORNER, NO TABLES
+#
+#   KEY LEMMA : every cell contributes a NON-NEGATIVE number of 2s and 5s, so
+#   lengthening an arm can never lower either exponent total, hence never
+#   lower min(#2, #5). the best arm in a direction is therefore always the
+#   FULL arm, all the way to the border — the path length never has to be
+#   searched, only the four (horizontal, vertical) direction pairs.
+#
+#   this version leans on that lemma alone : for each cell it re-walks the row
+#   and the column, counting factors on the fly. no prefix tables and no
+#   exponent grids at all, so memory is O(1) and the cost becomes
+#   O(m * n * (m + n)).
+#
+# time = O(m * n * (m + n)), space = O(1)
+class Solution(object):
+    def maxTrailingZeros(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        def count(x, p):
+            c = 0
+            while x % p == 0:
+                x //= p
+                c += 1
+            return c
+
+        res = 0
+        for i in range(m):
+            for j in range(n):
+                c2, c5 = count(grid[i][j], 2), count(grid[i][j], 5)
+
+                arms = []
+                # horizontal arms : towards column 0, and towards column n-1
+                for step in (-1, 1):
+                    a2 = a5 = 0
+                    y = j
+                    while 0 <= y < n:
+                        a2 += count(grid[i][y], 2)
+                        a5 += count(grid[i][y], 5)
+                        y += step
+                    arms.append((a2, a5))
+                # vertical arms : towards row 0, and towards row m-1
+                verts = []
+                for step in (-1, 1):
+                    b2 = b5 = 0
+                    x = i
+                    while 0 <= x < m:
+                        b2 += count(grid[x][j], 2)
+                        b5 += count(grid[x][j], 5)
+                        x += step
+                    verts.append((b2, b5))
+
+                for a2, a5 in arms:
+                    for b2, b5 in verts:
+                        # the corner is inside both arms -> remove it once
+                        cur = min(a2 + b2 - c2, a5 + b5 - c5)
+                        if cur > res:
+                            res = cur
+        return res
+
+
+# V0-2
+# IDEA : ROW / COLUMN TOTALS + RUNNING "LEFT" AND "UP" — O(n) EXTRA MEMORY
+#
+#   V0 stores four m x n prefix tables. they are not needed : an arm total is
+#   always either a running sum or its complement inside the line's total,
+#       right = rowTotal - left + cell
+#       down  = colTotal - up   + cell
+#   (+ cell because both "left" and "right" include the corner).
+#
+#   so a single top-to-bottom sweep suffices, carrying
+#       up2[j], up5[j]  — column running sums, one entry per column
+#   plus a per-row scalar for `left`. the column totals are the only thing
+#   that has to be gathered in advance, again O(n) numbers.
+#
+#   this matters here because the constraints allow m * n <= 10^5 with n up to
+#   10^5, i.e. a very wide or very tall grid — the table version allocates
+#   4 * m * n ints, this one 4 * n.
+#
+# time = O(m * n), space = O(n)
+class Solution(object):
+    def maxTrailingZeros(self, grid):
+        m, n = len(grid), len(grid[0])
+
+        def count(x, p):
+            c = 0
+            while x % p == 0:
+                x //= p
+                c += 1
+            return c
+
+        # exponent totals per column (over all rows)
+        col2 = [0] * n
+        col5 = [0] * n
+        for i in range(m):
+            row = grid[i]
+            for j in range(n):
+                col2[j] += count(row[j], 2)
+                col5[j] += count(row[j], 5)
+
+        up2 = [0] * n           # rows 0..i-1 of column j, grows as we sweep
+        up5 = [0] * n
+        res = 0
+        for i in range(m):
+            row = grid[i]
+            e2 = [count(v, 2) for v in row]
+            e5 = [count(v, 5) for v in row]
+            row2, row5 = sum(e2), sum(e5)
+
+            left2 = left5 = 0
+            for j in range(n):
+                left2 += e2[j]                     # columns 0..j
+                left5 += e5[j]
+                right2 = row2 - left2 + e2[j]      # columns j..n-1
+                right5 = row5 - left5 + e5[j]
+
+                u2 = up2[j] + e2[j]                # rows 0..i
+                u5 = up5[j] + e5[j]
+                d2 = col2[j] - up2[j]              # rows i..m-1
+                d5 = col5[j] - up5[j]
+
+                for a2, a5 in ((left2, left5), (right2, right5)):
+                    for b2, b5 in ((u2, u5), (d2, d5)):
+                        cur = min(a2 + b2 - e2[j], a5 + b5 - e5[j])
+                        if cur > res:
+                            res = cur
+
+                up2[j] += e2[j]
+                up5[j] += e5[j]
+        return res

--- a/leetcode_python/Array/maximum-value-of-an-ordered-triplet-i.py
+++ b/leetcode_python/Array/maximum-value-of-an-ordered-triplet-i.py
@@ -69,3 +69,57 @@ class Solution(object):
             mx_diff = max(mx_diff, mx - x)
             mx = max(mx, x)
         return ans
+
+
+# V0-1
+# IDEA : BRUTE FORCE — TRY EVERY (i, j, k)
+#
+#   n <= 100, so the 161700 triples of the worst case are free. this is the
+#   definition typed out, and the version the O(n) tricks get checked against.
+#
+# time = O(n^3), space = O(1)
+class Solution(object):
+    def maximumTripletValue(self, nums):
+        n = len(nums)
+        ans = 0
+        for i in range(n):
+            for j in range(i + 1, n):
+                for k in range(j + 1, n):
+                    cur = (nums[i] - nums[j]) * nums[k]
+                    if cur > ans:
+                        ans = cur
+        return ans
+
+
+# V0-2
+# IDEA : FIX THE MIDDLE INDEX — PREFIX MAX ON THE LEFT, SUFFIX MAX ON THE RIGHT
+#
+#   for a fixed j the value (nums[i] - nums[j]) * nums[k] is maximised by
+#   taking the largest nums[i] to its left and the largest nums[k] to its
+#   right, independently — nums[k] >= 1 so a bigger nums[k] never hurts once
+#   the difference is positive, and a negative difference is discarded by the
+#   0 clamp anyway.
+#
+#   so precompute
+#       pmax[j] = max(nums[0..j-1])
+#       smax[j] = max(nums[j+1..n-1])
+#   and scan j once. tabulating both directions instead of folding them into
+#   the same pass makes the "left / middle / right" decomposition explicit.
+#
+# time = O(n), space = O(n)
+class Solution(object):
+    def maximumTripletValue(self, nums):
+        n = len(nums)
+        pmax = [0] * n            # max strictly to the left of j
+        for j in range(1, n):
+            pmax[j] = max(pmax[j - 1], nums[j - 1])
+        smax = [0] * n            # max strictly to the right of j
+        for j in range(n - 2, -1, -1):
+            smax[j] = max(smax[j + 1], nums[j + 1])
+
+        ans = 0
+        for j in range(1, n - 1):
+            cur = (pmax[j] - nums[j]) * smax[j]
+            if cur > ans:
+                ans = cur
+        return ans

--- a/leetcode_python/Array/maximum-value-sum-by-placing-three-rooks-i.py
+++ b/leetcode_python/Array/maximum-value-sum-by-placing-three-rooks-i.py
@@ -81,3 +81,131 @@ class Solution(object):
                         if total > res:
                             res = total
         return res
+
+
+# V0-1
+# IDEA : ROW SWEEP CARRYING "BEST k ROOKS THAT AVOID COLUMN c"
+#
+#   walk the rows once and carry two things about the rows already seen :
+#       best1  — the 3 best single cells with PAIRWISE DISTINCT columns
+#       best2[c] — the best 2-rook sum that uses no cell in column c
+#
+#   with those, the row currently being visited can act as the last rook :
+#   picking cell (i, c) gives best2[c] + board[i][c], and only that row's top
+#   three cells are ever worth trying (at most two columns are blocked).
+#
+#   why 3 candidates is provably enough for best1 : the two other rooks block
+#   two columns, and three kept cells have three different columns, so at
+#   least one survives — and it is at least as good as anything dropped
+#   (dropped cells were either smaller than all three, or shared a column with
+#   a larger kept cell).
+#
+#   this needs no combinations over row triples at all, so it stays linear in
+#   the number of board cells and is what LC 3257 (m, n <= 500) requires.
+#
+# time = O(m * n * log n), space = O(n)
+class Solution(object):
+    def maximumValueSum(self, board):
+        m, n = len(board), len(board[0])
+        NEG = float('-inf')
+
+        def keep3(entries):
+            """3 best (value, col), columns pairwise distinct, value-desc"""
+            best = []
+            for v, c in sorted(entries, reverse=True):
+                if any(c == oc for _, oc in best):
+                    continue
+                best.append((v, c))
+                if len(best) == 3:
+                    break
+            return best
+
+        rows = [sorted(((board[i][j], j) for j in range(n)),
+                       reverse=True)[:3] for i in range(m)]
+
+        best1 = []
+        best2 = [NEG] * n
+        res = NEG
+        for i in range(m):
+            cur = rows[i]
+
+            # this row carries the third rook
+            for v, c in cur:
+                if best2[c] > NEG and best2[c] + v > res:
+                    res = best2[c] + v
+
+            # extend best2 to "rows 0..i" : one rook here + one from best1
+            if best1:
+                for c in range(n):
+                    top = best2[c]
+                    for v2, c2 in cur:
+                        if c2 == c:
+                            continue
+                        for v1, c1 in best1:
+                            if c1 == c or c1 == c2:
+                                continue
+                            if v1 + v2 > top:
+                                top = v1 + v2
+                            break          # best1 is value-desc
+                    best2[c] = top
+
+            best1 = keep3(best1 + cur)
+        return res
+
+
+# V0-2
+# IDEA : FIX THE MIDDLE ROW, BEST CELL ABOVE + BEST CELL BELOW
+#
+#   order the three rooks by row and sweep the MIDDLE one. what is needed from
+#   the outer two is just the best single cell in the rows above and the best
+#   single cell in the rows below, each dodging the columns already taken —
+#   again at most two columns, so top-3-with-distinct-columns prefixes and
+#   suffixes are enough.
+#
+#       pre[i] = top-3 distinct-column cells over rows 0..i
+#       suf[i] = top-3 distinct-column cells over rows i..m-1
+#
+#   compared with V0's C(m, 3) enumeration this drops the cubic term entirely,
+#   at the price of two auxiliary arrays of triples.
+#
+# time = O(m * n * log n), space = O(m)
+class Solution(object):
+    def maximumValueSum(self, board):
+        m, n = len(board), len(board[0])
+
+        def keep3(entries):
+            best = []
+            for v, c in sorted(entries, reverse=True):
+                if any(c == oc for _, oc in best):
+                    continue
+                best.append((v, c))
+                if len(best) == 3:
+                    break
+            return best
+
+        rows = [keep3([(board[i][j], j) for j in range(n)]) for i in range(m)]
+
+        pre = [None] * m
+        acc = []
+        for i in range(m):
+            acc = keep3(acc + rows[i])
+            pre[i] = acc
+
+        suf = [None] * m
+        acc = []
+        for i in range(m - 1, -1, -1):
+            acc = keep3(acc + rows[i])
+            suf[i] = acc
+
+        res = float('-inf')
+        for mid in range(1, m - 1):
+            for v2, c2 in rows[mid]:
+                for v1, c1 in pre[mid - 1]:
+                    if c1 == c2:
+                        continue
+                    for v3, c3 in suf[mid + 1]:
+                        if c3 == c1 or c3 == c2:
+                            continue
+                        if v1 + v2 + v3 > res:
+                            res = v1 + v2 + v3
+        return res

--- a/leetcode_python/Array/maximum-value-sum-by-placing-three-rooks-ii.py
+++ b/leetcode_python/Array/maximum-value-sum-by-placing-three-rooks-ii.py
@@ -103,3 +103,104 @@ class Solution(object):
                         if total > res:
                             res = total
         return res
+
+
+# V0-1
+# IDEA : ROW SWEEP CARRYING "BEST k ROOKS THAT AVOID COLUMN c"
+#
+#   same top-3 insight as V0 but organised as a single left-to-right (here
+#   top-to-bottom) DP instead of prefix + suffix tables. carried state :
+#       best1     — 3 best single cells over the rows already seen, columns
+#                   pairwise distinct
+#       best2[c]  — best 2-rook sum over the rows already seen that touches no
+#                   cell in column c
+#
+#   at row i : the row can hold the LAST rook, worth best2[c] + board[i][c]
+#   for one of its top three cells; then best2 is pushed forward with
+#   "one rook in row i + one from best1", and best1 absorbs row i.
+#
+#   only ONE pass and O(n) carried numbers — no suffix array, so it also works
+#   streaming the board row by row.
+#
+# time = O(m * n * log n), space = O(n)
+class Solution(object):
+    def maximumValueSum(self, board):
+        m, n = len(board), len(board[0])
+        NEG = float('-inf')
+
+        def keep3(entries):
+            """3 best (value, col), columns pairwise distinct, value-desc"""
+            best = []
+            for v, c in sorted(entries, reverse=True):
+                if any(c == oc for _, oc in best):
+                    continue
+                best.append((v, c))
+                if len(best) == 3:
+                    break
+            return best
+
+        rows = [sorted(((board[i][j], j) for j in range(n)),
+                       reverse=True)[:3] for i in range(m)]
+
+        best1 = []
+        best2 = [NEG] * n
+        res = NEG
+        for i in range(m):
+            cur = rows[i]
+
+            for v, c in cur:
+                if best2[c] > NEG and best2[c] + v > res:
+                    res = best2[c] + v
+
+            if best1:
+                for c in range(n):
+                    top = best2[c]
+                    for v2, c2 in cur:
+                        if c2 == c:
+                            continue
+                        for v1, c1 in best1:
+                            if c1 == c or c1 == c2:
+                                continue
+                            if v1 + v2 > top:
+                                top = v1 + v2
+                            break          # best1 is value-desc
+                    best2[c] = top
+
+            best1 = keep3(best1 + cur)
+        return res
+
+
+# V0-2
+# IDEA : ENUMERATE THE ROW TRIPLE DIRECTLY OVER EACH ROW'S TOP THREE CELLS
+#
+#   the reference / baseline version (and the intended solution of LC 3256,
+#   where m <= 100) : keep each row's three largest cells, then try every
+#   C(m, 3) choice of rows against the 27 cell combinations, skipping any that
+#   repeats a column.
+#
+#   correct here too, but O(m^3) means ~2 * 10^7 row triples at m = 500, so it
+#   is the one to check V0 / V0-1 against on small boards rather than to
+#   submit at this problem's limits.
+#
+# time = O(m * n * log n + m^3), space = O(m)
+import itertools
+
+
+class Solution(object):
+    def maximumValueSum(self, board):
+        m, n = len(board), len(board[0])
+        top = [sorted(((board[i][j], j) for j in range(n)),
+                      reverse=True)[:3] for i in range(m)]
+
+        res = float('-inf')
+        for r1, r2, r3 in itertools.combinations(range(m), 3):
+            for v1, c1 in top[r1]:
+                for v2, c2 in top[r2]:
+                    if c2 == c1:
+                        continue
+                    for v3, c3 in top[r3]:
+                        if c3 == c1 or c3 == c2:
+                            continue
+                        if v1 + v2 + v3 > res:
+                            res = v1 + v2 + v3
+        return res

--- a/leetcode_python/Array/maximum-white-tiles-covered-by-a-carpet.py
+++ b/leetcode_python/Array/maximum-white-tiles-covered-by-a-carpet.py
@@ -72,3 +72,68 @@ class Solution(object):
                 res = cur
             covered -= ri - li + 1
         return res
+
+
+# V0-1
+# IDEA : SORT + PREFIX SUM + BINARY SEARCH FOR THE LAST TOUCHED INTERVAL
+#
+#   same exchange argument (only starts at tiles[i][0] matter), but instead of
+#   maintaining the window incrementally, precompute pre[] = prefix sums of
+#   interval lengths and BINARY SEARCH the last interval whose LEFT end still
+#   falls inside the carpet [li, li + carpetLen - 1].
+#
+#   every interval from i up to that index j is (at least partly) touched, so
+#   the covered amount is pre[j+1] - pre[i] minus the part of interval j that
+#   hangs over the carpet's right edge.
+#
+#   this trades the two-pointer bookkeeping for a log factor per start, and it
+#   is easier to reason about because each start is computed independently.
+#
+# time = O(n log n), space = O(n) for the prefix sums
+from bisect import bisect_right
+class Solution(object):
+    def maximumWhiteTiles(self, tiles, carpetLen):
+        tiles.sort()
+        n = len(tiles)
+        lefts = [t[0] for t in tiles]
+        pre = [0] * (n + 1)
+        for i in range(n):
+            pre[i + 1] = pre[i] + tiles[i][1] - tiles[i][0] + 1
+        res = 0
+        for i in range(n):
+            end = tiles[i][0] + carpetLen - 1
+            # last interval that starts at or before the carpet's right edge
+            j = bisect_right(lefts, end) - 1
+            covered = pre[j + 1] - pre[i]
+            if tiles[j][1] > end:
+                covered -= tiles[j][1] - end
+            if covered > res:
+                res = covered
+        return res
+
+
+# V0-2
+# IDEA : BRUTE FORCE — TRY EVERY CANDIDATE START, RESCAN ALL INTERVALS
+#
+#   the plain version of the same exchange argument: for each candidate start
+#   li = tiles[i][0], walk the whole list and add the overlap of every interval
+#   with [li, li + carpetLen - 1], i.e. max(0, min(ri, end) - max(li_k, start) + 1).
+#
+#   needs no sorting and no prefix sums at all, which makes it a useful
+#   correctness reference for the O(n log n) versions above.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def maximumWhiteTiles(self, tiles, carpetLen):
+        res = 0
+        for start, _ in tiles:
+            end = start + carpetLen - 1
+            cur = 0
+            for a, b in tiles:
+                lo = a if a > start else start
+                hi = b if b < end else end
+                if hi >= lo:
+                    cur += hi - lo + 1
+            if cur > res:
+                res = cur
+        return res

--- a/leetcode_python/Array/mean-of-array-after-removing-some-elements.py
+++ b/leetcode_python/Array/mean-of-array-after-removing-some-elements.py
@@ -48,3 +48,64 @@ class Solution(object):
         cut = n // 20
         kept = sorted(arr)[cut:n - cut]
         return float(sum(kept)) / len(kept)
+
+
+# V0-1
+# IDEA : HEAP — PULL OUT THE TWO 5% TAILS WITHOUT A FULL SORT
+#
+#   we never need the whole order, only the sum of the cut = n // 20 smallest
+#   and the cut largest elements. heapq.nsmallest / nlargest do that with a
+#   size-cut heap, so subtract both tail sums from the total.
+#
+#   NOTE : this is multiset-correct with duplicates — nsmallest(cut) returns
+#          cut *elements*, not cut distinct values.
+#
+# time = O(n log cut), space = O(cut)
+import heapq
+class Solution(object):
+    def trimMean(self, arr):
+        n = len(arr)
+        cut = n // 20
+        total = sum(arr) - sum(heapq.nsmallest(cut, arr))
+        total -= sum(heapq.nlargest(cut, arr))
+        return float(total) / (n - 2 * cut)
+
+
+# V0-2
+# IDEA : COUNTING SORT OVER THE VALUE RANGE (0 .. 10^5)
+#
+#   values are bounded, so bucket them and walk the buckets in ascending value
+#   order: first skip `cut` elements (the low 5%), then take the next
+#   n - 2*cut elements and accumulate value * multiplicity. whatever is left
+#   at the top is the high 5% and never gets read.
+#
+#   comparison-free — linear in n once the bucket array is allocated.
+#
+# time = O(n + V), V = 10^5 + 1 buckets
+# space = O(V)
+class Solution(object):
+    def trimMean(self, arr):
+        n = len(arr)
+        cut = n // 20
+        kept = n - 2 * cut
+        cnt = [0] * 100001
+        for v in arr:
+            cnt[v] += 1
+        total = 0
+        skip = cut
+        take = kept
+        for v in range(100001):
+            c = cnt[v]
+            if not c:
+                continue
+            if skip:
+                drop = c if c < skip else skip
+                c -= drop
+                skip -= drop
+            if c and take:
+                use = c if c < take else take
+                total += v * use
+                take -= use
+                if not take:
+                    break
+        return float(total) / kept

--- a/leetcode_python/Array/min-max-game.py
+++ b/leetcode_python/Array/min-max-game.py
@@ -61,3 +61,57 @@ class Solution(object):
                 nxt[i] = min(a, b) if i % 2 == 0 else max(a, b)
             nums = nxt
         return nums[0]
+
+
+# V0-1
+# IDEA : DIVIDE AND CONQUER ON THE ORIGINAL ARRAY (NO NEW ARRAYS)
+#
+#   the slot at index i of the round whose blocks have size 2^r is built from
+#   exactly the contiguous original block [i * 2^r, (i+1) * 2^r), and it merges
+#   the two half-blocks that sit at indices 2i and 2i+1 of the previous round.
+#
+#   so recurse on (lo, size, idx) : split the block in half, solve the halves
+#   as indices 2*idx and 2*idx+1, then combine with min when idx is even and
+#   max when idx is odd. the answer is the block (0, n, 0).
+#
+#   reads the input in place — no per-round allocation, only the call stack.
+#
+# time = O(n), space = O(log n) recursion depth
+class Solution(object):
+    def minMaxGame(self, nums):
+        def rec(lo, size, idx):
+            if size == 1:
+                return nums[lo]
+            half = size // 2
+            a = rec(lo, half, 2 * idx)
+            b = rec(lo + half, half, 2 * idx + 1)
+            return min(a, b) if idx % 2 == 0 else max(a, b)
+
+        return rec(0, len(nums), 0)
+
+
+# V0-2
+# IDEA : STACK MERGE, BINARY-COUNTER STYLE (SINGLE PASS, NO ROUNDS)
+#
+#   push elements one at a time as (value, level, index-at-that-level). whenever
+#   the top two entries share a level they are the two children of the same
+#   parent, so collapse them immediately: the parent index is a.index // 2 and
+#   the operator is min for an even parent index, max for an odd one.
+#
+#   this is the "carry" of a binary counter — the stack never holds two entries
+#   of the same level after the loop, so it holds O(log n) entries and the whole
+#   pass finishes the tournament without ever materialising a round.
+#
+# time = O(n), space = O(log n)
+class Solution(object):
+    def minMaxGame(self, nums):
+        stack = []
+        for i, v in enumerate(nums):
+            stack.append((v, 0, i))
+            while len(stack) >= 2 and stack[-1][1] == stack[-2][1]:
+                bv = stack.pop()[0]
+                av, alvl, aidx = stack.pop()
+                idx = aidx // 2
+                val = min(av, bv) if idx % 2 == 0 else max(av, bv)
+                stack.append((val, alvl + 1, idx))
+        return stack[0][0]

--- a/leetcode_python/Array/minimize-maximum-component-cost.py
+++ b/leetcode_python/Array/minimize-maximum-component-cost.py
@@ -89,3 +89,102 @@ class Solution(object):
                 if cnt <= k:
                     return w
         return 0
+
+
+# V0-1
+# IDEA : BINARY SEARCH THE BUDGET + DFS COMPONENT COUNT (NO UNION-FIND)
+#
+#   spell out the monotone predicate that V0 short-circuits: for a budget w,
+#   keep every edge of weight <= w and count the connected components. that
+#   count only shrinks as w grows, so binary search the sorted distinct weights
+#   for the smallest w whose count is <= k.
+#
+#   the feasibility test here is a plain iterative DFS over a pre-built
+#   adjacency list, skipping any edge heavier than the budget — no DSU at all,
+#   which makes the "keep everything within budget" reading explicit.
+#
+# time = O(m log m + (n + m) log m), space = O(n + m)
+class Solution(object):
+    def minCost(self, n, edges, k):
+        if k >= n:
+            return 0
+
+        adj = [[] for _ in range(n)]
+        for u, v, w in edges:
+            adj[u].append((v, w))
+            adj[v].append((u, w))
+
+        def components(limit):
+            seen = [False] * n
+            cnt = 0
+            for s in range(n):
+                if seen[s]:
+                    continue
+                cnt += 1
+                if cnt > k:
+                    return cnt          # already too fragmented
+                seen[s] = True
+                stack = [s]
+                while stack:
+                    x = stack.pop()
+                    for y, w in adj[x]:
+                        if w <= limit and not seen[y]:
+                            seen[y] = True
+                            stack.append(y)
+            return cnt
+
+        ws = sorted(set(w for _, _, w in edges))
+        lo, hi = 0, len(ws) - 1
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if components(ws[mid]) <= k:
+                hi = mid
+            else:
+                lo = mid + 1
+        return ws[lo]
+
+
+# V0-2
+# IDEA : PRIM'S MST + PICK ITS (n - k)-TH SMALLEST EDGE
+#
+#   kruskal performs exactly n - 1 merges on a connected graph, in ascending
+#   weight order, and those merging edges are an MST. after t merges the
+#   component count is n - t, so reaching <= k components needs t >= n - k
+#   merges — which means the answer is simply the (n - k)-th smallest edge of
+#   ANY minimum spanning tree.
+#
+#   so the sort-and-union sweep can be replaced by building the MST any way we
+#   like: grow it with Prim's heap from node 0, collect the n - 1 chosen
+#   weights, sort them and read index n - k - 1.
+#
+#   k >= 1 and k < n here, so that index is always inside [0, n - 2].
+#
+# time = O(m log m), space = O(n + m)
+import heapq
+class Solution(object):
+    def minCost(self, n, edges, k):
+        if k >= n:
+            return 0
+
+        adj = [[] for _ in range(n)]
+        for u, v, w in edges:
+            adj[u].append((w, v))
+            adj[v].append((w, u))
+
+        seen = [False] * n
+        seen[0] = True
+        heap = list(adj[0])
+        heapq.heapify(heap)
+        mst = []
+        while heap:
+            w, x = heapq.heappop(heap)
+            if seen[x]:
+                continue
+            seen[x] = True
+            mst.append(w)
+            for nw, y in adj[x]:
+                if not seen[y]:
+                    heapq.heappush(heap, (nw, y))
+
+        mst.sort()
+        return mst[n - k - 1]

--- a/leetcode_python/Array/minimum-absolute-difference-in-sliding-submatrix.py
+++ b/leetcode_python/Array/minimum-absolute-difference-in-sliding-submatrix.py
@@ -83,3 +83,100 @@ class Solution(object):
                 best = min(sv[t + 1] - sv[t] for t in range(len(sv) - 1))
                 ans[i][j] = best
         return ans
+
+
+# V0-1
+# IDEA : COORDINATE COMPRESSION + BUCKET COUNTS SLID ACROSS THE COLUMNS
+#
+#   at most m * n <= 900 distinct values exist in the whole grid, so compress
+#   them once to 0 .. D-1. then, for a fixed band of k rows, slide the window
+#   one column at a time: drop the k cells of the leaving column and add the k
+#   cells of the entering column in the count array.
+#
+#   with counts in hand the answer needs no sort — scanning t = 0 .. D-1 walks
+#   the present values in ascending order, and the smallest gap between two
+#   consecutive present values is the answer (0 when fewer than two are
+#   present).
+#
+# time = O(m * n * k + m * n * D), space = O(m * n + D)
+class Solution(object):
+    def minAbsDiff(self, grid, k):
+        m, n = len(grid), len(grid[0])
+        vals = sorted(set(v for row in grid for v in row))
+        pos = {v: i for i, v in enumerate(vals)}
+        D = len(vals)
+        code = [[pos[v] for v in row] for row in grid]
+
+        ans = [[0] * (n - k + 1) for _ in range(m - k + 1)]
+        for i in range(m - k + 1):
+            cnt = [0] * D
+            for r in range(i, i + k):
+                for c in range(k):
+                    cnt[code[r][c]] += 1
+            for j in range(n - k + 1):
+                if j:
+                    for r in range(i, i + k):
+                        cnt[code[r][j - 1]] -= 1
+                        cnt[code[r][j + k - 1]] += 1
+                best = 0
+                prev = -1
+                for t in range(D):
+                    if cnt[t]:
+                        if prev != -1:
+                            gap = vals[t] - vals[prev]
+                            if best == 0 or gap < best:
+                                best = gap
+                        prev = t
+                ans[i][j] = best
+        return ans
+
+
+# V0-2
+# IDEA : BITSET UNION OF ROW SEGMENTS + LOWEST-SET-BIT WALK
+#
+#   after compression the "set of values in a window" is just a bitmask, and a
+#   k x k window is the OR of the k row segments grid[r][j : j+k]. precompute
+#   every row segment mask once, then each window costs k big-int ORs.
+#
+#   extracting the sorted present values from a mask is the classic
+#   mask & -mask trick : the lowest set bit is always the next value up, so one
+#   walk over the set bits yields the consecutive pairs whose gap we minimise.
+#
+#   NOTE : OR cannot un-set a bit, so masks are built per (row, start) rather
+#          than slid — which is why the row-segment precompute is O(m * n * k).
+#
+# time = O(m * n * k + m * n * (k + D / 64)), space = O(m * n)
+class Solution(object):
+    def minAbsDiff(self, grid, k):
+        m, n = len(grid), len(grid[0])
+        vals = sorted(set(v for row in grid for v in row))
+        pos = {v: i for i, v in enumerate(vals)}
+
+        rowmask = [[0] * (n - k + 1) for _ in range(m)]
+        for r in range(m):
+            bits = [1 << pos[v] for v in grid[r]]
+            for j in range(n - k + 1):
+                mask = 0
+                for c in range(j, j + k):
+                    mask |= bits[c]
+                rowmask[r][j] = mask
+
+        ans = [[0] * (n - k + 1) for _ in range(m - k + 1)]
+        for i in range(m - k + 1):
+            for j in range(n - k + 1):
+                mask = 0
+                for r in range(i, i + k):
+                    mask |= rowmask[r][j]
+                best = 0
+                prev = -1
+                while mask:
+                    low = mask & -mask
+                    t = low.bit_length() - 1
+                    if prev != -1:
+                        gap = vals[t] - vals[prev]
+                        if best == 0 or gap < best:
+                            best = gap
+                    prev = t
+                    mask ^= low
+                ans[i][j] = best
+        return ans

--- a/leetcode_python/Array/minimum-absolute-difference-queries.py
+++ b/leetcode_python/Array/minimum-absolute-difference-queries.py
@@ -89,3 +89,94 @@ class Solution(object):
             res.append(-1 if best == float('inf') else best)
 
         return res
+
+
+# V0-1
+# IDEA : OFFLINE SWEEP BY RIGHT ENDPOINT + LAST-OCCURRENCE TABLE
+#
+#   answer the queries out of order: sort them by r and move a pointer through
+#   nums, recording last[v] = the most recent index where value v was seen.
+#
+#   once the pointer has consumed nums[0..r], value v is present in nums[l..r]
+#   exactly when last[v] >= l — a single comparison, no binary search. then the
+#   usual scan over v = 1..100 takes the smallest gap between consecutive
+#   present values.
+#
+#   NOTE : each index is consumed once across the whole sweep, so the table
+#          maintenance is O(n) total, not O(n) per query.
+#
+# time = O(n + q log q + q * V), V = 100 values
+# space = O(q + V)
+class Solution(object):
+    def minDifference(self, nums, queries):
+        order = sorted(range(len(queries)), key=lambda i: queries[i][1])
+        last = [-1] * 101
+        res = [0] * len(queries)
+        p = 0
+        for qi in order:
+            l, r = queries[qi]
+            while p <= r:
+                last[nums[p]] = p
+                p += 1
+            best = -1
+            prev = -1
+            for v in range(1, 101):
+                if last[v] >= l:
+                    if prev != -1 and (best == -1 or v - prev < best):
+                        best = v - prev
+                    prev = v
+            res[qi] = best
+        return res
+
+
+# V0-2
+# IDEA : SQRT BLOCK DECOMPOSITION WITH 101-BIT PRESENCE MASKS
+#
+#   because values fit in 1..100, the whole "which values occur here" set is a
+#   single 101-bit integer. precompute one mask per block of B consecutive
+#   indices; a query then ORs the masks of the fully covered blocks and ORs the
+#   individual bits of the two partial ends — O(n / B + B) work per query.
+#
+#   with the union mask built, walk its set bits low to high (mask & -mask) to
+#   visit the present values in ascending order and take the smallest gap; an
+#   empty gap list means one distinct value only, i.e. -1.
+#
+#   no per-value position lists and no binary search — the value range itself
+#   is the index.
+#
+# time = O(n + q * (B + n / B)), space = O(n / B)
+class Solution(object):
+    def minDifference(self, nums, queries):
+        n = len(nums)
+        B = 512
+        nb = (n + B - 1) // B
+        bmask = [0] * nb
+        for i in range(n):
+            bmask[i // B] |= 1 << nums[i]
+
+        res = []
+        for l, r in queries:
+            bl, br = l // B, r // B
+            mask = 0
+            if bl == br:
+                for i in range(l, r + 1):
+                    mask |= 1 << nums[i]
+            else:
+                for i in range(l, (bl + 1) * B):
+                    mask |= 1 << nums[i]
+                for b in range(bl + 1, br):
+                    mask |= bmask[b]
+                for i in range(br * B, r + 1):
+                    mask |= 1 << nums[i]
+
+            best = -1
+            prev = -1
+            while mask:
+                low = mask & -mask
+                v = low.bit_length() - 1
+                if prev != -1 and (best == -1 or v - prev < best):
+                    best = v - prev
+                prev = v
+                mask ^= low
+            res.append(best)
+        return res

--- a/leetcode_python/Array/minimum-absolute-difference.py
+++ b/leetcode_python/Array/minimum-absolute-difference.py
@@ -65,3 +65,66 @@ class Solution(object):
                 res.append([arr[i], arr[i + 1]])
 
         return res
+
+
+# V0-1
+# IDEA : COUNTING SORT OVER THE VALUE RANGE (NO COMPARISON SORT)
+#
+#   values are bounded by |arr[i]| <= 10^6, so mark every value present in a
+#   boolean bucket array and then walk the value axis upward. the previous
+#   marked value is exactly the sorted predecessor, which gives the adjacent
+#   gaps without ever comparing two elements.
+#
+#   two sweeps over the same buckets : one for the min gap, one to collect.
+#
+# time = O(n + R), R = max(arr) - min(arr)
+# space = O(R)
+class Solution(object):
+    def minimumAbsDifference(self, arr):
+        lo, hi = min(arr), max(arr)
+        seen = [False] * (hi - lo + 1)
+        for x in arr:
+            seen[x - lo] = True
+
+        # sweep 1 : smallest gap between consecutive marked values
+        mn = float('inf')
+        prev = None
+        for i in range(hi - lo + 1):
+            if seen[i]:
+                if prev is not None and i - prev < mn:
+                    mn = i - prev
+                prev = i
+
+        # sweep 2 : collect every consecutive pair whose gap == mn
+        res = []
+        prev = None
+        for i in range(hi - lo + 1):
+            if seen[i]:
+                if prev is not None and i - prev == mn:
+                    res.append([prev + lo, i + lo])
+                prev = i
+        return res
+
+
+# V0-2
+# IDEA : SORT + SINGLE PASS, RESET THE ANSWER WHEN A SMALLER GAP APPEARS
+#
+#   instead of learning the min gap first and collecting after, keep the best
+#   gap seen so far together with its pairs : a strictly smaller gap wipes the
+#   list, an equal gap appends to it. one pass over the sorted array.
+#
+# time = O(n log n)
+# space = O(n)
+class Solution(object):
+    def minimumAbsDifference(self, arr):
+        arr = sorted(arr)
+        best = float('inf')
+        res = []
+        for a, b in zip(arr, arr[1:]):
+            gap = b - a
+            if gap < best:
+                best = gap
+                res = [[a, b]]
+            elif gap == best:
+                res.append([a, b])
+        return res

--- a/leetcode_python/Array/minimum-amount-of-time-to-collect-garbage.py
+++ b/leetcode_python/Array/minimum-amount-of-time-to-collect-garbage.py
@@ -88,3 +88,53 @@ class Solution(object):
         for i in last.values():
             res += prefix[i]
         return res
+
+
+# V0-1
+# IDEA : SCAN FROM THE RIGHT, COUNT HOW MANY TRUCKS STILL HAVE TO PASS
+#
+#   walk the houses backwards while remembering which types have already been
+#   met on the right. a truck must drive over the edge travel[i-1] exactly
+#   when its type still appears at house i or further right, i.e. once for
+#   every type currently in `seen`.
+#
+#   so each edge is charged len(seen) times, which folds the three prefix
+#   sums of V0 into a single backward pass with no auxiliary array.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def garbageCollection(self, garbage, travel):
+        res = sum(len(g) for g in garbage)
+        seen = set()
+        for i in range(len(garbage) - 1, 0, -1):
+            seen.update(garbage[i])
+            res += len(seen) * travel[i - 1]
+        return res
+
+
+# V0-2
+# IDEA : SIMULATE EACH TRUCK SEPARATELY
+#
+#   run three independent simulations, one per garbage type. a truck walks the
+#   houses left to right and buffers the driving time of the edges it crosses
+#   in `pending`; the buffer is only paid (and cleared) when the truck
+#   actually meets its own type, so edges past the last occurrence are never
+#   charged and nothing has to be trimmed afterwards.
+#
+#   slower in constant factor (three passes) but it mirrors the problem
+#   statement directly instead of relying on the prefix-sum shortcut.
+#
+# time = O(3n) = O(n), space = O(1)
+class Solution(object):
+    def garbageCollection(self, garbage, travel):
+        total = 0
+        for t in "MPG":
+            pending = 0
+            for i, g in enumerate(garbage):
+                if i:
+                    pending += travel[i - 1]
+                cnt = g.count(t)
+                if cnt:
+                    total += pending + cnt
+                    pending = 0
+        return total

--- a/leetcode_python/Array/minimum-amount-of-time-to-fill-cups.py
+++ b/leetcode_python/Array/minimum-amount-of-time-to-fill-cups.py
@@ -63,3 +63,77 @@ class Solution(object):
     def fillCups(self, amount):
         total = sum(amount)
         return max(max(amount), (total + 1) // 2)
+
+
+# V0-1
+# IDEA : GREEDY SIMULATION WITH A MAX HEAP
+#
+#   at every second, pour from the two currently LARGEST piles (they are the
+#   ones at risk of being left alone at the end); if only one pile is left,
+#   pour a single cup. python's heapq is a min heap, so store negated counts.
+#
+#   this is the constructive proof of the O(1) formula : it actually builds a
+#   schedule, second by second, instead of reasoning about lower bounds.
+#
+# time = O(S log 3) = O(S), S = sum(amount)
+# space = O(1)
+import heapq
+class Solution(object):
+    def fillCups(self, amount):
+        h = [-a for a in amount if a > 0]
+        heapq.heapify(h)
+        sec = 0
+        while h:
+            a = heapq.heappop(h) + 1     # negated -> += 1 means "one cup out"
+            if h:
+                b = heapq.heappop(h) + 1
+                if b:
+                    heapq.heappush(h, b)
+            if a:
+                heapq.heappush(h, a)
+            sec += 1
+        return sec
+
+
+# V0-2
+# IDEA : TOP-DOWN DP (MEMOIZED SEARCH OVER THE STATE SPACE)
+#
+#   state = the three remaining counts. from a state we may fill any single
+#   pile, or any PAIR of distinct piles, each costing 1 second :
+#
+#       dp(a, b, c) = 1 + min(dp over all legal moves)
+#
+#   sorting the triple before memoizing collapses permutations of the same
+#   state, so the table stays small. this makes no greedy assumption at all —
+#   it searches every schedule — which is why it is the right cross-check for
+#   the O(1) formula in V0.
+#
+# time = O(k^3) states, k = max cup count (<= 100)
+# space = O(k^3)
+from functools import lru_cache
+class Solution(object):
+    def fillCups(self, amount):
+
+        @lru_cache(None)
+        def dp(a, b, c):
+            if a == 0 and b == 0 and c == 0:
+                return 0
+            best = float('inf')
+            cur = (a, b, c)
+            # fill one cup
+            for i in range(3):
+                if cur[i]:
+                    nxt = list(cur)
+                    nxt[i] -= 1
+                    best = min(best, 1 + dp(*sorted(nxt)))
+            # fill two cups of different types
+            for i in range(3):
+                for j in range(i + 1, 3):
+                    if cur[i] and cur[j]:
+                        nxt = list(cur)
+                        nxt[i] -= 1
+                        nxt[j] -= 1
+                        best = min(best, 1 + dp(*sorted(nxt)))
+            return best
+
+        return dp(*sorted(amount))

--- a/leetcode_python/Array/minimum-array-changes-to-make-differences-equal.py
+++ b/leetcode_python/Array/minimum-array-changes-to-make-differences-equal.py
@@ -88,3 +88,78 @@ class Solution(object):
             if cost < best:
                 best = cost
         return best
+
+
+# V0-1
+# IDEA : BRUTE FORCE — TRY EVERY X, PRICE EVERY PAIR
+#
+#   the baseline the counting solution compresses. for a fixed target gap X,
+#   walk all n/2 pairs and charge each one directly :
+#       0  if abs(a - b) == X
+#       1  if X <= max(max(a, b), k - min(a, b))   (one element can be moved)
+#       2  otherwise                               (both must be rewritten)
+#
+#   correct and easy to trust, but re-reads every pair for each of the k + 1
+#   candidates, so it only survives on small inputs.
+#
+# time = O(n * k)
+# space = O(n)
+class Solution(object):
+    def minChanges(self, nums, k):
+        n = len(nums)
+        pairs = [(abs(nums[i] - nums[n - 1 - i]),
+                  max(max(nums[i], nums[n - 1 - i]),
+                      k - min(nums[i], nums[n - 1 - i])))
+                 for i in range(n // 2)]
+
+        best = float('inf')
+        for X in range(k + 1):
+            cost = 0
+            for gap, reach in pairs:
+                if gap == X:
+                    continue
+                cost += 1 if X <= reach else 2
+            best = min(best, cost)
+        return best
+
+
+# V0-2
+# IDEA : SORT THE REACHES + SWEEP X WITH A POINTER
+#
+#   same cost formula as V0, but the "how many pairs can still be fixed with a
+#   single change at target X" question is answered by sorting the reaches
+#   instead of by a difference array : as X grows the pointer only moves
+#   forward over the reaches that have fallen below X.
+#
+#       dead     = pairs whose reach < X          -> cost 2 each
+#       alive    = pairs - dead                   -> cost 1 each,
+#                  except the cnt[X] pairs already at gap X, which cost 0
+#
+#   trades the O(k) difference array for an O(n log n) sort + O(n) counter,
+#   which is the better shape when k is much larger than n.
+#
+# time = O(n log n + k)
+# space = O(n)
+import collections
+class Solution(object):
+    def minChanges(self, nums, k):
+        n = len(nums)
+        gaps = collections.Counter()
+        reaches = []
+        for i in range(n // 2):
+            a, b = nums[i], nums[n - 1 - i]
+            gaps[abs(a - b)] += 1
+            reaches.append(max(max(a, b), k - min(a, b)))
+        reaches.sort()
+
+        total = n // 2
+        best = float('inf')
+        dead = 0
+        for X in range(k + 1):
+            while dead < total and reaches[dead] < X:
+                dead += 1
+            alive = total - dead
+            cost = (alive - gaps[X]) + 2 * dead
+            if cost < best:
+                best = cost
+        return best

--- a/leetcode_python/Array/minimum-array-length-after-pair-removals.py
+++ b/leetcode_python/Array/minimum-array-length-after-pair-removals.py
@@ -81,3 +81,55 @@ class Solution(object):
         if mx * 2 > n:
             return 2 * mx - n
         return n % 2
+
+
+# V0-1
+# IDEA : TWO POINTERS ACROSS THE TWO HALVES
+#
+#   a constructive greedy instead of the counting argument : try to marry the
+#   small half [0, n/2) with the big half [n/2, n). scan i over the first half
+#   and j over the second; whenever nums[i] < nums[j] the pair can be removed
+#   and BOTH advance, otherwise only j advances to look for a strictly bigger
+#   partner.
+#
+#   this is optimal because a matching that pairs a small-half element with a
+#   large-half element always exists whenever any valid pairing does — two
+#   elements of the same half can only be paired if they are already
+#   separated by the middle in some other matching.
+#
+#   the answer is whatever the matching could not consume : n - 2 * matched.
+#
+# time = O(n), space = O(1)
+class Solution(object):
+    def minLengthAfterRemovals(self, nums):
+        n = len(nums)
+        i = 0
+        matched = 0
+        for j in range(n // 2 + (n % 2), n):
+            if nums[i] < nums[j]:
+                matched += 1
+                i += 1
+        return n - 2 * matched
+
+
+# V0-2
+# IDEA : BINARY SEARCH THE MIDDLE VALUE'S RUN
+#
+#   only a value occupying MORE than half of the array can force leftovers,
+#   and such a value must cover the middle index — so nums[n // 2] is the one
+#   and only candidate for the dominant group.
+#
+#   since nums is sorted, its group size is found with two binary searches
+#   (bisect_left / bisect_right) rather than by scanning, which answers the
+#   whole problem in logarithmic time.
+#
+# time = O(log n), space = O(1)
+import bisect
+class Solution(object):
+    def minLengthAfterRemovals(self, nums):
+        n = len(nums)
+        mid = nums[n // 2]
+        cnt = bisect.bisect_right(nums, mid) - bisect.bisect_left(nums, mid)
+        if 2 * cnt > n:
+            return 2 * cnt - n
+        return n % 2

--- a/leetcode_python/Array/minimum-average-difference.py
+++ b/leetcode_python/Array/minimum-average-difference.py
@@ -76,3 +76,58 @@ class Solution(object):
                 best_diff = diff
                 best_idx = i
         return best_idx
+
+
+# V0-1
+# IDEA : BRUTE FORCE — RE-SUM BOTH SIDES AT EVERY INDEX
+#
+#   the literal reading of the statement : for each i, add up the first i + 1
+#   elements and the remaining n - i - 1 elements from scratch, floor both
+#   averages and compare. no prefix trick at all, which makes it the obvious
+#   reference implementation to check the linear versions against — but the
+#   repeated summing makes it quadratic.
+#
+# time = O(n^2), space = O(1)
+class Solution(object):
+    def minimumAverageDifference(self, nums):
+        n = len(nums)
+        best_diff = float('inf')
+        best_idx = 0
+        for i in range(n):
+            left = sum(nums[:i + 1]) // (i + 1)
+            right = sum(nums[i + 1:]) // (n - i - 1) if i < n - 1 else 0
+            diff = abs(left - right)
+            if diff < best_diff:
+                best_diff = diff
+                best_idx = i
+        return best_idx
+
+
+# V0-2
+# IDEA : PRECOMPUTED PREFIX TABLE + MIN WITH KEY
+#
+#   materialise all prefix sums up front with itertools.accumulate, then let
+#   min() do the scan : the average difference of index i is a pure function
+#   of prefix[i], so the whole answer collapses to one min-with-key call.
+#
+#   min() returns the FIRST index achieving the minimum, which is exactly the
+#   "smallest index wins" tie-break the statement asks for — no manual strict
+#   comparison needed.
+#
+#   trades V0's O(1) running sum for an O(n) table in exchange for a fully
+#   declarative formulation.
+#
+# time = O(n), space = O(n)
+import itertools
+class Solution(object):
+    def minimumAverageDifference(self, nums):
+        n = len(nums)
+        prefix = list(itertools.accumulate(nums))
+        total = prefix[-1]
+
+        def diff(i):
+            left = prefix[i] // (i + 1)
+            right = (total - prefix[i]) // (n - i - 1) if i < n - 1 else 0
+            return abs(left - right)
+
+        return min(range(n), key=diff)


### PR DESCRIPTION
Batches 021-030 of task 3: every LC problem should carry at least 3 genuinely distinct, tested solution versions. All 60 files are Array problems that had a single implementation. 60/60 pass script/py_multi_version/verify.py, and the diff has zero deletions — existing blocks are untouched.

This wave leans harder on structurally different algorithms than restatements: convex hull trick on prefix-sum points against an O(n^2) scan for maximum average subarray; sqrt decomposition with per-block flip tags against a segment tree for the flip-and-sum queries; SPF sieve plus union-find against prime buckets with iterative DFS for common-factor components; Prim's MST against binary search on the budget; digit DP that is independent of n against a Counter of digit sums; Stern's diatomic bit walk against top-down memoization.

Two interactive problems were tested against mock judges enforcing the real constraints, not just the happy path. LC 1538 (guess the majority) was checked exhaustively over every binary array of length 5..12 with a reader asserting a < b < c < d and the 2n query budget — the two added approaches come in at n+1 and under n calls. LC 2569 was stress-tested at 1000 elements and 500 queries with all three implementations agreeing.