### PR TITLE
docs(bit): teach the CS foundations the tricks are derived from

### DIFF
--- a/doc/cheatsheet-zh-progress.md
+++ b/doc/cheatsheet-zh-progress.md
@@ -41,7 +41,7 @@ half-translated sheet renders with English gaps rather than failing.
   is what makes a problem findable on LeetCode itself.
 
 
-## Status — 5061 / 5070 sections (100%)
+## Status — 5060 / 5090 sections (99%)
 
 | Sheet | Sections | 繁體中文 |
 |---|---:|:---:|
@@ -71,8 +71,8 @@ half-translated sheet renders with English gaps rather than failing.
 | [binary_search](./cheatsheet/binary_search.md) | 54 | [✅](../i18n/zh/binary_search.md) |
 | [binary_search_examples](./cheatsheet/binary_search_examples.md) | 43 | [✅](../i18n/zh/binary_search_examples.md) |
 | [binary_search_on_answer](./cheatsheet/binary_search_on_answer.md) | 42 | [✅](../i18n/zh/binary_search_on_answer.md) |
-| [binary_tree](./cheatsheet/binary_tree.md) | 74 | [✅](../i18n/zh/binary_tree.md) |
-| [bit_manipulation](./cheatsheet/bit_manipulation.md) | 22 | [✅](../i18n/zh/bit_manipulation.md) |
+| [binary_tree](./cheatsheet/binary_tree.md) | 74 | [72/74](../i18n/zh/binary_tree.md) |
+| [bit_manipulation](./cheatsheet/bit_manipulation.md) | 33 | [✅](../i18n/zh/bit_manipulation.md) |
 | [bit_manipulation_examples](./cheatsheet/bit_manipulation_examples.md) | 22 | [✅](../i18n/zh/bit_manipulation_examples.md) |
 | [bst](./cheatsheet/bst.md) | 61 | [✅](../i18n/zh/bst.md) |
 | [bst_advanced](./cheatsheet/bst_advanced.md) | 51 | [✅](../i18n/zh/bst_advanced.md) |
@@ -130,8 +130,8 @@ half-translated sheet renders with English gaps rather than failing.
 | [n_sum](./cheatsheet/n_sum.md) | 16 | [✅](../i18n/zh/n_sum.md) |
 | [ood_design](./cheatsheet/ood_design.md) | 34 | [✅](../i18n/zh/ood_design.md) |
 | [palindrome](./cheatsheet/palindrome.md) | 66 | [✅](../i18n/zh/palindrome.md) |
-| [prefix_sum](./cheatsheet/prefix_sum.md) | 80 | [✅](../i18n/zh/prefix_sum.md) |
-| [prefix_sum_advanced](./cheatsheet/prefix_sum_advanced.md) | 14 | [✅](../i18n/zh/prefix_sum_advanced.md) |
+| [prefix_sum](./cheatsheet/prefix_sum.md) | 80 | [76/80](../i18n/zh/prefix_sum.md) |
+| [prefix_sum_advanced](./cheatsheet/prefix_sum_advanced.md) | 23 | [10/23](../i18n/zh/prefix_sum_advanced.md) |
 | [prefix_sum_examples](./cheatsheet/prefix_sum_examples.md) | 15 | [✅](../i18n/zh/prefix_sum_examples.md) |
 | [priority_queue](./cheatsheet/priority_queue.md) | 3 | [✅](../i18n/zh/priority_queue.md) |
 | [python_gotchas](./cheatsheet/python_gotchas.md) | 44 | [✅](../i18n/zh/python_gotchas.md) |
@@ -163,7 +163,7 @@ half-translated sheet renders with English gaps rather than failing.
 | [time_space_complexity](./cheatsheet/time_space_complexity.md) | 39 | [✅](../i18n/zh/time_space_complexity.md) |
 | [topology_sorting](./cheatsheet/topology_sorting.md) | 47 | [✅](../i18n/zh/topology_sorting.md) |
 | [topology_sorting_examples](./cheatsheet/topology_sorting_examples.md) | 16 | [✅](../i18n/zh/topology_sorting_examples.md) |
-| [tree](./cheatsheet/tree.md) | 55 | [54/55](../i18n/zh/tree.md) |
+| [tree](./cheatsheet/tree.md) | 55 | [52/55](../i18n/zh/tree.md) |
 | [tree2](./cheatsheet/tree2.md) | 101 | [100/101](../i18n/zh/tree2.md) |
 | [tree_backtrack](./cheatsheet/tree_backtrack.md) | 17 | [✅](../i18n/zh/tree_backtrack.md) |
 | [tree_codec](./cheatsheet/tree_codec.md) | 26 | [✅](../i18n/zh/tree_codec.md) |

--- a/doc/cheatsheet/bit_manipulation.md
+++ b/doc/cheatsheet/bit_manipulation.md
@@ -1,6 +1,6 @@
 # Bit Manipulation
 
