### PR TITLE
feat(script): score LeetCode readiness against a G SWE coding bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ _site/
 
 # scrape_lc_discuss_company.py download cache (re-fetchable, one file per post)
 data/.lc_discuss_cache/
+
+# eval_lc_readiness.py LeetCode GraphQL cache (re-fetchable)
+.lc_cache/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,3 +252,17 @@ The build fails on a taxonomy key that is missing, points at an unknown topic, o
 ## Adding Time/Space Complexity Javadoc Comments
 
 For the full guide, see [`doc/add-time-space-guide.md`](doc/add-time-space-guide.md). Quick start: `/add-time-space <DirectoryName>`.
+
+---
+
+## Evaluating Interview Readiness
+
+`script/eval_lc_readiness.py` scores a LeetCode profile against a Google SWE coding bar
+(`--level L3` by default) using the public GraphQL API plus `README.md`'s status column.
+
+For the full guide — flags, how to read each section, and which numbers to act on — see
+[`doc/lc-readiness-guide.md`](doc/lc-readiness-guide.md). Quick start:
+
+```bash
+python3 script/eval_lc_readiness.py
+```

--- a/data/progress.md
+++ b/data/progress.md
@@ -156,7 +156,6 @@
 					- 907
 					- 2104
 		- 2 pointers
-			- 986
 			- Exactly K Problems (At Most K Transformation) -
 				- Exactly K = At Most K - At Most (K-1) 
 					- 992
@@ -262,7 +261,6 @@
 				- 139
 				- 140
 			- DP on tree
-				- 337
 				- 124
 				- 979
 				- 968

--- a/data/progress.txt
+++ b/data/progress.txt
@@ -1,4 +1,4 @@
-20260827: 4026(to note),776(todo),449(todo),394(todo),907(again!!),34(todo),227(again, with univeral algo),104(ok),572(again*),39(again*).79(again*),212(todo),211(again*) | 524(ok*), 809(again**),986(todo),337(todo)
+20260827: 4026(to note),776(todo),449(todo),394(todo),907(again!!),34(todo),227(again, with univeral algo),104(ok),572(again*),39(again*).79(again*),212(todo),211(again*) | 524(ok*), 809(again**),986(todo),337(again!!)
 
 
 20260826: 621(again!!), 538(ok***), 623(again!!!)

--- a/data/progress.txt
+++ b/data/progress.txt
@@ -1,4 +1,4 @@
-20260827: 4026(to note),776(todo),449(todo),394(todo),907(again!!),34(todo),227(again, with univeral algo),104(ok),572(again*),39(again*).79(again*),212(todo),211(again*) | 524(ok*), 809(again**)
+20260827: 4026(to note),776(todo),449(todo),394(todo),907(again!!),34(todo),227(again, with univeral algo),104(ok),572(again*),39(again*).79(again*),212(todo),211(again*) | 524(ok*), 809(again**),986(todo),337(todo)
 
 
 20260826: 621(again!!), 538(ok***), 623(again!!!)

