### PR TITLE
feat(site): add a NeetCode-style Study Roadmap page

### DIFF
--- a/.github/workflows/validate-pages.yml
+++ b/.github/workflows/validate-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master ]
     paths:
+      - 'data/roadmap.json'
       - 'doc/**'
       - 'README.md'
       - '.github/workflows/deploy-pages.yml'
@@ -15,6 +16,7 @@ on:
       - 'site/ensure-nav-pages.js'
       - 'site/nav.js'
       - 'site/nav.css'
+      - 'site/roadmap.js'
       - 'site/site.js'
       - 'site/test/**'
       - 'site/package.json'
@@ -24,6 +26,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
+      - 'data/roadmap.json'
       - 'doc/**'
       - 'README.md'
       - '.github/workflows/deploy-pages.yml'
@@ -35,6 +38,7 @@ on:
       - 'site/ensure-nav-pages.js'
       - 'site/nav.js'
       - 'site/nav.css'
+      - 'site/roadmap.js'
       - 'site/site.js'
       - 'site/test/**'
       - 'site/package.json'
@@ -99,6 +103,9 @@ jobs:
           '_site/style.css',
           '_site/nav.css',
           '_site/nav.js',
+          '_site/roadmap.js',
+          '_site/lc-roadmap.html',
+          '_site/data/roadmap.json',
           '_site/site.js'
         ];
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ CS_basics is a comprehensive computer science fundamentals repository containing
   - `build.sh` - **The** build recipe: builds the whole `_site/` tree. Both workflows call it
   - `build-site.js` - Builds HTML pages from markdown docs
   - `build-leetcode.js` - Generates LeetCode JSON data for the LC Explorer
-  - `pages/` - Hand-maintained static pages (LC Explorer/Similar/Review-Plan/Random-Picker, 404)
+  - `build-roadmap.js` - Resolves [`data/roadmap.json`](data/roadmap.json) against `README.md` into the Study Roadmap's data; fails the build on a bad topic id, cheatsheet slug or LC number
+  - `pages/` - Hand-maintained static pages (LC Explorer/Similar/Review-Plan/Random-Picker/Roadmap, 404)
+  - `nav.js` / `roadmap.js` - Browser scripts copied to `_site/`; unit-tested under `site/test/`
   - `style.css` - Site stylesheet
   - `package.json` / `package-lock.json` - Node.js dependencies (markdown-it, highlight.js)
 