-> **Scope** — Bit-level operations and the tricks built on them — masks, XOR identities, lowest set bit, subset enumeration, and bitmask DP.
+> **Scope** — How integers are represented in bits (two's complement, fixed width, shifts) and the operations and tricks built on that — masks, XOR identities, lowest set bit, subset enumeration, and bitmask DP.
 > **See also**: [bit_manipulation_examples.md](./bit_manipulation_examples.md) — the fourteen worked problems behind these techniques; [math.md](./math.md) — numeric manipulation without bits; [combinatorics_math_patterns.md](./combinatorics_math_patterns.md) — counting; [dp.md](./dp.md) — the wider DP catalogue that bitmask DP belongs to.
 
 ## LeetCode Problem Lists
@@ -40,31 +40,229 @@ each operation is a single CPU instruction, bitwise tricks turn many `O(n)` scan
 - [LeetCode — Bit Manipulation card](https://leetcode.com/explore/learn/card/bit-manipulation/)
 - [bit_manipulation.md](https://github.com/yennanliu/CS_basics/blob/master/doc/bit_manipulation.md)
 - [leetcode-easy-bitwise-xor-summary](https://steveyang.blog/2022/07/02/leetcode-easy-bitwise-xor-summary/)
+- [bit VS byte VS char](http://web.ntnu.edu.tw/~algo/Bit.html) — bit widths, with Java examples
+- [Python operators](https://www.runoob.com/python/python-operators.html) — precedence table
 
-## 0) Concept
-- Base
-    - [Ref](https://leetcode.com/explore/learn/card/bit-manipulation/669/bit-manipulation-concepts/4494/)
-    - The actual value of a base-X number is determined by each digit and its location.
-    - example :
-        - 123.45 (base 10) = 1 * 10^2 + 2 * 10^1 + 3 * 10^0 + 4 * 10^(-1) + 5 * 10^(-2)
-        - 720.5 (base 8) = 7 * 8^2 + 2 * 8^1 + 0 * 8^0 + 5 * 8^(-1)
-    - In computer science, the binary system is most commonly used. It has two digits: 0, and 1. Octal (base-8) and hexadecimal (base 16) are also commonly used. Octal has eight digits: 0, 1, 2, 3, 4, 5, 6, and 7.
+## 0) CS Foundations ⭐⭐⭐⭐⭐
 
-- [bit VS byte VS char](http://web.ntnu.edu.tw/~algo/Bit.html)
-    - basic
-        - bit : binary number (use 2 as base : 0, 1)
-        - Hexadecimal Number : use 16 as base : 0123456789abcdef (lower, upper case are same)
-    - byte : 8 bytes (字節)
-    - char : 16 bytes (字符)
-    - ref:
-        - [java example](https://github.com/yennanliu/JavaHelloWorld/blob/main/src/main/java/Advances/IOFlow/demo1.java#L25)
-- ref
-    - [bit_manipulation.md](https://github.com/yennanliu/CS_basics/blob/master/doc/bit_manipulation.md)
-    - [python-operators.html](https://www.runoob.com/python/python-operators.html)
-    - [leetcode-easy-bitwise-xor-summary](https://steveyang.blog/2022/07/02/leetcode-easy-bitwise-xor-summary/)
+Almost every "clever" bit trick is a direct consequence of **how a machine stores an
+integer**. Five facts cover it — learn these and the tricks below stop needing memorisation.
+
+| # | Fact | What it explains |
+| - | ---- | ---------------- |
+| 1 | A number is digits × **place values**; binary's place values are powers of two | reading and writing binary/hex by hand |
+| 2 | An `int` is a **fixed-width 32-bit box** that wraps around | overflow, `MIN_VALUE`, why masks exist |
+| 3 | Negatives are stored in **two's complement** | `~x = -x-1`, `x & -x`, `>>` on negatives |
+| 4 | Shifting **is** multiplying/dividing by powers of two | `<<`, `>>`, `>>>` and their edge cases |
+| 5 | The bits of an int **are** a subset of 32 items | bitmask, subset enumeration, bitmask DP |
+
+### 0-1) Place values, binary, and hex
+
+The value of a base-`X` number is decided by each digit **and its position**
+([ref](https://leetcode.com/explore/learn/card/bit-manipulation/669/bit-manipulation-concepts/4494/)):
+
+```text
+123.45 (base 10) = 1*10^2 + 2*10^1 + 3*10^0 + 4*10^-1 + 5*10^-2
+ 720.5 (base 8)  = 7*8^2  + 2*8^1  + 0*8^0  + 5*8^-1
+  1011 (base 2)  = 1*2^3  + 0*2^2  + 1*2^1  + 1*2^0    = 8 + 0 + 2 + 1 = 11
+```
+
+To read binary, **add the place values that carry a 1**. To write it, halve repeatedly and
+record the remainders bottom-up. That is the entire conversion.
+
+**Hex is binary in groups of four.** One hex digit = 4 bits (a *nibble*), so a 32-bit `int`
+is exactly 8 hex digits — which is why masks are written that way:
+
+```text
+1011 1101  ->  B    D  ->  0xBD  =  11*16 + 13  =  189
+                           each nibble maps to one hex digit — no arithmetic needed
+
+0xFFFFFFFF = 32 ones       0x7FFFFFFF = 31 ones = Integer.MAX_VALUE
+```
+
+Powers of two are worth knowing cold — they appear both as constraints and as masks:
+
+| `n`   | 4  | 8   | 10   | 16    | 20        | 31           | 32           |
+| ----- | -- | --- | ---- | ----- | --------- | ------------ | ------------ |
+| `2^n` | 16 | 256 | 1024 | 65536 | ~1 million | 2 147 483 648 | 4 294 967 296 |
 
 <p align="center"><img src="../pic/bit_basic1.png"></p>
 <p align="center"><img src="../pic/bit_basic2.png"></p>
+
+### 0-2) Fixed width — an `int` is a 32-bit box
+
+| Java type | Width | Range |
+| --------- | ----- | ----- |
+| `byte`    | 8 **bits** | `-128 … 127` |
+| `char`    | 16 **bits** | `0 … 65535` (unsigned) |
+| `int`     | 32 bits | `-2^31 … 2^31 - 1` |
+| `long`    | 64 bits | `-2^63 … 2^63 - 1` |
+
+- Bit `i` carries place value `2^i`. In an `int`, **bit 31 is the sign bit**, so the usable
+  magnitude is 31 bits — this is why so many solutions loop `for i in 0..31`.
+- Anything that leaves the box **wraps silently**: `Integer.MAX_VALUE + 1 == Integer.MIN_VALUE`.
+  A problem statement saying "assume the result fits in a 32-bit integer" is telling you this
+  is the edge case being tested.
+- `1 << 31` is already **negative**. Write `1L << 31` when you want the *value* `2^31`.
+
+### 0-3) Two's complement — how negatives are stored ⭐⭐⭐⭐⭐
+
+**The rule**: `-x` is stored as `~x + 1` — *flip every bit, then add one*. Equivalently,
+the pattern for `-x` is the unsigned value `2^32 - x`.
+
+```text
+(traces are 8-bit for space; a real int is the same picture, 32 wide)
+
+ 5  = 0000 0101
+~5  = 1111 1010     flip every bit
+-5  = 1111 1011     ... + 1
+
+check:  5 + (-5) = 1 0000 0000  ->  the carry falls out of the box, leaving 0 ✓
+```
+
+Why this representation and not a sign bit + magnitude? Because **one adder handles both
+signs** — `a + b` is the same circuit whether the operands are positive or negative, and
+there is only one zero.
+
+Three facts drop straight out of it:
+
+| Fact | Where it shows up |
+| ---- | ----------------- |
+| `~x == -x - 1` | rewriting `~` when a language has no unsigned type |
+| top bit set ⇔ negative | the `for i in 0..31` bit-column loops |
+| `x >> 31` is `0` (non-negative) or `-1` (negative) | branchless `abs`, sign extraction |
+
+**The asymmetry that bites**: the range holds one more negative than positive, so
+`Integer.MIN_VALUE` has **no positive twin** — `-Integer.MIN_VALUE` and
+`Math.abs(Integer.MIN_VALUE)` are both still `Integer.MIN_VALUE`. That single value is the
+hidden test case in LC 29 (Divide Two Integers); handle it before you negate anything.
+
+### 0-4) Why `x & (x - 1)` and `x & -x` work
+
+Both fall out of two's complement. Derive them once and you never have to memorise which
+is which:
+
+```text
+x       = 0101 1000        lowest set bit is bit 3
+x - 1   = 0101 0111        borrowing flips that 1 to 0, and every 0 below it to 1
+-x      = 1010 1000        = ~x + 1
+
+               above bit 3     at bit 3    below bit 3
+  x vs x-1  :  identical       1 vs 0      complementary
+  x vs -x   :  complementary   1 vs 1      both 0
+
+x & (x-1) = 0101 0000      above survives; bit 3 and everything under it AND to 0
+x & (-x)  = 0000 1000      above ANDs to 0; only bit 3 survives
+```
+
+So `x & (x - 1)` means **"drop the lowest 1"** (loop it → Brian Kernighan's popcount, [§1-3](#1-3-counting-set-bits-population-count))
+and `x & -x` means **"keep only the lowest 1"** (also the step rule of a Fenwick tree — see
+[binary_indexed_tree.md](./binary_indexed_tree.md)).
+
+### 0-5) Shifts — `<<`, `>>`, and Java's `>>>`
+
+| Op | Name | Shifts in | Effect |
+| -- | ---- | --------- | ------ |
+| `x << n`  | left shift | zeros on the right | `x * 2^n`; bits pushed off the top are **lost** |
+| `x >> n`  | **arithmetic** right shift | copies of the **sign bit** | `floor(x / 2^n)` |
+| `x >>> n` | **logical** right shift (Java only) | zeros | treats the pattern as unsigned |
+
+```text
+-8 >> 1  = -4            1111 1000 -> 1111 1100    sign preserved
+-8 >>> 1 = 2147483644    1111 1000 -> 0111 1100    sign bit treated as just another bit
+```
+
+**When you need `>>>`**: any loop that walks all 32 bits of a possibly-negative `int` —
+LC 190 (Reverse Bits), LC 191 (Number of 1 Bits), LC 338. With `>>`, a negative number
+shifts in 1s forever and `while (x != 0)` never terminates.
+
+Two more rules that surprise people, both verified above:
+
+- **Java masks the shift count to 5 bits**: `1 << 32` is `1 << 0`, i.e. `1` — **not** `0`.
+  Shift a `long` (6-bit count), or split the shift.
+- **`+` binds tighter than `<<`**: `x << 1 + 2` is `x << 3`. See [§0-7](#0-7-precedence--parenthesise-everything-).
+
+### 0-6) Python is not Java here ⭐⭐⭐⭐⭐
+
+Python's ints are **arbitrary precision** and behave as if they had infinitely many sign
+bits. There is no box, so there is nothing to overflow — and no `>>>`, because there is no
+top bit to stop at.
+
+| | Java (`int`, 32-bit) | Python (unbounded) |
+| --- | --- | --- |
+| `1 << 31` | `-2147483648` (it hit the sign bit) | `2147483648` |
+| `Integer.MAX_VALUE + 1` | wraps to `MIN_VALUE` | just keeps growing |
+| `-1 >> 100` | `-1` | `-1` (infinite sign bits) |
+| logical right shift | `x >>> n` | **none** — mask by hand |
+| `~5` | `-6` | `-6` (same) |
+
+So a Python loop that relies on 32-bit wrap-around has to **simulate the box**:
+
+```python
+# python
+MASK    = 0xFFFFFFFF        # keep only the low 32 bits
+INT_MAX = 0x7FFFFFFF        # 2^31 - 1
+
+def to_signed(x):
+    """read a masked 32-bit pattern back as a signed Python int"""
+    return x if x <= INT_MAX else ~(x ^ MASK)
+```
+
+This is the whole reason LC 371 (Sum of Two Integers) looks so much worse in Python than in
+Java: the carry loop is the same three lines, but every step needs `& MASK` and the result
+needs `to_signed`.
+
+> **Rule of thumb**: in Python, iterate `for i in range(32): (x >> i) & 1` rather than
+> `while x:` whenever `x` can be negative — the `while` never ends.
+
+### 0-7) Precedence — parenthesise everything ⭐⭐⭐⭐
+
+Tightest to loosest — this chain is the same in C, Java and Python:
+
+```text
+~   ->   * / %   ->   + -   ->   << >>   ->   &   ->   ^   ->   |
+```
+
+Two things go wrong with it:
+
+```text
+x << 1 + 2        parses as  x << (1 + 2)     -> x << 3, not (x << 1) + 2
+a ^ b + 1         parses as  a ^ (b + 1)
+```
+
+**Comparison is the one place the languages disagree**: C and Java slot `==` *between*
+`>>` and `&`, Python puts it *below* `|`. So `x & 1 == 0` means three different things:
+
+| Language | `x & 1 == 0` | Outcome |
+| -------- | ------------ | ------- |
+| C / C++  | `x & (1 == 0)` → `x & 0` | **silently always 0** |
+| Java     | `x & (1 == 0)` → `int & boolean` | compile error (`bad operand types`) |
+| Python   | `(x & 1) == 0` | correct — comparison binds *looser* than `&` here |
+
+Never rely on which one you are in. **Write `(x & 1) == 0`.**
+
+### 0-8) A bitmask *is* a set
+
+The final foundation: subsets of `n` items are in **one-to-one correspondence** with the
+integers `0 … 2^n - 1`. Once you see that, "bitmask" needs no further explanation — every
+set operation is one instruction.
+
+| Set language | Bit language |
+| ------------ | ------------ |
+| `S = {}` / `S = {0..n-1}` | `0` / `(1 << n) - 1` |
+| `i ∈ S` | `(mask >> i) & 1` |
+| `S ∪ {i}` / `S \ {i}` / toggle `i` | `mask \| (1<<i)` / `mask & ~(1<<i)` / `mask ^ (1<<i)` |
+| `A ∪ B` / `A ∩ B` / `A \ B` | `a \| b` / `a & b` / `a & ~b` |
+| `A ⊆ B` | `(a & b) == a` |
+| `A ∩ B = ∅` | `(a & b) == 0` |
+| `\|S\|` | `Integer.bitCount(mask)` / `bin(mask).count("1")` |
+| complement within `n` items | `mask ^ ((1 << n) - 1)` |
+
+**Two counting facts** tell you whether a bitmask solution fits the constraints:
+
+- there are `2^n` subsets, so `n ≤ ~20` for an `O(2^n · n)` DP (`2^20 ≈ 10^6`);
+- summed over *every* mask, the number of **sub**masks is `3^n`, not `4^n` — which is what
+  makes the `sub = (sub - 1) & mask` loop in [§2-1](#2-1-subset-enumeration-lc-78-recap) affordable.
 
 ## 1) Core Operations
 
@@ -107,8 +305,8 @@ def clear_lowest(x):   return x & (x - 1)      # turn OFF lowest 1-bit
 
 ### 1-3) Counting set bits (population count)
 
-**Key Idea**: `x & (x - 1)` clears the lowest set bit, so the loop runs **once per 1-bit**
-(Brian Kernighan's algorithm) → `O(popcount)` instead of `O(32)`.
+**Key Idea**: `x & (x - 1)` clears the lowest set bit (why: [§0-4](#0-4-why-x--x---1-and-x---x-work)), so the loop
+runs **once per 1-bit** (Brian Kernighan's algorithm) → `O(popcount)` instead of `O(32)`.
 
 ```java
 // java
@@ -406,16 +604,16 @@ class Solution(object):
 > Adding a Letter), LC 1684 (Count the Number of Consistent Strings — `word & ~allowed == 0`).
 
 
-## 3) Bitmask DP
+## 2) Bitmask DP
 
 A **bitmask** lets an integer represent a **set of visited/chosen items** (bit `i` set ⇔ item
 `i` in the set). When a DP state needs "which subset of ≤ ~20 items have I used", the mask
 **is** the state — enabling exponential subset problems to run in `O(2^n · n)`.
 
-### 3-1) Subset enumeration (LC 78 recap)
+### 2-1) Subset enumeration (LC 78 recap)
 
 Iterating `mask` from `0` to `2^n − 1` visits **every** subset exactly once; bit tests pick
-members (see [2-12](./bit_manipulation_examples.md#12-subsets--lc-78--the-bitmask-enumeration-)). Handy mask idioms:
+members (see [§12 of the worked examples](./bit_manipulation_examples.md#12-subsets--lc-78--the-bitmask-enumeration-)). Handy mask idioms:
 
 ```python
 # python
@@ -426,7 +624,7 @@ bin(mask).count("1")     # size of the subset
 sub = (sub - 1) & mask   # enumerate all SUB-masks of `mask` (classic trick)
 ```
 
-### 3-2) TSP-style bitmask DP (Held–Karp)
+### 2-2) TSP-style bitmask DP (Held–Karp)
 
 The **Travelling Salesman** family is the canonical bitmask DP: `dp[mask][i]` = min cost of a
 path that has **visited exactly the cities in `mask`** and currently sits at city `i`.
@@ -466,7 +664,7 @@ int tsp(int[][] dist) {
 > is "which subset have I used/visited". Related LC: 847 (Shortest Path Visiting All Nodes),
 > 1349 (Maximum Students Taking Exam), 691 (Stickers to Spell Word), 526 (Beautiful Arrangement).
 
-### 3-3) "Fill buckets one at a time" bitmask DP — LC 698 ⭐⭐⭐⭐⭐
+### 2-3) "Fill buckets one at a time" bitmask DP — LC 698 ⭐⭐⭐⭐⭐
 
 **Pattern**: partition-into-`k`-equal-groups problems look like they need `k` nested searches.
 The trick is to **stop tracking which bucket** you are filling and only track:
@@ -601,3 +799,31 @@ grouped by which property of the bit operators they lean on:
 | [Counting & transforming bits](./bit_manipulation_examples.md#counting--transforming-bits) | `x & (x-1)` clears the lowest set bit | LC 191, 338, 190, 231 |
 | [Arithmetic without arithmetic](./bit_manipulation_examples.md#arithmetic-without-arithmetic) | XOR is addition without carry; AND finds the carry | LC 371, 67, 29 |
 | [Enumerating & constructing](./bit_manipulation_examples.md#enumerating-and-constructing-with-bits) | an integer *is* a subset, and counting up visits every one | LC 78, 89, 201 |
+
+## Summary
+
+### Pick the technique from the question
+
+| The problem says… | Reach for | Section |
+| ----------------- | --------- | ------- |
+| "every element appears twice except one" | XOR the whole array | [XOR — cancelling pairs](./bit_manipulation_examples.md#xor--cancelling-pairs) |
+| "count the 1 bits" / "for every `i` in `0..n`" | `x & (x-1)` loop, or DP on `i >> 1` | [§1-3](#1-3-counting-set-bits-population-count) |
+| "sum over all pairs" of a bit property | loop the 32 **bit columns**, not the pairs | [§1-4](#1-4-counting-over-bit-columns--lc-461--lc-477) |
+| lowercase words, "share a letter" / "unique characters" | a 26-bit letter mask | [§1-5](#1-5-a-bitmask-as-a-character-set--lc-318-) |
+| a small fixed alphabet + a sliding window | pack `k` bits per symbol, roll with `<<` and a mask | [Variation B](#variation-b--pack-fixed-width-symbols-into-a-rolling-int-key-lc-187) |
+| "choose a subset", `n ≤ ~20` | `dp[mask]`, bitmask DP | [§2](#2-bitmask-dp) |
+| "partition into `k` equal groups" | `dp[mask]` = fill level, `% target` | [§2-3](#2-3-fill-buckets-one-at-a-time-bitmask-dp--lc-698-) |
+| "add / divide without `+` or `/`" | XOR = sum, AND = carry | [Arithmetic without arithmetic](./bit_manipulation_examples.md#arithmetic-without-arithmetic) |
+| "maximum XOR of two numbers" | binary trie — see [trie.md](./trie.md) | — |
+
+### The five bugs that fail a bit-manipulation submission
+
+1. **`while (x != 0) x >>= 1` on a negative `int`** — arithmetic shift feeds in 1s forever.
+   Use `>>>` in Java, or `for i in range(32)` in Python. ([§0-5](#0-5-shifts---and-javas-), [§0-6](#0-6-python-is-not-java-here-))
+2. **Missing parentheses** — write `(x & 1) == 0`, never `x & 1 == 0`. ([§0-7](#0-7-precedence--parenthesise-everything-))
+3. **`Integer.MIN_VALUE` has no positive twin** — `Math.abs` and unary `-` both return it
+   unchanged, so negate-then-divide silently breaks. ([§0-3](#0-3-twos-complement--how-negatives-are-stored-))
+4. **`1 << i` overflows at `i >= 31`** — use `1L << i` (and remember Java masks the shift
+   count, so `1 << 32 == 1`). ([§0-2](#0-2-fixed-width--an-int-is-a-32-bit-box), [§0-5](#0-5-shifts---and-javas-))
+5. **Porting a 32-bit loop to Python unchanged** — Python never overflows, so every step
+   needs `& 0xFFFFFFFF` and the result needs converting back. ([§0-6](#0-6-python-is-not-java-here-))

--- a/doc/cheatsheet/bit_manipulation.md
+++ b/doc/cheatsheet/bit_manipulation.md
@@ -159,7 +159,7 @@ So `x & (x - 1)` means **"drop the lowest 1"** (loop it → Brian Kernighan's po
 and `x & -x` means **"keep only the lowest 1"** (also the step rule of a Fenwick tree — see
 [binary_indexed_tree.md](./binary_indexed_tree.md)).
 
-### 0-5) Shifts — `<<`, `>>`, and Java's `>>>`
+### 0-5) Shifts: left, arithmetic right, and logical right
 
 | Op | Name | Shifts in | Effect |
 | -- | ---- | --------- | ------ |
@@ -819,11 +819,11 @@ grouped by which property of the bit operators they lean on:
 ### The five bugs that fail a bit-manipulation submission
 
 1. **`while (x != 0) x >>= 1` on a negative `int`** — arithmetic shift feeds in 1s forever.
-   Use `>>>` in Java, or `for i in range(32)` in Python. ([§0-5](#0-5-shifts---and-javas-), [§0-6](#0-6-python-is-not-java-here-))
+   Use `>>>` in Java, or `for i in range(32)` in Python. ([§0-5](#0-5-shifts-left-arithmetic-right-and-logical-right), [§0-6](#0-6-python-is-not-java-here-))
 2. **Missing parentheses** — write `(x & 1) == 0`, never `x & 1 == 0`. ([§0-7](#0-7-precedence--parenthesise-everything-))
 3. **`Integer.MIN_VALUE` has no positive twin** — `Math.abs` and unary `-` both return it
    unchanged, so negate-then-divide silently breaks. ([§0-3](#0-3-twos-complement--how-negatives-are-stored-))
 4. **`1 << i` overflows at `i >= 31`** — use `1L << i` (and remember Java masks the shift
-   count, so `1 << 32 == 1`). ([§0-2](#0-2-fixed-width--an-int-is-a-32-bit-box), [§0-5](#0-5-shifts---and-javas-))
+   count, so `1 << 32 == 1`). ([§0-2](#0-2-fixed-width--an-int-is-a-32-bit-box), [§0-5](#0-5-shifts-left-arithmetic-right-and-logical-right))
 5. **Porting a 32-bit loop to Python unchanged** — Python never overflows, so every step
    needs `& 0xFFFFFFFF` and the result needs converting back. ([§0-6](#0-6-python-is-not-java-here-))

--- a/i18n/zh/bit_manipulation.md
+++ b/i18n/zh/bit_manipulation.md
@@ -137,8 +137,8 @@ popcount，見 [§1-3](#1-3-counting-set-bits-population-count)）；`x & -x` �
 **「只留下最低位的 1」**（這也是 Fenwick tree 的前進規則 — 見
 [binary_indexed_tree.md](./binary_indexed_tree.md)）。
 
-<!-- e60ac7250caf -->
-### 0-5) 位移 — `<<`、`>>`，以及 Java 的 `>>>`
+<!-- dc4341d77bf4 -->
+### 0-5) 位移：左移、算術右移、邏輯右移
 
 | 運算子 | 名稱 | 補進來的是 | 效果 |
 | ------ | ---- | ---------- | ---- |
@@ -434,15 +434,15 @@ Python 卻把它放在 `|` *下面*。所以 `x & 1 == 0` 在三個語言裡是�
 | 「不用 `+` 或 `/` 做加法／除法」 | XOR 是和，AND 是進位 | [不用算術做算術](./bit_manipulation_examples.md#arithmetic-without-arithmetic) |
 | 「兩個數字的最大 XOR」 | 二元字典樹 — 見 [trie.md](./trie.md) | — |
 
-<!-- 191e5ccd4087 -->
+<!-- 2d37034aeb5b -->
 ### 讓位元運算題掛掉的五個 bug
 
 1. **對負的 `int` 跑 `while (x != 0) x >>= 1`** — 算術右移會一直補 1 進來。
-   Java 要用 `>>>`，Python 要改成 `for i in range(32)`。（[§0-5](#0-5-shifts---and-javas-)、[§0-6](#0-6-python-is-not-java-here-)）
+   Java 要用 `>>>`，Python 要改成 `for i in range(32)`。（[§0-5](#0-5-shifts-left-arithmetic-right-and-logical-right)、[§0-6](#0-6-python-is-not-java-here-)）
 2. **少了括號** — 要寫 `(x & 1) == 0`，絕不要寫 `x & 1 == 0`。（[§0-7](#0-7-precedence--parenthesise-everything-)）
 3. **`Integer.MIN_VALUE` 沒有對應的正數** — `Math.abs` 和一元 `-` 算完都還是它本身，
    所以「先取負再相除」會無聲地壞掉。（[§0-3](#0-3-twos-complement--how-negatives-are-stored-)）
 4. **`1 << i` 在 `i >= 31` 時溢位** — 要用 `1L << i`（也別忘了 Java 會把位移量取低 5 位，
-   所以 `1 << 32 == 1`）。（[§0-2](#0-2-fixed-width--an-int-is-a-32-bit-box)、[§0-5](#0-5-shifts---and-javas-)）
+   所以 `1 << 32 == 1`）。（[§0-2](#0-2-fixed-width--an-int-is-a-32-bit-box)、[§0-5](#0-5-shifts-left-arithmetic-right-and-logical-right)）
 5. **把 32 位元的迴圈原封不動搬到 Python** — Python 永遠不會溢位，所以每一步都要
    `& 0xFFFFFFFF`，最後還要把結果轉回有號數。（[§0-6](#0-6-python-is-not-java-here-)）

--- a/i18n/zh/bit_manipulation.md
+++ b/i18n/zh/bit_manipulation.md
@@ -1,7 +1,7 @@
-<!-- 760c54ae042f -->
+<!-- a09d9cef8fd7 -->
 # 位元運算
 
-> **範圍** — 位元層級的操作，以及建立在其上的各種技巧：遮罩、XOR 恆等式、最低位 1、子集列舉，還有 bitmask DP。
+> **範圍** — 整數在位元層次上是怎麼被表示的（二補數、固定位寬、位移），以及建立在其上的各種運算與技巧：遮罩、XOR 恆等式、最低位 1、子集列舉，還有 bitmask DP。
 > **另見**：[bit_manipulation_examples.md](./bit_manipulation_examples.md) — 支撐這些技巧的十四道詳解題；[math.md](./math.md) — 不靠位元的數值操作；[combinatorics_math_patterns.md](./combinatorics_math_patterns.md) — 計數；[dp.md](./dp.md) — bitmask DP 所屬的完整 DP 目錄。
 
 <!-- 5992a4abfe2f -->
@@ -39,37 +39,193 @@
 | 是不是偶數？ | `(x & 1) == 0` |
 | XOR 自我抵消 | `a ^ a = 0`, `a ^ 0 = a` |
 
-<!-- b056f1d3238b -->
+<!-- 5c6cc3d4230c -->
 ### 參考資料
 - [LeetCode — Bit Manipulation card](https://leetcode.com/explore/learn/card/bit-manipulation/)
 - [bit_manipulation.md](https://github.com/yennanliu/CS_basics/blob/master/doc/bit_manipulation.md)
 - [leetcode-easy-bitwise-xor-summary](https://steveyang.blog/2022/07/02/leetcode-easy-bitwise-xor-summary/)
+- [bit VS byte VS char](http://web.ntnu.edu.tw/~algo/Bit.html) — 各種位寬，附 Java 範例
+- [Python operators](https://www.runoob.com/python/python-operators.html) — 運算子優先順序表
 
-<!-- 506fdba8a820 -->
-## 0) 概念
-- 進位制
-    - [Ref](https://leetcode.com/explore/learn/card/bit-manipulation/669/bit-manipulation-concepts/4494/)
-    - 一個 X 進位數字的實際數值，由每一位的數字和它的位置共同決定。
-    - 例子：
-        - 123.45（10 進位）= 1 * 10^2 + 2 * 10^1 + 3 * 10^0 + 4 * 10^(-1) + 5 * 10^(-2)
-        - 720.5（8 進位）= 7 * 8^2 + 2 * 8^1 + 0 * 8^0 + 5 * 8^(-1)
-    - 在電腦科學裡最常用的是二進位，只有兩個數字：0 和 1。八進位（base-8）和十六進位（base 16）也很常用。八進位有八個數字：0、1、2、3、4、5、6、7。
+<!-- f602e4415587 -->
+## 0) 電腦科學基礎 ⭐⭐⭐⭐⭐
 
-- [bit VS byte VS char](http://web.ntnu.edu.tw/~algo/Bit.html)
-    - 基礎
-        - bit：二進位數字（以 2 為底：0, 1）
-        - 十六進位數字：以 16 為底：0123456789abcdef（大小寫視為相同）
-    - byte：8 bytes（字節）
-    - char：16 bytes（字符）
-    - 參考：
-        - [java example](https://github.com/yennanliu/JavaHelloWorld/blob/main/src/main/java/Advances/IOFlow/demo1.java#L25)
-- 參考
-    - [bit_manipulation.md](https://github.com/yennanliu/CS_basics/blob/master/doc/bit_manipulation.md)
-    - [python-operators.html](https://www.runoob.com/python/python-operators.html)
-    - [leetcode-easy-bitwise-xor-summary](https://steveyang.blog/2022/07/02/leetcode-easy-bitwise-xor-summary/)
+幾乎每一個看起來「很巧妙」的位元技巧，都只是**機器如何儲存整數**的直接後果。
+五個事實就講完了 — 把它們學起來，下面的技巧就不再需要硬背。
+
+| # | 事實 | 它解釋了什麼 |
+| - | ---- | ------------ |
+| 1 | 一個數字是「數字 × **位值**」，而二進位的位值就是 2 的次方 | 用手讀寫二進位／十六進位 |
+| 2 | `int` 是一個**固定寬度的 32 位元盒子**，滿了會繞回來 | 溢位、`MIN_VALUE`、為什麼需要遮罩 |
+| 3 | 負數是用**二補數**存的 | `~x = -x-1`、`x & -x`、負數的 `>>` |
+| 4 | 位移**就是**乘以／除以 2 的次方 | `<<`、`>>`、`>>>` 和它們的邊界狀況 |
+| 5 | 一個 int 的各個位元**就是** 32 個項目的子集 | bitmask、子集列舉、bitmask DP |
+
+<!-- 15d5b90c8918 -->
+### 0-1) 位值、二進位與十六進位
+
+一個 `X` 進位數字的實際數值，由每一位的數字**和它的位置**共同決定
+（[參考](https://leetcode.com/explore/learn/card/bit-manipulation/669/bit-manipulation-concepts/4494/)）：
+
+<!--CODE-->
+
+要**讀**二進位，就把帶著 1 的那些位值加起來；要**寫**二進位，就一直除以 2、由下往上記下餘數。
+整個轉換就只有這樣。
+
+**十六進位就是四個一組的二進位。** 一個十六進位數字 = 4 個位元（一個 *nibble*），
+所以一個 32 位元的 `int` 剛好是 8 個十六進位數字 — 這也是遮罩都寫成這種形式的原因：
+
+<!--CODE-->
+
+2 的次方值得背熟 — 它們同時會以「題目限制」和「遮罩」兩種身分出現：
+
+| `n`   | 4  | 8   | 10   | 16    | 20    | 31            | 32            |
+| ----- | -- | --- | ---- | ----- | ----- | ------------- | ------------- |
+| `2^n` | 16 | 256 | 1024 | 65536 | 約一百萬 | 2 147 483 648 | 4 294 967 296 |
 
 <p align="center"><img src="../pic/bit_basic1.png"></p>
 <p align="center"><img src="../pic/bit_basic2.png"></p>
+
+<!-- 98787204bec0 -->
+### 0-2) 固定寬度 — `int` 是一個 32 位元的盒子
+
+| Java 型別 | 寬度 | 範圍 |
+| --------- | ---- | ---- |
+| `byte`    | 8 **bits** | `-128 … 127` |
+| `char`    | 16 **bits** | `0 … 65535`（無號） |
+| `int`     | 32 bits | `-2^31 … 2^31 - 1` |
+| `long`    | 64 bits | `-2^63 … 2^63 - 1` |
+
+- 第 `i` 位帶著位值 `2^i`。在 `int` 裡，**第 31 位是符號位**，所以真正能用的大小只有 31 位 —
+  這就是為什麼那麼多解法都在跑 `for i in 0..31`。
+- 任何超出盒子的運算都會**無聲地繞回來**：`Integer.MAX_VALUE + 1 == Integer.MIN_VALUE`。
+  題目寫「假設結果可以用 32 位元整數表示」時，其實就是在告訴你這正是它要考的邊界狀況。
+- `1 << 31` 已經是**負數**了。想要 `2^31` 這個*數值*時，要寫 `1L << 31`。
+
+<!-- ef3856b1a806 -->
+### 0-3) 二補數 — 負數是怎麼存的 ⭐⭐⭐⭐⭐
+
+**規則**：`-x` 是以 `~x + 1` 的形式儲存的 — *每個位元都翻轉，然後加一*。
+等價地說，`-x` 的位元樣式就是無號數 `2^32 - x`。
+
+<!--CODE-->
+
+為什麼用這種表示法，而不是「符號位 + 大小」？因為這樣**一個加法器就能處理兩種符號** —
+不管運算元是正是負，`a + b` 都走同一組電路，而且零只有一種寫法。
+
+三個直接推論：
+
+| 事實 | 會在哪裡遇到 |
+| ---- | ------------ |
+| `~x == -x - 1` | 在沒有無號型別的語言裡改寫 `~` |
+| 最高位是 1 ⇔ 負數 | `for i in 0..31` 那種逐位掃描的迴圈 |
+| `x >> 31` 不是 `0`（非負）就是 `-1`（負） | 無分支的 `abs`、取出符號 |
+
+**會咬人的不對稱**：範圍裡的負數比正數多一個，所以 `Integer.MIN_VALUE` **沒有對應的正數** —
+`-Integer.MIN_VALUE` 和 `Math.abs(Integer.MIN_VALUE)` 算完都還是 `Integer.MIN_VALUE`。
+這一個值正是 LC 29（Divide Two Integers）藏起來的測資；在取負號之前就要先處理掉它。
+
+<!-- fdfad9acb40a -->
+### 0-4) 為什麼 `x & (x - 1)` 和 `x & -x` 有效
+
+兩者都是從二補數直接推出來的。推導過一次，就再也不用去背哪個是哪個：
+
+<!--CODE-->
+
+所以 `x & (x - 1)` 的意思是**「丟掉最低位的 1」**（把它包成迴圈 → Brian Kernighan 的
+popcount，見 [§1-3](#1-3-counting-set-bits-population-count)）；`x & -x` 的意思是
+**「只留下最低位的 1」**（這也是 Fenwick tree 的前進規則 — 見
+[binary_indexed_tree.md](./binary_indexed_tree.md)）。
+
+<!-- e60ac7250caf -->
+### 0-5) 位移 — `<<`、`>>`，以及 Java 的 `>>>`
+
+| 運算子 | 名稱 | 補進來的是 | 效果 |
+| ------ | ---- | ---------- | ---- |
+| `x << n`  | 左移 | 右邊補 0 | `x * 2^n`；被擠出最高位的位元會**消失** |
+| `x >> n`  | **算術**右移 | 複製**符號位** | `floor(x / 2^n)` |
+| `x >>> n` | **邏輯**右移（只有 Java 有） | 補 0 | 把整個位元樣式當成無號數 |
+
+<!--CODE-->
+
+**什麼時候需要 `>>>`**：任何要走完一個可能為負的 `int` 全部 32 個位元的迴圈 —
+LC 190（Reverse Bits）、LC 191（Number of 1 Bits）、LC 338。
+用 `>>` 的話，負數會永無止盡地補進 1，`while (x != 0)` 永遠不會結束。
+
+另外兩條會讓人意外的規則（上面都驗證過了）：
+
+- **Java 會把位移量取低 5 位**：`1 << 32` 等同 `1 << 0`，也就是 `1` — **不是** `0`。
+  要嘛改移 `long`（取低 6 位），要嘛把位移拆成兩次。
+- **`+` 比 `<<` 更緊**：`x << 1 + 2` 其實是 `x << 3`。見 [§0-7](#0-7-precedence--parenthesise-everything-)。
+
+<!-- 94b3c5b40b57 -->
+### 0-6) 在這件事上 Python 不是 Java ⭐⭐⭐⭐⭐
+
+Python 的整數是**任意精度**的，行為上就像有無限多個符號位。
+沒有盒子，所以沒有東西會溢位 — 也沒有 `>>>`，因為根本沒有一個「最高位」可以停。
+
+| | Java（`int`，32 位元） | Python（無上限） |
+| --- | --- | --- |
+| `1 << 31` | `-2147483648`（撞到符號位了） | `2147483648` |
+| `Integer.MAX_VALUE + 1` | 繞回 `MIN_VALUE` | 就繼續變大 |
+| `-1 >> 100` | `-1` | `-1`（無限多個符號位） |
+| 邏輯右移 | `x >>> n` | **沒有** — 要自己用遮罩模擬 |
+| `~5` | `-6` | `-6`（一樣） |
+
+所以一段倚賴 32 位元繞回行為的 Python 迴圈，必須**自己把盒子做出來**：
+
+<!--CODE-->
+
+這正是為什麼 LC 371（Sum of Two Integers）在 Python 看起來比 Java 醜那麼多：
+進位迴圈其實是同樣的三行，但每一步都得 `& MASK`，最後的結果還得用 `to_signed` 轉回來。
+
+> **經驗法則**：在 Python 裡，只要 `x` 可能為負，就用 `for i in range(32): (x >> i) & 1`
+> 逐位掃描，而不要用 `while x:` — 那個 `while` 不會停。
+
+<!-- 5bba21700ebf -->
+### 0-7) 優先順序 — 全部加上括號 ⭐⭐⭐⭐
+
+由緊到鬆 — 這條鏈在 C、Java、Python 裡都一樣：
+
+<!--CODE-->
+
+這個順序會造成兩種出錯：
+
+<!--CODE-->
+
+**比較運算子則是三個語言唯一不一致的地方**：C 和 Java 把 `==` 塞在 `>>` 和 `&` *中間*，
+Python 卻把它放在 `|` *下面*。所以 `x & 1 == 0` 在三個語言裡是三件不同的事：
+
+| 語言 | `x & 1 == 0` 實際被解讀成 | 結果 |
+| ---- | ------------------------- | ---- |
+| C / C++  | `x & (1 == 0)` → `x & 0` | **無聲地永遠是 0** |
+| Java     | `x & (1 == 0)` → `int & boolean` | 編譯錯誤（`bad operand types`） |
+| Python   | `(x & 1) == 0` | 正確 — 在 Python 裡比較運算子綁得比 `&` *更鬆* |
+
+不要去賭你現在在哪個語言裡。**就寫 `(x & 1) == 0`。**
+
+<!-- 6d4cb26c3e30 -->
+### 0-8) 一個 bitmask **就是**一個集合
+
+最後一塊基礎：`n` 個項目的所有子集，和整數 `0 … 2^n - 1` 是**一對一對應**的。
+看懂這件事之後，「bitmask」就不需要再多解釋了 — 每一個集合操作都只是一道指令。
+
+| 集合語言 | 位元語言 |
+| -------- | -------- |
+| `S = {}` / `S = {0..n-1}` | `0` / `(1 << n) - 1` |
+| `i ∈ S` | `(mask >> i) & 1` |
+| `S ∪ {i}` / `S \ {i}` / 翻轉 `i` | `mask \| (1<<i)` / `mask & ~(1<<i)` / `mask ^ (1<<i)` |
+| `A ∪ B` / `A ∩ B` / `A \ B` | `a \| b` / `a & b` / `a & ~b` |
+| `A ⊆ B` | `(a & b) == a` |
+| `A ∩ B = ∅` | `(a & b) == 0` |
+| `\|S\|` | `Integer.bitCount(mask)` / `bin(mask).count("1")` |
+| 在 `n` 個項目內取補集 | `mask ^ ((1 << n) - 1)` |
+
+**兩個計數事實**能告訴你 bitmask 解法塞不塞得進題目的限制：
+
+- 子集有 `2^n` 個，所以 `O(2^n · n)` 的 DP 需要 `n ≤ 約 20`（`2^20 ≈ 10^6`）；
+- 把*所有*遮罩加總起來，**子**遮罩的總數是 `3^n` 而不是 `4^n` — 這正是
+  [§2-1](#2-1-subset-enumeration-lc-78-recap) 裡 `sub = (sub - 1) & mask` 迴圈跑得動的原因。
 
 <!-- b6471f7cfe0c -->
 ## 1) 核心運算
@@ -97,11 +253,11 @@
 
 <!--CODE-->
 
-<!-- 9f3ec976face -->
+<!-- e9fad9465afe -->
 ### 1-3) 計算 1 的個數（population count）
 
-**核心想法**：`x & (x - 1)` 會清掉最低位的 1，所以迴圈**每個 1 只跑一次**
-（Brian Kernighan 演算法）→ 是 `O(popcount)` 而不是 `O(32)`。
+**核心想法**：`x & (x - 1)` 會清掉最低位的 1（原因見 [§0-4](#0-4-why-x--x---1-and-x---x-work)），
+所以迴圈**每個 1 只跑一次**（Brian Kernighan 演算法）→ 是 `O(popcount)` 而不是 `O(32)`。
 
 <!--CODE-->
 
@@ -173,23 +329,23 @@
 > LC 1255（Maximum Score Words Formed by Letters）、LC 2135（Count Words Obtained After
 > Adding a Letter）、LC 1684（Count the Number of Consistent Strings — `word & ~allowed == 0`）。
 
-<!-- eef797ad92f1 -->
-## 3) Bitmask DP
+<!-- ac01a9681408 -->
+## 2) Bitmask DP
 
 **bitmask** 讓一個整數代表**一組已走訪／已選取的項目**（第 `i` 位是 1 ⇔ 項目 `i` 在集合裡）。
 當 DP 狀態需要記錄「我用掉了 ≤ 約 20 個項目中的哪個子集」時，遮罩**本身就是**狀態 —
 這讓指數級的子集問題能在 `O(2^n · n)` 內跑完。
 
-<!-- 96a0803ef26f -->
-### 3-1) 子集列舉（LC 78 回顧）
+<!-- c9648be0b509 -->
+### 2-1) 子集列舉（LC 78 回顧）
 
 讓 `mask` 從 `0` 跑到 `2^n − 1`，就會**不重不漏**地走過每一個子集；用位元測試挑出成員
-（見 [2-12](./bit_manipulation_examples.md#12-subsets--lc-78--the-bitmask-enumeration-)）。幾個好用的遮罩慣用寫法：
+（見[詳解題第 12 節](./bit_manipulation_examples.md#12-subsets--lc-78--the-bitmask-enumeration-)）。幾個好用的遮罩慣用寫法：
 
 <!--CODE-->
 
-<!-- 9256e44f0c55 -->
-### 3-2) TSP 型的 bitmask DP（Held–Karp）
+<!-- 536bc2dfcd1d -->
+### 2-2) TSP 型的 bitmask DP（Held–Karp）
 
 **旅行推銷員**家族是 bitmask DP 的代表題：`dp[mask][i]` = 一條**恰好走訪 `mask` 中所有城市**
 且目前停在城市 `i` 的路徑的最小成本。
@@ -202,8 +358,8 @@
 > 「我用過／走訪過哪個子集」。相關 LC：847（Shortest Path Visiting All Nodes）、
 > 1349（Maximum Students Taking Exam）、691（Stickers to Spell Word）、526（Beautiful Arrangement）。
 
-<!-- 4cae482389d2 -->
-### 3-3) 「一次填滿一個桶」的 bitmask DP — LC 698 ⭐⭐⭐⭐⭐
+<!-- 31cb0d39f80c -->
+### 2-3) 「一次填滿一個桶」的 bitmask DP — LC 698 ⭐⭐⭐⭐⭐
 
 **模式**：切成 `k` 個相等群組的題目，看起來需要 `k` 層巢狀搜尋。
 訣竅是**不要再去追蹤你正在填哪一個桶**，只追蹤：
@@ -259,3 +415,34 @@
 | [計數與轉換位元](./bit_manipulation_examples.md#counting--transforming-bits) | `x & (x-1)` 清掉最低位的 1 | LC 191, 338, 190, 231 |
 | [不用算術做算術](./bit_manipulation_examples.md#arithmetic-without-arithmetic) | XOR 是不帶進位的加法；AND 找出進位 | LC 371, 67, 29 |
 | [列舉與建構](./bit_manipulation_examples.md#enumerating-and-constructing-with-bits) | 一個整數*就是*一個子集，往上數就能走遍所有子集 | LC 78, 89, 201 |
+
+<!-- cf146c401303 -->
+## 總結
+
+<!-- b40a11452f76 -->
+### 從題目敘述挑出該用的技巧
+
+| 題目說… | 就用 | 章節 |
+| ------- | ---- | ---- |
+| 「每個元素都出現兩次，只有一個例外」 | 把整個陣列 XOR 起來 | [XOR — 抵消成對元素](./bit_manipulation_examples.md#xor--cancelling-pairs) |
+| 「數 1 的個數」／「對 `0..n` 的每個 `i`」 | `x & (x-1)` 迴圈，或對 `i >> 1` 做 DP | [§1-3](#1-3-counting-set-bits-population-count) |
+| 對某個位元性質「所有配對加總」 | 跑 32 個**位元欄**，不要跑配對 | [§1-4](#1-4-counting-over-bit-columns--lc-461--lc-477) |
+| 小寫單字、「有共同字母」／「字元不重複」 | 26 位元的字母遮罩 | [§1-5](#1-5-a-bitmask-as-a-character-set--lc-318-) |
+| 固定的小字母表 + 滑動視窗 | 每個符號打包 `k` 位元，用 `<<` 加遮罩滾動 | [變形 B](#variation-b--pack-fixed-width-symbols-into-a-rolling-int-key-lc-187) |
+| 「選一個子集」，`n ≤ 約 20` | `dp[mask]`，bitmask DP | [§2](#2-bitmask-dp) |
+| 「切成 `k` 個總和相等的群組」 | `dp[mask]` = 目前桶的填充量，配 `% target` | [§2-3](#2-3-fill-buckets-one-at-a-time-bitmask-dp--lc-698-) |
+| 「不用 `+` 或 `/` 做加法／除法」 | XOR 是和，AND 是進位 | [不用算術做算術](./bit_manipulation_examples.md#arithmetic-without-arithmetic) |
+| 「兩個數字的最大 XOR」 | 二元字典樹 — 見 [trie.md](./trie.md) | — |
+
+<!-- 191e5ccd4087 -->
+### 讓位元運算題掛掉的五個 bug
+
+1. **對負的 `int` 跑 `while (x != 0) x >>= 1`** — 算術右移會一直補 1 進來。
+   Java 要用 `>>>`，Python 要改成 `for i in range(32)`。（[§0-5](#0-5-shifts---and-javas-)、[§0-6](#0-6-python-is-not-java-here-)）
+2. **少了括號** — 要寫 `(x & 1) == 0`，絕不要寫 `x & 1 == 0`。（[§0-7](#0-7-precedence--parenthesise-everything-)）
+3. **`Integer.MIN_VALUE` 沒有對應的正數** — `Math.abs` 和一元 `-` 算完都還是它本身，
+   所以「先取負再相除」會無聲地壞掉。（[§0-3](#0-3-twos-complement--how-negatives-are-stored-)）
+4. **`1 << i` 在 `i >= 31` 時溢位** — 要用 `1L << i`（也別忘了 Java 會把位移量取低 5 位，
+   所以 `1 << 32 == 1`）。（[§0-2](#0-2-fixed-width--an-int-is-a-32-bit-box)、[§0-5](#0-5-shifts---and-javas-)）
+5. **把 32 位元的迴圈原封不動搬到 Python** — Python 永遠不會溢位，所以每一步都要
+   `& 0xFFFFFFFF`，最後還要把結果轉回有號數。（[§0-6](#0-6-python-is-not-java-here-)）


### PR DESCRIPTION
The sheet opened with a `0) Concept` section that was a link dump plus a base-conversion example, then jumped straight to "memorise `x & -x`". Every trick below it was stated, none was explained, and the two facts that actually break submissions — two's complement and Python's unbounded ints — were absent.

Replace it with `0) CS Foundations`, eight short subsections that each pay for themselves in a later section:

- 0-1 place values, binary and hex (nibbles, the powers-of-two table)
- 0-2 fixed width: `byte`/`char`/`int`/`long`, silent wrap, `1 << 31` is negative
- 0-3 two's complement, and the `Integer.MIN_VALUE` asymmetry behind LC 29
- 0-4 derives `x & (x-1)` and `x & -x` instead of asserting them
- 0-5 `>>` vs `>>>`, Java's 5-bit shift count, `+` binding tighter than `<<`
- 0-6 Python has no box: why LC 371 needs `& 0xFFFFFFFF` and a signed read-back
- 0-7 precedence, and the three different meanings of `x & 1 == 0`
- 0-8 the set/bitmask dictionary, plus the 2^n and 3^n counting facts

Every claim about Java and Python behaviour here was run, not recalled.

Also: renumber `3) Bitmask DP` to `2)` (section 2 was vacant); fix `byte`/`char` listed as 8 and 16 *bytes*; point the popcount and subset sections at their derivations; add a `## Summary` with a question -> technique table and the five bugs that fail a bit submission.

The zh overlay is re-synced to 33/33 sections. `doc/cheatsheet-zh-progress.md` is regenerated, which also surfaces pre-existing drift in binary_tree, prefix_sum, prefix_sum_advanced and tree that the tracker had not been rebuilt for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the bit-manipulation cheatsheets with integer representation, two’s complement, shifts, operator precedence, bitmask techniques, and language-specific guidance.
  - Added reference links, a technique-selection table, and common troubleshooting tips.
  - Reorganized and renumbered Bitmask DP sections and updated cross-references.
  - Applied equivalent updates to the Chinese-language documentation.
  - Updated the Chinese translation progress report and per-topic completion counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->