### PR TITLE
docs: add cheatsheet split & simplify plan (Aug 2026)

### DIFF
--- a/doc/cheatsheet-review-2026-08.md
+++ b/doc/cheatsheet-review-2026-08.md
@@ -4,6 +4,8 @@ A structural review of all 74 markdown files in [`doc/cheatsheet/`](cheatsheet/)
 
 This document exists so the same drift can be recognised early next time. The rules distilled from it now live in [`CLAUDE.md`](../CLAUDE.md#cheatsheet-style-guide) and [`doc/cheatsheet/00_template.md`](cheatsheet/00_template.md).
 
+> **Follow-up** — the two items left under [Not done](#not-done), plus the file-size problem this review never addressed, are planned in [`cheatsheet-split-plan-2026-08.md`](cheatsheet-split-plan-2026-08.md).
+
 ---
 
 ## Verdict

--- a/doc/cheatsheet-split-plan-2026-08.md
+++ b/doc/cheatsheet-split-plan-2026-08.md
@@ -1,0 +1,210 @@
+# Cheatsheet Split & Simplify Plan — August 2026
+
+A follow-up review of [`doc/cheatsheet/`](cheatsheet/) — 80 markdown files, 143,068 lines — measuring **size and internal redundancy** rather than format.
+
+The [August 2026 structural review](cheatsheet-review-2026-08.md) fixed *format* drift and it has held. Re-measured at the time of writing:
+
+| Check | Aug review (after) | Now |
+|---|---:|---:|
+| Untagged code fences | 0 | **0** |
+| Heading-level jumps | 0 | **0** |
+| Headings stating the LC number twice | 0 | 6 |
+| Files with a `Scope` statement | 35 | **79 / 79** |
+| `Missing Google Patterns` catch-alls | 0 | 3 (regrown under new names) |
+
+What that review **deliberately deferred** is what this document plans:
+
+> *"~450 `# V0 / V0' / V0''` solution variants … Collapsing them means deciding which variant teaches something the others do not."*
+> *"`lc_category.md` (1,513 lines) is a verbatim paste of an external GitHub README … It should be a link."*
+
+and, implicitly, the thing it never addressed at all: **the files are too big to use as cheatsheets.** 21 sheets are over 2,000 lines. `tree.md` is 6,485.
+
+---
+
+## Verdict
+
+The content is still strong. The problem is that every large sheet has grown into three documents wearing one filename: a teaching doc, a solution archive, and a deep-dive appendix.
+
+**30% of the corpus — 43,201 lines — sits inside `LC Example` / `Problems by pattern` / `Detailed examples` tail sections.**
+
+| file | lines | example-tail | share |
+|---|---:|---:|---:|
+| `stack.md` | 3,483 | 2,723 | **78%** |
+| `binary_indexed_tree.md` | 786 | 688 | **87%** |
+| `bit_manipulation.md` | 1,289 | 960 | 74% |
+| `greedy.md` | 1,660 | 1,179 | 71% |
+| `set.md` | 1,382 | 906 | 65% |
+| `union_find.md` | 1,882 | 1,152 | 61% |
+| `monotonic_stack.md` | 1,501 | 928 | 61% |
+| `matrix.md` | 2,035 | 1,185 | 58% |
+| `Dijkstra.md` | 2,359 | 1,338 | 56% |
+| `topology_sorting.md` | 2,454 | 1,266 | 51% |
+| `2_pointers.md` | 4,658 | 2,356 | 50% |
+| `backtrack.md` | 3,423 | 1,729 | 50% |
+| `linked_list.md` | 2,868 | 1,419 | 49% |
+| `design.md` | 2,647 | 1,308 | 49% |
+| `heap.md` | 5,345 | 2,266 | 42% |
+| `hash_map.md` | 4,119 | 1,734 | 42% |
+| `binary_search.md` | 4,591 | 1,895 | 41% |
+| `bst.md` | 3,956 | 1,468 | 37% |
+| `string.md` | 3,512 | 1,310 | 37% |
+| `dfs.md` | 6,033 | 2,217 | 36% |
+| `bfs.md` | 4,256 | 1,203 | 28% |
+| `dp.md` | 5,157 | 1,155 | 22% |
+| `tree.md` | 6,485 | 1,414 | 21% |
+
+---
+
+## The four pathologies
+
+### 1. The example tail dwarfs the teaching part
+
+`stack.md` is the clearest case — and it has *no* summary or decision section at all:
+
+```text
+## 0) Concept              lines   57– 511
+## 1) Core Patterns        lines  511– 761   (250 lines)
+## 2) LeetCode Examples    lines  761–3483   (2,723 lines — 78% of the file)
+```
+
+The reader who wants "when do I reach for a stack" has nowhere to look.
+
+### 2. The same problem solved 3–7 times inside one file
+
+Counting only `###`/`####` **solution headings**, not passing mentions:
+
+| file | duplicate headings | worst offenders |
+|---|---:|---|
+| `binary_search.md` | 32 | LC 34 ×**7**, LC 875 ×5, LC 704/33/153/74/410/1011 ×3 |
+| `dfs.md` | 20 | LC 112/200/450/1254/694 ×3 |
+| `sliding_window.md` | 15 | LC 992 ×4, LC 3/209 ×3 |
+| `prefix_sum.md` | 14 | LC 303/560/370/1248/2615/769 ×3 |
+| `intervals.md` | 11 | LC 56/435/986/253/729 ×3 |
+| `dp.md` | 11 | LC 70/72 ×3 |
+| `bfs.md` | 11 | LC 994 ×4, LC 542/127 ×3 |
+| `Dijkstra.md` | 10 | LC 1631 ×**8**, LC 64 ×4 |
+| `2_pointers.md` | 10 | LC 27 ×3 |
+| `monotonic_stack.md` | 9 | LC 84 ×5 |
+
+Concrete instances:
+
+- **`binary_search.md`** solves LC 34 at §1.5, §1.7, §2.2, §2.3, §4.13, §4.16 and §2-1. §4.16 is titled `Find First and Last Position - Alternative Implementation — LC 34 — LC 34` — the double-LC-number anti-pattern, back.
+- **`dfs.md`** presents LC 694 three times: `Pattern 8` (line 96), `Template 8` (line 937), `§2-28` (line 5360, 226 lines). Its 18 `Problem Categories` map **1:1** onto its 16 `Templates` — two parallel presentations of one list. Four more LC examples (`2-28`…`2-31`) sit *after* `Related Topics`, i.e. appended past the end of the document.
+- **`tree.md`** §3.14 fully solves LC 606 and LC 536; §4-1 then re-solves LC 606 while *linking back to* §3.14 for the explanation, and §4-7 re-solves LC 536 in 263 lines with three variants. §0-2's nine "Common Tree Patterns" (549 lines) restate §1's templates, which restate §3's algorithms — three parallel passes over the same nine ideas.
+- **~450 `V0 / V0' / V0'' / V1` variant blocks** remain: `tree.md` 40, `dfs.md` 37, `backtrack.md` 35, `stack.md` 32, `array.md` 28, `hash_map.md` 25.
+
+### 3. A sheet duplicating its own satellites
+
+Shared **worked problems** (heading-level), which is what the Scope lines were supposed to prevent:
+
+| pair | shared | problems |
+|---|---:|---|
+| `tree.md` × `tree2.md` | **21** | 98, 100, 101, 104, 105, 110, 111, 114, 117, 124, 199, 222, 226, 236, 297, 606, 617, 863, 987, 1448, 1740 |
+| `dp.md` × `dp_pattern.md` | 13 | 62, 64, 70, 91, 300, 309, 312, 322, 403, 410, 416, 1143, 1751 |
+| `stack.md` × `monotonic_stack.md` | 12 | 32, 84, 155, 388, 402, 496, 503, 735, 739, 901, 907, 2104 |
+| `tree2.md` × `dfs.md` | 9 | 94, 98, 112, 113, 129, 236, 297, 543, 606 |
+| `tree.md` × `dfs.md` | 7 | 98, 236, 297, 536, 606, 652, 662 |
+| `dp.md` × `recursion_to_dp.md` | 7 | 62, 70, 72, 198, 322, 403, 516 |
+| `bst.md` × `dfs.md` | 6 | 98, 449, 538, 669, 701, 776 |
+| `dfs.md` × `bfs.md` | 6 | 200, 399, 417, 623, 662, 1530 |
+| `intervals.md` × `scanning_line.md` | 6 | 56, 253, 452, 986, 1235, 1465 |
+
+`tree2.md`'s Scope says "template-first, no theory" and `tree.md`'s says "concepts" — but they solve the same 21 problems. `dfs.md`'s example tail is ~21 tree/BST problems: it teaches DFS by re-solving `tree.md` and `bst.md`.
+
+### 4. Multiple decision/summary sections, and catch-alls creeping back
+
+- `dfs.md`: `Pattern Selection Strategy` + `Summary & Quick Reference` + `Quick Decision Tree: Which DFS Pattern to Use?`
+- `bst.md`: `Pattern Selection Strategy` + `Summary & Quick Reference` + `🚀 Quick Decision Tree`
+- `Dijkstra.md`: three
+- `binary_search.md`: `3) Summary & Quick Reference` lands at line 1,952 — and 2,639 more lines follow it, including `5) Additional High-Frequency Templates`
+- Catch-alls regrown: `binary_search.md:3989` *Classic Google Patterns*, `hash_map.md:3791` *Google-Specific Patterns*, `complexity_cheatsheet.md:589` *Classic Google Interview Problems*
+
+**Mixed skeletons** (forbidden by [`CLAUDE.md`](../CLAUDE.md#which-skeleton)) in `hash_map.md`, `bst.md`, `string.md`, `dfs.md` — Skeleton B's `Templates & Algorithms` followed by Skeleton A's `0) Concept` / `1) General form` / `2) LC Example`.
+
+**Flat dumps**: `python_trick.md` is 3,672 lines under a *single* `## 1) Examples` heading with 68 unsorted `###`s. `java_trick.md` has both `6) Other tricks` and `9) Others`.
+
+---
+
+## The reference model is itself only half-done
+
+`dp.md` was the file the split was piloted on — five satellites extracted (`knapsack`, `dp_string`, `dp_bitmask`, `dp_digit`, `dp_monotonic_stack`). It is **still 5,157 lines**:
+
+```text
+## Templates & Algorithms          121–2700   (2,579 lines)
+## Comprehensive Pattern Analysis 2700–3473   (773, overlapping the above)
+## LC Examples                    3582–4655   (1,073)
+## Advanced DP Techniques         5042–5157   (trailing bolt-on)
+```
+
+plus 11 duplicate LC headings and 13 problems shared with `dp_pattern.md`. **The satellites were extracted but the parent was never trimmed.** "Do what we did for `dp.md`" therefore has to mean *split **and** trim*, or the outcome is 20 files of 5,000 lines.
+
+---
+
+## Plan
+
+### Rule 1 — three documents per heavy topic
+
+| role | file | contents | ceiling |
+|---|---|---|---:|
+| main | `X.md` | Overview → Problem Categories → decision table → canonical templates → 5–8 must-know worked examples → Summary | **1,500 lines** |
+| archive | `X_examples.md` | the long tail of worked problems, one canonical solution each | — |
+| appendix | `X_advanced.md` | rare / hard techniques a first pass should skip | — |
+
+Where a satellite already exists (`tree2.md`, `monotonic_stack.md`, `dp_pattern.md`, `binary_tree.md`), it absorbs the material instead of a new file being invented.
+
+### Rule 2 — what the main sheet may contain
+
+1. **One canonical solution per problem per language.** A second variant needs a stated reason (different complexity, different language idiom, distinct trick).
+2. **One** decision section. **One** summary section.
+3. An example may not re-solve what a template above already solves — link to the template.
+4. A problem owned by another sheet moves there, or is reduced to a one-line pointer.
+5. No catch-all headings. New material is filed under the pattern it belongs to.
+
+### Tier 1 — the eight tier-5 sheets over 4,000 lines
+
+| file | now | main target | split out |
+|---|---:|---:|---|
+| `tree.md` | 6,485 | ~1,400 | `tree_lca_distance.md`, `tree_codec.md` (§3.13–3.14), `tree_construction.md`, `tree_examples.md`; fold §0-2's nine patterns into §1 templates |
+| `dfs.md` | 6,033 | ~1,300 | collapse `Patterns 1–18` into `Templates 1–16`; `dfs_advanced.md` (Tarjan, Hierholzer, depth-indexed stack); `dfs_examples.md` |
+| `heap.md` | 5,345 | ~1,400 | `heap_examples.md`; `Language APIs` is a `Collection.md` concern |
+| `dp.md` | 5,157 | ~1,500 | finish the pilot: dedup against `dp_pattern.md`, tail → `dp_examples.md` |
+| `2_pointers.md` | 4,658 | ~1,200 | QuickSelect + median-of-medians (~500 lines, mis-filed) → `2_pointers_quickselect.md`; `2_pointers_examples.md` |
+| `binary_search.md` | 4,591 | ~1,100 | largest dedup win (32 duplicate headings); `binary_search_on_answer.md`; `binary_search_examples.md` |
+| `bfs.md` | 4,256 | ~1,200 | `bfs_examples.md`; `bfs_advanced.md` (multi-source, bidirectional, 0-1 BFS) |
+| `hash_map.md` | 4,119 | ~1,200 | un-mix the skeletons; `hash_map_examples.md` |
+
+### Tier 2 — same treatment, smaller files
+
+`bst.md`, `string.md`, `stack.md` (single largest tail share), `backtrack.md`, `sliding_window.md`, `graph.md`, `linked_list.md`, `design.md`, `array.md`, `topology_sorting.md`, `tree2.md`, `Dijkstra.md`, `prefix_sum.md`, `matrix.md`, and the two language sheets (`python_trick.md`, `java_trick.md` — categorise the flat dump, delete `Other tricks` / `Others`).
+
+### Tier 3 — dedup only, no split
+
+`greedy.md`, `union_find.md`, `set.md`, `bit_manipulation.md`, `monotonic_stack.md`, `intervals.md`, `binary_indexed_tree.md`, `segment_tree.md`, `scanning_line.md`, `sort.md`, `trie.md`, `math.md`. High tail share, but small enough that Rule 2 alone fixes them.
+
+### No action
+
+The ~30 sheets under ~1,200 lines that are already right: `knapsack.md`, `kadane_algorithm.md`, `palindrome.md`, `hashing.md`, `dp_string.md`, `dp_digit.md`, `dp_bitmask.md`, `dp_monotonic_stack.md`, `monotonic_queue.md`, `iterator.md`, `n_sum.md`, `add_x_sum.md`, `difference_array.md`, `complexity_*`, `Bellman-Ford.md`, `Floyd-Warshall.md`, `shortest_path_comparison.md`, `string_matching_kmp_rolling_hash.md`, `python_gotchas.md`, `ood_design.md`, `concurrency_patterns.md`, `diff_toposort_quickunion.md`, `array_overlap_explaination.md`, `recursion.md`, `recursion_to_dp.md`, `advanced_*`, `streaming_algorithms.md`, `knapsack_01_zh.md`, `tree_backtrack.md`.
+
+### Still open from the Aug review
+
+- `lc_category.md` — 1,516 lines, a verbatim paste of an external GitHub README including 12 `TODO` markers that are not this repo's. Should be a link.
+- `code_interview_general_cheatsheet.md` — 33 lines, belongs inside another doc.
+- `time = O(...)` coverage is 35% of ~3,177 code blocks.
+
+---
+
+## Expected outcome
+
+**143,068 → roughly 105,000–115,000 lines**, no sheet over ~1,500 lines, ~20 new satellite files, nothing worth keeping lost. Recoverable duplication runs 15–25% per heavy sheet.
+
+## Constraints
+
+- Every new `doc/cheatsheet/*.md` needs a [`data/cheatsheet_meta.json`](../data/cheatsheet_meta.json) entry — **the site build fails otherwise, on purpose.**
+- Every new file opens with H1 → `> **Scope**` → `> **See also**` → `## LeetCode Problem Lists`.
+- The parent's `See also` line must name each satellite it spawned, and each satellite must point back.
+- Moving a section breaks inbound anchor links from other sheets. A repo-wide link check belongs at the end of each phase.
+- `_site/` is generated by CI and gitignored — never commit it. Verify locally with `SKIP_FONTS=1 bash site/build.sh`.
+
+## Risk
+
+The mechanics are safe; the *judgement* is not. Deciding which of three `V0 / V0' / V1` spellings teaches something the others do not is exactly why the August pass skipped them. Mitigation: phase by cluster — **tree → dfs/bfs/graph → arrays & strings → dp → hashing/stacks/queues** — so each phase is reviewable on its own, and never delete a block whose duplicate is only *similar*; verify same problem, same language, same approach first.


### PR DESCRIPTION
Measures size and internal redundancy across doc/cheatsheet/ (80 files, 143,068 lines) rather than format, which the Aug 2026 review already fixed and which has held.

Findings: 30% of the corpus (43,201 lines) sits in LC-example tail sections; 21 sheets exceed 2,000 lines; one problem is solved up to 7 times in a single file (LC 34 in binary_search.md); tree.md and tree2.md share 21 worked problems; dp.md - the file the split was piloted on - was never trimmed after its satellites were extracted.

Plan: three documents per heavy topic (main <= 1,500 lines / _examples / _advanced), one canonical solution per problem per language, one decision and one summary section per sheet. Tiered by file, with the Aug review's deferred items folded in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a follow-up plan for improving the structure and readability of the cheatsheet documentation.
  * Documented measured file-size issues, duplicated content, and recommended splitting or consolidating oversized materials.
  * Recorded structural standards and safeguards for future documentation updates.
  * Noted remaining items from the previous review for planned follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->