@@ -153,6 +155,30 @@ A new `doc/cheatsheet/*.md` must also get an entry in [`data/cheatsheet_meta.jso
 - `title` — only when the H1 is too long or too literal for a card.
 - `kind` — `"stub"` for a redirect file, `"reference"` for an imported index. Omit for a normal sheet.
 - Add it to `startHere` only if it belongs in the beginner reading ladder.
+
+### Adding a topic to the Study Roadmap
+
+The roadmap page (`lc-roadmap.html`) is driven entirely by [`data/roadmap.json`](data/roadmap.json) — one entry per topic:
+
+```json
+{
+  "id": "monotonic-stack",
+  "title": "Monotonic Stack",
+  "row": 2,
+  "prereqs": ["stack"],
+  "sheets": ["monotonic_stack", "monotonic_queue"],
+  "blurb": "One sentence on what the topic buys you.",
+  "problems": [496, 503, 85, 901, 907]
+}
+```
+
+Titles, difficulty and links to this repo's solutions come from `README.md` at build time — never repeat them here. `site/build-roadmap.js` fails the build if:
+
+- a `problems` id is not in a README table, or a `sheets` slug is not a file in `doc/cheatsheet/`;
+- `row` is not strictly greater than every prereq's `row` (edges must point downward);
+- the prereqs contain a cycle, or an edge the graph **already implies** — the roadmap has to stay a transitive reduction, or the drawing turns into spaghetti.
+
+Within a row, topics are drawn in the order they appear in the file, so put a topic near the column its prerequisite sits in to keep the edges short.
 
 ### Formatting Rules
 

--- a/data/roadmap.json
+++ b/data/roadmap.json
@@ -1,0 +1,278 @@
+{
+  "_comment": "Drives the study roadmap page (site/build-roadmap.js -> _site/data/roadmap.json, rendered by site/pages/lc-roadmap.html). Each node is one topic in the dependency graph: `prereqs` are the topics you should have done first (these become the drawn edges), `row` is the layer it sits on (must be greater than every prereq's row — the build enforces it), `sheets` are doc/cheatsheet slugs, and `problems` are LeetCode ids that must exist in README.md's tables. Titles, difficulty and repo solution links are resolved from README.md at build time, so they are never duplicated here.",
+
+  "meta": {
+    "title": "Study Roadmap",
+    "intro": "A dependency graph over the topics in this repo. Start at the top, unlock a topic once its prerequisites are done, and tick problems off as you solve them — progress is stored in your browser."
+  },
+
+  "nodes": [
+    {
+      "id": "arrays-hashing",
+      "title": "Arrays & Hashing",
+      "row": 0,
+      "prereqs": [],
+      "sheets": ["array", "hash_map", "set", "string"],
+      "blurb": "The root of everything: index arithmetic, and trading space for O(1) lookup.",
+      "problems": [1, 217, 242, 49, 347, 238, 271, 36, 128]
+    },
+
+    {
+      "id": "two-pointers",
+      "title": "Two Pointers",
+      "row": 1,
+      "prereqs": ["arrays-hashing"],
+      "sheets": ["2_pointers", "n_sum", "palindrome"],
+      "blurb": "Converging, trailing and fast/slow pointers — the cheapest way to drop a nested loop.",
+      "problems": [125, 167, 15, 11, 42, 680, 26]
+    },
+    {
+      "id": "stack",
+      "title": "Stack",
+      "row": 1,
+      "prereqs": ["arrays-hashing"],
+      "sheets": ["stack", "stack_expression_parsing"],
+      "blurb": "LIFO discipline: matching, nesting and expression evaluation.",
+      "problems": [20, 155, 150, 22, 739, 84, 853]
+    },
+    {
+      "id": "prefix-sum",
+      "title": "Prefix Sum",
+      "row": 1,
+      "prereqs": ["arrays-hashing"],
+      "sheets": ["prefix_sum", "prefix_sum_advanced", "difference_array"],
+      "blurb": "Precompute once, answer any range in O(1). Pair it with a hash map for subarray counting.",
+      "problems": [303, 304, 560, 523, 325, 974, 930]
+    },
+    {
+      "id": "bit-manipulation",
+      "title": "Bit Manipulation",
+      "row": 1,
+      "prereqs": ["arrays-hashing"],
+      "sheets": ["bit_manipulation", "bit_manipulation_examples"],
+      "blurb": "XOR tricks, masks and the lowest set bit. Small topic, occasionally decisive.",
+      "problems": [136, 191, 338, 190, 268, 371, 7]
+    },
+    {
+      "id": "math",
+      "title": "Math & Number Theory",
+      "row": 1,
+      "prereqs": ["arrays-hashing"],
+      "sheets": ["math", "combinatorics_math_patterns"],
+      "blurb": "Digit handling, overflow, primes and modular arithmetic.",
+      "problems": [50, 66, 69, 166, 172, 204, 233]
+    },
+
+    {
+      "id": "sliding-window",
+      "title": "Sliding Window",
+      "row": 2,
+      "prereqs": ["two-pointers"],
+      "sheets": ["sliding_window", "sliding_window_advanced"],
+      "blurb": "Expand on a condition, contract when it breaks. A whole question family with one template.",
+      "problems": [121, 3, 424, 567, 76, 239, 340]
+    },
+    {
+      "id": "binary-search",
+      "title": "Binary Search",
+      "row": 2,
+      "prereqs": ["two-pointers"],
+      "sheets": ["binary_search", "binary_search_examples"],
+      "blurb": "Halving a monotonic space. Get the boundary templates exact and the variants fall out.",
+      "problems": [35, 74, 153, 33, 981, 4, 162]
+    },
+    {
+      "id": "linked-list",
+      "title": "Linked List",
+      "row": 2,
+      "prereqs": ["two-pointers"],
+      "sheets": ["linked_list", "2_pointers_linkedlist"],
+      "blurb": "Pointer surgery. Low conceptual depth, high implementation-precision bar.",
+      "problems": [206, 21, 143, 19, 138, 2, 141, 23, 25]
+    },
+    {
+      "id": "monotonic-stack",
+      "title": "Monotonic Stack",
+      "row": 2,
+      "prereqs": ["stack"],
+      "sheets": ["monotonic_stack", "monotonic_queue"],
+      "blurb": "\"Next greater / previous smaller\" in one pass, by keeping the stack sorted.",
+      "problems": [496, 503, 85, 901, 907, 316, 402]
+    },
+    {
+      "id": "matrix",
+      "title": "Matrix / 2D Grid",
+      "row": 2,
+      "prereqs": ["prefix-sum"],
+      "sheets": ["matrix", "matrix_examples"],
+      "blurb": "Row/column indexing, in-place rotation, and 2D range sums.",
+      "problems": [48, 54, 59, 73, 240, 289, 766]
+    },
+
+    {
+      "id": "string-algorithms",
+      "title": "String Algorithms",
+      "row": 3,
+      "prereqs": ["sliding-window"],
+      "sheets": ["string_matching_kmp_rolling_hash", "advanced_string_algorithms", "palindrome"],
+      "blurb": "Substring search beyond the naive scan: KMP, rolling hash, and expand-around-centre.",
+      "problems": [28, 214, 459, 686, 5, 647]
+    },
+    {
+      "id": "trees",
+      "title": "Trees & BST",
+      "row": 3,
+      "prereqs": ["binary-search", "linked-list"],
+      "sheets": ["binary_tree", "tree", "bst", "tree_lca_distance"],
+      "blurb": "How DFS state flows down and back up. The single largest interview surface after arrays.",
+      "problems": [226, 104, 543, 110, 100, 572, 235, 102, 199, 98, 230, 105, 124, 297]
+    },
+    {
+      "id": "sorting",
+      "title": "Sorting & Selection",
+      "row": 3,
+      "prereqs": ["binary-search"],
+      "sheets": ["sort", "2_pointers_quickselect", "advanced_divide_and_conquer"],
+      "blurb": "What sorting buys you, custom comparators, and quickselect for top-k without a heap.",
+      "problems": [912, 75, 215, 148, 179, 274, 1057]
+    },
+    {
+      "id": "binary-search-answer",
+      "title": "Binary Search on the Answer",
+      "row": 3,
+      "prereqs": ["binary-search"],
+      "sheets": ["binary_search_on_answer"],
+      "blurb": "Guess the answer, write a monotone feasibility check, binary search on it. The most under-practised tier-5 skill.",
+      "problems": [875, 1011, 410, 1231, 1482, 774, 1552]
+    },
+
+    {
+      "id": "heap",
+      "title": "Heap & Priority Queue",
+      "row": 4,
+      "prereqs": ["trees", "sorting"],
+      "sheets": ["heap", "heap_advanced", "heap_language_apis"],
+      "blurb": "\"Repeatedly take the best\" and top-k. Two heaps give you a running median.",
+      "problems": [703, 1046, 973, 621, 355, 295, 767]
+    },
+    {
+      "id": "tries",
+      "title": "Trie",
+      "row": 4,
+      "prereqs": ["trees"],
+      "sheets": ["trie", "trie_examples"],
+      "blurb": "Prefix trees: shared-prefix lookup, wildcard matching, and word-search pruning.",
+      "problems": [208, 211, 212, 648, 820]
+    },
+    {
+      "id": "backtracking",
+      "title": "Backtracking",
+      "row": 4,
+      "prereqs": ["trees"],
+      "sheets": ["backtrack", "backtrack_advanced", "recursion"],
+      "blurb": "Choose, recurse, un-choose. Subsets, permutations, and the pruning that makes them tractable.",
+      "problems": [78, 39, 46, 90, 40, 79, 131, 17, 51]
+    },
+    {
+      "id": "graphs",
+      "title": "Graphs (BFS / DFS)",
+      "row": 4,
+      "prereqs": ["trees"],
+      "sheets": ["graph", "bfs", "dfs"],
+      "blurb": "Traversal and connectivity on grids and adjacency lists. BFS on an unweighted graph is shortest path.",
+      "problems": [200, 133, 695, 417, 130, 994, 286, 261, 323, 127]
+    },
+    {
+      "id": "greedy",
+      "title": "Greedy",
+      "row": 4,
+      "prereqs": ["sorting"],
+      "sheets": ["greedy", "greedy_examples"],
+      "blurb": "Sort, then take the locally best choice — and be ready to justify it with an exchange argument.",
+      "problems": [53, 55, 45, 122, 134, 763, 678]
+    },
+
+    {
+      "id": "design",
+      "title": "Design a X",
+      "row": 5,
+      "prereqs": ["heap"],
+      "sheets": ["design", "ood_design", "iterator"],
+      "blurb": "Compose the structures you already know to hit a per-operation complexity target.",
+      "problems": [146, 155, 232, 380, 706, 1206, 348]
+    },
+    {
+      "id": "dp-1d",
+      "title": "1-D Dynamic Programming",
+      "row": 5,
+      "prereqs": ["backtracking"],
+      "sheets": ["dp", "recursion_to_dp", "kadane_algorithm", "dp_pattern"],
+      "blurb": "Start from the recursion you wrote for backtracking, memoise it, then flatten to a table.",
+      "problems": [70, 746, 198, 213, 91, 322, 152, 139, 300]
+    },
+    {
+      "id": "union-find",
+      "title": "Union Find",
+      "row": 5,
+      "prereqs": ["graphs"],
+      "sheets": ["union_find", "union_find_examples", "diff_toposort_quickunion"],
+      "blurb": "Disjoint sets with path compression — connectivity under incremental merges.",
+      "problems": [547, 684, 721, 839, 990, 305, 323]
+    },
+    {
+      "id": "topological-sort",
+      "title": "Topological Sort",
+      "row": 5,
+      "prereqs": ["graphs"],
+      "sheets": ["topology_sorting", "topology_sorting_examples"],
+      "blurb": "Kahn's in-degree peeling on a DAG. Also how you detect a cycle in a dependency graph.",
+      "problems": [207, 210, 269, 310, 444, 2115]
+    },
+    {
+      "id": "intervals",
+      "title": "Intervals & Sweep Line",
+      "row": 5,
+      "prereqs": ["greedy"],
+      "sheets": ["intervals", "scanning_line", "array_overlap_explaination"],
+      "blurb": "Sort by start or end, then sweep. Get the overlap predicate right once and reuse it.",
+      "problems": [57, 56, 435, 252, 253, 1851, 452]
+    },
+
+    {
+      "id": "advanced-structures",
+      "title": "Segment Tree & Fenwick",
+      "row": 6,
+      "prereqs": ["prefix-sum", "binary-search"],
+      "sheets": ["segment_tree", "binary_indexed_tree", "streaming_algorithms"],
+      "blurb": "Reach for these only when you need range queries *and* point updates — otherwise a prefix sum is enough.",
+      "problems": [307, 315, 327, 493, 308]
+    },
+    {
+      "id": "dp-2d",
+      "title": "2-D Dynamic Programming",
+      "row": 6,
+      "prereqs": ["dp-1d", "matrix"],
+      "sheets": ["dp_advanced", "dp_string", "dp_examples"],
+      "blurb": "Two indices, one table. Grid paths, two-string alignment, and interval DP.",
+      "problems": [62, 1143, 309, 97, 329, 115, 72, 312, 10]
+    },
+    {
+      "id": "knapsack",
+      "title": "Knapsack DP",
+      "row": 6,
+      "prereqs": ["dp-1d"],
+      "sheets": ["knapsack", "knapsack_01_zh"],
+      "blurb": "0/1 vs unbounded, and the loop order that separates them. Recognise it and the rest is mechanical.",
+      "problems": [416, 494, 518, 377, 1049, 879]
+    },
+    {
+      "id": "advanced-graphs",
+      "title": "Advanced Graphs",
+      "row": 6,
+      "prereqs": ["union-find", "topological-sort", "heap"],
+      "sheets": ["Dijkstra", "shortest_path_comparison", "Bellman-Ford", "Floyd-Warshall"],
+      "blurb": "Weighted shortest paths, MST and Eulerian paths. Mostly L5+ territory — know which algorithm fits.",
+      "problems": [332, 1584, 743, 778, 269, 787]
+    }
+  ]
+}

--- a/site/build-roadmap.js
+++ b/site/build-roadmap.js
@@ -350,7 +350,10 @@ function main() {
   fs.mkdirSync('_site/data', { recursive: true });
   fs.writeFileSync('_site/data/roadmap.json', JSON.stringify(built));
   console.log(
-    `✓ Created data/roadmap.json (${built.stats.topics} topics over ${built.stats.rows} rows, ` +
+    // Fully qualified on purpose: `data/roadmap.json` is the hand-authored
+    // input, so logging that path for the output reads as "your source file
+    // was overwritten".
+    `✓ Created _site/data/roadmap.json (${built.stats.topics} topics over ${built.stats.rows} rows, ` +
     `${built.stats.problems} distinct problems in ${built.stats.problemSlots} slots)`
   );
 }

--- a/site/build-roadmap.js
+++ b/site/build-roadmap.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+
+/**
+ * Build the study-roadmap data.
+ *
+ *   data/roadmap.json  (hand-authored topic graph)
+ * + README.md          (the repo's master problem index)
+ * → _site/data/roadmap.json  (enriched, laid out, ready to render)
+ *
+ * The roadmap is a DAG: each node is a topic, each `prereqs` entry is an edge,
+ * and `row` is the layer the topic is drawn on. Problem titles, difficulty and
+ * links to the solutions in this repo are resolved from README.md at build time
+ * so that they live in exactly one place — data/roadmap.json carries only the
+ * LeetCode ids.
+ *
+ * Every inconsistency is a hard failure rather than a silently-dropped node: a
+ * typo'd cheatsheet slug or a problem id that is not in README would otherwise
+ * ship as an empty box on the page.
+ *
+ * Run via site/build.sh; exported helpers are unit-tested in site/test.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const GH_BLOB = 'https://github.com/yennanliu/CS_basics/blob/master';
+const DIFFICULTIES = ['Easy', 'Medium', 'Hard'];
+
+// `[Label](href)`, tolerating the stray whitespace the README has in places —
+// `[Swim in Rising Water]( https://…)` and `[Java ](./path)` both occur, and a
+// strict pattern silently drops those rows.
+const MD_LINK = /\[([^\]]+)\]\(\s*([^)\s]+)/;
+const MD_LINK_ALL = new RegExp(MD_LINK.source, 'g');
+
+// ── README problem index ─────────────────────────────────────────────────────
+
+/**
+ * Parses the LeetCode tables in README.md into a Map of id → problem.
+ *
+ * Row shape: `| <id> | [Title](lc-url) | [Java](path), [Python](path) | time |
+ * space | Difficulty | tags | status |`. The id column is zero-padded in places
+ * ("026"), so it is normalised to its integer form.
+ *
+ * A handful of rows are malformed (a stray `\` in the solutions column, a
+ * missing difficulty). Those still yield a usable title, so they are kept with
+ * whatever fields did parse rather than dropped — only a row with no linked
+ * title at all is skipped, since without it there is nothing to show.
+ *
+ * The same id can appear under more than one `##` section with different
+ * language columns. The first row wins for title/difficulty, and the solution
+ * links are unioned across every row, so a problem does not lose its Scala link
+ * just because the Array table listed only Java.
+ */
+function parseReadmeProblems(markdown) {
+  const problems = new Map();
+  let section = null;
+
+  for (const line of markdown.split('\n')) {
+    const h2 = line.match(/^## +(.+?) *$/);
+    if (h2) { section = h2[1]; continue; }
+    if (!line.startsWith('|')) continue;
+
+    const cells = line.split('|').map(cell => cell.trim());
+    // cells[0] is the empty string before the leading pipe.
+    const rawId = cells[1];
+    if (!rawId || !/^\d+$/.test(rawId)) continue;
+
+    const titleCell = cells[2] || '';
+    const titleMatch = titleCell.match(MD_LINK);
+    if (!titleMatch) continue;
+
+    const id = String(parseInt(rawId, 10));
+    const difficulty = DIFFICULTIES.includes(cells[6]) ? cells[6] : 'Unknown';
+    const solutions = parseSolutionLinks(cells[3] || '');
+
+    const existing = problems.get(id);
+    if (existing) {
+      Object.assign(existing.solutions, solutions, existing.solutions);
+      continue;
+    }
+    problems.set(id, {
+      id,
+      title: titleMatch[1].trim(),
+      url: titleMatch[2],
+      difficulty,
+      section,
+      solutions
+    });
+  }
+  return problems;
+}
+
+/**
+ * `[Python](./leetcode_python/x.py), [Java](./y.java)` → `{Python: <gh url>, …}`.
+ * Repo-relative paths become absolute GitHub blob URLs; anything already
+ * absolute is passed through untouched.
+ */
+function parseSolutionLinks(cell) {
+  const solutions = {};
+  for (const match of cell.matchAll(MD_LINK_ALL)) {
+    const lang = match[1].trim();
+    const href = match[2].trim();
+    if (!lang || !href) continue;
+    solutions[lang] = /^https?:\/\//.test(href)
+      ? href
+      : `${GH_BLOB}/${href.replace(/^\.\//, '')}`;
+  }
+  return solutions;
+}
+
+// ── Cheatsheet titles ────────────────────────────────────────────────────────
+
+/**
+ * slug → the label to show on a roadmap node's cheatsheet chip.
+ *
+ * Same precedence the site index uses: the `title` override in
+ * data/cheatsheet_meta.json wins, otherwise the sheet's own H1. Falling back to
+ * the slug would leak filenames like "2_pointers" onto the page.
+ */
+function buildSheetTitles(dir, meta) {
+  const overrides = (meta && meta.sheets) || {};
+  const titles = new Map();
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.md') || file === '00_template.md') continue;
+    const slug = path.basename(file, '.md');
+    const override = overrides[slug] && overrides[slug].title;
+    if (override) { titles.set(slug, override); continue; }
+    const h1 = fs.readFileSync(path.join(dir, file), 'utf8').match(/^# +(.+?) *$/m);
+    titles.set(slug, h1 ? h1[1].trim() : slug);
+  }
+  return titles;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+/**
+ * Returns every structural problem with the authored graph, as a list of
+ * human-readable strings. Collecting them all beats throwing on the first one:
+ * a new node usually trips several checks at once, and fixing them one build
+ * at a time is miserable.
+ */
+function validateGraph(nodes, { problems, sheetSlugs }) {
+  const errors = [];
+  const byId = new Map();
+
+  for (const node of nodes) {
+    if (!node.id) { errors.push(`a node is missing an "id" (title: ${node.title || '?'})`); continue; }
+    if (byId.has(node.id)) errors.push(`duplicate node id "${node.id}"`);
+    byId.set(node.id, node);
+    if (!node.title) errors.push(`node "${node.id}" is missing a "title"`);
+    if (!Number.isInteger(node.row) || node.row < 0) {
+      errors.push(`node "${node.id}" needs an integer "row" >= 0 (got ${JSON.stringify(node.row)})`);
+    }
+    if (!Array.isArray(node.problems) || node.problems.length === 0) {
+      errors.push(`node "${node.id}" lists no problems`);
+    }
+  }
+
+  for (const node of nodes) {
+    const prereqs = node.prereqs || [];
+    for (const prereq of prereqs) {
+      const parent = byId.get(prereq);
+      if (!parent) { errors.push(`node "${node.id}" lists unknown prereq "${prereq}"`); continue; }
+      // The row order is what makes the drawing readable: every edge must point
+      // downward, so a topic never sits level with or above something it needs.
+      if (Number.isInteger(parent.row) && Number.isInteger(node.row) && parent.row >= node.row) {
+        errors.push(
+          `node "${node.id}" (row ${node.row}) must sit below its prereq "${prereq}" (row ${parent.row})`
+        );
+      }
+    }
+    if (new Set(prereqs).size !== prereqs.length) {
+      errors.push(`node "${node.id}" repeats a prereq`);
+    }
+
+    for (const slug of node.sheets || []) {
+      if (!sheetSlugs.has(slug)) errors.push(`node "${node.id}" links unknown cheatsheet "${slug}"`);
+    }
+
+    const seen = new Set();
+    for (const raw of node.problems || []) {
+      const id = String(raw);
+      if (seen.has(id)) errors.push(`node "${node.id}" repeats problem #${id}`);
+      seen.add(id);
+      if (!problems.has(id)) {
+        errors.push(`node "${node.id}" lists problem #${id}, which is not in README.md`);
+      }
+    }
+  }
+
+  for (const cycle of findCycles(nodes)) {
+    errors.push(`prereq cycle: ${cycle.join(' → ')}`);
+  }
+  for (const [node, prereq, via] of findRedundantEdges(nodes)) {
+    errors.push(
+      `node "${node}" lists prereq "${prereq}", which it already reaches through "${via}" — ` +
+      'drop the direct edge (it draws a line across the graph that says nothing new)'
+    );
+  }
+  return errors;
+}
+
+/**
+ * Edges that the rest of the graph already implies, as [node, prereq, via].
+ *
+ * A roadmap only reads as a roadmap if it is a transitive reduction. "Design a
+ * X after Linked List" is true but redundant once Design already sits behind
+ * Heap → Trees → Linked List, and drawing it costs a line spanning three rows
+ * for no information. Keeping the authored graph reduced is what keeps the
+ * picture legible as topics are added.
+ */
+function findRedundantEdges(nodes) {
+  const prereqsOf = new Map(nodes.map(n => [n.id, (n.prereqs || []).filter(p => p !== n.id)]));
+
+  // Ancestors reachable *without* using the direct edge under test.
+  function reaches(from, target, skip, seen = new Set()) {
+    for (const next of prereqsOf.get(from) || []) {
+      if (from === skip[0] && next === skip[1]) continue;
+      if (next === target) return true;
+      if (seen.has(next)) continue;
+      seen.add(next);
+      if (reaches(next, target, skip, seen)) return true;
+    }
+    return false;
+  }
+
+  const redundant = [];
+  for (const node of nodes) {
+    for (const prereq of prereqsOf.get(node.id) || []) {
+      if (!prereqsOf.has(prereq)) continue; // unknown — already reported
+      for (const other of prereqsOf.get(node.id)) {
+        if (other === prereq || !prereqsOf.has(other)) continue;
+        if (reaches(other, prereq, [node.id, prereq])) {
+          redundant.push([node.id, prereq, other]);
+          break;
+        }
+      }
+    }
+  }
+  return redundant;
+}
+
+/**
+ * Depth-first cycle detection over the prereq edges. The row check above
+ * already rules cycles out for a well-formed graph, but it is skipped when a
+ * row is missing or non-integer — and an un-caught cycle would hang the
+ * downstream unlock computation on the page.
+ */
+function findCycles(nodes) {
+  const edges = new Map(nodes.map(n => [n.id, (n.prereqs || []).filter(p => n.id !== p)]));
+  const selfLoops = nodes.filter(n => (n.prereqs || []).includes(n.id)).map(n => [n.id, n.id]);
+  const state = new Map();
+  const cycles = [];
+  const stack = [];
+
+  function visit(id) {
+    if (state.get(id) === 'done') return;
+    if (state.get(id) === 'open') {
+      cycles.push([...stack.slice(stack.indexOf(id)), id]);
+      return;
+    }
+    if (!edges.has(id)) return; // unknown prereq — already reported
+    state.set(id, 'open');
+    stack.push(id);
+    for (const next of edges.get(id)) visit(next);
+    stack.pop();
+    state.set(id, 'done');
+  }
+
+  for (const node of nodes) visit(node.id);
+  return [...selfLoops, ...cycles];
+}
+
+// ── Assembly ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolves each node's problem ids against the README index and stamps on the
+ * layout fields the page needs: `row` (authored) plus `col`/`rowSize`, which
+ * place the node horizontally within its row in authored order.
+ */
+function buildRoadmap(roadmap, problems, sheetTitles = new Map()) {
+  const rowCounts = new Map();
+  for (const node of roadmap.nodes) {
+    rowCounts.set(node.row, (rowCounts.get(node.row) || 0) + 1);
+  }
+
+  const seenInRow = new Map();
+  const nodes = roadmap.nodes.map(node => {
+    const col = seenInRow.get(node.row) || 0;
+    seenInRow.set(node.row, col + 1);
+    return {
+      id: node.id,
+      title: node.title,
+      blurb: node.blurb || '',
+      row: node.row,
+      col,
+      rowSize: rowCounts.get(node.row),
+      prereqs: node.prereqs || [],
+      sheets: (node.sheets || []).map(slug => ({
+        slug,
+        title: sheetTitles.get(slug) || slug,
+        url: `cheatsheets/${slug}.html`
+      })),
+      problems: node.problems.map(raw => {
+        const p = problems.get(String(raw));
+        return {
+          id: p.id,
+          title: p.title,
+          url: p.url,
+          difficulty: p.difficulty,
+          solutions: p.solutions
+        };
+      })
+    };
+  });
+
+  const allIds = new Set();
+  nodes.forEach(n => n.problems.forEach(p => allIds.add(p.id)));
+
+  return {
+    meta: roadmap.meta || {},
+    nodes,
+    stats: {
+      topics: nodes.length,
+      problems: allIds.size,
+      // Counted distinctly: a problem that two topics both list (LC 323 sits in
+      // both Graphs and Union Find) is one problem to solve, not two.
+      problemSlots: nodes.reduce((sum, n) => sum + n.problems.length, 0),
+      rows: rowCounts.size
+    }
+  };
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+function main() {
+  const roadmap = JSON.parse(fs.readFileSync('data/roadmap.json', 'utf8'));
+  const problems = parseReadmeProblems(fs.readFileSync('README.md', 'utf8'));
+  console.log(`Indexed ${problems.size} problems from README.md`);
+
+  const cheatsheetMeta = JSON.parse(fs.readFileSync('data/cheatsheet_meta.json', 'utf8'));
+  const sheetTitles = buildSheetTitles('doc/cheatsheet', cheatsheetMeta);
+
+  const errors = validateGraph(roadmap.nodes, { problems, sheetSlugs: new Set(sheetTitles.keys()) });
+  if (errors.length) {
+    throw new Error(`data/roadmap.json is inconsistent:\n  - ${errors.join('\n  - ')}`);
+  }
+
+  const built = buildRoadmap(roadmap, problems, sheetTitles);
+  fs.mkdirSync('_site/data', { recursive: true });
+  fs.writeFileSync('_site/data/roadmap.json', JSON.stringify(built));
+  console.log(
+    `✓ Created data/roadmap.json (${built.stats.topics} topics over ${built.stats.rows} rows, ` +
+    `${built.stats.problems} distinct problems in ${built.stats.problemSlots} slots)`
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`❌ ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  GH_BLOB,
+  parseReadmeProblems,
+  parseSolutionLinks,
+  buildSheetTitles,
+  validateGraph,
+  findCycles,
+  findRedundantEdges,
+  buildRoadmap
+};

--- a/site/build.sh
+++ b/site/build.sh
@@ -33,9 +33,10 @@ cp -r doc/pic _site/doc/pic
 # ── Generated pages ───────────────────────────────────────────────────────────
 node site/build-site.js       # doc/**.md      -> HTML pages + search index
 node site/build-leetcode.js   # leetcode_*/**  -> _site/data/lc-problems.json
+node site/build-roadmap.js    # data/roadmap.json + README.md -> _site/data/roadmap.json
 
 # ── Shared CSS + JS ───────────────────────────────────────────────────────────
-cp site/style.css site/nav.css site/nav.js site/site.js _site/
+cp site/style.css site/nav.css site/nav.js site/site.js site/roadmap.js _site/
 
 # ── Hand-maintained static pages (LC tools, 404) ──────────────────────────────
 cp site/pages/*.html _site/

--- a/site/nav.js
+++ b/site/nav.js
@@ -35,23 +35,29 @@
 
   // Entries rendered inline in the bar.
   var PRIMARY = [
-    { id: 'home',             label: 'home',        href: 'index.html' },
-    { id: 'search',           label: 'search',      href: 'search.html' },
-    { id: 'cheatsheets',      label: 'cheatsheets', href: 'cheatsheets.html' },
-    { id: 'faqs',             label: 'faqs',        href: 'faqs.html' },
-    { id: 'lc-explorer',      label: 'lc-explorer', href: 'lc-explorer.html' },
-    { id: 'lc-random-picker', label: 'random',      href: 'lc-random-picker.html' },
-    { id: 'visualizer',       label: 'visualizer',  href: 'algo_demo/index.html' }
+    { id: 'home',        label: 'home',        href: 'index.html' },
+    { id: 'search',      label: 'search',      href: 'search.html' },
+    { id: 'lc-roadmap',  label: 'roadmap',     href: 'lc-roadmap.html' },
+    { id: 'cheatsheets', label: 'cheatsheets', href: 'cheatsheets.html' },
+    { id: 'faqs',        label: 'faqs',        href: 'faqs.html' },
+    { id: 'lc-explorer', label: 'lc-explorer', href: 'lc-explorer.html' },
+    { id: 'visualizer',  label: 'visualizer',  href: 'algo_demo/index.html' }
   ];
 
   // Secondary entries, collapsed behind the "more" dropdown. The button lights
   // up when the current page is one of them, so the trail survives collapsing.
+  //
+  // The inline row is capacity-bound, not preference-bound: eight entries
+  // overflow the bar between 768px and 1024px. The roadmap took the slot the
+  // random picker held, since the picker's siblings (similar, review) already
+  // live down here.
   var MORE = [
-    { id: 'patterns',       label: 'patterns',  href: 'patterns.html' },
-    { id: 'lc-similar',     label: 'similar',   href: 'lc-similar.html' },
-    { id: 'lc-review-plan', label: 'review',    href: 'lc-review-plan.html' },
-    { id: 'resources',      label: 'resources', href: 'resources.html' },
-    { id: 'github',         label: 'github',    href: 'https://github.com/yennanliu/CS_basics', external: true }
+    { id: 'patterns',         label: 'patterns',  href: 'patterns.html' },
+    { id: 'lc-similar',       label: 'similar',   href: 'lc-similar.html' },
+    { id: 'lc-review-plan',   label: 'review',    href: 'lc-review-plan.html' },
+    { id: 'lc-random-picker', label: 'random',    href: 'lc-random-picker.html' },
+    { id: 'resources',        label: 'resources', href: 'resources.html' },
+    { id: 'github',           label: 'github',    href: 'https://github.com/yennanliu/CS_basics', external: true }
   ];
 
   // ── Markup ──────────────────────────────────────────────────────────────

--- a/site/pages/lc-roadmap.html
+++ b/site/pages/lc-roadmap.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#000000">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <title>Study Roadmap - CS Basics</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🗺️</text></svg>">
+  <link rel="stylesheet" href="nav.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    :root {
+      --bg: #ffffff; --surface: #f0f0f0; --text: #000000;
+      --text-light: #555555; --border: #cccccc; --radius: 0px; --accent: #000000;
+      --edge: #bbbbbb; --edge-live: #1e7e34; --locked-ink: #8a8a8a;
+    }
+    [data-theme="dark"] {
+      --bg: #000000; --surface: #111111; --text: #ffffff;
+      --text-light: #8a8a8a; --border: #1f1f1f; --accent: #ffffff;
+      --edge: #333333; --edge-live: #2f9e4f; --locked-ink: #5a5a5a;
+    }
+    body {
+      margin: 0; padding: 0;
+      font-family: 'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,'Menlo',monospace;
+      background: var(--bg); color: var(--text);
+      transition: background 0.2s, color 0.2s; font-size: 13px;
+    }
+    a { color: inherit; }
+
+    .container { max-width: 1200px; margin: 2rem auto 4rem; padding: 0 1.5rem; }
+
+    /* ── Header ── */
+    .page-header { text-align: center; margin-bottom: 1.75rem; }
+    .page-header h1 { margin: 0 0 0.4rem; font-size: 2rem; }
+    .page-header p { color: var(--text-light); margin: 0 auto; font-size: 0.95rem; max-width: 64ch; line-height: 1.6; }
+
+    .summary {
+      display: flex; align-items: center; gap: 1.25rem; flex-wrap: wrap;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; padding: 1rem 1.25rem; margin-bottom: 1rem;
+    }
+    .summary-figure { display: flex; flex-direction: column; gap: 0.15rem; }
+    .summary-figure b { font-size: 1.35rem; line-height: 1.1; white-space: nowrap; }
+    .summary-figure span {
+      font-size: 0.7rem; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--text-light);
+    }
+    .summary-bar-wrap { flex: 1 1 200px; min-width: 160px; }
+    .summary-bar { height: 8px; background: var(--border); border-radius: 999px; overflow: hidden; }
+    .summary-bar > i { display: block; height: 100%; width: 0; background: var(--edge-live); transition: width 0.25s; }
+    .summary-bar-label { font-size: 0.75rem; color: var(--text-light); margin-top: 0.4rem; }
+
+    .btn {
+      background: var(--bg); color: var(--text);
+      border: 1px solid var(--border); border-radius: 6px;
+      padding: 0.4rem 0.8rem; font-size: 0.78rem; font-family: inherit;
+      cursor: pointer; transition: border-color 0.15s, opacity 0.15s;
+    }
+    .btn:hover { border-color: var(--text); }
+    .btn-primary { background: var(--text); color: var(--bg); border-color: var(--text); font-weight: 700; }
+    .btn-primary:hover { opacity: 0.85; }
+
+    /* ── Next-up hint ── */
+    .next-up {
+      display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
+      border: 1px dashed var(--border); border-radius: 10px;
+      padding: 0.7rem 1rem; margin-bottom: 1.5rem; font-size: 0.85rem;
+    }
+    .next-up .label {
+      text-transform: uppercase; letter-spacing: 0.08em;
+      font-size: 0.7rem; color: var(--text-light);
+    }
+    .next-up .where { color: var(--text-light); }
+
+    /* ── Graph ── */
+    .graph-scroll { overflow-x: auto; padding-bottom: 0.5rem; }
+    .graph { position: relative; min-width: 940px; padding: 0.5rem 0 1rem; }
+    .graph-edges { position: absolute; top: 0; left: 0; pointer-events: none; }
+    .graph-edges path {
+      fill: none; stroke: var(--edge); stroke-width: 1.5;
+      transition: opacity 0.15s, stroke 0.15s;
+    }
+    .graph-edges path.live { stroke: var(--edge-live); stroke-width: 2; }
+    /* Hovering a topic pulls its own edges out of the tangle. */
+    .graph-edges.focused path { opacity: 0.18; }
+    .graph-edges.focused path.hot { opacity: 1; stroke: var(--text); stroke-width: 2.5; }
+    .graph-edges.focused path.hot.live { stroke: var(--edge-live); }
+
+    .row {
+      position: relative; z-index: 1;
+      display: flex; justify-content: center; gap: 1rem;
+      margin-bottom: 2.6rem;
+    }
+    .row:last-child { margin-bottom: 0; }
+
+    .node {
+      /* display:flex, not the button default: a stretched <button> lays its
+         content out from an anonymous box that does not grow with it, which
+         pushed the progress bar outside the border. */
+      display: flex; flex-direction: column; justify-content: space-between;
+      flex: 0 1 190px; max-width: 230px; text-align: left;
+      background: var(--surface); color: var(--text);
+      border: 1px solid var(--border); border-radius: 10px;
+      padding: 0.7rem 0.8rem 0.75rem;
+      font-family: inherit; font-size: 0.82rem;
+      cursor: pointer; transition: border-color 0.15s, transform 0.15s, background 0.15s;
+    }
+    .node:hover { border-color: var(--text); transform: translateY(-2px); }
+    .node:focus-visible { outline: 2px solid var(--edge-live); outline-offset: 2px; }
+    /* Opaque, not transparent: a locked box still has to hide the edges that
+       pass behind it, or long curves read as strikethroughs across the title. */
+    .node.locked { color: var(--locked-ink); background: var(--bg); border-style: dashed; }
+    .node.done { border-color: var(--edge-live); }
+
+    .node-head { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; }
+    .node-title { font-weight: 700; line-height: 1.35; }
+    .node-count { font-size: 0.72rem; color: var(--text-light); white-space: nowrap; }
+    .node.done .node-count { color: var(--edge-live); }
+    .node-bar { height: 4px; background: var(--edge); border-radius: 999px; margin-top: 0.65rem; overflow: hidden; }
+    .node-bar > i { display: block; height: 100%; width: 0; background: var(--text); transition: width 0.25s; }
+    .node.done .node-bar > i { background: var(--edge-live); }
+
+    /* ── Drawer ── */
+    .overlay {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.45);
+      opacity: 0; pointer-events: none; transition: opacity 0.2s; z-index: 200;
+    }
+    .overlay.open { opacity: 1; pointer-events: auto; }
+
+    .drawer {
+      position: fixed; top: 0; right: 0; bottom: 0; width: min(480px, 100%);
+      background: var(--bg); border-left: 1px solid var(--border);
+      transform: translateX(100%); transition: transform 0.22s ease;
+      z-index: 201; display: flex; flex-direction: column;
+    }
+    .drawer.open { transform: none; }
+    .drawer-head { position: relative; padding: 1.1rem 3rem 0.9rem 1.25rem; border-bottom: 1px solid var(--border); }
+    .drawer-head h2 { margin: 0 0 0.35rem; font-size: 1.1rem; }
+    .drawer-head p { margin: 0; color: var(--text-light); font-size: 0.82rem; line-height: 1.55; }
+    .drawer-close {
+      position: absolute; top: 0.7rem; right: 0.85rem;
+      background: none; border: none; color: var(--text-light);
+      font-size: 1.5rem; line-height: 1; cursor: pointer; font-family: inherit;
+    }
+    .drawer-close:hover { color: var(--text); }
+    /* Opening the drawer moves focus here, so the ring is seen often enough
+       that the UA default (bright blue) reads as an error against this palette. */
+    .drawer-close:focus-visible { outline: 2px solid var(--edge-live); outline-offset: 2px; border-radius: 4px; }
+    .drawer-body { flex: 1; overflow-y: auto; padding: 1rem 1.25rem 2.5rem; }
+    .drawer-section { margin-bottom: 1.4rem; }
+    .drawer-section h3 {
+      margin: 0 0 0.5rem; font-size: 0.7rem; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--text-light); font-weight: 700;
+    }
+    .chips { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+    .chips.bulk { margin-bottom: 0.6rem; }
+    .chip {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      border: 1px solid var(--border); border-radius: 999px;
+      padding: 0.22rem 0.6rem; font-size: 0.74rem; font-family: inherit;
+      background: none; color: var(--text-light); text-decoration: none; cursor: pointer;
+    }
+    .chip:hover { border-color: var(--text); color: var(--text); }
+    .chip.met { border-color: var(--edge-live); color: var(--edge-live); }
+
+    .prob {
+      display: flex; align-items: center; gap: 0.55rem;
+      padding: 0.42rem 0; border-bottom: 1px solid var(--border);
+    }
+    .prob:last-child { border-bottom: none; }
+    .prob input { width: 15px; height: 15px; accent-color: var(--edge-live); cursor: pointer; flex-shrink: 0; }
+    .prob-id { font-size: 0.72rem; color: var(--text-light); width: 3.2rem; flex-shrink: 0; }
+    .prob-title { flex: 1; min-width: 0; font-size: 0.82rem; text-decoration: none; line-height: 1.35; }
+    .prob-title:hover { text-decoration: underline; }
+    .prob.solved .prob-title { color: var(--text-light); text-decoration: line-through; }
+    .prob-links { display: flex; gap: 0.3rem; flex-shrink: 0; }
+    .prob-links a {
+      border: 1px solid var(--border); border-radius: 4px;
+      padding: 0.1rem 0.35rem; font-size: 0.68rem; text-decoration: none; color: var(--text-light);
+    }
+    .prob-links a:hover { border-color: var(--text); color: var(--text); }
+
+    .diff-badge {
+      padding: 0.12rem 0.45rem; border-radius: 4px;
+      font-size: 0.62rem; font-weight: 700; flex-shrink: 0;
+      text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap;
+    }
+    .diff-badge.Easy    { background: #1e7e34; color: #fff; }
+    .diff-badge.Medium  { background: #b45309; color: #fff; }
+    .diff-badge.Hard    { background: #b91c1c; color: #fff; }
+    .diff-badge.Unknown { background: var(--border); color: var(--text-light); }
+    [data-theme="dark"] .diff-badge.Easy   { background: #166534; }
+    [data-theme="dark"] .diff-badge.Medium { background: #92400e; }
+    [data-theme="dark"] .diff-badge.Hard   { background: #991b1b; }
+
+    .loading { color: var(--text-light); text-align: center; padding: 2rem 0; }
+    .note {
+      color: var(--text-light); font-size: 0.78rem;
+      line-height: 1.6; padding-top: 1.75rem; margin: 0;
+      border-top: 1px solid var(--border); margin-top: 2rem;
+    }
+
+    @media (max-width: 700px) {
+      .container { padding: 0 1rem; }
+      .page-header h1 { font-size: 1.5rem; }
+      .drawer { width: 100%; border-left: none; }
+    }
+  </style>
+</head>
+<body>
+  <div id="site-nav" data-page="lc-roadmap" data-base=""></div>
+  <script>CSNav.mount();</script>
+
+  <main class="container">
+    <div class="page-header">
+      <h1 id="pageTitle">Study Roadmap</h1>
+      <p id="pageIntro"></p>
+    </div>
+
+    <div class="summary" id="summary" hidden>
+      <div class="summary-figure"><b id="statProblems">–</b><span>problems</span></div>
+      <div class="summary-figure"><b id="statTopics">–</b><span>topics done</span></div>
+      <div class="summary-bar-wrap">
+        <div class="summary-bar"><i id="summaryFill"></i></div>
+        <div class="summary-bar-label" id="summaryLabel"></div>
+      </div>
+      <button class="btn" id="resetBtn" type="button">reset progress</button>
+    </div>
+
+    <div class="next-up" id="nextUp" hidden></div>
+
+    <div class="graph-scroll">
+      <div class="graph" id="graph">
+        <svg class="graph-edges" id="edges" aria-hidden="true"></svg>
+      </div>
+    </div>
+
+    <div class="loading" id="loading">Loading roadmap…</div>
+
+    <p class="note" id="note" hidden>
+      Click a topic to see its problems, its prerequisites and the cheatsheets that cover it.
+      A topic unlocks once everything it depends on is finished — the lock is a suggested order,
+      not a gate, so you can always open it anyway. Progress is stored in this browser only and
+      is never uploaded. A problem that two topics both list (LC 323 sits in both Graphs and
+      Union Find) is one tick, counted once.
+    </p>
+  </main>
+
+  <div class="overlay" id="overlay"></div>
+  <aside class="drawer" id="drawer" role="dialog" aria-hidden="true" aria-labelledby="drawerTitle">
+    <div class="drawer-head">
+      <button class="drawer-close" id="drawerClose" type="button" aria-label="Close">×</button>
+      <h2 id="drawerTitle"></h2>
+      <p id="drawerBlurb"></p>
+    </div>
+    <div class="drawer-body" id="drawerBody"></div>
+  </aside>
+
+  <script src="roadmap.js"></script>
+  <script>CSRoadmap.init();</script>
+</body>
+</html>

--- a/site/pages/lc-roadmap.html
+++ b/site/pages/lc-roadmap.html
@@ -197,6 +197,17 @@
     [data-theme="dark"] .diff-badge.Medium { background: #92400e; }
     [data-theme="dark"] .diff-badge.Hard   { background: #991b1b; }
 
+    /* Mirrors the generated pages' footer (site/style.css), which this page
+       cannot reuse — the hand-maintained tools carry their own tokens. */
+    footer {
+      background: var(--surface); border-top: 1px solid var(--border);
+      padding: 1.5rem 0; text-align: center; color: var(--text-light);
+    }
+    footer p { margin: 0.25rem 0; font-size: 0.85rem; }
+    footer a { color: var(--text-light); margin: 0 0.5rem; text-decoration: none; }
+    footer a:hover { color: var(--text); }
+    footer .container { margin: 0 auto; }
+
     .loading { color: var(--text-light); text-align: center; padding: 2rem 0; }
     .note {
       color: var(--text-light); font-size: 0.78rem;
@@ -249,6 +260,17 @@
       Union Find) is one tick, counted once.
     </p>
   </main>
+
+  <footer>
+    <div class="container">
+      <p>CS_basics — computer science fundamentals &amp; interview preparation</p>
+      <p>
+        <a href="https://github.com/yennanliu/CS_basics">github</a> |
+        <a href="https://github.com/yennanliu/CS_basics/tree/master/doc">docs</a> |
+        <a href="https://github.com/yennanliu/CS_basics/issues">issues</a>
+      </p>
+    </div>
+  </footer>
 
   <div class="overlay" id="overlay"></div>
   <aside class="drawer" id="drawer" role="dialog" aria-hidden="true" aria-labelledby="drawerTitle">

--- a/site/roadmap.js
+++ b/site/roadmap.js
@@ -22,7 +22,12 @@
   // tick it in the other.
   var STORE_KEY = 'cs:roadmap:solved';
 
-  var state = { roadmap: null, byId: {}, solved: Object.create(null), openId: null };
+  var state = {
+    roadmap: null, byId: {}, solved: Object.create(null),
+    openId: null,
+    // The element focus should go back to when the drawer closes.
+    returnFocus: null
+  };
 
   // ── Storage ─────────────────────────────────────────────────────────────
 
@@ -343,9 +348,20 @@
     }
   }
 
-  function openDrawer(id) {
+  /**
+   * Shows `node`'s problems, prerequisites and cheatsheets.
+   *
+   * `opener` is the control that asked for it, remembered so closing can hand
+   * focus back. It is passed in rather than read off `document.activeElement`
+   * because a click does not reliably leave focus on the thing clicked. Only
+   * the first open records it: hopping prereq → prereq inside the drawer should
+   * still return you to the box you started from, not to a chip the next render
+   * has already thrown away.
+   */
+  function openDrawer(id, opener) {
     var node = state.byId[id];
     if (!node) return;
+    if (!state.openId) state.returnFocus = opener || null;
     state.openId = id;
     $('drawerTitle').textContent = node.title;
     $('drawerBlurb').textContent = node.blurb || '';
@@ -364,6 +380,12 @@
     $('drawer').setAttribute('aria-hidden', 'true');
     $('overlay').classList.remove('open');
     setHash(null);
+    // The close button we were sitting on is now inside an aria-hidden panel
+    // parked off-screen. Without this a keyboard or screen-reader user is left
+    // focused on nothing and has to tab in from the top of the document.
+    var opener = state.returnFocus;
+    state.returnFocus = null;
+    if (opener && opener.isConnected && typeof opener.focus === 'function') opener.focus();
   }
 
   // replaceState rather than assigning location.hash: the drawer is not a
@@ -384,7 +406,7 @@
   function wire() {
     $('graph').addEventListener('click', function (event) {
       var el = event.target.closest('.node');
-      if (el) openDrawer(el.getAttribute('data-id'));
+      if (el) openDrawer(el.getAttribute('data-id'), el);
     });
 
     // Twenty-nine boxes make for a lot of crossing lines. Hovering a topic
@@ -425,7 +447,7 @@
 
     $('nextUp').addEventListener('click', function (event) {
       var jump = event.target.closest('[data-open]');
-      if (jump) openDrawer(jump.getAttribute('data-open'));
+      if (jump) openDrawer(jump.getAttribute('data-open'), jump);
     });
 
     $('resetBtn').addEventListener('click', function () {
@@ -446,6 +468,11 @@
     state.roadmap = roadmap;
     state.byId = indexNodes(roadmap.nodes);
     state.solved = readSolved();
+    // A browser renders once per page load, but `state` outlives a re-render.
+    // Carrying an open topic — or a focus target belonging to the previous
+    // document — over into a fresh render leaves both pointing at dead nodes.
+    state.openId = null;
+    state.returnFocus = null;
 
     if (roadmap.meta && roadmap.meta.title) {
       $('pageTitle').textContent = roadmap.meta.title;

--- a/site/roadmap.js
+++ b/site/roadmap.js
@@ -1,0 +1,506 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   CS_basics — study roadmap
+
+   Behaviour for lc-roadmap.html: a topic DAG where each box tracks how many
+   of its problems you have solved, and a topic unlocks once its prerequisites
+   are finished. `_site/data/roadmap.json` (built by site/build-roadmap.js) is
+   the only input; progress lives in localStorage and never leaves the browser.
+
+   Loaded as a plain script next to nav.js, and required directly by
+   site/test/roadmap.test.js — everything above `init` is a pure function of
+   (nodes, solved) so the unlock and counting rules can be tested without a
+   rendered page.
+   ───────────────────────────────────────────────────────────────────────── */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.CSRoadmap = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // Progress is keyed by LeetCode id, not by (topic, id): a problem that two
+  // topics both list is one problem to solve, so ticking it in one place must
+  // tick it in the other.
+  var STORE_KEY = 'cs:roadmap:solved';
+
+  var state = { roadmap: null, byId: {}, solved: Object.create(null), openId: null };
+
+  // ── Storage ─────────────────────────────────────────────────────────────
+
+  // Wrapped because Safari's private mode throws on localStorage access rather
+  // than returning null, which would otherwise break the whole page.
+  function readSolved() {
+    var solved = Object.create(null);
+    try {
+      var raw = typeof localStorage !== 'undefined' && localStorage.getItem(STORE_KEY);
+      var ids = raw ? JSON.parse(raw) : [];
+      if (Array.isArray(ids)) {
+        for (var i = 0; i < ids.length; i++) solved[String(ids[i])] = true;
+      }
+    } catch (e) { /* unreadable or corrupt — start from empty */ }
+    return solved;
+  }
+
+  function writeSolved(solved) {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(STORE_KEY, JSON.stringify(Object.keys(solved)));
+      }
+    } catch (e) { /* storage unavailable — the page still works for this visit */ }
+  }
+
+  // ── Derived state ───────────────────────────────────────────────────────
+
+  function esc(value) {
+    return String(value).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  function indexNodes(nodes) {
+    var byId = {};
+    for (var i = 0; i < nodes.length; i++) byId[nodes[i].id] = nodes[i];
+    return byId;
+  }
+
+  function statsFor(node, solved) {
+    var done = 0;
+    for (var i = 0; i < node.problems.length; i++) {
+      if (solved[node.problems[i].id]) done++;
+    }
+    return { done: done, total: node.problems.length };
+  }
+
+  function isDone(node, solved) {
+    var s = statsFor(node, solved);
+    return s.total > 0 && s.done === s.total;
+  }
+
+  function percent(s) { return s.total ? Math.round((s.done / s.total) * 100) : 0; }
+
+  // A topic is unlocked once every prerequisite is finished. An unknown prereq
+  // id counts as met so a data slip cannot strand a branch — build-roadmap.js
+  // already fails the build on one.
+  function isUnlocked(node, byId, solved) {
+    var prereqs = node.prereqs || [];
+    for (var i = 0; i < prereqs.length; i++) {
+      var parent = byId[prereqs[i]];
+      if (parent && !isDone(parent, solved)) return false;
+    }
+    return true;
+  }
+
+  function unmetPrereqs(node, byId, solved) {
+    return (node.prereqs || []).filter(function (id) {
+      return byId[id] && !isDone(byId[id], solved);
+    });
+  }
+
+  // Counted distinctly: a problem two topics share is one tick, so summing the
+  // per-topic totals would overstate both the numerator and the denominator.
+  function distinctSolved(nodes, solved) {
+    var seen = Object.create(null);
+    for (var i = 0; i < nodes.length; i++) {
+      var problems = nodes[i].problems;
+      for (var j = 0; j < problems.length; j++) {
+        if (solved[problems[j].id]) seen[problems[j].id] = true;
+      }
+    }
+    return Object.keys(seen).length;
+  }
+
+  /**
+   * The shallowest unlocked, unfinished topic and its first unsolved problem —
+   * an answer to "what do I do next?" that does not require reading the graph.
+   * Ties go to the topic authored first, which is the left-most box in its row.
+   */
+  function nextUp(nodes, byId, solved) {
+    var best = null;
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (isDone(node, solved) || !isUnlocked(node, byId, solved)) continue;
+      if (best && node.row >= best.row) continue;
+      best = node;
+    }
+    if (!best) return null;
+    var problem = null;
+    for (var j = 0; j < best.problems.length; j++) {
+      if (!solved[best.problems[j].id]) { problem = best.problems[j]; break; }
+    }
+    return { node: best, problem: problem };
+  }
+
+  // ── Markup ──────────────────────────────────────────────────────────────
+
+  /**
+   * The edges already say what a topic waits on, so the box itself carries no
+   * "after X" line — printing it on all 29 boxes buried the graph in repeated
+   * labels. The waiting list lives in the tooltip and in the drawer instead.
+   */
+  function lockLabel(node, byId, solved) {
+    var unmet = unmetPrereqs(node, byId, solved);
+    if (!unmet.length) return '';
+    return 'Finish first: ' + unmet.map(function (id) { return byId[id].title; }).join(', ');
+  }
+
+  function nodeHTML(node, byId, solved) {
+    var s = statsFor(node, solved);
+    var lock = lockLabel(node, byId, solved);
+    var cls = 'node' + (isDone(node, solved) ? ' done' : '') + (lock ? ' locked' : '');
+    var label = node.title + ' — ' + s.done + ' of ' + s.total + ' solved' + (lock ? '. ' + lock : '');
+
+    return '<button type="button" class="' + cls + '" data-id="' + esc(node.id) + '"' +
+      ' title="' + esc(label) + '" aria-label="' + esc(label) + '">' +
+      '<span class="node-head">' +
+        '<span class="node-title">' + esc(node.title) + '</span>' +
+        '<span class="node-count">' + s.done + '/' + s.total + '</span>' +
+      '</span>' +
+      '<span class="node-bar"><i style="width:' + percent(s) + '%"></i></span>' +
+    '</button>';
+  }
+
+  function graphHTML(nodes, byId, solved) {
+    var rows = {};
+    for (var i = 0; i < nodes.length; i++) {
+      (rows[nodes[i].row] = rows[nodes[i].row] || []).push(nodes[i]);
+    }
+    return Object.keys(rows).map(Number).sort(function (a, b) { return a - b; })
+      .map(function (row) {
+        return '<div class="row" data-row="' + row + '">' + rows[row].map(function (node) {
+          return nodeHTML(node, byId, solved);
+        }).join('') + '</div>';
+      }).join('');
+  }
+
+  function problemHTML(problem, solved) {
+    var links = Object.keys(problem.solutions || {}).map(function (lang) {
+      return '<a href="' + esc(problem.solutions[lang]) + '" target="_blank" rel="noopener" ' +
+        'title="' + esc(lang) + ' solution in this repo">' + esc(lang.slice(0, 2)) + '</a>';
+    }).join('');
+
+    return '<div class="prob' + (solved[problem.id] ? ' solved' : '') + '">' +
+      '<input type="checkbox" data-check="' + esc(problem.id) + '"' +
+        (solved[problem.id] ? ' checked' : '') +
+        ' aria-label="Mark ' + esc('#' + problem.id + ' ' + problem.title) + ' as solved">' +
+      '<span class="prob-id">#' + esc(problem.id) + '</span>' +
+      '<a class="prob-title" href="' + esc(problem.url) + '" target="_blank" rel="noopener">' +
+        esc(problem.title) + '</a>' +
+      '<span class="diff-badge ' + esc(problem.difficulty) + '">' + esc(problem.difficulty) + '</span>' +
+      '<span class="prob-links">' + links + '</span>' +
+    '</div>';
+  }
+
+  function drawerBodyHTML(node, byId, solved) {
+    var s = statsFor(node, solved);
+    var html = '';
+
+    if ((node.prereqs || []).length) {
+      html += '<div class="drawer-section"><h3>Prerequisites</h3><div class="chips">' +
+        node.prereqs.map(function (id) {
+          var parent = byId[id];
+          if (!parent) return '';
+          var met = isDone(parent, solved);
+          return '<button type="button" class="chip' + (met ? ' met' : '') + '" data-open="' +
+            esc(id) + '">' + (met ? '✓ ' : '') + esc(parent.title) + '</button>';
+        }).join('') + '</div></div>';
+    }
+
+    if ((node.sheets || []).length) {
+      html += '<div class="drawer-section"><h3>Cheatsheets</h3><div class="chips">' +
+        node.sheets.map(function (sheet) {
+          return '<a class="chip" href="' + esc(sheet.url) + '">' + esc(sheet.title) + '</a>';
+        }).join('') + '</div></div>';
+    }
+
+    return html +
+      '<div class="drawer-section">' +
+        '<h3>Problems — ' + s.done + ' / ' + s.total + '</h3>' +
+        '<div class="chips bulk">' +
+          '<button type="button" class="chip" data-bulk="all">tick all</button>' +
+          '<button type="button" class="chip" data-bulk="none">clear all</button>' +
+        '</div>' +
+        node.problems.map(function (problem) {
+          return problemHTML(problem, solved);
+        }).join('') +
+      '</div>';
+  }
+
+  // A cubic curve that leaves the parent box downward and enters the child box
+  // downward, so edges read as flowing top-to-bottom even when they cross.
+  function edgePath(x1, y1, x2, y2) {
+    var mid = (y1 + y2) / 2;
+    return 'M' + x1 + ' ' + y1 + ' C' + x1 + ' ' + mid + ' ' + x2 + ' ' + mid + ' ' + x2 + ' ' + y2;
+  }
+
+  // ── DOM ─────────────────────────────────────────────────────────────────
+
+  function $(id) { return document.getElementById(id); }
+
+  // CSS.escape is missing on older Safari, and node ids are kebab-case, so only
+  // the two characters that could break out of the attribute selector matter.
+  function selectorFor(id) { return '.node[data-id="' + String(id).replace(/["\\]/g, '\\$&') + '"]'; }
+
+  /**
+   * Draws one curve per prereq edge, measured from where the boxes actually
+   * landed. Reading real geometry — rather than deriving it from row/col —
+   * keeps the lines attached when the canvas is scrolled or the rows reflow.
+   */
+  function drawEdges() {
+    var graph = $('graph');
+    var svg = $('edges');
+    if (!graph || !svg || !state.roadmap) return;
+
+    var base = graph.getBoundingClientRect();
+    svg.setAttribute('width', graph.offsetWidth);
+    svg.setAttribute('height', graph.offsetHeight);
+    svg.setAttribute('viewBox', '0 0 ' + graph.offsetWidth + ' ' + graph.offsetHeight);
+
+    var paths = '';
+    state.roadmap.nodes.forEach(function (node) {
+      var childEl = graph.querySelector(selectorFor(node.id));
+      if (!childEl) return;
+      var child = childEl.getBoundingClientRect();
+      (node.prereqs || []).forEach(function (prereqId) {
+        var parentEl = graph.querySelector(selectorFor(prereqId));
+        if (!parentEl) return;
+        var parent = parentEl.getBoundingClientRect();
+        var live = state.byId[prereqId] && isDone(state.byId[prereqId], state.solved);
+        paths += '<path class="' + (live ? 'live' : '') + '"' +
+          ' data-from="' + esc(prereqId) + '" data-to="' + esc(node.id) + '" d="' + edgePath(
+            parent.left - base.left + parent.width / 2, parent.bottom - base.top,
+            child.left - base.left + child.width / 2, child.top - base.top
+          ) + '"/>';
+      });
+    });
+    svg.innerHTML = paths;
+  }
+
+  /** Dims every edge except the ones entering or leaving `id`. */
+  function highlightEdges(id) {
+    var svg = $('edges');
+    if (!svg) return;
+    svg.classList.toggle('focused', Boolean(id));
+    var paths = svg.querySelectorAll('path');
+    for (var i = 0; i < paths.length; i++) {
+      var touches = id && (paths[i].getAttribute('data-from') === id ||
+                           paths[i].getAttribute('data-to') === id);
+      paths[i].classList.toggle('hot', Boolean(touches));
+    }
+  }
+
+  function renderSummary() {
+    var nodes = state.roadmap.nodes;
+    var done = distinctSolved(nodes, state.solved);
+    var total = state.roadmap.stats.problems;
+    var topicsDone = nodes.filter(function (n) { return isDone(n, state.solved); }).length;
+    var pct = total ? Math.round((done / total) * 100) : 0;
+
+    $('statProblems').textContent = done + ' / ' + total;
+    $('statTopics').textContent = topicsDone + ' / ' + nodes.length;
+    $('summaryFill').style.width = pct + '%';
+    $('summaryLabel').textContent = pct + '% of the roadmap solved';
+
+    var hint = $('nextUp');
+    var next = nextUp(nodes, state.byId, state.solved);
+    hint.hidden = false;
+    hint.innerHTML = next
+      ? '<span class="label">next up</span>' +
+        '<button class="btn btn-primary" type="button" data-open="' + esc(next.node.id) + '">' +
+          esc(next.node.title) + '</button>' +
+        (next.problem
+          ? '<span class="where">start with <a href="' + esc(next.problem.url) + '" ' +
+            'target="_blank" rel="noopener">#' + esc(next.problem.id) + ' ' +
+            esc(next.problem.title) + '</a></span>'
+          : '')
+      : '<span class="label">next up</span><span>Every topic is complete — ' +
+        'nothing left on the roadmap.</span>';
+  }
+
+  // Repaints the boxes in place instead of rebuilding the graph, so nothing
+  // under the pointer moves while you are ticking problems off.
+  function refreshNodes() {
+    state.roadmap.nodes.forEach(function (node) {
+      var el = document.querySelector(selectorFor(node.id));
+      if (!el) return;
+      var s = statsFor(node, state.solved);
+      var lock = lockLabel(node, state.byId, state.solved);
+      var label = node.title + ' — ' + s.done + ' of ' + s.total + ' solved' + (lock ? '. ' + lock : '');
+      el.classList.toggle('done', isDone(node, state.solved));
+      el.classList.toggle('locked', lock !== '');
+      el.setAttribute('title', label);
+      el.setAttribute('aria-label', label);
+      el.querySelector('.node-count').textContent = s.done + '/' + s.total;
+      el.querySelector('.node-bar > i').style.width = percent(s) + '%';
+    });
+  }
+
+  function afterChange() {
+    writeSolved(state.solved);
+    refreshNodes();
+    renderSummary();
+    drawEdges();
+    if (state.openId) {
+      $('drawerBody').innerHTML = drawerBodyHTML(state.byId[state.openId], state.byId, state.solved);
+    }
+  }
+
+  function openDrawer(id) {
+    var node = state.byId[id];
+    if (!node) return;
+    state.openId = id;
+    $('drawerTitle').textContent = node.title;
+    $('drawerBlurb').textContent = node.blurb || '';
+    $('drawerBody').innerHTML = drawerBodyHTML(node, state.byId, state.solved);
+    $('drawer').classList.add('open');
+    $('drawer').setAttribute('aria-hidden', 'false');
+    $('overlay').classList.add('open');
+    $('drawerClose').focus();
+    setHash(id);
+  }
+
+  function closeDrawer() {
+    if (!state.openId) return;
+    state.openId = null;
+    $('drawer').classList.remove('open');
+    $('drawer').setAttribute('aria-hidden', 'true');
+    $('overlay').classList.remove('open');
+    setHash(null);
+  }
+
+  // replaceState rather than assigning location.hash: the drawer is not a
+  // separate page, so it should not stack up history entries you have to
+  // back out of one by one — but the URL still names the open topic so it
+  // can be shared.
+  function setHash(id) {
+    if (typeof history === 'undefined' || !history.replaceState) return;
+    var target = id ? '#' + id : location.pathname + location.search;
+    if (id ? location.hash !== '#' + id : location.hash) history.replaceState(null, '', target);
+  }
+
+  function setSolved(id, on) {
+    if (on) state.solved[id] = true;
+    else delete state.solved[id];
+  }
+
+  function wire() {
+    $('graph').addEventListener('click', function (event) {
+      var el = event.target.closest('.node');
+      if (el) openDrawer(el.getAttribute('data-id'));
+    });
+
+    // Twenty-nine boxes make for a lot of crossing lines. Hovering a topic
+    // pulls out just the edges that touch it, which is the only way to read
+    // "what feeds this, and what does it feed" out of the tangle.
+    $('graph').addEventListener('mouseover', function (event) {
+      var el = event.target.closest('.node');
+      if (el) highlightEdges(el.getAttribute('data-id'));
+    });
+    $('graph').addEventListener('mouseout', function (event) {
+      if (event.target.closest('.node')) highlightEdges(null);
+    });
+
+    $('overlay').addEventListener('click', closeDrawer);
+    $('drawerClose').addEventListener('click', closeDrawer);
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') closeDrawer();
+    });
+
+    $('drawerBody').addEventListener('change', function (event) {
+      var box = event.target.closest('input[data-check]');
+      if (!box) return;
+      setSolved(box.getAttribute('data-check'), box.checked);
+      afterChange();
+    });
+
+    $('drawerBody').addEventListener('click', function (event) {
+      var bulk = event.target.closest('[data-bulk]');
+      if (bulk && state.openId) {
+        var on = bulk.getAttribute('data-bulk') === 'all';
+        state.byId[state.openId].problems.forEach(function (p) { setSolved(p.id, on); });
+        afterChange();
+        return;
+      }
+      var jump = event.target.closest('[data-open]');
+      if (jump) openDrawer(jump.getAttribute('data-open'));
+    });
+
+    $('nextUp').addEventListener('click', function (event) {
+      var jump = event.target.closest('[data-open]');
+      if (jump) openDrawer(jump.getAttribute('data-open'));
+    });
+
+    $('resetBtn').addEventListener('click', function () {
+      if (!Object.keys(state.solved).length) return;
+      if (typeof confirm === 'function' && !confirm('Clear all roadmap progress in this browser?')) return;
+      state.solved = Object.create(null);
+      afterChange();
+    });
+
+    window.addEventListener('resize', drawEdges);
+    if (typeof CSNav !== 'undefined') document.addEventListener(CSNav.THEME_EVENT, drawEdges);
+  }
+
+  // ── Boot ────────────────────────────────────────────────────────────────
+
+  /** Renders the roadmap from already-fetched data and wires up the page. */
+  function render(roadmap) {
+    state.roadmap = roadmap;
+    state.byId = indexNodes(roadmap.nodes);
+    state.solved = readSolved();
+
+    if (roadmap.meta && roadmap.meta.title) {
+      $('pageTitle').textContent = roadmap.meta.title;
+      document.title = roadmap.meta.title + ' - CS Basics';
+    }
+    $('pageIntro').textContent = (roadmap.meta && roadmap.meta.intro) || '';
+
+    $('graph').insertAdjacentHTML('beforeend', graphHTML(roadmap.nodes, state.byId, state.solved));
+    $('loading').hidden = true;
+    $('summary').hidden = false;
+    $('note').hidden = false;
+
+    renderSummary();
+    drawEdges();
+    wire();
+
+    var hash = location.hash.replace(/^#/, '');
+    if (hash && state.byId[hash]) openDrawer(hash);
+    return state;
+  }
+
+  function init(url) {
+    return fetch(url || './data/roadmap.json')
+      .then(function (res) { return res.json(); })
+      .then(render)
+      .catch(function () {
+        $('loading').textContent = 'Failed to load the roadmap data (data/roadmap.json).';
+      });
+  }
+
+  return {
+    STORE_KEY: STORE_KEY,
+    esc: esc,
+    indexNodes: indexNodes,
+    statsFor: statsFor,
+    isDone: isDone,
+    percent: percent,
+    isUnlocked: isUnlocked,
+    lockLabel: lockLabel,
+    highlightEdges: highlightEdges,
+    unmetPrereqs: unmetPrereqs,
+    distinctSolved: distinctSolved,
+    nextUp: nextUp,
+    nodeHTML: nodeHTML,
+    graphHTML: graphHTML,
+    problemHTML: problemHTML,
+    drawerBodyHTML: drawerBodyHTML,
+    edgePath: edgePath,
+    readSolved: readSolved,
+    writeSolved: writeSolved,
+    drawEdges: drawEdges,
+    openDrawer: openDrawer,
+    closeDrawer: closeDrawer,
+    render: render,
+    init: init,
+    state: state
+  };
+});

--- a/site/test/build-roadmap.test.js
+++ b/site/test/build-roadmap.test.js
@@ -1,0 +1,301 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const lib = require('../build-roadmap.js');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+// ── parseReadmeProblems ───────────────────────────────────────────────────
+
+const README_SAMPLE = [
+  '## Array',
+  '',
+  '| # | Problem | Solution | Time | Space | Difficulty | Tag | Note |',
+  '|---|---------|----------|------|-------|------------|-----|------|',
+  '| 026 | [Remove Duplicates](https://leetcode.com/problems/remove-duplicates/) | [Python](./leetcode_python/Array/rd.py), [Java](./leetcode_java/RD.java) | _O(n)_ | _O(1)_ | Easy | **array** | AGAIN |',
+  '| 121 | [Best Time to Buy](https://leetcode.com/problems/best-time/) | [Java](./leetcode_java/BT.java) | _O(n)_ | _O(1)_ | Easy | **array** |  |',
+  '',
+  '## Graph',
+  '',
+  '| 026 | [Remove Duplicates](https://leetcode.com/problems/remove-duplicates/) | [Scala](./leetcode_scala/rd.scala) | _O(n)_ | _O(1)_ | Medium | **graph** |  |',
+].join('\n');
+
+test('parseReadmeProblems normalises the zero-padded id column', () => {
+  const problems = lib.parseReadmeProblems(README_SAMPLE);
+  assert.ok(problems.has('26'), 'id 026 should be indexed as "26"');
+  assert.ok(!problems.has('026'));
+  assert.equal(problems.get('26').title, 'Remove Duplicates');
+});
+
+test('parseReadmeProblems turns repo-relative solution paths into GitHub blob URLs', () => {
+  const solutions = lib.parseReadmeProblems(README_SAMPLE).get('121').solutions;
+  assert.deepEqual(solutions, { Java: `${lib.GH_BLOB}/leetcode_java/BT.java` });
+});
+
+// A problem listed under two sections lists different languages in each. Losing
+// one of them would silently drop a solution link the repo actually has.
+test('parseReadmeProblems unions solution links across duplicate rows', () => {
+  const problem = lib.parseReadmeProblems(README_SAMPLE).get('26');
+  assert.deepEqual(Object.keys(problem.solutions).sort(), ['Java', 'Python', 'Scala']);
+  // First row wins for the scalar fields, so the topic tables cannot fight over them.
+  assert.equal(problem.difficulty, 'Easy');
+  assert.equal(problem.section, 'Array');
+});
+
+// README has both `[Swim in Rising Water]( https://…)` and `[Java ](./path)`.
+// A strict link pattern drops those rows, and the roadmap build then fails on a
+// problem id that is demonstrably in the file.
+test('parseReadmeProblems tolerates stray whitespace inside markdown links', () => {
+  const problems = lib.parseReadmeProblems(
+    '| 778 | [Swim in Rising Water]( https://leetcode.com/problems/swim/) ' +
+    '| [Java ](./leetcode_java/Swim.java) | _O(n)_ | _O(n)_ | Medium | **graph** |  |'
+  );
+  const problem = problems.get('778');
+  assert.equal(problem.url, 'https://leetcode.com/problems/swim/');
+  assert.deepEqual(problem.solutions, { Java: `${lib.GH_BLOB}/leetcode_java/Swim.java` });
+});
+
+test('parseReadmeProblems keeps a row whose difficulty column is malformed', () => {
+  const problems = lib.parseReadmeProblems(
+    '| 1242 | [Web Crawler](https://leetcode.com/problems/web-crawler/) | + \\ |  |  |  |  |  |'
+  );
+  assert.equal(problems.get('1242').difficulty, 'Unknown');
+});
+
+test('parseReadmeProblems skips separator rows and rows with no linked title', () => {
+  const problems = lib.parseReadmeProblems([
+    '| # | Problem |',
+    '|---|---------|',
+    '| 42 | Trapping Rain Water |',
+  ].join('\n'));
+  assert.equal(problems.size, 0);
+});
+
+// ── parseSolutionLinks ────────────────────────────────────────────────────
+
+test('parseSolutionLinks passes absolute URLs through unchanged', () => {
+  assert.deepEqual(
+    lib.parseSolutionLinks('[C++](https://example.test/a.cpp)'),
+    { 'C++': 'https://example.test/a.cpp' }
+  );
+});
+
+test('parseSolutionLinks returns an empty map for an empty cell', () => {
+  assert.deepEqual(lib.parseSolutionLinks(''), {});
+});
+
+// ── validateGraph ─────────────────────────────────────────────────────────
+
+function ctx() {
+  return {
+    problems: new Map([['1', { id: '1' }], ['2', { id: '2' }]]),
+    sheetSlugs: new Set(['array', 'heap'])
+  };
+}
+
+const OK_NODES = [
+  { id: 'a', title: 'A', row: 0, prereqs: [], sheets: ['array'], problems: [1] },
+  { id: 'b', title: 'B', row: 1, prereqs: ['a'], sheets: ['heap'], problems: [2] }
+];
+
+test('validateGraph accepts a well-formed graph', () => {
+  assert.deepEqual(lib.validateGraph(OK_NODES, ctx()), []);
+});
+
+test('validateGraph rejects an edge that does not point downward', () => {
+  const nodes = [
+    { id: 'a', title: 'A', row: 1, prereqs: [], problems: [1] },
+    { id: 'b', title: 'B', row: 1, prereqs: ['a'], problems: [2] }
+  ];
+  const errors = lib.validateGraph(nodes, ctx());
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /must sit below its prereq "a"/);
+});
+
+test('validateGraph reports unknown prereqs, sheets and problem ids', () => {
+  const nodes = [{ id: 'a', title: 'A', row: 0, prereqs: ['ghost'], sheets: ['nope'], problems: [999] }];
+  const errors = lib.validateGraph(nodes, ctx());
+  assert.equal(errors.length, 3);
+  assert.ok(errors.some(e => /unknown prereq "ghost"/.test(e)));
+  assert.ok(errors.some(e => /unknown cheatsheet "nope"/.test(e)));
+  assert.ok(errors.some(e => /#999, which is not in README/.test(e)));
+});
+
+test('validateGraph reports duplicates rather than quietly de-duplicating them', () => {
+  const nodes = [
+    { id: 'a', title: 'A', row: 0, prereqs: [], problems: [1, 1] },
+    { id: 'a', title: 'A again', row: 1, prereqs: ['a', 'a'], problems: [2] }
+  ];
+  const errors = lib.validateGraph(nodes, ctx());
+  assert.ok(errors.some(e => /duplicate node id "a"/.test(e)));
+  assert.ok(errors.some(e => /repeats problem #1/.test(e)));
+  assert.ok(errors.some(e => /repeats a prereq/.test(e)));
+});
+
+test('validateGraph rejects a node with no problems and no row', () => {
+  const errors = lib.validateGraph([{ id: 'a', title: 'A', problems: [] }], ctx());
+  assert.ok(errors.some(e => /needs an integer "row"/.test(e)));
+  assert.ok(errors.some(e => /lists no problems/.test(e)));
+});
+
+// ── findCycles ────────────────────────────────────────────────────────────
+
+// Rows normally make a cycle impossible, but the row check is skipped when a
+// row is missing — and a cycle would hang the page's unlock computation.
+test('findCycles catches a loop that the row check cannot see', () => {
+  const cycles = lib.findCycles([
+    { id: 'a', prereqs: ['c'] },
+    { id: 'b', prereqs: ['a'] },
+    { id: 'c', prereqs: ['b'] }
+  ]);
+  assert.equal(cycles.length, 1);
+  assert.deepEqual(cycles[0], ['a', 'c', 'b', 'a']);
+});
+
+test('findCycles catches a node that lists itself', () => {
+  assert.deepEqual(lib.findCycles([{ id: 'a', prereqs: ['a'] }]), [['a', 'a']]);
+});
+
+test('findCycles returns nothing for a diamond', () => {
+  assert.deepEqual(lib.findCycles([
+    { id: 'a', prereqs: [] },
+    { id: 'b', prereqs: ['a'] },
+    { id: 'c', prereqs: ['a'] },
+    { id: 'd', prereqs: ['b', 'c'] }
+  ]), []);
+});
+
+// ── findRedundantEdges ────────────────────────────────────────────────────
+
+// The roadmap has to stay a transitive reduction or the picture turns to
+// spaghetti: "design after linked-list" was true but already implied by
+// design → heap → trees → linked-list, and drawing it cost a three-row line.
+test('findRedundantEdges flags an edge the graph already implies', () => {
+  const redundant = lib.findRedundantEdges([
+    { id: 'a', prereqs: [] },
+    { id: 'b', prereqs: ['a'] },
+    { id: 'c', prereqs: ['b', 'a'] }
+  ]);
+  assert.deepEqual(redundant, [['c', 'a', 'b']]);
+});
+
+test('findRedundantEdges leaves a genuine diamond alone', () => {
+  assert.deepEqual(lib.findRedundantEdges([
+    { id: 'a', prereqs: [] },
+    { id: 'b', prereqs: ['a'] },
+    { id: 'c', prereqs: ['a'] },
+    { id: 'd', prereqs: ['b', 'c'] }
+  ]), []);
+});
+
+test('findRedundantEdges sees through a longer chain', () => {
+  const redundant = lib.findRedundantEdges([
+    { id: 'a', prereqs: [] },
+    { id: 'b', prereqs: ['a'] },
+    { id: 'c', prereqs: ['b'] },
+    { id: 'd', prereqs: ['c', 'a'] }
+  ]);
+  assert.deepEqual(redundant, [['d', 'a', 'c']]);
+});
+
+test('validateGraph surfaces a redundant edge as an error', () => {
+  const errors = lib.validateGraph([
+    { id: 'a', title: 'A', row: 0, prereqs: [], problems: [1] },
+    { id: 'b', title: 'B', row: 1, prereqs: ['a'], problems: [2] },
+    { id: 'c', title: 'C', row: 2, prereqs: ['b', 'a'], problems: [1] }
+  ], ctx());
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /already reaches through "b"/);
+});
+
+// ── buildRoadmap ──────────────────────────────────────────────────────────
+
+test('buildRoadmap resolves problems and stamps the layout position', () => {
+  const problems = new Map([
+    ['1', { id: '1', title: 'Two Sum', url: 'u1', difficulty: 'Easy', solutions: { Java: 'j' }, section: 'Array' }],
+    ['2', { id: '2', title: 'Add Two', url: 'u2', difficulty: 'Medium', solutions: {}, section: 'Linked list' }]
+  ]);
+  const built = lib.buildRoadmap(
+    { meta: { title: 'T' }, nodes: [
+      { id: 'a', title: 'A', row: 0, prereqs: [], sheets: ['array'], problems: [1] },
+      { id: 'b', title: 'B', row: 1, prereqs: ['a'], sheets: [], problems: [1, 2] },
+      { id: 'c', title: 'C', row: 1, prereqs: ['a'], sheets: [], problems: [2] }
+    ] },
+    problems,
+    new Map([['array', 'Array']])
+  );
+
+  assert.equal(built.meta.title, 'T');
+  assert.deepEqual(built.nodes.map(n => [n.row, n.col, n.rowSize]), [[0, 0, 1], [1, 0, 2], [1, 1, 2]]);
+  assert.deepEqual(built.nodes[0].sheets, [{ slug: 'array', title: 'Array', url: 'cheatsheets/array.html' }]);
+  // The `section` field is README bookkeeping and has no business shipping.
+  assert.deepEqual(Object.keys(built.nodes[0].problems[0]).sort(),
+    ['difficulty', 'id', 'solutions', 'title', 'url']);
+});
+
+// LC 323 is listed under both Graphs and Union Find. It is one problem to
+// solve, so the headline count must not double it.
+test('buildRoadmap counts a shared problem once, and its slots twice', () => {
+  const problems = new Map([['1', { id: '1', title: 'x', url: 'u', difficulty: 'Easy', solutions: {} }]]);
+  const built = lib.buildRoadmap({ nodes: [
+    { id: 'a', title: 'A', row: 0, problems: [1] },
+    { id: 'b', title: 'B', row: 1, prereqs: ['a'], problems: [1] }
+  ] }, problems);
+  assert.equal(built.stats.problems, 1);
+  assert.equal(built.stats.problemSlots, 2);
+  assert.equal(built.stats.topics, 2);
+  assert.equal(built.stats.rows, 2);
+});
+
+// ── buildSheetTitles ──────────────────────────────────────────────────────
+
+test('buildSheetTitles prefers the meta override, then the H1, and skips the template', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sheets-'));
+  fs.writeFileSync(path.join(dir, '2_pointers.md'), '# Two Pointers\n\ntext\n');
+  fs.writeFileSync(path.join(dir, 'n_sum.md'), '# N Sum\n');
+  fs.writeFileSync(path.join(dir, '00_template.md'), '# Template\n');
+  fs.writeFileSync(path.join(dir, 'notes.txt'), 'ignored');
+
+  const titles = lib.buildSheetTitles(dir, { sheets: { n_sum: { title: 'N Sum (2Sum → kSum)' } } });
+  assert.equal(titles.get('2_pointers'), 'Two Pointers');
+  assert.equal(titles.get('n_sum'), 'N Sum (2Sum → kSum)');
+  assert.equal(titles.size, 2, 'the template and non-markdown files are not sheets');
+});
+
+// ── The real data ─────────────────────────────────────────────────────────
+
+// data/roadmap.json is hand-authored, so the checks above only pay off if they
+// actually run against it. This is the same gate site/build-roadmap.js applies.
+test('the checked-in roadmap passes every validation against the real README', () => {
+  const roadmap = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/roadmap.json'), 'utf8'));
+  const problems = lib.parseReadmeProblems(fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8'));
+  const sheetTitles = lib.buildSheetTitles(
+    path.join(ROOT, 'doc/cheatsheet'),
+    JSON.parse(fs.readFileSync(path.join(ROOT, 'data/cheatsheet_meta.json'), 'utf8'))
+  );
+  const errors = lib.validateGraph(roadmap.nodes, {
+    problems,
+    sheetSlugs: new Set(sheetTitles.keys())
+  });
+  assert.deepEqual(errors, []);
+
+  // Every roadmap problem should link to a solution in this repo — that link is
+  // the whole reason the roadmap reads from README instead of a curated list.
+  const built = lib.buildRoadmap(roadmap, problems, sheetTitles);
+  const unlinked = [];
+  built.nodes.forEach(node => node.problems.forEach(p => {
+    if (!Object.keys(p.solutions).length) unlinked.push(`${node.id} #${p.id}`);
+  }));
+  assert.deepEqual(unlinked, []);
+});
+
+// The page reads `roadmap.nodes[].prereqs` to decide what is unlocked, so a
+// dangling root would leave a whole branch permanently locked.
+test('the checked-in roadmap has exactly one root', () => {
+  const roadmap = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/roadmap.json'), 'utf8'));
+  const roots = roadmap.nodes.filter(n => !(n.prereqs || []).length);
+  assert.deepEqual(roots.map(n => n.id), ['arrays-hashing']);
+});

--- a/site/test/roadmap.test.js
+++ b/site/test/roadmap.test.js
@@ -240,9 +240,9 @@ test('writeSolved round-trips through readSolved as string keys', () => {
  * fetch. This is what catches an id in the markup drifting away from the id
  * roadmap.js looks up.
  */
-function renderPage(roadmap) {
+function renderPage(roadmap, url) {
   const html = fs.readFileSync(PAGE, 'utf8');
-  const dom = new JSDOM(html, { url: 'https://example.test/lc-roadmap.html' });
+  const dom = new JSDOM(html, { url: url || 'https://example.test/lc-roadmap.html' });
   for (const key of ['window', 'document', 'localStorage', 'CustomEvent', 'Event', 'navigator', 'self', 'history', 'location']) {
     global[key] = key === 'self' ? dom.window : dom.window[key];
   }
@@ -277,6 +277,44 @@ test('clicking a topic opens the drawer with that topic loaded', () => {
   assert.equal(doc.getElementById('drawerTitle').textContent, 'A');
   assert.equal(doc.getElementById('drawerBody').querySelectorAll('.prob').length, 2);
   assert.equal(global.location.hash, '#a', 'the open topic is shareable via the URL');
+});
+
+// Closing parks the drawer off-screen under aria-hidden. Leaving focus on the
+// close button would strand a keyboard user on an invisible control.
+test('closing the drawer hands focus back to the topic that opened it', () => {
+  const doc = renderPage();
+  const box = doc.querySelector('.node[data-id="a"]');
+  click(box);
+  assert.equal(doc.activeElement, doc.getElementById('drawerClose'));
+
+  click(doc.getElementById('overlay'));
+  assert.equal(doc.activeElement, box);
+});
+
+test('hopping between prereqs returns focus to the topic you started from', () => {
+  const doc = renderPage();
+  const box = doc.querySelector('.node[data-id="d"]');
+  click(box);
+  // The chip that moves us to B is discarded by the re-render, so remembering
+  // the most recent opener instead of the first would strand focus on <body>.
+  click(doc.getElementById('drawerBody').querySelector('[data-open="b"]'));
+  click(doc.getElementById('drawerClose'));
+  assert.equal(doc.activeElement, box);
+});
+
+// `state` outlives a render. A second render that inherited the previous
+// document's open topic silently kept a focus target pointing at a dead node.
+test('a fresh render starts with the drawer shut', () => {
+  const first = renderPage();
+  click(first.querySelector('.node[data-id="a"]'));
+  assert.ok(first.getElementById('drawer').classList.contains('open'));
+
+  const second = renderPage();
+  assert.ok(!second.getElementById('drawer').classList.contains('open'));
+  const box = second.querySelector('.node[data-id="b"]');
+  click(box);
+  click(second.getElementById('drawerClose'));
+  assert.equal(second.activeElement, box, 'focus returns inside the current document');
 });
 
 test('the overlay closes the drawer and clears the hash', () => {
@@ -373,25 +411,44 @@ test('a prereq chip in the drawer navigates to that prereq', () => {
 
 test('reset clears every tick and the stored value', () => {
   const doc = renderPage();
-  global.window.confirm = () => true;
+  // roadmap.js calls the bare `confirm`, which resolves against the Node
+  // global here — not `window`. Stubbing the wrong one leaves the guard
+  // short-circuited and this test silently skips the dialog branch.
+  let asked = 0;
+  global.confirm = () => { asked++; return true; };
   click(doc.querySelector('.node[data-id="a"]'));
   click(doc.getElementById('drawerBody').querySelector('[data-bulk="all"]'));
   assert.equal(doc.getElementById('statProblems').textContent, '2 / 4');
 
   click(doc.getElementById('resetBtn'));
+  assert.equal(asked, 1, 'reset must ask before wiping progress');
   assert.equal(doc.getElementById('statProblems').textContent, '0 / 4');
   assert.deepEqual(Object.keys(CSRoadmap.readSolved()), []);
 });
 
+test('declining the confirm leaves progress untouched', () => {
+  const doc = renderPage();
+  global.confirm = () => false;
+  click(doc.querySelector('.node[data-id="a"]'));
+  click(doc.getElementById('drawerBody').querySelector('[data-bulk="all"]'));
+
+  click(doc.getElementById('resetBtn'));
+  assert.equal(doc.getElementById('statProblems').textContent, '2 / 4');
+  assert.deepEqual(Object.keys(CSRoadmap.readSolved()).sort(), ['1', '2']);
+});
+
+// Reset on an untouched board should not pop a dialog asking to clear nothing.
+test('reset does not ask when there is nothing to clear', () => {
+  const doc = renderPage();
+  let asked = 0;
+  global.confirm = () => { asked++; return true; };
+  click(doc.getElementById('resetBtn'));
+  assert.equal(asked, 0);
+});
+
 test('a topic named in the URL hash opens on load', () => {
-  const html = fs.readFileSync(PAGE, 'utf8');
-  const dom = new JSDOM(html, { url: 'https://example.test/lc-roadmap.html#c' });
-  for (const key of ['window', 'document', 'localStorage', 'CustomEvent', 'Event', 'navigator', 'self', 'history', 'location']) {
-    global[key] = key === 'self' ? dom.window : dom.window[key];
-  }
-  require('../nav.js').mount();
-  CSRoadmap.render(fixture());
-  assert.equal(dom.window.document.getElementById('drawerTitle').textContent, 'C');
+  const doc = renderPage(null, 'https://example.test/lc-roadmap.html#c');
+  assert.equal(doc.getElementById('drawerTitle').textContent, 'C');
 });
 
 // ── The page's markup contract ────────────────────────────────────────────
@@ -406,6 +463,21 @@ test('lc-roadmap.html carries every element roadmap.js looks up', () => {
                     'drawerBlurb', 'drawerBody']) {
     assert.ok(doc.getElementById(id), `#${id} is missing from lc-roadmap.html`);
   }
+});
+
+// validate-pages.yml runs its HTML-structure check over every entry in its
+// requiredFiles list, and that check demands a footer. This page is on the
+// list, so a missing footer fails CI rather than merely looking odd.
+test('lc-roadmap.html carries the site footer CI requires', () => {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  assert.ok(html.includes('<footer>'), 'validate-pages.yml greps for a literal <footer>');
+  const doc = new JSDOM(html).window.document;
+  const links = [...doc.querySelectorAll('footer a')].map((a) => a.getAttribute('href'));
+  assert.deepEqual(links, [
+    'https://github.com/yennanliu/CS_basics',
+    'https://github.com/yennanliu/CS_basics/tree/master/doc',
+    'https://github.com/yennanliu/CS_basics/issues'
+  ]);
 });
 
 test('lc-roadmap.html loads roadmap.js and tells the navbar which page it is', () => {

--- a/site/test/roadmap.test.js
+++ b/site/test/roadmap.test.js
@@ -1,0 +1,420 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+const { setupDOM, teardownDOM, click } = require('./helpers');
+
+// roadmap.js reads `document`/`localStorage` off the global scope at call time,
+// so a DOM has to exist before it is required.
+setupDOM();
+const CSRoadmap = require('../roadmap.js');
+
+const PAGE = path.join(__dirname, '..', 'pages', 'lc-roadmap.html');
+
+// ── Fixture ───────────────────────────────────────────────────────────────
+
+function problem(id, extra) {
+  return Object.assign({
+    id: String(id), title: 'P' + id, url: 'https://leetcode.com/problems/p' + id + '/',
+    difficulty: 'Easy', solutions: { Java: 'https://example.test/' + id + '.java' }
+  }, extra);
+}
+
+// a → b, a → c, (b, c) → d. `d` also lists P1, which `a` owns: the shared
+// problem is what the distinct-counting and cross-topic rules hang on.
+function fixture() {
+  return {
+    meta: { title: 'Study Roadmap', intro: 'intro text' },
+    stats: { topics: 4, problems: 4, problemSlots: 5, rows: 3 },
+    nodes: [
+      { id: 'a', title: 'A', blurb: 'root', row: 0, col: 0, rowSize: 1, prereqs: [],
+        sheets: [{ slug: 'array', title: 'Array', url: 'cheatsheets/array.html' }],
+        problems: [problem(1), problem(2, { difficulty: 'Hard' })] },
+      { id: 'b', title: 'B', blurb: '', row: 1, col: 0, rowSize: 2, prereqs: ['a'],
+        sheets: [], problems: [problem(3)] },
+      { id: 'c', title: 'C', blurb: '', row: 1, col: 1, rowSize: 2, prereqs: ['a'],
+        sheets: [], problems: [problem(4, { solutions: {} })] },
+      { id: 'd', title: 'D', blurb: '', row: 2, col: 0, rowSize: 1, prereqs: ['b', 'c'],
+        sheets: [], problems: [problem(1)] }
+    ]
+  };
+}
+
+function solvedSet(ids) {
+  const set = Object.create(null);
+  ids.forEach((id) => { set[String(id)] = true; });
+  return set;
+}
+
+// ── Counting ──────────────────────────────────────────────────────────────
+
+test('statsFor counts only the problems the topic itself lists', () => {
+  const roadmap = fixture();
+  assert.deepEqual(CSRoadmap.statsFor(roadmap.nodes[0], solvedSet([1])), { done: 1, total: 2 });
+  assert.deepEqual(CSRoadmap.statsFor(roadmap.nodes[1], solvedSet([1])), { done: 0, total: 1 });
+});
+
+test('isDone needs every problem, and is false for an empty topic', () => {
+  const roadmap = fixture();
+  assert.equal(CSRoadmap.isDone(roadmap.nodes[0], solvedSet([1])), false);
+  assert.equal(CSRoadmap.isDone(roadmap.nodes[0], solvedSet([1, 2])), true);
+  assert.equal(CSRoadmap.isDone({ problems: [] }, solvedSet([])), false);
+});
+
+// The headline figure would otherwise read 5 when there are only 4 problems.
+test('distinctSolved counts a problem shared by two topics once', () => {
+  const roadmap = fixture();
+  assert.equal(CSRoadmap.distinctSolved(roadmap.nodes, solvedSet([1])), 1);
+  assert.equal(CSRoadmap.distinctSolved(roadmap.nodes, solvedSet([1, 2, 3, 4])), 4);
+});
+
+test('distinctSolved ignores ticks for problems no topic lists', () => {
+  assert.equal(CSRoadmap.distinctSolved(fixture().nodes, solvedSet([999])), 0);
+});
+
+// ── Unlocking ─────────────────────────────────────────────────────────────
+
+test('isUnlocked opens a topic only once every prereq is finished', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  const b = byId.b, d = byId.d;
+
+  assert.equal(CSRoadmap.isUnlocked(byId.a, byId, solvedSet([])), true, 'the root is always open');
+  assert.equal(CSRoadmap.isUnlocked(b, byId, solvedSet([1])), false, 'A is only half done');
+  assert.equal(CSRoadmap.isUnlocked(b, byId, solvedSet([1, 2])), true);
+  // D needs BOTH B and C, so finishing one branch is not enough.
+  assert.equal(CSRoadmap.isUnlocked(d, byId, solvedSet([1, 2, 3])), false);
+  assert.equal(CSRoadmap.isUnlocked(d, byId, solvedSet([1, 2, 3, 4])), true);
+});
+
+test('unmetPrereqs names the topics still in the way, in authored order', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  assert.deepEqual(CSRoadmap.unmetPrereqs(byId.d, byId, solvedSet([1, 2, 3])), ['c']);
+  assert.deepEqual(CSRoadmap.unmetPrereqs(byId.d, byId, solvedSet([1, 2])), ['b', 'c']);
+  assert.deepEqual(CSRoadmap.unmetPrereqs(byId.a, byId, solvedSet([])), []);
+});
+
+// build-roadmap.js fails the build on an unknown prereq, so if one ever reaches
+// the page it is better to leave the branch reachable than to strand it.
+test('an unknown prereq id does not lock a topic forever', () => {
+  const node = { id: 'x', title: 'X', prereqs: ['ghost'], problems: [problem(9)] };
+  assert.equal(CSRoadmap.isUnlocked(node, { x: node }, solvedSet([])), true);
+});
+
+// ── nextUp ────────────────────────────────────────────────────────────────
+
+test('nextUp starts at the root and names its first unsolved problem', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  const next = CSRoadmap.nextUp(roadmap.nodes, byId, solvedSet([1]));
+  assert.equal(next.node.id, 'a');
+  assert.equal(next.problem.id, '2');
+});
+
+test('nextUp prefers the shallowest open topic and skips locked ones', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  // A done, B and C open at row 1: the left-most (authored first) wins. D is
+  // still locked, so it must not be suggested even though it is unfinished.
+  const next = CSRoadmap.nextUp(roadmap.nodes, byId, solvedSet([1, 2]));
+  assert.equal(next.node.id, 'b');
+});
+
+test('nextUp returns null when everything is solved', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  assert.equal(CSRoadmap.nextUp(roadmap.nodes, byId, solvedSet([1, 2, 3, 4])), null);
+});
+
+// ── Markup ────────────────────────────────────────────────────────────────
+
+function parse(html) {
+  return new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`).window.document;
+}
+
+test('graphHTML emits one .row per row, in ascending order', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  const doc = parse(CSRoadmap.graphHTML(roadmap.nodes, byId, solvedSet([])));
+  const rows = [...doc.querySelectorAll('.row')];
+  assert.deepEqual(rows.map((r) => r.getAttribute('data-row')), ['0', '1', '2']);
+  assert.equal(rows[1].querySelectorAll('.node').length, 2);
+});
+
+test('nodeHTML marks a finished topic done and an unmet one locked', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+
+  const fresh = parse(CSRoadmap.nodeHTML(byId.b, byId, solvedSet([]))).querySelector('.node');
+  assert.ok(fresh.classList.contains('locked'));
+  assert.ok(!fresh.classList.contains('done'));
+  assert.equal(fresh.getAttribute('title'), 'B — 0 of 1 solved. Finish first: A');
+
+  const open = parse(CSRoadmap.nodeHTML(byId.b, byId, solvedSet([1, 2, 3]))).querySelector('.node');
+  assert.ok(open.classList.contains('done'));
+  assert.ok(!open.classList.contains('locked'));
+  assert.equal(open.getAttribute('title'), 'B — 1 of 1 solved');
+  assert.equal(open.querySelector('.node-count').textContent, '1/1');
+});
+
+// The label used to be printed on every box; 29 repetitions of "after Arrays &
+// Hashing" buried the graph, so it moved into the tooltip and the drawer.
+test('lockLabel names the unmet prereqs and is empty once they are met', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+  assert.equal(CSRoadmap.lockLabel(byId.d, byId, solvedSet([1, 2])), 'Finish first: B, C');
+  assert.equal(CSRoadmap.lockLabel(byId.d, byId, solvedSet([1, 2, 3, 4])), '');
+  assert.equal(CSRoadmap.lockLabel(byId.a, byId, solvedSet([])), '');
+});
+
+test('problemHTML links every language the repo has, and nothing when it has none', () => {
+  const withJava = parse(CSRoadmap.problemHTML(
+    problem(1, { solutions: { Java: 'https://x.test/a.java', Python: 'https://x.test/a.py' } }),
+    solvedSet([])
+  ));
+  assert.deepEqual([...withJava.querySelectorAll('.prob-links a')].map((a) => a.textContent), ['Ja', 'Py']);
+
+  const bare = parse(CSRoadmap.problemHTML(problem(1, { solutions: {} }), solvedSet([])));
+  assert.equal(bare.querySelectorAll('.prob-links a').length, 0);
+});
+
+test('problemHTML reflects the solved tick in both the class and the checkbox', () => {
+  const doc = parse(CSRoadmap.problemHTML(problem(7), solvedSet([7])));
+  assert.ok(doc.querySelector('.prob').classList.contains('solved'));
+  assert.equal(doc.querySelector('input').checked, true);
+});
+
+test('problemHTML escapes a title that would otherwise inject markup', () => {
+  const doc = parse(CSRoadmap.problemHTML(
+    problem(1, { title: '<img src=x onerror=alert(1)>' }), solvedSet([])
+  ));
+  assert.equal(doc.querySelectorAll('img').length, 0);
+  assert.equal(doc.querySelector('.prob-title').textContent, '<img src=x onerror=alert(1)>');
+});
+
+test('drawerBodyHTML ticks the prereqs that are met and links the cheatsheets', () => {
+  const roadmap = fixture();
+  const byId = CSRoadmap.indexNodes(roadmap.nodes);
+
+  const rootDoc = parse(CSRoadmap.drawerBodyHTML(byId.a, byId, solvedSet([])));
+  assert.equal(rootDoc.querySelectorAll('.chip.met').length, 0, 'the root has no prereq section');
+  assert.equal(rootDoc.querySelector('a.chip').getAttribute('href'), 'cheatsheets/array.html');
+  assert.equal(rootDoc.querySelectorAll('.prob').length, 2);
+
+  const dDoc = parse(CSRoadmap.drawerBodyHTML(byId.d, byId, solvedSet([1, 2, 3])));
+  const chips = [...dDoc.querySelectorAll('[data-open]')];
+  assert.deepEqual(chips.map((c) => c.getAttribute('data-open')), ['b', 'c']);
+  assert.deepEqual(chips.map((c) => c.classList.contains('met')), [true, false]);
+});
+
+test('edgePath leaves the parent and enters the child vertically', () => {
+  assert.equal(CSRoadmap.edgePath(10, 20, 50, 120), 'M10 20 C10 70 50 70 50 120');
+});
+
+// ── Storage ───────────────────────────────────────────────────────────────
+
+test('readSolved survives a missing, malformed or non-array value', () => {
+  setupDOM();
+  assert.deepEqual(CSRoadmap.readSolved(), Object.create(null));
+
+  localStorage.setItem(CSRoadmap.STORE_KEY, 'not json');
+  assert.deepEqual(Object.keys(CSRoadmap.readSolved()), []);
+
+  localStorage.setItem(CSRoadmap.STORE_KEY, '{"1":true}');
+  assert.deepEqual(Object.keys(CSRoadmap.readSolved()), []);
+});
+
+test('writeSolved round-trips through readSolved as string keys', () => {
+  setupDOM();
+  CSRoadmap.writeSolved(solvedSet([1, 322]));
+  assert.deepEqual(Object.keys(CSRoadmap.readSolved()).sort(), ['1', '322']);
+});
+
+// ── The page, end to end ──────────────────────────────────────────────────
+
+/**
+ * Loads the real lc-roadmap.html into jsdom, mounts the navbar, and hands the
+ * fixture to CSRoadmap.render — the same path the browser takes minus the
+ * fetch. This is what catches an id in the markup drifting away from the id
+ * roadmap.js looks up.
+ */
+function renderPage(roadmap) {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  const dom = new JSDOM(html, { url: 'https://example.test/lc-roadmap.html' });
+  for (const key of ['window', 'document', 'localStorage', 'CustomEvent', 'Event', 'navigator', 'self', 'history', 'location']) {
+    global[key] = key === 'self' ? dom.window : dom.window[key];
+  }
+  require('../nav.js').mount();
+  CSRoadmap.render(roadmap || fixture());
+  return dom.window.document;
+}
+
+test.after(() => { teardownDOM(); });
+
+test('the page renders every topic and reveals the summary', () => {
+  const doc = renderPage();
+  assert.equal(doc.querySelectorAll('.node').length, 4);
+  assert.equal(doc.getElementById('loading').hidden, true);
+  assert.equal(doc.getElementById('summary').hidden, false);
+  assert.equal(doc.getElementById('statProblems').textContent, '0 / 4');
+  assert.equal(doc.getElementById('statTopics').textContent, '0 / 4');
+  assert.equal(doc.getElementById('pageIntro').textContent, 'intro text');
+});
+
+test('the navbar marks the roadmap as the active page', () => {
+  const doc = renderPage();
+  const active = doc.querySelector('.nav-links a.active');
+  assert.equal(active.getAttribute('href'), 'lc-roadmap.html');
+});
+
+test('clicking a topic opens the drawer with that topic loaded', () => {
+  const doc = renderPage();
+  click(doc.querySelector('.node[data-id="a"]'));
+  assert.ok(doc.getElementById('drawer').classList.contains('open'));
+  assert.equal(doc.getElementById('drawer').getAttribute('aria-hidden'), 'false');
+  assert.equal(doc.getElementById('drawerTitle').textContent, 'A');
+  assert.equal(doc.getElementById('drawerBody').querySelectorAll('.prob').length, 2);
+  assert.equal(global.location.hash, '#a', 'the open topic is shareable via the URL');
+});
+
+test('the overlay closes the drawer and clears the hash', () => {
+  const doc = renderPage();
+  click(doc.querySelector('.node[data-id="a"]'));
+  click(doc.getElementById('overlay'));
+  assert.ok(!doc.getElementById('drawer').classList.contains('open'));
+  assert.equal(global.location.hash, '');
+});
+
+// The whole point of keying progress by problem id: A and D share LC 1.
+test('ticking a shared problem updates every topic that lists it', () => {
+  const doc = renderPage();
+  click(doc.querySelector('.node[data-id="a"]'));
+
+  const box = doc.getElementById('drawerBody').querySelector('input[data-check="1"]');
+  box.checked = true;
+  box.dispatchEvent(new global.window.Event('change', { bubbles: true }));
+
+  assert.equal(doc.querySelector('.node[data-id="a"] .node-count').textContent, '1/2');
+  assert.equal(doc.querySelector('.node[data-id="d"] .node-count').textContent, '1/1');
+  assert.ok(doc.querySelector('.node[data-id="d"]').classList.contains('done'));
+  assert.equal(doc.getElementById('statProblems').textContent, '1 / 4');
+  assert.deepEqual(Object.keys(CSRoadmap.readSolved()), ['1'], 'and it is persisted');
+});
+
+test('"tick all" completes a topic and unlocks what came after it', () => {
+  const doc = renderPage();
+  click(doc.querySelector('.node[data-id="a"]'));
+  click(doc.getElementById('drawerBody').querySelector('[data-bulk="all"]'));
+
+  assert.ok(doc.querySelector('.node[data-id="a"]').classList.contains('done'));
+  assert.ok(!doc.querySelector('.node[data-id="b"]').classList.contains('locked'));
+  assert.equal(doc.querySelector('.node[data-id="b"]').getAttribute('title'), 'B — 0 of 1 solved');
+  // D still needs B and C, so it stays locked.
+  assert.ok(doc.querySelector('.node[data-id="d"]').classList.contains('locked'));
+
+  click(doc.getElementById('drawerBody').querySelector('[data-bulk="none"]'));
+  assert.ok(!doc.querySelector('.node[data-id="a"]').classList.contains('done'));
+  assert.ok(doc.querySelector('.node[data-id="b"]').classList.contains('locked'));
+  assert.match(doc.querySelector('.node[data-id="b"]').getAttribute('title'), /Finish first: A$/);
+});
+
+test('every prereq becomes one edge, tagged with the pair it joins', () => {
+  const doc = renderPage();
+  const edges = [...doc.querySelectorAll('#edges path')]
+    .map((p) => [p.getAttribute('data-from'), p.getAttribute('data-to')]);
+  assert.deepEqual(edges, [['a', 'b'], ['a', 'c'], ['b', 'd'], ['c', 'd']]);
+});
+
+test('hovering a topic lifts only the edges that touch it', () => {
+  const doc = renderPage();
+  const svg = doc.getElementById('edges');
+
+  CSRoadmap.highlightEdges('b');
+  assert.ok(svg.classList.contains('focused'));
+  assert.deepEqual(
+    [...svg.querySelectorAll('path')].map((p) => p.classList.contains('hot')),
+    [true, false, true, false]
+  );
+
+  CSRoadmap.highlightEdges(null);
+  assert.ok(!svg.classList.contains('focused'));
+  assert.equal(svg.querySelectorAll('path.hot').length, 0);
+});
+
+test('an edge out of a finished topic is drawn as live', () => {
+  const doc = renderPage();
+  click(doc.querySelector('.node[data-id="a"]'));
+  click(doc.getElementById('drawerBody').querySelector('[data-bulk="all"]'));
+  const live = [...doc.querySelectorAll('#edges path')]
+    .filter((p) => p.classList.contains('live'))
+    .map((p) => p.getAttribute('data-to'));
+  assert.deepEqual(live, ['b', 'c']);
+});
+
+test('the next-up hint follows progress and jumps to the topic', () => {
+  const doc = renderPage();
+  const hint = doc.getElementById('nextUp');
+  assert.equal(hint.hidden, false);
+  assert.equal(hint.querySelector('[data-open]').getAttribute('data-open'), 'a');
+  assert.match(hint.querySelector('.where').textContent, /#1 P1/);
+
+  click(hint.querySelector('[data-open]'));
+  assert.equal(doc.getElementById('drawerTitle').textContent, 'A');
+});
+
+test('a prereq chip in the drawer navigates to that prereq', () => {
+  const doc = renderPage();
+  click(doc.querySelector('.node[data-id="d"]'));
+  click(doc.getElementById('drawerBody').querySelector('[data-open="b"]'));
+  assert.equal(doc.getElementById('drawerTitle').textContent, 'B');
+});
+
+test('reset clears every tick and the stored value', () => {
+  const doc = renderPage();
+  global.window.confirm = () => true;
+  click(doc.querySelector('.node[data-id="a"]'));
+  click(doc.getElementById('drawerBody').querySelector('[data-bulk="all"]'));
+  assert.equal(doc.getElementById('statProblems').textContent, '2 / 4');
+
+  click(doc.getElementById('resetBtn'));
+  assert.equal(doc.getElementById('statProblems').textContent, '0 / 4');
+  assert.deepEqual(Object.keys(CSRoadmap.readSolved()), []);
+});
+
+test('a topic named in the URL hash opens on load', () => {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  const dom = new JSDOM(html, { url: 'https://example.test/lc-roadmap.html#c' });
+  for (const key of ['window', 'document', 'localStorage', 'CustomEvent', 'Event', 'navigator', 'self', 'history', 'location']) {
+    global[key] = key === 'self' ? dom.window : dom.window[key];
+  }
+  require('../nav.js').mount();
+  CSRoadmap.render(fixture());
+  assert.equal(dom.window.document.getElementById('drawerTitle').textContent, 'C');
+});
+
+// ── The page's markup contract ────────────────────────────────────────────
+
+// render() reaches for these by id. A rename in the HTML that misses roadmap.js
+// would throw at load, and the page would show a permanent "Loading…".
+test('lc-roadmap.html carries every element roadmap.js looks up', () => {
+  const doc = new JSDOM(fs.readFileSync(PAGE, 'utf8')).window.document;
+  for (const id of ['pageTitle', 'pageIntro', 'summary', 'statProblems', 'statTopics',
+                    'summaryFill', 'summaryLabel', 'resetBtn', 'nextUp', 'graph', 'edges',
+                    'loading', 'note', 'overlay', 'drawer', 'drawerClose', 'drawerTitle',
+                    'drawerBlurb', 'drawerBody']) {
+    assert.ok(doc.getElementById(id), `#${id} is missing from lc-roadmap.html`);
+  }
+});
+
+test('lc-roadmap.html loads roadmap.js and tells the navbar which page it is', () => {
+  const html = fs.readFileSync(PAGE, 'utf8');
+  assert.match(html, /<script src="roadmap\.js"><\/script>/);
+  assert.match(html, /data-page="lc-roadmap"/);
+  const CSNav = require('../nav.js');
+  assert.ok(
+    CSNav.PRIMARY.concat(CSNav.MORE).some((item) => item.id === 'lc-roadmap'),
+    'the navbar has no lc-roadmap entry, so the page would be unreachable'
+  );
+});


### PR DESCRIPTION
A dependency graph over the repo's own topics: 29 boxes across 7 rows, each tracking how many of its problems you have solved, unlocking once its prerequisites are finished. Clicking a topic opens its problems, its prerequisites and the cheatsheets that cover it.

The problem data is not a second curated list. data/roadmap.json carries only LeetCode numbers; site/build-roadmap.js resolves each one against README.md's tables for the title, difficulty and links to the Java / Python solutions already in this repo — all 212 problems on the roadmap have at least one. Cheatsheet chips resolve their labels the same way the index does, from data/cheatsheet_meta.json and the sheet's H1.

Everything the authored graph can get wrong is a build failure, not a blank box: an LC number missing from README, a cheatsheet slug that does not exist, an edge pointing sideways or upward, a prereq cycle, or an edge the graph already implies. That last check is what keeps the picture legible — it caught "design after linked-list" and "intervals after sorting", both true and both already reachable, each drawing a line across three rows that said nothing new.

Progress is a set of LeetCode ids in localStorage, so a problem two topics share (LC 323 sits in both Graphs and Union Find) is one tick and is counted once in the headline figure.

The navbar's inline row is capacity-bound at seven entries, so the roadmap took the random picker's slot; the picker moves into "more", next to the similar and review tools it belongs with.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive, responsive Study Roadmap spanning foundational through advanced topics.
  - View prerequisites, descriptions, study sheets, practice problems, difficulty badges, and dependency relationships.
  - Track solved problems locally, monitor progress, unlock topics, and reset completion status.
  - Promoted the roadmap to the main site navigation.

- **Bug Fixes**
  - Improved build-time validation for roadmap data, links, dependencies, and generated pages.

- **Documentation**
  - Added guidance for configuring roadmap topics and maintaining prerequisite relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->