--- a/doc/lc-readiness-guide.md
+++ b/doc/lc-readiness-guide.md
@@ -1,0 +1,346 @@
+# LeetCode Readiness Evaluation — Running It, and Reading It
+
+`script/eval_lc_readiness.py` scores a LeetCode profile against a Google SWE coding
+bar and prints a terminal report. This guide covers how to run it, what every
+section of the output means, and — the part that actually matters — which numbers to
+act on and which to ignore.
+
+For the one-paragraph version, see [`doc/utility-scripts.md`](./utility-scripts.md).
+
+---
+
+## Quick Start
+
+```bash
+# Full report against the L3 bar (the default)
+python3 script/eval_lc_readiness.py
+```
+
+No install, no dependencies, no LeetCode login, no Premium. It reads the public
+GraphQL API and this repo's `README.md`.
+
+### All the flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--level {L3,L4,L5}` | `L3` | Which bar to score against. Moves the grade a lot — see [Levels](#levels). |
+| `--user <name>` | `yennanliu` | Any public LeetCode username. |
+| `--offline` | off | Replay the cache, make no network calls. Fails if the cache is cold. |
+| `--json <path>` | — | Also dump the raw result for tracking over time. |
+| `--cache-dir <dir>` | `.lc_cache/` | Where fetched JSON lands. Gitignored. |
+| `--readme <path>` | `README.md` | The status-column source. |
+| `--year <yyyy>` | current year | Which year's submission calendar to summarise. |
+
+```bash
+python3 script/eval_lc_readiness.py --level L4          # harder bar, same data
+python3 script/eval_lc_readiness.py --offline           # no network
+python3 script/eval_lc_readiness.py --json out.json     # machine-readable
+python3 script/eval_lc_readiness.py --user someone_else # scout a friend's profile
+```
+
+### Caching
+
+Every fetch is written to `--cache-dir` as one JSON file per query. A second run
+without `--offline` re-fetches the profile, tags, contest, recent and calendar
+queries, but **reuses `universe.json`** — the per-tag problem totals, which cost one
+request per tag and essentially never change.
+
+So the cheap loop while iterating on the report itself is:
+
+```bash
+python3 script/eval_lc_readiness.py            # once, online
+python3 script/eval_lc_readiness.py --offline  # as many times as you like
+```
+
+---
+
+## Where the numbers come from
+
+Two sources, and it matters which is which, because they disagree in a useful way.
+
+**1. LeetCode's public GraphQL API** (`https://leetcode.com/graphql`) — ground truth
+for what has actually been accepted on the platform:
+
+| Query | Gives |
+|-------|-------|
+| `matchedUser.submitStats` | solved counts and submission counts per difficulty |
+| `matchedUser.tagProblemCounts` | distinct problems solved per topic tag |
+| `userContestRanking` | rating, contests attended, percentile |
+| `matchedUser.userCalendar` | streak, active days, per-day submission counts |
+| `questionList(filters:{tags})` | how many problems exist per tag — the denominator |
+
+**2. This repo's `README.md`** — ground truth for *your own assessment* of each
+problem: the `OK` / `AGAIN` status, the trailing `*` run that counts review passes,
+and the note column's `google` / `MUST` tags.
+
+The gap between them is informative. A problem can have a README row, a Java file
+and a Python file, and still have never been accepted on LeetCode — which is exactly
+what the graph topics turned out to look like.
+
+---
+
+## Levels
+
+The level changes what "enough" means, not what gets asked. Passing `--level` is the
+single biggest lever on the output.
+
+| | `L3` (default) | `L4` | `L5` |
+|---|---|---|---|
+| Solved | 300 | 500 | 600 |
+| Medium | 200 | 300 | 350 |
+| Hard | 60 | 150 | 200 |
+| Hard share | 12% | 20% | 25% |
+| Contest rating | 1650 | 1800 | 1900 |
+| Contests attended | 8 | 10 | 12 |
+| Topic target scale | 0.70× | 1.00× | 1.15× |
+
+Why they differ:
+
+- **L3** is entry level. There is no system design round, so the coding rounds carry
+  almost the whole packet, and what they ask for is a *clean medium* — clarified,
+  reasoned aloud, written correctly, complexity stated — not a clever hard. Hard
+  problems are upside, not a requirement.
+- **L4** asks the same problems with less hand-holding, and hard-flavoured mediums
+  appear often enough that the hard tier has to be familiar.
+- **L5** adds a system design round that this data cannot see at all, so an L5 score
+  from this tool is necessarily incomplete.
+
+> **These are modelled numbers, not official ones.** Google publishes no LeetCode
+> threshold. They encode the widely-reported "medium fluency plus hard exposure"
+> consensus. Treat the grade as calibration, and re-tune `LEVELS` in the script if
+> you disagree — it is a dict at the top of the file for exactly that reason.
+
+---
+
+## Reading the report
+
+### The header: four axes and one grade
+
+```text
+OVERALL vs Google L3 SWE coding bar: B+  (83%)
+
+  Volume    ██████████████████████ 100%  A
+  Breadth   █████████████████████░  94%  A
+  Mastery   ███████████░░░░░░░░░░░  51%  C
+  Signal    ████████████████░░░░░░  74%  B
+```
+
+| Axis | Answers | Weight |
+|------|---------|--------|
+| **Volume** | Have you solved enough, with the right difficulty mix? | 30% |
+| **Breadth** | Is every topic the loop draws from covered? | 30% |
+| **Mastery** | Do solved problems stay solved? | 20% |
+| **Signal** | Any evidence of performance under time pressure? | 20% |
+
+Grade scale: `A` ≥ 90%, `B+` ≥ 78%, `B` ≥ 66%, `C+` ≥ 54%, `C` ≥ 42%, `D` ≥ 30%,
+`E` below.
+
+**Read the axes, not the overall grade.** The single number averages four things that
+call for completely different responses. Two profiles can both score B: one needs
+more problems, the other needs to stop solving problems and start timing itself.
+
+### Volume
+
+```text
+  OK  all      809 / 300  target
+  OK  medium   487 / 200  target
+  OK  hard     113 / 60   target
+      easy     209
+      hard share 14.0%  (target 12%)
+      7,813 accepted / 12,660 submissions = 62% ; 9.7 AC per problem
+```
+
+`OK` / `GAP` is just target comparison. The line worth staring at is the last one:
+**AC per problem**. A value near 1.0 means each problem was solved once and never
+revisited. A high value means deliberate re-solving. Neither is wrong, but it tells
+you which failure mode to look for — low means fragile recall, high means the review
+loop may be spinning without retiring anything (see [Mastery](#mastery-the-cost-curve)).
+
+Scoring: the mean of the three target ratios (each capped at 1.0), then
+`0.75 × that + 0.25 × hard-share ratio`.
+
+### Precision and drill depth
+
+```text
+           solved    subs  rejected  AC/problem
+  easy        209    2859       44%         7.6
+  medium      487    8764       37%        11.3
+  hard        113    1037       31%         6.4
+```
+
+This table is not scored — it is diagnostic, and it is the fastest way to spot a
+verification problem.
+
+LeetCode publishes no first-attempt statistic, so `rejected` is
+`(total submissions − accepted submissions) / total submissions` per difficulty: a
+proxy for how often a first cut is wrong.
+
+**How to read it:** rejection rate should *rise* with difficulty. If it is flat, or
+inverted so that easy problems fail more often than hard ones, the cause is not
+difficulty — it is speed without a self-check habit. Free retries hide that on
+LeetCode; an interview has no submit button.
+
+`AC/problem` shows which tier actually gets drilled. A tier that is both thin and
+lightly drilled is the one that will surprise you.
+
+### Breadth
+
+```text
+  You have solved 809/4033 = 20% of all LeetCode. A topic's 'x base' is its own
+  coverage over that baseline: <1.0x means under-practised for you.
+  topic                      solved    of   cov  x base  w
+  GAP Shortest Path (Dijkstra)      7    42   17%   0.83x  3  █████░░░░░
+      DFS                       125   349   36%   1.79x  3  ██████████
+      Heap / PQ                 ~66     -     -       -  3  ██████████
+  n/a BST                         -     -     -       -  2  (not reported by the API)
+```
+
+Six columns:
+
+- **solved** — distinct problems accepted with that tag. A leading `~` means the
+  number came from a README regex, not the API (see below).
+- **of** — how many problems carry that tag in total, fetched from LeetCode.
+- **cov** — solved ÷ of.
+- **x base** — coverage divided by your overall coverage of all of LeetCode.
+  **This is the column to trust.** `<1.00×` means under-practised *by your own
+  standard*, which is a far stronger claim than missing a target someone made up.
+- **w** — weight, 1–3, for how often the topic comes up in a Google loop. Drives the
+  weighted breadth score and the `GAP` flag.
+- **bar** — progress toward the level-scaled target.
+
+Row prefixes: `GAP` = under 60% of target on a weight-2-or-3 topic, i.e. worth acting
+on. `thin` = under 60% but low weight. `n/a` = not measurable.
+
+Three quirks, all deliberate:
+
+- **`~` rows.** LeetCode's skill-stats endpoint returns only a curated tag set and
+  silently omits Heap/PQ and prefix sum. Those fall back to a regex over the README
+  rows, which is a *lower bound* — it counts only what this repo tracks — so they are
+  measured but not compared against a denominator.
+- **`n/a` rows.** BST is omitted by the API and its README notes are full of
+  "check with BST" cross-references, so any regex over-counts. Rather than report a
+  bad number, it is excluded from the score entirely. An unmeasured topic is not a
+  proven gap. Tree coverage is the honest proxy.
+- **Targets are capped at the tag's own problem count.** Sweep line has only 8
+  problems on all of LeetCode, so a target of 20 would be unreachable by definition.
+
+### Mastery: the cost curve
+
+This is the most useful part of the report and none of it is visible from LeetCode.
+
+```text
+  tracked rows 1191   OK 337   AGAIN 854   -> 28% marked solid
+
+  Cost curve - mean review passes per problem, by README section.
+  High mean = the topic keeps costing you re-learns. Ranked worst first:
+    section                      n   OK  AGAIN  mean passes
+    Recursion                   30    3     27       7.3  █████████░
+    Math                        81   19     62       1.1  █░░░░░░░░░
+```
+
+**Mean passes** is the average of the trailing `*` run across a section's rows: how
+many times a topic has to be re-learned before it sticks. Ranking sections by it
+separates two very different situations that a plain solved-count conflates —
+*never seen* versus *never sticks*.
+
+The comparison is what carries meaning, not the absolute value. If cheap topics
+(array, string, math) sit at 1–3 passes and expensive ones (recursion, tree, BST,
+BFS, backtracking, stack, heap) sit at 5–7, then volume is not your constraint —
+retention on recursive structure is. And since the expensive group is most of what a
+coding round is made of, that is where the remaining work is.
+
+> **The `OK` / `AGAIN` ratio is a floor, not a measurement.** In this repo the
+> `AGAIN` marker behaves as a permanent review tag rather than a mastery verdict —
+> 125 of 136 hard rows carry it, some after 20+ passes. So the Mastery percentage is
+> understated by a bookkeeping convention. Trust the *relative* cost curve; discount
+> the absolute percentage. Fixing this needs a graduation rule, not a code change:
+> decide what "solid" means (solved clean, first attempt, under 20 minutes,
+> complexity stated) and promote rows that clear it.
+
+### Chronic blind spots
+
+```text
+  Chronic blind spots - AGAIN after 12+ passes (106 problems):
+    LC 91     23 passes  Medium Dynamic Programming     MUST
+    LC 658    22 passes  Medium Binary Search           google MUST
+```
+
+Rows still queued after 12 or more passes. This is the most directly actionable list
+the tool produces, and the point is a change of tactics rather than a change of
+effort: **more repetition has already been proven not to work on these.**
+
+What is missing is a written *invariant* — one sentence naming the state, the
+transition, and the specific thing you get wrong — filed in the matching
+[`doc/cheatsheet/`](./cheatsheet/) page. Check the difficulty column too. If the
+chronic list is all mediums, it is describing the exact tier an L3 round is built
+from, which makes it urgent rather than academic.
+
+### Signal
+
+```text
+  contest rating 1528  (target 1650) from 1 contest(s), top 37.4%
+  2026: 210 active days, current streak 92
+  submissions by month:
+    2026-03   433 subs / 31 days  ██████████████░░
+```
+
+Contests are the only speed-under-pressure evidence LeetCode exposes, which is why
+they carry 55% of this axis (contests attended 25%, active days 20%).
+
+**A rating from very few contests is not a low rating — it is no rating.** Ratings
+start near 1500 and converge slowly, so one or two samples leave the number
+essentially at its initial value. That is why `contests` is scored separately: the
+report is asking whether the measurement exists at all, not just whether it is high.
+
+The monthly histogram is for spotting a collapse or a taper, which the streak number
+hides — a live 90-day streak is compatible with volume having quietly dropped by 80%.
+
+---
+
+## Acting on it
+
+A rough priority order, because the axes are not equally expensive to fix:
+
+1. **Signal at C or below with few contests** — fix first. It is cheap (two virtual
+   contests a week) and nothing else substitutes for it.
+2. **An inverted rejection curve** — easy problems failing more than hard ones.
+   Fix with timed, no-run practice, not more problems.
+3. **A steep cost curve on interview-core topics** — write invariants for the
+   chronic list; stop re-solving.
+4. **`GAP` topics with weight 3** — targeted, and usually small once the targets are
+   level-scaled.
+5. **Volume** — last, and often not at all. If Volume already scores A, more solved
+   problems cannot move the overall grade.
+
+And the thing the report cannot tell you: **it measures one of the three or four
+things a loop scores.** Communication during coding, Googleyness, and (from L5)
+system design are all invisible here.
+
+---
+
+## Tracking over time
+
+```bash
+python3 script/eval_lc_readiness.py --json "data/readiness-$(date +%Y-%m).json"
+```
+
+The four axis percentages in `scores` are the tracking metric. Re-run monthly rather
+than weekly — solved counts and cost curves move on a scale of months, and a weekly
+cadence mostly measures noise.
+
+## Changing the bar
+
+Everything tunable is at the top of the script:
+
+- `LEVELS` — per-level volume targets, signal targets, and the topic target scale.
+- `GOOGLE_TOPICS` — the topic list, as
+  `(tag slug, display name, target, weight, README fallback regex)`.
+- `grade()` — the letter cutoffs.
+- The axis weights are in `evaluate()`, on the line that computes `overall`.
+
+Adding a topic needs a real LeetCode tag slug. An unknown slug is not an error —
+LeetCode ignores the filter and returns the entire problem set, which would read as
+"1% coverage" on a topic you had actually covered. The script detects that case by
+comparing against the unfiltered total and drops the denominator instead, but the
+solved count will still be missing, so check the row shows `n/a` rather than a
+plausible-looking number.

--- a/doc/lc-readiness-guide.md
+++ b/doc/lc-readiness-guide.md
@@ -25,8 +25,8 @@ GraphQL API and this repo's `README.md`.
 |------|---------|---------|
 | `--level {L3,L4,L5}` | `L3` | Which bar to score against. Moves the grade a lot — see [Levels](#levels). |
 | `--user <name>` | `yennanliu` | Any public LeetCode username. |
-| `--offline` | off | Replay the cache, make no network calls. Fails if the cache is cold. |
-| `--json <path>` | — | Also dump the raw result for tracking over time. |
+| `--offline` | off | Replay the cache, make no network calls. Fails if any cache file for the requested user, year, or the shared tag universe is missing. |
+| `--json <path>` | — | Write the evaluated report as JSON, for tracking over time. It is everything the terminal shows minus the raw tag map, not the untouched evaluator result. |
 | `--cache-dir <dir>` | `.lc_cache/` | Where fetched JSON lands. Gitignored. |
 | `--readme <path>` | `README.md` | The status-column source. |
 | `--year <yyyy>` | current year | Which year's submission calendar to summarise. |
@@ -34,16 +34,38 @@ GraphQL API and this repo's `README.md`.
 ```bash
 python3 script/eval_lc_readiness.py --level L4          # harder bar, same data
 python3 script/eval_lc_readiness.py --offline           # no network
-python3 script/eval_lc_readiness.py --json out.json     # machine-readable
+python3 script/eval_lc_readiness.py --json out.json     # evaluated report as JSON
 python3 script/eval_lc_readiness.py --user someone_else # scout a friend's profile
 ```
 
 ### Caching
 
-Every fetch is written to `--cache-dir` as one JSON file per query. A second run
-without `--offline` re-fetches the profile, tags, contest, recent and calendar
-queries, but **reuses `universe.json`** — the per-tag problem totals, which cost one
-request per tag and essentially never change.
+Every fetch is written to `--cache-dir`, one JSON file per query, namespaced so that
+two profiles can never be mixed up:
+
+```text
+.lc_cache/
+├── universe.json          # per-tag problem totals — shared, describes the problem set
+└── <username>/
+    ├── profile.json
+    ├── tags.json
+    ├── contest.json
+    ├── recent.json
+    └── calendar-2026.json # per year
+```
+
+Profile data is keyed by user, and the calendar additionally by year, so
+`--user b --offline` cannot replay user a's cache and print it under b's name. As a
+second guard, the run aborts if the profile payload's own username disagrees with
+`--user` — which catches a hand-edited or hand-copied cache file.
+
+A second run without `--offline` re-fetches the five per-user queries but **reuses
+`universe.json`**, which costs one request per tag and essentially never changes. It is
+shared across users because it describes the problem set, not a profile.
+
+`--offline` requires `universe.json` too. Without it the topic targets are no longer
+capped at each tag's own problem count, so the breadth score would shift by a point or
+two with no visible cause — a silent difference is worse than a hard failure.
 
 So the cheap loop while iterating on the report itself is:
 
@@ -237,6 +259,11 @@ This is the most useful part of the report and none of it is visible from LeetCo
     Recursion                   30    3     27       7.3  █████████░
     Math                        81   19     62       1.1  █░░░░░░░░░
 ```
+
+`parse_readme()` also recognises `TODO` and `NOT_OK`. Neither appears in the README
+today, but they are counted in their own bucket rather than folded into `AGAIN`, so the
+per-section totals always reconcile with the header line. They stay in the mastery
+denominator — a `TODO` row is tracked but not solid.
 
 **Mean passes** is the average of the trailing `*` run across a section's rows: how
 many times a topic has to be re-learned before it sticks. Ranking sections by it

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -128,6 +128,9 @@ Two views carry most of the diagnostic value:
 - **Chronic blind spots** — rows still marked `AGAIN` after 12+ passes. More passes have
   already failed to fix these, so they need a different intervention, not another rep.
 
+**Full guide**: [`doc/lc-readiness-guide.md`](./lc-readiness-guide.md) — every flag, what
+each section of the output means, and which numbers to act on versus ignore.
+
 Two caveats the output flags on its own:
 
 - LeetCode's skill-stats endpoint reports only a curated tag set and silently omits Heap,

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -96,7 +96,7 @@ python3 script/eval_lc_readiness.py                    # fetch + report, L3 bar
 python3 script/eval_lc_readiness.py --level L4         # or L3 / L4 / L5
 python3 script/eval_lc_readiness.py --user someone
 python3 script/eval_lc_readiness.py --offline          # replay the cache, no network
-python3 script/eval_lc_readiness.py --json out.json    # machine-readable dump
+python3 script/eval_lc_readiness.py --json out.json    # evaluated report as JSON
 ```
 
 `--level` picks which bar to score against, and it moves the grade a lot — the level
@@ -133,9 +133,12 @@ each section of the output means, and which numbers to act on versus ignore.
 
 Two caveats the output flags on its own:
 
-- LeetCode's skill-stats endpoint reports only a curated tag set and silently omits Heap,
-  BST, Prefix Sum and Intervals. Those four fall back to a regex over the README rows and
-  print with a `~` — a lower bound, since it only counts what this repo tracks.
+- LeetCode's skill-stats endpoint reports only a curated tag set and silently omits three
+  of the topics scored here. Heap/PQ and Prefix Sum fall back to a regex over the README
+  rows and print with a `~` — a lower bound, since it counts only what this repo tracks.
+  BST has no usable fallback (its README notes are full of "check with BST"
+  cross-references, so any regex over-counts), so it prints `n/a` and is left out of the
+  breadth score entirely — an unmeasured topic is not a proven gap.
 - The `OK`/`AGAIN` marker behaves as a permanent review-queue tag, not a mastery verdict
   (92% of Hard rows sit at `AGAIN`, some after 20+ passes). So read the Mastery axis as a
   floor, and trust the *relative* cost curve over the absolute `OK` share.

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -85,6 +85,58 @@ Two traps the parser has to dodge, both of which silently inflate coverage:
 - `1. Populate the graph map` in a mid-function comment is not an LC id. The id scan stops at the first type declaration, and a candidate title must look like a title (short noun phrase, no operators or quotes).
 - `check with LC 542` is a cross-reference, not a solution. A `// LC n` tag counts only when it sits alone on its line and a problem url follows within a few lines — the shape `LCWeekly/*.java` uses to hold a whole contest.
 
+## eval_lc_readiness.py
+
+Scores a LeetCode profile against a Google SWE coding bar and prints a terminal report.
+Pulls the public LeetCode GraphQL API (no auth, no premium) and cross-references it with
+`README.md`'s status column.
+
+```bash
+python3 script/eval_lc_readiness.py                    # fetch + report, L3 bar
+python3 script/eval_lc_readiness.py --level L4         # or L3 / L4 / L5
+python3 script/eval_lc_readiness.py --user someone
+python3 script/eval_lc_readiness.py --offline          # replay the cache, no network
+python3 script/eval_lc_readiness.py --json out.json    # machine-readable dump
+```
+
+`--level` picks which bar to score against, and it moves the grade a lot — the level
+changes what "enough" means, not what gets asked:
+
+| Level | Solved / medium / hard | Contest rating | Notes |
+|-------|------------------------|----------------|-------|
+| `L3` (default) | 300 / 200 / 60 | 1650 | entry; no system design round, medium fluency is the bar |
+| `L4` | 500 / 300 / 150 | 1800 | hard-flavoured mediums common, so the hard tier must be familiar |
+| `L5` | 600 / 350 / 200 | 1900 | adds a system design round this data cannot see |
+
+Topic targets scale with the level too (`topic_scale`: 0.70 / 1.00 / 1.15).
+
+Fetched JSON is cached under `.lc_cache/` (gitignored), so `--offline` replays the last
+fetch for free. Four axes, weighted into one grade:
+
+| Axis | What it measures | Source |
+|------|------------------|--------|
+| Volume | solved counts and the Easy/Medium/Hard mix vs target | LC `submitStats` |
+| Breadth | per-topic solved vs a target for each topic Google asks, weighted by how often it comes up | LC `tagProblemCounts` |
+| Mastery | share of README rows marked `OK` rather than `AGAIN` | README status column |
+| Signal | contest rating, contests attended, active days — the only speed-under-pressure proxy available | LC contest + calendar |
+
+Two views carry most of the diagnostic value:
+
+- **Cost curve** — mean review passes per problem, per README section. A high mean means
+  the topic keeps costing re-learns even after it is "solved"; ranking sections by it
+  separates *never seen* from *never stuck*.
+- **Chronic blind spots** — rows still marked `AGAIN` after 12+ passes. More passes have
+  already failed to fix these, so they need a different intervention, not another rep.
+
+Two caveats the output flags on its own:
+
+- LeetCode's skill-stats endpoint reports only a curated tag set and silently omits Heap,
+  BST, Prefix Sum and Intervals. Those four fall back to a regex over the README rows and
+  print with a `~` — a lower bound, since it only counts what this repo tracks.
+- The `OK`/`AGAIN` marker behaves as a permanent review-queue tag, not a mastery verdict
+  (92% of Hard rows sit at `AGAIN`, some after 20+ passes). So read the Mastery axis as a
+  floor, and trust the *relative* cost curve over the absolute `OK` share.
+
 ## Other Scripts
 
 | Script | Purpose |

--- a/leetcode_python/Recursion/house-robber-iii.py
+++ b/leetcode_python/Recursion/house-robber-iii.py
@@ -44,7 +44,15 @@ class Solution(object):
 
 
 # V0-0-1
-# IDEA: tree DP with post-order DFS (gpt)
+# IDEA: tree DP with POST-order DFS (gpt)
+"""
+NOTE !!!
+
+
+1. bottom up DFS (post order)
+
+2. [rob_val, not_rob_val] is the helper func return type
+"""
 class Solution(object):
     def rob(self, root):
         """
@@ -75,17 +83,31 @@ class Solution(object):
         l_rob, l_not_rob = self.helper(root.left)
         r_rob, r_not_rob = self.helper(root.right)
 
+        #---------------------------
         # Case 1:
         # ROB current node
         #
         # Then we CANNOT rob either child.
+        #---------------------------
         rob_val = root.val + l_not_rob + r_not_rob
 
+        #---------------------------
         # Case 2:
         # DO NOT ROB current node
         #
-        # Each child can independently choose
-        # whether to rob or not.
+        # Each child can `independently` choose
+        # `whether to rob or not.`
+        #---------------------------
+        """
+        NOTE !!!
+
+        1. left, right sub tree status are INDEPENDENT !!!
+
+        2. so, we get the max from 2 choice from each sub tree
+            -> e.g. max(l_rob, l_not_rob)
+
+            (rob or NOT rob)
+        """
         not_rob_val = max(l_rob, l_not_rob) + \
                       max(r_rob, r_not_rob)
 

--- a/leetcode_python/Recursion/house-robber-iii.py
+++ b/leetcode_python/Recursion/house-robber-iii.py
@@ -42,6 +42,56 @@ class Solution(object):
         pass
 
 
+
+# V0-0-1
+# IDEA: tree DP with post-order DFS (gpt)
+class Solution(object):
+    def rob(self, root):
+        """
+        :type root: Optional[TreeNode]
+        :rtype: int
+        """
+
+        rob_val, not_rob_val = self.helper(root)
+
+        return max(rob_val, not_rob_val)
+
+
+    # Return:
+    # [rob_val, not_rob_val]
+    #
+    # rob_val:
+    #   Maximum money if we ROB this node.
+    #
+    # not_rob_val:
+    #   Maximum money if we DO NOT ROB this node.
+    def helper(self, root):
+
+        # Empty tree
+        if not root:
+            return [0, 0]
+
+        # Bottom-up / post-order DFS
+        l_rob, l_not_rob = self.helper(root.left)
+        r_rob, r_not_rob = self.helper(root.right)
+
+        # Case 1:
+        # ROB current node
+        #
+        # Then we CANNOT rob either child.
+        rob_val = root.val + l_not_rob + r_not_rob
+
+        # Case 2:
+        # DO NOT ROB current node
+        #
+        # Each child can independently choose
+        # whether to rob or not.
+        not_rob_val = max(l_rob, l_not_rob) + \
+                      max(r_rob, r_not_rob)
+
+        return [rob_val, not_rob_val]
+
+
 # V0-1
 # IDEA: tree DP with post-order DFS (gpt)
 class Solution(object):

--- a/script/eval_lc_readiness.py
+++ b/script/eval_lc_readiness.py
@@ -120,6 +120,10 @@ GOOGLE_TOPICS = [
 # ---------------------------------------------------------------------------
 # Fetch
 # ---------------------------------------------------------------------------
+class GraphQLError(RuntimeError):
+    """A 200 response that is not a usable GraphQL result."""
+
+
 def gql(query, variables, user):
     body = json.dumps({"query": query, "variables": variables}).encode()
     req = urllib.request.Request(
@@ -132,7 +136,20 @@ def gql(query, variables, user):
         },
     )
     with urllib.request.urlopen(req, timeout=30) as r:
-        return json.loads(r.read())
+        payload = json.loads(r.read())
+
+    # LeetCode answers a rejected query with HTTP 200 and {"errors": [...],
+    # "data": null}. Caching that would destroy a good cache and then crash
+    # evaluate() on a missing field, so refuse it here instead.
+    if not isinstance(payload, dict):
+        raise GraphQLError(f"expected a JSON object, got {type(payload).__name__}")
+    if payload.get("errors"):
+        first = payload["errors"][0]
+        msg = first.get("message", first) if isinstance(first, dict) else first
+        raise GraphQLError(f"GraphQL error: {msg}")
+    if payload.get("data") is None:
+        raise GraphQLError("GraphQL response carried no data")
+    return payload
 
 
 QUERIES = {
@@ -185,29 +202,42 @@ QUERIES = {
 }
 
 
+def cache_slug(user):
+    """Filesystem-safe directory name for a username."""
+    slug = re.sub(r"[^A-Za-z0-9_-]", "_", user).lower().strip("._-")
+    return slug or "_unnamed"
+
+
 def fetch_all(user, cache_dir, offline, year):
-    """Return {key: payload}. Cached to cache_dir so re-runs are free."""
+    """Return {key: payload}.
+
+    Profile data is cached under a per-user directory, and the calendar
+    additionally per year. Without that, `--user b --offline` would happily
+    replay user a's cache and print it under b's name, and a partial online
+    failure could splice two profiles together.
+    """
     out = {}
-    os.makedirs(cache_dir, exist_ok=True)
+    user_dir = os.path.join(cache_dir, cache_slug(user))
+    os.makedirs(user_dir, exist_ok=True)
     plan = [
-        ("profile", {"username": user}),
-        ("tags", {"username": user}),
-        ("contest", {"username": user}),
-        ("recent", {"username": user, "limit": 100}),
-        ("calendar", {"username": user, "year": year}),
+        ("profile", "profile", {"username": user}),
+        ("tags", "tags", {"username": user}),
+        ("contest", "contest", {"username": user}),
+        ("recent", "recent", {"username": user, "limit": 100}),
+        ("calendar", f"calendar-{year}", {"username": user, "year": year}),
     ]
-    for key, variables in plan:
-        path = os.path.join(cache_dir, f"{key}.json")
-        if offline or (os.path.exists(path) and offline):
-            pass
+    for key, filename, variables in plan:
+        path = os.path.join(user_dir, f"{filename}.json")
         if offline:
             if not os.path.exists(path):
-                sys.exit(f"--offline but {path} is missing; run once online first")
+                sys.exit(f"--offline but {path} is missing; "
+                         f"run once online for {user} first")
             out[key] = json.load(open(path))
             continue
         try:
             payload = gql(QUERIES[key], variables, user)
-        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError,
+                GraphQLError) as e:
             if os.path.exists(path):
                 print(f"warn: {key} fetch failed ({e}); using cache", file=sys.stderr)
                 out[key] = json.load(open(path))
@@ -217,10 +247,29 @@ def fetch_all(user, cache_dir, offline, year):
             json.dump(payload, f, indent=1)
         out[key] = payload
 
+    # A username that does not exist comes back as a clean {"matchedUser": null},
+    # which would otherwise surface as a TypeError deep inside evaluate().
+    matched = (out["profile"].get("data") or {}).get("matchedUser")
+    if matched is None:
+        sys.exit(f"error: LeetCode has no public profile for user {user!r}")
+
+    # The report header, and every number under it, come from this payload. If a
+    # cache file has been hand-edited or copied between directories, say so
+    # rather than printing one profile's data under another profile's name.
+    got = (matched.get("username") or "").lower()
+    if got and got != user.lower():
+        sys.exit(f"error: asked for user {user!r} but the profile data is for "
+                 f"{matched['username']!r}. Delete {user_dir} and re-run online.")
+
     # Per-tag problem totals, so topic coverage can be stated as a share of what
     # exists rather than against a target picked by hand. One request per tag,
     # cached in a single file.
+    # Shared across users: it describes the problem set, not a profile.
     upath = os.path.join(cache_dir, "universe.json")
+    if offline and not os.path.exists(upath):
+        sys.exit(f"--offline but {upath} is missing; run once online first. "
+                 "Without it, topic targets are not capped at each tag's own "
+                 "problem count and the breadth score would differ silently.")
     universe = json.load(open(upath)) if os.path.exists(upath) else {}
     wanted = ["__all__"] + [t[0] for t in GOOGLE_TOPICS]
     missing = [t for t in wanted if t not in universe]
@@ -234,7 +283,8 @@ def fetch_all(user, cache_dir, offline, year):
                 universe[tag] = d["data"]["problemsetQuestionList"]["total"]
                 if tag != "__all__" and universe[tag] == universe.get("__all__"):
                     universe[tag] = None   # filter was ignored -> bad slug
-            except Exception as e:                       # non-fatal enrichment
+            except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError,
+                    GraphQLError, KeyError, TypeError) as e:   # non-fatal enrichment
                 print(f"warn: universe fetch for {tag} failed: {e}", file=sys.stderr)
         with open(upath, "w") as f:
             json.dump(universe, f, indent=1)
@@ -382,11 +432,17 @@ def evaluate(data, problems, year, level="L4"):
     # a healthy spaced-repetition backlog is fine; being >70% AGAIN is not
     mastery_score = score(mastery_ratio, 0.55)
 
-    by_section = defaultdict(lambda: {"ok": 0, "again": 0, "google": 0,
+    other = [p for p in tracked if p["status"] not in ("OK", "AGAIN")]
+
+    by_section = defaultdict(lambda: {"ok": 0, "again": 0, "other": 0, "google": 0,
                                       "google_again": 0, "reps": 0})
     for p in tracked:
         b = by_section[p["section"] or "?"]
-        b["ok" if p["status"] == "OK" else "again"] += 1
+        # Bucket by the actual status. Lumping every non-OK row into `again`
+        # would make these counts disagree with the top-level AGAIN total, since
+        # parse_readme also recognises TODO and NOT_OK.
+        b["ok" if p["status"] == "OK" else
+          "again" if p["status"] == "AGAIN" else "other"] += 1
         b["reps"] += p["reps"]
         if p["google"]:
             b["google"] += 1
@@ -466,6 +522,7 @@ def evaluate(data, problems, year, level="L4"):
                      "days_by_month": dict(sorted(day_count.items()))},
         "readme": {
             "tracked": len(tracked), "ok": len(ok), "again": len(again),
+            "other": len(other),
             "mastery_ratio": mastery_ratio,
             "google_tracked": len(g_tracked), "google_ok": len(g_ok),
             "must_tracked": len(must), "must_ok": len(must_ok),
@@ -546,18 +603,21 @@ def render(r):
     p("")
     p("-- Mastery: this repo's README status column " + "-" * 29)
     rd = r["readme"]
-    p(f"  tracked rows {rd['tracked']}   OK {rd['ok']}   AGAIN {rd['again']}"
+    other_bit = f"   TODO/NOT_OK {rd['other']}" if rd.get("other") else ""
+    p(f"  tracked rows {rd['tracked']}   OK {rd['ok']}   AGAIN {rd['again']}{other_bit}"
       f"   -> {rd['mastery_ratio']*100:.0f}% marked solid")
     p(f"  google-tagged  {rd['google_ok']}/{rd['google_tracked']} OK")
     p(f"  MUST-tagged    {rd['must_ok']}/{rd['must_tracked']} OK")
     p("")
     p("  Cost curve - mean review passes per problem, by README section.")
     p("  High mean = the topic keeps costing you re-learns. Ranked worst first:")
-    rows = [(k, v) for k, v in rd["by_section"].items() if v["ok"] + v["again"] >= 8]
-    rows.sort(key=lambda kv: -kv[1]["reps"] / (kv[1]["ok"] + kv[1]["again"]))
+    def sec_n(v):
+        return v["ok"] + v["again"] + v.get("other", 0)
+    rows = [(k, v) for k, v in rd["by_section"].items() if sec_n(v) >= 8]
+    rows.sort(key=lambda kv: -kv[1]["reps"] / sec_n(kv[1]))
     p(f"    {'section':<26}{'n':>4}{'OK':>5}{'AGAIN':>7}{'mean passes':>13}")
     for k, v in rows:
-        n = v["ok"] + v["again"]
+        n = sec_n(v)
         p(f"    {k:<26}{n:>4}{v['ok']:>5}{v['again']:>7}{v['reps']/n:>10.1f}  "
           f"{bar(min(1, v['reps']/n/8), 10)}")
     p("")
@@ -596,7 +656,9 @@ def main():
     ap.add_argument("--year", type=int, default=datetime.now().year)
     ap.add_argument("--cache-dir", default=os.path.join(ROOT, ".lc_cache"))
     ap.add_argument("--offline", action="store_true", help="use cached JSON only")
-    ap.add_argument("--json", dest="json_out", help="also write the raw result here")
+    ap.add_argument("--json", dest="json_out",
+                    help="write the evaluated report here as JSON "
+                         "(everything the terminal shows, minus the raw tag map)")
     a = ap.parse_args()
 
     data = fetch_all(a.user, a.cache_dir, a.offline, a.year)

--- a/script/eval_lc_readiness.py
+++ b/script/eval_lc_readiness.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Score LeetCode readiness against a Google SWE coding bar.
+
+Pulls the public LeetCode GraphQL profile (no auth, no premium) and cross-references
+it with this repo's README status column, then scores four axes:
+
+  volume     - are enough problems solved, with the right Easy/Medium/Hard mix
+  mastery    - how many solved problems are still marked AGAIN in README
+  breadth    - per-topic coverage vs the topics Google actually asks
+  signal     - contest rating + consistency, the only speed/pressure proxy available
+
+Usage:
+    python3 script/eval_lc_readiness.py                        # fetch + report (L3 bar)
+    python3 script/eval_lc_readiness.py --level L4             # score against L4 instead
+    python3 script/eval_lc_readiness.py --user someone_else
+    python3 script/eval_lc_readiness.py --cache-dir /tmp/lc    # reuse fetched JSON
+    python3 script/eval_lc_readiness.py --offline               # cache only, no network
+    python3 script/eval_lc_readiness.py --json out.json         # machine-readable dump
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+
+GRAPHQL = "https://leetcode.com/graphql"
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+)
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# ---------------------------------------------------------------------------
+# The bar, per level. A Google coding round is ~45 min for 1-2 problems, and the
+# level changes what "enough" means rather than what gets asked:
+#
+#   L3  entry / new-grad. Coding rounds carry nearly the whole packet - there is
+#       no system design round. Medium fluency is the bar; hard is upside, not a
+#       requirement. Interviewers expect a clean medium, not a clever hard.
+#   L4  mid. Same problems, less hand-holding, and hard-flavoured mediums show up
+#       often enough that the hard tier has to be familiar.
+#   L5  senior. Adds a system design round this data cannot see at all.
+#
+# Sources: Google's published interview guidance on topics, plus the widely
+# reported medium-fluency threshold. Calibration, not official figures.
+# ---------------------------------------------------------------------------
+LEVELS = {
+    "L3": {
+        "volume": {"total": 300, "medium": 200, "hard": 60, "hard_share": 0.12},
+        "signal": {"contest_rating": 1650, "contests": 8, "active_days_year": 120},
+        # Advanced topics matter less at L3, so topic targets scale down together.
+        "topic_scale": 0.70,
+    },
+    "L4": {
+        "volume": {"total": 500, "medium": 300, "hard": 150, "hard_share": 0.20},
+        "signal": {"contest_rating": 1800, "contests": 10, "active_days_year": 150},
+        "topic_scale": 1.00,
+    },
+    "L5": {
+        "volume": {"total": 600, "medium": 350, "hard": 200, "hard_share": 0.25},
+        "signal": {"contest_rating": 1900, "contests": 12, "active_days_year": 150},
+        "topic_scale": 1.15,
+    },
+}
+
+# tagSlug -> (display, target solved, weight) ; weight = how often Google asks it
+#
+# LeetCode's skill-stats endpoint only reports a curated tag set, and silently
+# omits Heap, BST, Prefix Sum and Intervals. For those, `fallback` is a regex run
+# over the README rows so the topic is measured instead of scored as zero. A
+# README count is a lower bound (only what this repo tracks), so it is flagged (~).
+GOOGLE_TOPICS = [
+    # slug,                   display,               target, weight, fallback
+    ("array",                 "Array",                  120, 3, None),
+    ("hash-table",            "Hash Table",              80, 3, None),
+    ("string",                "String",                  80, 2, None),
+    ("two-pointers",          "Two Pointers",            50, 2, None),
+    ("sliding-window",        "Sliding Window",          40, 3, None),
+    ("binary-search",         "Binary Search",           50, 3, None),
+    ("sorting",               "Sorting",                 50, 1, None),
+    ("stack",                 "Stack",                   40, 2, None),
+    ("monotonic-stack",       "Monotonic Stack",         25, 2, None),
+    ("heap-priority-queue",   "Heap / PQ",               45, 3,
+     r"\bheap\b|priority ?queue|\bpq\b|kth largest|top k"),
+    ("linked-list",           "Linked List",             30, 1, None),
+    ("tree",                  "Tree",                    70, 2, None),
+    # BST: the skill-stats API omits it and the README notes are full of "check
+    # with BST" cross-references, so any regex over-counts. Tree coverage is the
+    # honest proxy; left here as n/a rather than scored on a bad number.
+    ("binary-search-tree",    "BST",                     25, 2, None),
+    ("depth-first-search",    "DFS",                     80, 3, None),
+    ("breadth-first-search",  "BFS",                     70, 3, None),
+    ("graph",                 "Graph Theory",            60, 3, None),
+    ("topological-sort",      "Topological Sort",        20, 3, None),
+    ("shortest-path",         "Shortest Path (Dijkstra)",20, 3, None),
+    ("union-find",            "Union-Find",              30, 3, None),
+    ("trie",                  "Trie",                    25, 3, None),
+    ("dynamic-programming",   "Dynamic Programming",    130, 3, None),
+    ("backtracking",          "Backtracking",            50, 3, None),
+    ("greedy",                "Greedy",                  70, 2, None),
+    ("bit-manipulation",      "Bit Manipulation",        30, 1, None),
+    ("math",                  "Math",                    60, 1, None),
+    ("design",                "Design",                  40, 3, None),
+    ("matrix",                "Matrix / Grid",           50, 2, None),
+    ("divide-and-conquer",    "Divide & Conquer",        25, 1, None),
+    ("segment-tree",          "Segment Tree",            15, 1, None),
+    ("binary-indexed-tree",   "Binary Indexed Tree",     10, 1, None),
+    ("prefix-sum",            "Prefix Sum",              40, 2,
+     r"prefix ?sum|pre ?sum|presum|diff array|difference array"),
+    ("sweep-line",            "Sweep Line / Intervals",  20, 2, None),
+]
+
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+def gql(query, variables, user):
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(
+        GRAPHQL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": UA,
+            "Referer": f"https://leetcode.com/u/{user}/",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+QUERIES = {
+    "profile": """query q($username: String!) {
+      matchedUser(username: $username) {
+        username
+        profile { ranking realName }
+        submitStats {
+          acSubmissionNum { difficulty count submissions }
+          totalSubmissionNum { difficulty count submissions }
+        }
+      }
+    }""",
+    "tags": """query q($username: String!) {
+      matchedUser(username: $username) {
+        tagProblemCounts {
+          advanced { tagName tagSlug problemsSolved }
+          intermediate { tagName tagSlug problemsSolved }
+          fundamental { tagName tagSlug problemsSolved }
+        }
+      }
+    }""",
+    "contest": """query q($username: String!) {
+      userContestRanking(username: $username) {
+        attendedContestsCount rating globalRanking totalParticipants topPercentage
+      }
+      userContestRankingHistory(username: $username) {
+        attended rating ranking contest { title startTime }
+      }
+    }""",
+    "recent": """query q($username: String!, $limit: Int) {
+      recentAcSubmissionList(username: $username, limit: $limit) {
+        title titleSlug timestamp
+      }
+    }""",
+    "universe": """query pq($categorySlug: String, $limit: Int, $skip: Int,
+                            $filters: QuestionListFilterInput) {
+      problemsetQuestionList: questionList(categorySlug: $categorySlug, limit: $limit,
+                                           skip: $skip, filters: $filters) {
+        total: totalNum
+      }
+    }""",
+    "calendar": """query q($username: String!, $year: Int) {
+      matchedUser(username: $username) {
+        userCalendar(year: $year) {
+          activeYears streak totalActiveDays submissionCalendar
+        }
+      }
+    }""",
+}
+
+
+def fetch_all(user, cache_dir, offline, year):
+    """Return {key: payload}. Cached to cache_dir so re-runs are free."""
+    out = {}
+    os.makedirs(cache_dir, exist_ok=True)
+    plan = [
+        ("profile", {"username": user}),
+        ("tags", {"username": user}),
+        ("contest", {"username": user}),
+        ("recent", {"username": user, "limit": 100}),
+        ("calendar", {"username": user, "year": year}),
+    ]
+    for key, variables in plan:
+        path = os.path.join(cache_dir, f"{key}.json")
+        if offline or (os.path.exists(path) and offline):
+            pass
+        if offline:
+            if not os.path.exists(path):
+                sys.exit(f"--offline but {path} is missing; run once online first")
+            out[key] = json.load(open(path))
+            continue
+        try:
+            payload = gql(QUERIES[key], variables, user)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+            if os.path.exists(path):
+                print(f"warn: {key} fetch failed ({e}); using cache", file=sys.stderr)
+                out[key] = json.load(open(path))
+                continue
+            sys.exit(f"error: {key} fetch failed and no cache: {e}")
+        with open(path, "w") as f:
+            json.dump(payload, f, indent=1)
+        out[key] = payload
+
+    # Per-tag problem totals, so topic coverage can be stated as a share of what
+    # exists rather than against a target picked by hand. One request per tag,
+    # cached in a single file.
+    upath = os.path.join(cache_dir, "universe.json")
+    universe = json.load(open(upath)) if os.path.exists(upath) else {}
+    wanted = ["__all__"] + [t[0] for t in GOOGLE_TOPICS]
+    missing = [t for t in wanted if t not in universe]
+    if missing and not offline:
+        for tag in missing:
+            filters = {} if tag == "__all__" else {"tags": [tag]}
+            try:
+                d = gql(QUERIES["universe"],
+                        {"categorySlug": "", "limit": 1, "skip": 0, "filters": filters},
+                        user)
+                universe[tag] = d["data"]["problemsetQuestionList"]["total"]
+                if tag != "__all__" and universe[tag] == universe.get("__all__"):
+                    universe[tag] = None   # filter was ignored -> bad slug
+            except Exception as e:                       # non-fatal enrichment
+                print(f"warn: universe fetch for {tag} failed: {e}", file=sys.stderr)
+        with open(upath, "w") as f:
+            json.dump(universe, f, indent=1)
+    out["universe"] = universe
+    return out
+
+
+# ---------------------------------------------------------------------------
+# README parsing
+# ---------------------------------------------------------------------------
+ROW = re.compile(r"^\|\s*(\d{1,4})\s*\|(.+)$")
+STATUS = re.compile(r"\b(OK|AGAIN|NOT_OK|TODO)\b")
+DIFF = re.compile(r"\b(Easy|Medium|Hard)\b")
+COMPANIES = ("google", "amazon", "fb", "meta", "apple", "microsoft", "m\\$", "uber", "netflix")
+
+
+def parse_readme(path):
+    """Yield one dict per problem row, keyed by LC number (last row wins)."""
+    problems = {}
+    section = None
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("## "):
+                section = line[3:].strip()
+                continue
+            m = ROW.match(line.rstrip())
+            if not m:
+                continue
+            num = int(m.group(1))
+            rest = m.group(2)
+            cells = [c.strip() for c in rest.split("|")]
+            status_cell = cells[-1] if cells[-1] else (cells[-2] if len(cells) > 1 else "")
+            sm = STATUS.search(status_cell)
+            dm = DIFF.search(rest)
+            reps = status_cell.count("*")
+            note = rest.lower()
+            problems[num] = {
+                "num": num,
+                "section": section,
+                "difficulty": dm.group(1) if dm else None,
+                "status": sm.group(1) if sm else None,
+                "reps": reps,
+                "google": "google" in note,
+                "must": "must" in note,
+                "has_java": ".java" in rest,
+                "has_python": "leetcode_python" in rest,
+                "raw": note,
+            }
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+def score(value, target):
+    """Ratio capped at 1.0; None-safe."""
+    if not target:
+        return 1.0
+    if value is None:
+        return 0.0
+    return min(1.0, value / target)
+
+
+def grade(pct):
+    for cut, label in ((0.90, "A"), (0.78, "B+"), (0.66, "B"), (0.54, "C+"),
+                       (0.42, "C"), (0.30, "D")):
+        if pct >= cut:
+            return label
+    return "E"
+
+
+def evaluate(data, problems, year, level="L4"):
+    cfg = LEVELS[level]
+    volume_targets, signal_targets = cfg["volume"], cfg["signal"]
+    topic_scale = cfg["topic_scale"]
+    universe = data.get("universe") or {}
+    mu = data["profile"]["data"]["matchedUser"]
+    ac = {d["difficulty"].lower(): d for d in mu["submitStats"]["acSubmissionNum"]}
+    tot = {d["difficulty"].lower(): d for d in mu["submitStats"]["totalSubmissionNum"]}
+
+    solved = {k: ac[k]["count"] for k in ("all", "easy", "medium", "hard")}
+    accepted_subs = ac["all"]["submissions"]
+    all_subs = tot["all"]["submissions"]
+
+    tagmap = {}
+    tc = data["tags"]["data"]["matchedUser"]["tagProblemCounts"]
+    for bucket in ("fundamental", "intermediate", "advanced"):
+        for t in tc[bucket]:
+            tagmap[t["tagSlug"]] = {"name": t["tagName"], "solved": t["problemsSolved"],
+                                    "bucket": bucket}
+
+    cr = data["contest"]["data"]["userContestRanking"] or {}
+    cal = data["calendar"]["data"]["matchedUser"]["userCalendar"]
+    sc = json.loads(cal["submissionCalendar"])
+    by_month = Counter()
+    day_count = Counter()
+    for ts, n in sc.items():
+        d = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        by_month[d.strftime("%Y-%m")] += n
+        day_count[d.strftime("%Y-%m")] += 1
+
+    # --- volume
+    vol = {
+        "total": (solved["all"], volume_targets["total"]),
+        "medium": (solved["medium"], volume_targets["medium"]),
+        "hard": (solved["hard"], volume_targets["hard"]),
+    }
+    hard_share = solved["hard"] / solved["all"] if solved["all"] else 0
+    vol_score = sum(score(v, t) for v, t in vol.values()) / 3
+    vol_score = 0.75 * vol_score + 0.25 * score(hard_share, volume_targets["hard_share"])
+
+    # --- breadth
+    topics = []
+    for slug, disp, target, weight, fallback in GOOGLE_TOPICS:
+        s = tagmap.get(slug, {}).get("solved")
+        src = "api"
+        if s is None and fallback:
+            rx = re.compile(fallback)
+            s = sum(1 for pr in problems.values() if rx.search(pr["raw"]))
+            src = "readme"
+        elif s is None:
+            src = "missing"
+        tot_tag = universe.get(slug) if src == "api" else None
+        target = max(1, round(target * topic_scale))
+        # A target above the tag's whole problem set is unreachable by definition.
+        eff_target = min(target, tot_tag) if tot_tag else target
+        topics.append({
+            "slug": slug, "topic": disp, "solved": s, "target": eff_target,
+            "weight": weight, "source": src,
+            "score": None if src == "missing" else score(s, eff_target),
+            "tag_total": tot_tag,
+            "penetration": (s / tot_tag) if (tot_tag and s is not None) else None,
+        })
+    # Topics the API cannot report and that have no usable fallback are excluded
+    # rather than scored as zero - an unmeasured topic is not a proven gap.
+    scored = [t for t in topics if t["score"] is not None]
+    wsum = sum(t["weight"] for t in scored)
+    breadth_score = sum(t["score"] * t["weight"] for t in scored) / wsum
+
+    # --- mastery (README status column)
+    tracked = [p for p in problems.values() if p["status"]]
+    ok = [p for p in tracked if p["status"] == "OK"]
+    again = [p for p in tracked if p["status"] == "AGAIN"]
+    mastery_ratio = len(ok) / len(tracked) if tracked else 0
+    # a healthy spaced-repetition backlog is fine; being >70% AGAIN is not
+    mastery_score = score(mastery_ratio, 0.55)
+
+    by_section = defaultdict(lambda: {"ok": 0, "again": 0, "google": 0,
+                                      "google_again": 0, "reps": 0})
+    for p in tracked:
+        b = by_section[p["section"] or "?"]
+        b["ok" if p["status"] == "OK" else "again"] += 1
+        b["reps"] += p["reps"]
+        if p["google"]:
+            b["google"] += 1
+            if p["status"] == "AGAIN":
+                b["google_again"] += 1
+
+    # Chronic: still queued for review after many passes. The single most
+    # actionable list in the report - these are the recurring blind spots.
+    chronic = sorted(
+        ({"num": p["num"], "reps": p["reps"], "difficulty": p["difficulty"],
+          "section": p["section"], "google": p["google"], "must": p["must"]}
+         for p in tracked if p["status"] == "AGAIN" and p["reps"] >= 12),
+        key=lambda x: -x["reps"])
+
+    # Submission efficiency: LeetCode gives no first-attempt stat, but
+    # (failed / total) per difficulty is a usable proxy for how often a first
+    # cut is wrong - the thing a whiteboard round actually punishes.
+    efficiency = {}
+    for d in ("easy", "medium", "hard"):
+        t, a = tot[d]["submissions"], ac[d]["submissions"]
+        efficiency[d] = {
+            "problems": ac[d]["count"],
+            "submissions": t,
+            "accepted": a,
+            "reject_rate": (t - a) / t if t else 0,
+            "ac_per_problem": a / ac[d]["count"] if ac[d]["count"] else 0,
+        }
+
+    g_tracked = [p for p in tracked if p["google"]]
+    g_ok = [p for p in g_tracked if p["status"] == "OK"]
+    must = [p for p in tracked if p["must"]]
+    must_ok = [p for p in must if p["status"] == "OK"]
+
+    # --- signal
+    rating = cr.get("rating")
+    contests = cr.get("attendedContestsCount") or 0
+    active = cal["totalActiveDays"]
+    signal_score = (
+        0.55 * score(rating, signal_targets["contest_rating"])
+        + 0.25 * score(contests, signal_targets["contests"])
+        + 0.20 * score(active, signal_targets["active_days_year"])
+    )
+
+    # Personal baseline: share of the whole problem set solved. A topic sitting
+    # well under this is under-practised *relative to how you practise*, which is
+    # a stronger claim than missing an absolute target.
+    lc_total = universe.get("__all__")
+    baseline = (solved["all"] / lc_total) if lc_total else None
+    for t in topics:
+        t["vs_baseline"] = (t["penetration"] / baseline) if (baseline and t["penetration"]) else None
+
+    overall = (0.30 * vol_score + 0.30 * breadth_score
+               + 0.20 * mastery_score + 0.20 * signal_score)
+
+    return {
+        "level": level,
+        "targets": {"volume": volume_targets, "signal": signal_targets,
+                    "topic_scale": topic_scale},
+        "user": mu["username"],
+        "ranking": mu["profile"]["ranking"],
+        "solved": solved,
+        "accepted_submissions": accepted_subs,
+        "all_submissions": all_subs,
+        "acceptance_rate": accepted_subs / all_subs if all_subs else 0,
+        "reps_per_problem": accepted_subs / solved["all"] if solved["all"] else 0,
+        "hard_share": hard_share,
+        "tags": tagmap,
+        "topics": topics,
+        "lc_total": lc_total,
+        "baseline": baseline,
+        "contest": {"rating": rating, "contests": contests,
+                    "global": cr.get("globalRanking"),
+                    "top_pct": cr.get("topPercentage")},
+        "calendar": {"year": year, "streak": cal["streak"], "active_days": active,
+                     "active_years": cal["activeYears"],
+                     "by_month": dict(sorted(by_month.items())),
+                     "days_by_month": dict(sorted(day_count.items()))},
+        "readme": {
+            "tracked": len(tracked), "ok": len(ok), "again": len(again),
+            "mastery_ratio": mastery_ratio,
+            "google_tracked": len(g_tracked), "google_ok": len(g_ok),
+            "must_tracked": len(must), "must_ok": len(must_ok),
+            "by_section": {k: v for k, v in sorted(by_section.items())},
+            "chronic": chronic,
+        },
+        "efficiency": efficiency,
+        "scores": {
+            "volume": vol_score, "breadth": breadth_score,
+            "mastery": mastery_score, "signal": signal_score, "overall": overall,
+        },
+        "grades": {k: grade(v) for k, v in
+                   {"volume": vol_score, "breadth": breadth_score,
+                    "mastery": mastery_score, "signal": signal_score,
+                    "overall": overall}.items()},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+def bar(pct, width=22):
+    n = int(round(pct * width))
+    return "█" * n + "░" * (width - n)
+
+
+def render(r):
+    L = []
+    p = L.append
+    s, g = r["scores"], r["grades"]
+    vt, st = r["targets"]["volume"], r["targets"]["signal"]
+    p(f"LeetCode readiness — {r['user']}  (global rank #{r['ranking']:,})")
+    p("=" * 74)
+    p(f"OVERALL vs Google {r['level']} SWE coding bar: {g['overall']}  ({s['overall']*100:.0f}%)")
+    p("")
+    for k in ("volume", "breadth", "mastery", "signal"):
+        p(f"  {k.capitalize():<9} {bar(s[k])} {s[k]*100:3.0f}%  {g[k]}")
+    p("")
+    p("-- Volume " + "-" * 63)
+    sv = r["solved"]
+    for k, target in (("all", vt["total"]), ("medium", vt["medium"]),
+                      ("hard", vt["hard"])):
+        mark = "OK " if sv[k] >= target else "GAP"
+        p(f"  {mark} {k:<7} {sv[k]:>4} / {target:<4} target")
+    p(f"      easy    {sv['easy']:>4}")
+    p(f"      hard share {r['hard_share']*100:.1f}%  (target {vt['hard_share']*100:.0f}%)")
+    p(f"      {r['accepted_submissions']:,} accepted / {r['all_submissions']:,} submissions "
+      f"= {r['acceptance_rate']*100:.0f}% ; {r['reps_per_problem']:.1f} AC per problem")
+    p("")
+    p("-- Precision & drill depth, by difficulty " + "-" * 32)
+    p(f"  {'':<8}{'solved':>7}{'subs':>8}{'rejected':>10}{'AC/problem':>12}")
+    for d in ("easy", "medium", "hard"):
+        e = r["efficiency"][d]
+        p(f"  {d:<8}{e['problems']:>7}{e['submissions']:>8}"
+          f"{e['reject_rate']*100:>9.0f}%{e['ac_per_problem']:>12.1f}")
+    p("")
+    p("-- Breadth: topics Google asks " + "-" * 43)
+    if r["baseline"]:
+        p(f"  You have solved {r['solved']['all']}/{r['lc_total']} = "
+          f"{r['baseline']*100:.0f}% of all LeetCode. A topic's 'x base' is its own")
+        p("  coverage over that baseline: <1.0x means under-practised for you.")
+    p(f"  {'topic':<26}{'solved':>7}{'of':>6}{'cov':>6}{'x base':>8}  w")
+    for t in sorted(r["topics"], key=lambda x: (x["score"] is None, x["score"], -x["weight"])):
+        sv_ = "-" if t["solved"] is None else t["solved"]
+        if t["source"] == "readme":
+            sv_ = f"~{sv_}"
+        if t["score"] is None:
+            p(f"  n/a {t['topic']:<22}{'-':>7}{'-':>6}{'-':>6}{'-':>8}  {t['weight']}"
+              f"  (not reported by the API)")
+            continue
+        flag = "GAP " if t["score"] < 0.6 and t["weight"] >= 2 else ("thin" if t["score"] < 0.6 else "    ")
+        tt = t["tag_total"] or "-"
+        cov = f"{t['penetration']*100:.0f}%" if t["penetration"] else "-"
+        vb = f"{t['vs_baseline']:.2f}x" if t["vs_baseline"] else "-"
+        p(f"  {flag}{t['topic']:<22}{str(sv_):>7}{str(tt):>6}{cov:>6}{vb:>8}  {t['weight']}"
+          f"  {bar(t['score'], 10)}")
+    p("  (~ = counted from README rows; LeetCode's skill-stats API omits that tag)")
+    p("")
+    p("-- Mastery: this repo's README status column " + "-" * 29)
+    rd = r["readme"]
+    p(f"  tracked rows {rd['tracked']}   OK {rd['ok']}   AGAIN {rd['again']}"
+      f"   -> {rd['mastery_ratio']*100:.0f}% marked solid")
+    p(f"  google-tagged  {rd['google_ok']}/{rd['google_tracked']} OK")
+    p(f"  MUST-tagged    {rd['must_ok']}/{rd['must_tracked']} OK")
+    p("")
+    p("  Cost curve - mean review passes per problem, by README section.")
+    p("  High mean = the topic keeps costing you re-learns. Ranked worst first:")
+    rows = [(k, v) for k, v in rd["by_section"].items() if v["ok"] + v["again"] >= 8]
+    rows.sort(key=lambda kv: -kv[1]["reps"] / (kv[1]["ok"] + kv[1]["again"]))
+    p(f"    {'section':<26}{'n':>4}{'OK':>5}{'AGAIN':>7}{'mean passes':>13}")
+    for k, v in rows:
+        n = v["ok"] + v["again"]
+        p(f"    {k:<26}{n:>4}{v['ok']:>5}{v['again']:>7}{v['reps']/n:>10.1f}  "
+          f"{bar(min(1, v['reps']/n/8), 10)}")
+    p("")
+    p(f"  Chronic blind spots - AGAIN after 12+ passes ({len(rd['chronic'])} problems):")
+    for c in rd["chronic"][:25]:
+        tagbits = " ".join(t for t, on in
+                           (("google", c["google"]), ("MUST", c["must"])) if on)
+        p(f"    LC {c['num']:<5}{c['reps']:>3} passes  {c['difficulty'] or '?':<7}"
+          f"{(c['section'] or '?'):<24}{tagbits}")
+    if len(rd["chronic"]) > 25:
+        p(f"    ... and {len(rd['chronic']) - 25} more")
+    p("")
+    p("-- Signal: pressure / speed proxy " + "-" * 40)
+    c = r["contest"]
+    if c["rating"]:
+        p(f"  contest rating {c['rating']:.0f}  (target {st['contest_rating']}) "
+          f"from {c['contests']} contest(s), top {c['top_pct']:.1f}%")
+    else:
+        p("  no contest history — zero timed-pressure evidence")
+    cal = r["calendar"]
+    p(f"  {cal['year']}: {cal['active_days']} active days, current streak {cal['streak']}")
+    p(f"  active years: {', '.join(str(y) for y in cal['active_years'])}")
+    p("  submissions by month:")
+    for m, n in cal["by_month"].items():
+        p(f"    {m}  {n:>4} subs / {cal['days_by_month'][m]:>2} days  {bar(min(1, n/500), 16)}")
+    return "\n".join(L)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--user", default="yennanliu")
+    ap.add_argument("--level", default="L3", choices=sorted(LEVELS),
+                    help="Google level to score against (default L3)")
+    ap.add_argument("--readme", default=os.path.join(ROOT, "README.md"))
+    ap.add_argument("--year", type=int, default=datetime.now().year)
+    ap.add_argument("--cache-dir", default=os.path.join(ROOT, ".lc_cache"))
+    ap.add_argument("--offline", action="store_true", help="use cached JSON only")
+    ap.add_argument("--json", dest="json_out", help="also write the raw result here")
+    a = ap.parse_args()
+
+    data = fetch_all(a.user, a.cache_dir, a.offline, a.year)
+    problems = parse_readme(a.readme)
+    result = evaluate(data, problems, a.year, a.level)
+    print(render(result))
+    if a.json_out:
+        slim = {k: v for k, v in result.items() if k != "tags"}
+        with open(a.json_out, "w") as f:
+            json.dump(slim, f, indent=2)
+        print(f"\nwrote {a.json_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds script/eval_lc_readiness.py. It pulls the public LeetCode GraphQL API (no auth, no premium), cross-references README.md's status column, and grades four axes: volume, breadth, mastery and signal.

Two views carry most of the diagnostic value and neither is visible from LeetCode alone:

- the cost curve — mean review passes per problem per README section, which separates "never seen" from "never sticks";
- chronic blind spots — rows still marked AGAIN after 12+ passes, where more repetition has already been proven not to work.

--level scores against L3 / L4 / L5, since the level changes what "enough" means rather than what gets asked. L3 is the default.

Care is taken not to report a gap the data cannot support: LeetCode's skill-stats endpoint silently omits Heap, BST and prefix sum, so those fall back to a README regex or go unscored rather than reading as zero; an unknown tag slug makes LeetCode ignore the filter and return the whole problem set, which is detected instead of reported as 1% coverage; and topic targets are capped at the tag's own problem count.

Fetches cache to .lc_cache/ (gitignored) so --offline replays them for free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a readiness assessment for evaluating LeetCode progress against configurable software engineering benchmarks.
  - Supports online and offline analysis, cached results, JSON output, readiness grades, topic coverage, and diagnostic insights.
  - Added configurable assessment levels, profiles, and year-based analysis.

- **Documentation**
  - Added guidance for running the assessment and interpreting its scoring, reports, and recommendations.

- **Chores**
  - Added cache directories to ignore rules.
  - Updated progress tracking for completed problem entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->