### PR TITLE
feat(skill): add the LC SWE interview coach

### DIFF
--- a/.claude/skills/add-time-space/SKILL.md
+++ b/.claude/skills/add-time-space/SKILL.md
@@ -1,65 +1,70 @@
+---
 name: add-time-space
-description: Add standardized Javadoc time and space complexity comments to LeetCode Java solutions
-instructions: |
-  You are an expert at adding time and space complexity documentation to Java code.
+description: Add standardized Javadoc time and space complexity comments to LeetCode Java solutions. Use when a directory under leetcode_java/ needs its `time = O(...)` / `space = O(...)` annotations added, normalised from inline comments, or filled in by hand where the script could not infer them.
+allowed-tools: Read, Glob, Grep, Edit, Bash
+---
 
-  When the user runs `/add-time-space [DIRECTORY]`, follow these steps:
+# Add Time/Space Complexity
 
-  1. **Validate Input**:
-     - Directory should be a subdirectory name under `leetcode_java/src/main/java/LeetCodeJava/`
-     - Common directories: Array, BackTrack, BinarySearch, BinaryTree, DataStructure, DynamicProgramming, Graph, LinkedList, String, TwoPointers
-     - If no directory specified, ask the user which directory to process
+You are an expert at adding time and space complexity documentation to Java code.
 
-  2. **Run the Python Script**:
-     ```bash
-     python3 script/add_javadoc_complexity.py leetcode_java/src/main/java/LeetCodeJava/[DIRECTORY]/*.java
-     ```
+When the user runs `/add-time-space [DIRECTORY]`, follow these steps:
 
-  3. **Manual Processing (if needed)**:
-     - Check for any files that weren't processed automatically
-     - For files without inline comments, analyze the code and add Javadoc manually:
-       - Single loop: O(N) time
-       - Nested loops: O(N²) time
-       - Sorting: O(N log N) time
-       - Binary search: O(log N) time
-       - Backtracking: O(2^N) or O(N!) depending on problem
-       - New array of size N: O(N) space
-       - Only variables: O(1) space
+1. **Validate Input**:
+   - Directory should be a subdirectory name under `leetcode_java/src/main/java/LeetCodeJava/`
+   - Common directories: Array, BackTrack, BinarySearch, BinaryTree, DataStructure, DynamicProgramming, Graph, LinkedList, String, TwoPointers
+   - If no directory specified, ask the user which directory to process
 
-  4. **Verify Changes**:
-     ```bash
-     git diff leetcode_java/src/main/java/LeetCodeJava/[DIRECTORY]/
-     ```
-     - Confirm only comments changed, no logic modified
+2. **Run the Python Script**:
+   ```bash
+   python3 script/add_javadoc_complexity.py leetcode_java/src/main/java/LeetCodeJava/[DIRECTORY]/*.java
+   ```
 
-  5. **Commit Changes**:
-     ```bash
-     git add leetcode_java/src/main/java/LeetCodeJava/[DIRECTORY]/
-     git commit -m "Add time/space complexity Javadoc comments to LeetCode Java [DIRECTORY] solutions"
-     ```
+3. **Manual Processing (if needed)**:
+   - Check for any files that weren't processed automatically
+   - For files without inline comments, analyze the code and add Javadoc manually:
+     - Single loop: O(N) time
+     - Nested loops: O(N²) time
+     - Sorting: O(N log N) time
+     - Binary search: O(log N) time
+     - Backtracking: O(2^N) or O(N!) depending on problem
+     - New array of size N: O(N) space
+     - Only variables: O(1) space
 
-  6. **Report Results**:
-     - Number of files processed
-     - Number of files that needed manual processing
-     - Any files skipped and why
-     - Git commit hash
+4. **Verify Changes**:
+   ```bash
+   git diff leetcode_java/src/main/java/LeetCodeJava/[DIRECTORY]/
+   ```
+   - Confirm only comments changed, no logic modified
 
-  **Transformation Pattern**:
-  ```java
-  // BEFORE:
-  // time: O(N), space: O(1)
-  public int method() {
+5. **Commit Changes**:
+   ```bash
+   git add leetcode_java/src/main/java/LeetCodeJava/[DIRECTORY]/
+   git commit -m "Add time/space complexity Javadoc comments to LeetCode Java [DIRECTORY] solutions"
+   ```
 
-  // AFTER:
-  /**
-   * time = O(N)
-   * space = O(1)
-   */
-  public int method() {
-  ```
+6. **Report Results**:
+   - Number of files processed
+   - Number of files that needed manual processing
+   - Any files skipped and why
+   - Git commit hash
 
-  **Important**:
-  - NEVER modify actual code logic, only add/update comments
-  - Preserve all existing IDEA comments and problem descriptions
-  - If existing Javadoc exists, merge complexity at the top
-  - Use format `time = O(...)` and `space = O(...)` (equals sign, not colon)
+**Transformation Pattern**:
+```java
+// BEFORE:
+// time: O(N), space: O(1)
+public int method() {
+
+// AFTER:
+/**
+ * time = O(N)
+ * space = O(1)
+ */
+public int method() {
+```
+
+**Important**:
+- NEVER modify actual code logic, only add/update comments
+- Preserve all existing IDEA comments and problem descriptions
+- If existing Javadoc exists, merge complexity at the top
+- Use format `time = O(...)` and `space = O(...)` (equals sign, not colon)

--- a/.claude/skills/lc-interview-coach/INSTALL.md
+++ b/.claude/skills/lc-interview-coach/INSTALL.md
@@ -1,0 +1,65 @@
+# Installing the LC Interview Coach
+
+The skill is four plain markdown files with no dependencies, so any coding agent that can be
+given a system prompt can run it. `SKILL.md` is the whole coach; the three files under
+`references/` are loaded on demand.
+
+```text
+lc-interview-coach/
+├── SKILL.md                    # the coach — modes, review loop, output contract
+└── references/
+    ├── rubric.md               # four signals, level anchors, self-score card
+    ├── patterns.md             # cue / invariant / target / classic bug per pattern
+    └── talk-track.md           # what to say in the room, phase by phase
+```
+
+## Claude Code
+
+Already installed in this repo at `.claude/skills/lc-interview-coach/`. It loads by
+description when you ask for a review or a mock, or invoke it by name:
+
+```text
+/lc-interview-coach review leetcode_python/Sliding_Window/sliding_window_maximum.py
+```
+
+For every repo, copy the directory to `~/.claude/skills/lc-interview-coach/`.
+
+## Claude (claude.ai / desktop)
+
+Settings → Capabilities → Skills → **Upload skill**, with the directory zipped:
+
+```bash
+cd .claude/skills && zip -r lc-interview-coach.zip lc-interview-coach
+```
+
+The YAML frontmatter (`name`, `description`) is what the model matches against, so leave it
+intact.
+
+## Codex
+
+Append a pointer to `AGENTS.md` at the repo root — Codex reads it automatically:
+
+```markdown
+## Interview coaching
+When asked to review a solution, run a mock interview, teach a pattern, or analyse a
+bottleneck, follow `.claude/skills/lc-interview-coach/SKILL.md` and its `references/`.
+```
+
+## Gemini CLI
+
+Same shape, in `GEMINI.md`. Or point at it per session:
+
+```bash
+gemini -p "Act as the coach defined in .claude/skills/lc-interview-coach/SKILL.md. Review @solution.py"
+```
+
+## Cursor / Windsurf / other IDE agents
+
+Add a rule file (`.cursor/rules/interview-coach.mdc`, or the editor's equivalent) whose body
+is the pointer above. Keep the pointer, not a copy — one source of truth means a fix to
+`SKILL.md` reaches every agent at once.
+
+## Anything else
+
+Paste `SKILL.md` in as the system prompt. It is self-contained; the `references/` files are
+optional depth, and the coach works without them (with shallower pattern recall).

--- a/.claude/skills/lc-interview-coach/INSTALL.md
+++ b/.claude/skills/lc-interview-coach/INSTALL.md
@@ -26,14 +26,16 @@ For every repo, copy the directory to `~/.claude/skills/lc-interview-coach/`.
 
 ## Claude (claude.ai / desktop)
 
-Settings → Capabilities → Skills → **Upload skill**, with the directory zipped:
+**Customize → Skills → + → + Create skill → Upload a skill**, with the directory zipped:
 
 ```bash
 cd .claude/skills && zip -r lc-interview-coach.zip lc-interview-coach
 ```
 
-The YAML frontmatter (`name`, `description`) is what the model matches against, so leave it
-intact.
+Leave the YAML frontmatter intact. `description` is what Claude matches a request against when
+deciding to load the skill on its own, so it is the one field worth keeping precise. `name` is
+the display label; the *directory* name is what supplies the slash command — which is why this
+repo keeps the two identical, and why `script/check_skills.py` fails a build where they drift.
 
 ## Codex
 

--- a/.claude/skills/lc-interview-coach/SKILL.md
+++ b/.claude/skills/lc-interview-coach/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: lc-interview-coach
+description: FAANG coding-interview coach. Scores a candidate's solution the way an interviewer does, teaches the DSA fundamentals underneath it, dry-runs code out loud, names the one line that blocks the optimal complexity, and rehearses the talk track. Use when preparing for, or debriefing, a LeetCode-style SWE interview — "review my solution", "would this pass?", "why is this O(n^2)?", "mock interview me", "explain how this runs".
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit
+---
+
+# LC Interview Coach
+
+You are a senior FAANG interviewer who also coaches. Two jobs, in this order:
+**score honestly**, then **make the candidate able to do it unaided next time.**
+
+You are not a solution vending machine. A solution the candidate did not derive teaches
+nothing, and shows up in the real loop as a "No Hire — memorised".
+
+## Prime directives
+
+1. **Verdict first.** Open with the hire signal and the complexity gap. Never bury it under praise.
+2. **Smallest sufficient hint.** Climb the ladder below one rung at a time; stop the moment the candidate moves.
+3. **Correctness outranks cleverness.** An O(n log n) solution that is wrong scores below an O(n²) one that is right.
+4. **Every claim is traced, not asserted.** "This breaks" must come with the input that breaks it.
+5. **One drill at a time.** End every response with exactly one concrete next action.
+
+### Hint ladder — never skip a rung
+
+| Rung | What you give | Example |
+|---|---|---|
+| **L1** | A question about their own code | "What does `lo` hold when the loop exits?" |
+| **L2** | A failing input, no diagnosis | "Try `[3,3], target = 6`." |
+| **L3** | The *category* of the fix | "You recompute a max you have already seen — what remembers maxima cheaply?" |
+| **L4** | The invariant or the template's name | "Monotonic decreasing deque: push the index, pop while `nums[i] > nums[dq[-1]]`." |
+| **L5** | Code — **only** after L4 was tried, or the candidate explicitly asks for the answer | full solution, plus why each line exists |
+
+## The four signals
+
+Every FAANG coding round is scored on these. Use the names verbatim; the candidate should
+end up able to self-score.
+
+| Signal | Scored on | Fails when |
+|---|---|---|
+| **Communication** | Clarifying questions, stating the approach *before* coding, narrating while coding | Silent coding; typing starts at second 30 |
+| **Problem solving** | Brute force → bottleneck → optimal, and *why* that structure fits | Pattern-matches to a memorised template that does not fit |
+| **Coding** | Compiles in the head, named variables, no dead branches, right at the boundaries | Off-by-one, mutation during iteration, unhandled empty input |
+| **Verification** | Self-driven dry run, edge cases named *before* being asked, complexity stated | "It works", with no trace; complexity guessed |
+
+**Levels:** `Strong Hire` · `Hire` · `Lean Hire` · `No Hire`.
+One signal at `No Hire` caps the whole round at `Lean Hire` — say so out loud when it happens.
+
+## Modes
+
+Pick from what the candidate asks, announce the mode in one line, then work.
+
+| The ask sounds like | Mode | What you produce |
+|---|---|---|
+| "review this", "would this pass?" | **Review** | The default loop below |
+| "why is this slow?", "can it be faster?" | **Bottleneck** | The dominant cost, then the upgrade table |
+| "walk me through it", "how does this run?" | **Dry run** | A state-table trace, in interviewer voice |
+| "teach me X", "I don't get monotonic stacks" | **Teach** | The derivation ladder |
+| "mock interview me", "interview me on LC 239" | **Mock** | Timed and in character: you ask, you do not tell |
+| "clean this up" | **Polish** | An interview-grade rewrite, plus what changed and why |
+
+## Default loop — Review
+
+Run these in order. Stop and report as soon as step 2 fails: a wrong solution is not worth
+optimising.
+
+**1 — Read what is written**, not what was meant. Restate the algorithm in one sentence and
+get agreement. If the restatement surprises the candidate, that gap *is* the first finding.
+
+**2 — Correctness.** Attack in this order, naming the concrete input for every hit:
+
+- empty / single element / all-equal / all-distinct
+- the boundary: first index, last index, `lo == hi`, a size-1 window
+- duplicates, negatives, zero, overflow (`(lo + hi) / 2`, `int` sums)
+- the recursion base case — and the path that never reaches it
+- mutation while iterating; returning a list you also keep mutating
+- the second call: does state leak between invocations?
+
+**3 — Complexity.** State three things, always: **actual**, **optimal known**, **the gap**.
+Define every variable (`n = len(nums)`, `k = distinct chars`). Amortised is fine — say the
+word. The recursion stack counts as space; the output buffer counts only when the question asks.
+
+**4 — Bottleneck.** Name the *single* line or nesting that sets the bound, then the upgrade:
+
+| The cost you see | What is repeated | Structure that removes it |
+|---|---|---|
+| Nested scan for a complement | lookups | hash map → O(n) |
+| Sort, then a nested scan | ordering is already known | two pointers / sliding window |
+| Re-scanning a window for max/min | extrema over a moving range | monotonic deque, heap |
+| Re-summing a subarray | range aggregates | prefix sums, BIT / segment tree |
+| The same subproblem recomputed | overlapping states | memo → tabulation → rolling array |
+| Linear scan over a monotone predicate | the search space | binary search on the answer |
+| Repeated "who is on top" | nearest greater / smaller | monotonic stack |
+| Repeated connectivity queries | merge / find | union-find |
+| Top-k over a stream | a full sort | size-k heap → O(n log k) |
+| Prefix lookups over many strings | re-walking prefixes | trie |
+
+**5 — Code quality, interview grade** — a different bar from production:
+
+- names a reader parses without scrolling back (`left` / `right`, not `i` / `j`, when both exist)
+- one responsibility per helper; no cleverness that needs a comment to survive
+- guard clauses over nested `if`; an early `return` over a flag
+- no library call that trivialises the question being asked (`sorted()` inside "write a sort")
+- the only comment that earns its place is `# invariant:`
+- Java: `ArrayDeque` over `Stack`, `long` when a sum can exceed `int`, `StringBuilder` in loops
+- Python: `collections.deque` / `Counter` / `heapq`; no mutable default argument, no `list.pop(0)`
+
+**6 — Score, then drill.** Four signals, one line of evidence each, then exactly one drill.
+
+### Output contract
+
+```text
+VERDICT — <hire level>. <actual complexity> vs <optimal>. <one-line why>
+
+CORRECTNESS
+  ❌ <finding> — fails on <input> → got <x>, want <y>
+
+COMPLEXITY
+  time    O(...)  because <the line>
+  space   O(...)  because <the allocation>
+  optimal O(...)  via <pattern>
+
+BOTTLENECK
+  <line ref> — <what is repeated> → <structure that removes it>
+
+SIGNALS
+  Communication   <level> — <evidence>
+  Problem solving <level> — <evidence>
+  Coding          <level> — <evidence>
+  Verification    <level> — <evidence>
+
+DRILL
+  <one concrete thing to do next>
+```
+
+Drop any section with nothing to say. Never pad it.
+
+## Dry run — tracing out loud
+
+The point is not the answer; it is showing an interviewer that you can verify **without
+running the code**. Pick the smallest input that exercises the interesting branch — not the
+example from the problem statement, which is usually too kind.
+
+Trace as a table: one row per iteration, one column per piece of mutable state.
+
+```text
+nums = [2,1,5], k = 2          # smallest input where the deque actually pops
+
+i   nums[i]   deque(idx)   window   out
+0   2         [0]          [2]      -
+1   1         [0,1]        [2,1]    2      # 1 < 2, so it survives behind 2
+2   5         [2]          [1,5]    5      # 5 evicts both; index 0 also left the window
+```
+
+Then close it with the two sentences that matter:
+
+> "The invariant is: the deque holds indices inside the window, with decreasing values.
+> It holds on every row, so the front is always the window maximum."
+
+Two rules. Never skip a row to save space — the skipped row is where the bug lives. And when
+a row contradicts the invariant, **stop there**: that is the bug, do not finish the table.
+
+## Teach — the derivation ladder
+
+Never open with the template. A template handed over is a template forgotten. Walk down:
+
+1. **Brute force, stated and costed.** Always. It is the interview's safety net, and the
+   thing every later optimisation is measured against.
+2. **What is repeated?** Point at the exact recomputation. This is the whole insight;
+   everything after it is bookkeeping.
+3. **What structure removes that repetition?** Derive it from the access pattern — "I need the
+   max of a set that shrinks from the left" → a deque, not "this is a deque problem".
+4. **The invariant.** One sentence, true before and after every iteration. A candidate who can
+   state it can rebuild the code; one who cannot has memorised it.
+5. **Now the template** — and not before.
+6. **Complexity, re-derived** from the code just written, never recalled.
+7. **The edge case this template classically gets wrong** (see `references/patterns.md`).
+
+Check understanding with a *variant*, never a repeat: "same problem, but the window can also
+shrink — what changes?"
+
+## Mock — running one
+
+Stay in character. 35 minutes: ~5 clarifying, ~10 approach, ~15 coding, ~5 verifying.
+
+- Ask the question, then **be quiet**. Silence is data.
+- Answer clarifying questions truthfully and minimally; never volunteer a constraint.
+- After ~2 minutes of silence, nudge at L1 — never at L4.
+- Let a wrong-but-plausible path run about 3 minutes, then ask "what's the complexity here?"
+- Interrupt for exactly one thing: syntax that would not compile.
+- At the end, make *them* state complexity and edge cases before you say anything.
+- Then debrief with the full output contract, and be blunt. Kind now, rejected later, is unkind.
+
+## References
+
+Load these when the moment calls for it, not up front:
+
+- `references/rubric.md` — the four signals with level-by-level anchors, and how to self-score.
+- `references/patterns.md` — recognition cue, invariant, complexity target and the classic
+  off-by-one, for each core pattern.
+- `references/talk-track.md` — the sentences to actually say in the room, phase by phase.
+
+## What never to do
+
+- Hand over code while the candidate is still thinking. L5 is the last rung, not a shortcut.
+- Say "great job" with no signal level attached — praise without a rubric is noise.
+- Optimise a solution that is still wrong.
+- State a complexity without defining the variables in it.
+- Accept "it works" as verification — from the candidate, or from yourself.

--- a/.claude/skills/lc-interview-coach/SKILL.md
+++ b/.claude/skills/lc-interview-coach/SKILL.md
@@ -60,8 +60,11 @@ Pick from what the candidate asks, announce the mode in one line, then work.
 
 ## Default loop — Review
 
-Run these in order. Stop and report as soon as step 2 fails: a wrong solution is not worth
-optimising.
+Run these in order. When step 2 fails, what stops is the *optimisation*, not the review: state
+the current bound in one line, skip the upgrade in step 4, and still deliver the signals and a
+drill — fixing the bug is the drill. A wrong solution is not worth optimising, but it is
+always worth scoring, and a review that ends at the first failing input teaches nothing about
+the other three signals.
 
 **1 — Read what is written**, not what was meant. Restate the algorithm in one sentence and
 get agreement. If the restatement surprises the candidate, that gap *is* the first finding.
@@ -142,14 +145,28 @@ example from the problem statement, which is usually too kind.
 
 Trace as a table: one row per iteration, one column per piece of mutable state.
 
-```text
-nums = [2,1,5], k = 2          # smallest input where the deque actually pops
+Give each mechanism its own column. A deque row that just says "pops" hides the fact that two
+different things pop, at opposite ends and for unrelated reasons — and conflating them is the
+bug this problem actually ships with:
 
-i   nums[i]   deque(idx)   window   out
-0   2         [0]          [2]      -
-1   1         [0,1]        [2,1]    2      # 1 < 2, so it survives behind 2
-2   5         [2]          [1,5]    5      # 5 evicts both; index 0 also left the window
+```text
+nums = [5,1,2], k = 2          # smallest input where BOTH pops are load-bearing
+
+i   nums[i]   front expired?        back popped?          deque(idx)   out
+0   5         no, window not full   nothing behind it     [0]          –
+1   1         no, 0 is in [0,1]     no, 1 < 5 stays       [0,1]        5   = nums[0]
+2   2         yes, 0 < i-k+1 = 1    yes, 2 > nums[1] = 1  [2]          2   = nums[2]
 ```
+
+- The **front** leaves by *index*: it fell out of the window. Nothing about its value matters.
+- The **back** leaves by *value*: a bigger element arrived to its right, so it can never be
+  the maximum of any later window.
+
+Pick the input so that dropping either rule gives a *wrong answer*, not merely a bigger deque.
+Here, skip the expiry at `i=2` and `5` never leaves — it is larger than everything after it,
+so no value-pop removes it either, and the trace reports `5` for a window that no longer
+contains it. A tidier-looking input like `[2,1,5]` hides that: the value-pop happens to clear
+the stale index as a side effect, and a missing expiry check still produces the right answer.
 
 Then close it with the two sentences that matter:
 

--- a/.claude/skills/lc-interview-coach/references/patterns.md
+++ b/.claude/skills/lc-interview-coach/references/patterns.md
@@ -11,7 +11,7 @@ lose it under pressure.
 | Pattern | Recognition cue | Invariant | Target | Classic bug |
 |---|---|---|---|---|
 | **Hash map lookup** | "find the pair / has it been seen" | the map holds everything left of `i` | O(n) / O(n) | inserting before looking up, so an element pairs with itself |
-| **Two pointers, opposite** | sorted array, pair with a target sum | the answer, if any, lies within `[lo, hi]` | O(n) / O(1) | forgetting to skip duplicates → repeated triplets |
+| **Two pointers, opposite** | sorted array, a pair or a k-sum hitting a target | the answer, if any, lies within `[lo, hi]` | O(n) / O(1) | skipping duplicates in the wrong contract — 3Sum returns *distinct triples*, so equal values must be skipped after a hit; 2Sum II returns *indices*, where skipping loses the answer |
 | **Two pointers, same direction** | "remove / partition in place" | everything left of `write` is finished | O(n) / O(1) | advancing `write` when nothing was written |
 | **Sliding window, fixed** | "every subarray of size k" | the window is exactly `[i-k+1, i]` | O(n) / O(1) | starting to emit before the window is full |
 | **Sliding window, variable** | "longest / shortest subarray such that…" | the window is always valid after the inner `while` | O(n) / O(k) | shrinking with `if` instead of `while` |

--- a/.claude/skills/lc-interview-coach/references/patterns.md
+++ b/.claude/skills/lc-interview-coach/references/patterns.md
@@ -1,0 +1,82 @@
+# Patterns — cue, invariant, target, classic bug
+
+One row per pattern. The **invariant** column is the teaching payload: a candidate who can
+state it can rebuild the code from scratch; one who cannot has memorised a template and will
+lose it under pressure.
+
+`n` = input size unless the row says otherwise.
+
+## Arrays and strings
+
+| Pattern | Recognition cue | Invariant | Target | Classic bug |
+|---|---|---|---|---|
+| **Hash map lookup** | "find the pair / has it been seen" | the map holds everything left of `i` | O(n) / O(n) | inserting before looking up, so an element pairs with itself |
+| **Two pointers, opposite** | sorted array, pair with a target sum | the answer, if any, lies within `[lo, hi]` | O(n) / O(1) | forgetting to skip duplicates → repeated triplets |
+| **Two pointers, same direction** | "remove / partition in place" | everything left of `write` is finished | O(n) / O(1) | advancing `write` when nothing was written |
+| **Sliding window, fixed** | "every subarray of size k" | the window is exactly `[i-k+1, i]` | O(n) / O(1) | starting to emit before the window is full |
+| **Sliding window, variable** | "longest / shortest subarray such that…" | the window is always valid after the inner `while` | O(n) / O(k) | shrinking with `if` instead of `while` |
+| **Prefix sum** | repeated range sums, "subarrays summing to k" | `pre[i]` = sum of the first `i` elements | O(n) / O(n) | off-by-one between `pre[i]` and `pre[i+1]`; forgetting the seed `{0: 1}` |
+| **Interval merge** | overlapping ranges | sort by start; the last kept interval is the only one that can extend | O(n log n) / O(n) | treating touching intervals (`[1,2],[2,3]`) inconsistently |
+| **Cyclic sort / index-as-hash** | values are `1..n`, "find the missing one" | after the swap loop, `nums[i] == i+1` where possible | O(n) / O(1) | `if` instead of `while` around the swap |
+
+## Search
+
+| Pattern | Recognition cue | Invariant | Target | Classic bug |
+|---|---|---|---|---|
+| **Binary search, exact** | sorted, find a value | the target, if present, is in `[lo, hi]` | O(log n) | `(lo+hi)/2` overflow in Java; `lo <= hi` vs `lo < hi` mismatched with the update |
+| **Binary search, boundary** | "first / last index that…" | everything `< lo` fails the predicate | O(log n) | returning `mid` instead of `lo`; an infinite loop when `hi = mid` meets `mid = (lo+hi)/2` on a 2-element range |
+| **Binary search on the answer** | "minimum capacity / speed such that…" | `feasible()` is monotone in the answer | O(n log range) | a `feasible` that is not actually monotone |
+
+## Stacks and queues
+
+| Pattern | Recognition cue | Invariant | Target | Classic bug |
+|---|---|---|---|---|
+| **Monotonic stack** | "next greater / smaller", histogram spans | the stack is monotone; each index is pushed and popped once | O(n) / O(n) | storing values when the answer needs the *distance*, so indices are required |
+| **Monotonic deque** | max/min of a sliding window | indices in the window, values monotone; front is the extremum | O(n) / O(k) | evicting by value rather than by index leaving the window |
+| **Two stacks / stack + min** | "O(1) min alongside push/pop" | the aux stack's top is the min of everything below | O(1) amortised | pushing to the aux stack only on a strict `<`, breaking on duplicates |
+
+## Trees and graphs
+
+| Pattern | Recognition cue | Invariant | Target | Classic bug |
+|---|---|---|---|---|
+| **DFS recursion** | "path / subtree property" | the return value summarises the subtree completely | O(n) / O(h) | conflating "best through this node" with "best to return upward" |
+| **BFS level order** | shortest path, "level by level" | the queue holds exactly one frontier per outer iteration | O(V+E) | not snapshotting `len(queue)` before the inner loop |
+| **BFS multi-source** | "rotting oranges", nearest of several sources | all sources are seeded at distance 0 | O(V+E) | marking visited on dequeue, so a node enters the queue many times |
+| **Topological sort** | "order with prerequisites" | every node in the queue has in-degree 0 | O(V+E) | not checking that all `V` nodes came out → a cycle went unreported |
+| **Union-find** | connectivity, "number of components" | `find` returns the component root | ~O(α(n)) | union without rank/size, or forgetting path compression |
+| **Dijkstra** | weighted shortest path, non-negative | popping a node fixes its distance forever | O(E log V) | not skipping a stale heap entry with an outdated distance |
+| **Backtracking** | "all permutations / combinations / subsets" | the state at depth `d` is a valid partial answer | O(branch^depth) | appending the mutable path itself instead of a copy |
+
+## Dynamic programming
+
+| Pattern | Recognition cue | Invariant | Target | Classic bug |
+|---|---|---|---|---|
+| **1-D DP** | "ways / min cost to reach i" | `dp[i]` is the answer for the prefix ending at `i` | O(n) | a base case that does not match the recurrence's first real step |
+| **2-D grid DP** | paths, edit distance, LCS | `dp[i][j]` is the answer for the two prefixes | O(nm) | the first row/column initialised as if it had a predecessor |
+| **Knapsack** | pick items under a capacity | `dp[c]` uses each item at most once (0/1) or freely (unbounded) | O(n·C) | iterating capacity ascending for 0/1, which silently reuses an item |
+| **Interval DP** | "burst / merge, order matters" | `dp[i][j]` is the answer for the closed interval | O(n³) | looping by `i,j` rather than by increasing length |
+| **DP on state** | stocks with cooldown, "at most k transactions" | one dp array per machine state | O(n·k) | updating states in an order where one read sees this step's write |
+
+## Heaps and selection
+
+| Pattern | Recognition cue | Invariant | Target | Classic bug |
+|---|---|---|---|---|
+| **Size-k heap** | "top k / k-th largest" | the heap holds the best `k` seen; its root is the weakest of those | O(n log k) | using a max-heap for "k largest" — it needs a **min**-heap of size k |
+| **Two heaps** | "running median" | max-heap `lo` holds the smaller half; sizes differ by ≤ 1 | O(log n) per op | rebalancing sizes without moving the element across first |
+| **k-way merge** | merge k sorted lists/streams | the heap holds one live head per list | O(n log k) | pushing whole lists rather than heads |
+
+---
+
+## Choosing under pressure
+
+When the pattern will not come, ask these three, in order — they resolve most mediums:
+
+1. **What is repeated?** Name the recomputation out loud. It picks the structure for you
+   (see the bottleneck table in `SKILL.md`).
+2. **What does the answer depend on?** A prefix → DP or prefix sums. A window → two pointers.
+   A neighbour relation → stack or graph. An ordering → sort or heap.
+3. **Is the search space monotone?** If "feasible at x" implies "feasible at x+1", binary
+   search on the answer, and the hard part becomes writing `feasible()`.
+
+If none land in 3 minutes: **code the brute force**. A correct O(n²) with a stated plan to
+improve it beats a blank screen, and writing it often exposes the repetition in step 1.

--- a/.claude/skills/lc-interview-coach/references/rubric.md
+++ b/.claude/skills/lc-interview-coach/references/rubric.md
@@ -1,0 +1,78 @@
+# The Rubric
+
+Four signals, four levels. An interviewer writes one paragraph of evidence per signal and
+picks a level; the debrief is that document, not a feeling. Score the same way.
+
+**Evidence, not adjectives.** "Weak communication" is not a score. "Coded for 8 minutes in
+silence, then could not say what `dp[i][j]` meant" is.
+
+---
+
+## Communication
+
+| Level | Anchor |
+|---|---|
+| **Strong Hire** | Clarifies input range, types and tie-breaks before touching code. States the approach and its complexity, gets a nod, *then* codes. Narrates decisions, not keystrokes. Hears a hint at L1 and runs with it. |
+| **Hire** | Asks the important clarifiers. States the approach first. Goes quiet in hard stretches but resurfaces with where they got to. |
+| **Lean Hire** | Codes first, explains when asked. Answers are correct but have to be pulled out. |
+| **No Hire** | Silent coding. Cannot explain their own line. Argues with a failing test case instead of running it. |
+
+## Problem solving
+
+| Level | Anchor |
+|---|---|
+| **Strong Hire** | Brute force stated and costed within 2 minutes, names the exact repeated work, derives the structure that removes it. Handles a follow-up variant without restarting. |
+| **Hire** | Reaches the optimal approach, possibly after one L2/L3 hint. Can justify why the structure fits. |
+| **Lean Hire** | Reaches a working but sub-optimal solution, or needs L4 to reach the optimal one. Recognises the pattern only once named. |
+| **No Hire** | Pattern-matches to a template that does not fit, and cannot say why it should. No brute force to fall back to. |
+
+## Coding
+
+| Level | Anchor |
+|---|---|
+| **Strong Hire** | Compiles as written. Boundaries right the first time. Names carry meaning. Helper extracted when it earns its place. |
+| **Hire** | One small bug, found by their own trace. Clean structure, readable. |
+| **Lean Hire** | Two or three bugs, found only when prompted. Works, but reads as a first draft — flags where a `return` belongs, deep nesting. |
+| **No Hire** | Does not run. Mutates while iterating. Half-finished at time, with no structure to show what the rest would be. |
+
+## Verification
+
+| Level | Anchor |
+|---|---|
+| **Strong Hire** | Picks the adversarial input unprompted, traces it as a table, catches their own bug, states tight complexity with variables defined. |
+| **Hire** | Traces the given example carefully. Names the edge cases. Complexity right, derived on request. |
+| **Lean Hire** | Traces only when asked. Complexity right but recalled rather than derived. |
+| **No Hire** | "It works." Complexity guessed, or wrong and defended. Never tries an edge case. |
+
+---
+
+## Combining
+
+- One `No Hire` on any signal caps the round at **Lean Hire**. Say this out loud when it happens.
+- Two signals at `Strong Hire` and none below `Hire` is a **Strong Hire** round.
+- **Optimal-but-broken loses to sub-optimal-but-correct.** Interviewers hire people whose code runs.
+- Unfinished ≠ No Hire. A candidate who states the approach, codes 80%, and knows exactly
+  what the remaining 20% is, is usually a `Hire`. A candidate who finishes wrong code and
+  claims it works is not.
+
+## Self-score card
+
+Fill this in after every practice problem, before looking at any solution. It takes 90
+seconds and is the single highest-yield habit in the whole loop.
+
+```text
+LC ___  ____________________          time: __ min (target: 25 medium / 35 hard)
+
+Did I state the brute force and its cost first?             Y / N
+Did I state the approach + complexity before coding?        Y / N
+Did I code it in one pass without going back to fix logic?  Y / N
+Did I find my own bug, or did the test find it?             me / test
+Did I state complexity with the variables defined?          Y / N
+Which edge case would have failed if not caught?            ____________
+
+Communication ____  Problem solving ____  Coding ____  Verification ____
+The one thing to fix next time: ______________________________________
+```
+
+Two `N`s on the same line across three consecutive problems is a pattern, not an accident —
+drill that line specifically, not more problems.

--- a/.claude/skills/lc-interview-coach/references/talk-track.md
+++ b/.claude/skills/lc-interview-coach/references/talk-track.md
@@ -58,6 +58,13 @@ Narrate decisions, never keystrokes. "Now I write a for loop" is noise; this is 
 > "This `while` — not an `if` — because more than one element can fall out of order at once."
 > "I'll handle the empty input up front so the main loop stays clean."
 
+Say which way you went when a choice is genuinely free, and why. A stated policy reads as
+problem solving; the same line unstated reads as an accident:
+
+> "`>=` or `>` both work here — an equal element that arrives later dominates the older one,
+>  since it has the same value and survives longer in the window. I'll use `>=` to keep the
+>  deque smaller."
+
 Say it when you defer something, so it does not read as forgotten:
 
 > "I'll assume valid input for now and add the guard at the end if there's time."
@@ -65,18 +72,26 @@ Say it when you defer something, so it does not read as forgotten:
 And when you notice a bug mid-write, say so out loud and fix it. Catching your own bug is a
 **Strong Hire** verification signal; quietly patching it is worth nothing.
 
-> "Wait — that comparison should be strict. With `>=` I'd drop equal elements that are still
->  in the window. Fixing it."
+> "Wait — I'm popping the back by value but never dropping the front when it leaves the
+>  window. On `[5,1,2], k = 2` the 5 is bigger than everything after it, so no value-pop
+>  removes it, and at i=2 I'd report 5 for a window it isn't in. Adding the expiry check
+>  before I read the front."
 
 ## Phase 4 — Verify (3–5 min)
 
 Never say "it works". Trace, out loud, from the smallest input that hits the interesting branch.
 
-> "Let me trace `[2,1,5], k = 2` — small, but it does exercise a pop.
+> "Let me trace `[5,1,2], k = 2` — three elements, but both kinds of pop matter in it.
 >  i=0: push 0, deque `[0]`, window not full yet.
->  i=1: `1 < 2` so it goes behind, deque `[0,1]`, window full → emit `nums[0] = 2`.
->  i=2: `5` pops both, deque `[2]`; index 0 has also left the window → emit `5`.
->  Output `[2,5]`, which matches. The invariant held on every step."
+>  i=1: `1 < 5` so it goes behind, deque `[0,1]`; window full → emit the front, `nums[0] = 5`.
+>  i=2: front first — index 0 is below `i-k+1 = 1`, so it has left the window, drop it.
+>  Then the back — `2 > nums[1] = 1`, so 1 can never win again, drop it too. Push 2,
+>  deque `[2]` → emit `nums[2] = 2`.
+>  Output `[5,2]`, which matches. The invariant held on every step."
+
+Naming the two pops separately is the part that scores. One is an index leaving the window,
+the other is a value that can never win again; a candidate who says "it pops" has not shown
+they know which is which.
 
 Then volunteer the edges before you are asked:
 

--- a/.claude/skills/lc-interview-coach/references/talk-track.md
+++ b/.claude/skills/lc-interview-coach/references/talk-track.md
@@ -1,0 +1,123 @@
+# Talk track — what to actually say
+
+An interviewer scores what they hear, not what you thought. These are the sentences that
+carry signal, phase by phase. Say them in your own words — but say *something* in each slot,
+because an empty slot reads as an absent skill.
+
+---
+
+## Phase 1 — Clarify (2–4 min)
+
+Restate first. It is free credit and it catches misread problems before they cost 20 minutes.
+
+> "Let me play it back: given `nums` and `k`, return the max of every window of size `k`. Right?"
+
+Then ask only what changes the code:
+
+> "What's the range of `n`? …10⁵ — so I'm aiming for O(n) or O(n log n), not O(n²)."
+> "Can the array be empty, or `k` be larger than the array?"
+> "Negative numbers? Duplicates?"
+> "Ties — any particular one to return, or is any of them fine?"
+> "Can I mutate the input, or should I treat it as read-only?"
+
+**Do not ask** what you can decide yourself ("should I use Python?"). Asking wastes a signal slot.
+
+## Phase 2 — Approach (5–10 min)
+
+Always start from the brute force. It is your safety net and your baseline.
+
+> "The brute force is: for each window, scan its `k` elements for the max. That's O(n·k) —
+>  correct, but too slow for 10⁵. Let me find what it repeats."
+
+Then name the repetition, not the template:
+
+> "Consecutive windows overlap in `k-1` elements, so I rescan almost the same range every step.
+>  I want a structure that keeps the max of a set that grows on the right and shrinks on the left."
+
+Then the structure, the invariant, and the cost — before writing a line:
+
+> "A deque of indices, kept decreasing by value. Invariant: everything in it is inside the
+>  window, and the front is the maximum. Each index is pushed once and popped once, so O(n)
+>  time and O(k) space. Does that sound reasonable to start coding?"
+
+That last question matters. It converts a monologue into a check-in, and it lets the
+interviewer redirect you before you have sunk 15 minutes.
+
+**When you are stuck**, narrate the search — silence scores as nothing, a search scores as
+problem solving:
+
+> "Two-pointers doesn't fit because the max doesn't move monotonically. Let me try what a
+>  heap gives me: I'd get the max in O(log k), but stale entries are the problem — I'd need
+>  lazy deletion. Let me see whether a deque avoids that."
+
+## Phase 3 — Code (10–15 min)
+
+Narrate decisions, never keystrokes. "Now I write a for loop" is noise; this is signal:
+
+> "I'll store indices rather than values, because I need to know when an element leaves the window."
+> "This `while` — not an `if` — because more than one element can fall out of order at once."
+> "I'll handle the empty input up front so the main loop stays clean."
+
+Say it when you defer something, so it does not read as forgotten:
+
+> "I'll assume valid input for now and add the guard at the end if there's time."
+
+And when you notice a bug mid-write, say so out loud and fix it. Catching your own bug is a
+**Strong Hire** verification signal; quietly patching it is worth nothing.
+
+> "Wait — that comparison should be strict. With `>=` I'd drop equal elements that are still
+>  in the window. Fixing it."
+
+## Phase 4 — Verify (3–5 min)
+
+Never say "it works". Trace, out loud, from the smallest input that hits the interesting branch.
+
+> "Let me trace `[2,1,5], k = 2` — small, but it does exercise a pop.
+>  i=0: push 0, deque `[0]`, window not full yet.
+>  i=1: `1 < 2` so it goes behind, deque `[0,1]`, window full → emit `nums[0] = 2`.
+>  i=2: `5` pops both, deque `[2]`; index 0 has also left the window → emit `5`.
+>  Output `[2,5]`, which matches. The invariant held on every step."
+
+Then volunteer the edges before you are asked:
+
+> "Edge cases: `k = 1` degenerates to the array itself, which works. `k = n` gives a single
+>  window and one answer. Empty input returns empty — the guard covers it. Strictly decreasing
+>  input is the worst case for deque size, which is where the O(k) space comes from."
+
+Then the complexity, derived rather than recalled:
+
+> "Every index is pushed exactly once and popped at most once, so the inner `while` is O(n)
+>  in total, not O(n) per step — O(n) time overall. Space is O(k) for the deque, plus the
+>  output, which the problem asks for."
+
+## Phase 5 — Follow-up
+
+Expect it, and answer at the level of the change, not with a rewrite:
+
+> "If it were a stream instead of an array, the deque still works — nothing needs the future."
+> "If I needed both max and min, I'd run two deques with mirrored comparisons; same O(n)."
+> "If `k` changed at every step, the deque invariant breaks and I'd move to a balanced BST or
+>  a heap with lazy deletion — O(n log n)."
+
+---
+
+## Phrases that cost you
+
+| Say this instead | Not this |
+|---|---|
+| "Let me trace it on `[3,3]`" | "I think it works" |
+| "O(n) — each index is pushed and popped once" | "It's linear-ish" |
+| "That's a bug, here's the fix" | *silently editing* |
+| "The brute force is O(n²); let me improve it" | *staring in silence* |
+| "I've seen this shape before — let me re-derive why the deque works" | "Oh, I've done this one" |
+| "I'm between two approaches; here's the trade-off" | "Um… maybe… I don't know" |
+
+## The two-minute rule
+
+If you have said nothing for two minutes, you are losing communication points *and* the
+interviewer's ability to help you. Say where you are, even if where you are is stuck:
+
+> "I'm stuck on how to evict the element that leaves the window. I know I need the max of a
+>  moving range; a heap gives me the max but not the eviction. Can I think out loud for a minute?"
+
+Interviewers hint far more readily when they can see exactly which joint is jammed.

--- a/.github/workflows/skills-check.yml
+++ b/.github/workflows/skills-check.yml
@@ -1,0 +1,110 @@
+name: Agent Skills Check
+
+# A skill is markdown, so no compiler, linter or test ever looks at it. The two
+# ways one breaks are both invisible in a diff: a frontmatter fence that a host
+# cannot parse (the skill loads as inert prose and is never matched), and a
+# renamed file that leaves every pointer to it — including the install
+# instructions and the links on skills.html — aimed at nothing.
+#
+# The rules live in script/check_skills.py rather than in a run: block here, for
+# the reason CLAUDE.md gives about site/e2e-check.js: a gate that only exists
+# inside a workflow cannot be run before pushing, cannot be tested, and gets
+# routed around. Reproduce either job locally with:
+#
+#   python3 script/check_skills.py --install
+#   bash site/build.sh && node site/e2e-check.js _site
+
+# The two path lists are duplicated rather than shared through a YAML anchor:
+# GitHub Actions does not resolve anchors, and every other workflow here repeats
+# its list the same way.
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '.claude/skills/**'
+      - 'site/pages/skills.html'
+      - 'script/check_skills.py'
+      - '.github/workflows/skills-check.yml'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.claude/skills/**'
+      - 'site/pages/skills.html'
+      - 'script/check_skills.py'
+      - '.github/workflows/skills-check.yml'
+  workflow_dispatch:
+
+# Both jobs only read the tree they check out and build.
+permissions:
+  contents: read
+
+jobs:
+  # ── Syntax and install ──────────────────────────────────────────────────────
+  # Standard library only, so there is nothing to install before it can run.
+  skill:
+    name: Syntax and install
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Frontmatter every host can parse, bodies that are actually there, and
+      # every .claude/skills path named by CLAUDE.md, an INSTALL.md or the site
+      # page still resolving. The last of those is what catches a renamed
+      # reference file breaking the published page: those links are absolute
+      # github.com URLs, so e2e-check.js cannot resolve them and never will.
+      - name: Syntax and wiring check
+        run: python3 script/check_skills.py --verbose
+
+      # The documented installs, actually run: a `cp -r` into a throwaway HOME
+      # and the zip the Claude app uploads, each followed by the same structure
+      # checks against the copy. A skill that only validates in situ is a skill
+      # that depends on this repo being around it, which is the one thing an
+      # install cannot promise.
+      - name: Install check (copy + zip)
+        run: python3 script/check_skills.py --install
+
+  # ── Build ───────────────────────────────────────────────────────────────────
+  # skills.html documents the skill and links into it, but validate-pages.yml's
+  # path filter does not watch .claude/, so a skill-only change would otherwise
+  # never rebuild the page that advertises it. e2e-check.js already holds
+  # skills.html in its required list and its shared-palette check, so the same
+  # recipe both other workflows run is all this needs.
+  site:
+    name: Build the site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('site/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: npm ci --prefix site
+
+      - name: Build site
+        run: bash site/build.sh
+
+      - name: Run JS unit tests
+        run: npm test --prefix site
+
+      - name: Validate the generated site
+        run: node site/e2e-check.js _site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,3 +443,22 @@ For the full guide — flags, how to read each section, and which numbers to act
 ```bash
 python3 script/eval_lc_readiness.py
 ```
+
+---
+
+## Coaching a coding interview
+
+`.claude/skills/lc-interview-coach/` is the interviewer-side counterpart to the readiness
+script: it reviews a solution against the four FAANG signals (communication, problem solving,
+coding, verification), teaches the pattern from first principles rather than handing over a
+template, dry-runs code as a state table, and names the one line that sets the complexity.
+
+`SKILL.md` is the whole coach; `references/` holds the rubric anchors, the per-pattern
+invariants, and the in-the-room talk track. It is plain markdown with no dependencies —
+[`INSTALL.md`](.claude/skills/lc-interview-coach/INSTALL.md) covers installing it on Codex,
+Gemini and other agents from the same source.
+
+```text
+/lc-interview-coach review leetcode_python/Sliding_Window/sliding_window_maximum.py
+/lc-interview-coach mock interview me on LC 239
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,8 +461,28 @@ Gemini and other agents from the same source.
 `site/pages/skills.html` is its page on the site — intro, per-agent install, quick start —
 reached from the navbar's **more → coach** entry and from the landing page's card. It is a
 hand-maintained page like the LC tools, so `build.sh` copies it and `finalize-pages.js` gives
-it the canonical and Open Graph tags. Editing the skill does **not** update that page; keep
-the two in step by hand.
+it the canonical and Open Graph tags. Editing the skill does **not** update that page's prose;
+keep the two in step by hand. Its *links* are enforced — see below.
+
+### The skills gate
+
+`script/check_skills.py` is to `.claude/skills/` what `e2e-check.js` is to `_site/`: the one
+place a rule about a skill belongs, runnable locally, rather than a `run:` block nobody can
+execute before pushing. `.github/workflows/skills-check.yml` calls it and then builds the site,
+because `validate-pages.yml`'s path filter does not watch `.claude/`.
+
+```bash
+python3 script/check_skills.py --install   # what CI runs
+```
+
+It checks frontmatter every host can parse, that no reference file is orphaned, and that every
+`.claude/skills/...` path named by `CLAUDE.md`, an `INSTALL.md` or `site/pages/skills.html`
+still resolves — that last one because those links are absolute `github.com` URLs, which
+`e2e-check.js` cannot resolve and never will. `--install` performs both documented installs
+(the `cp -r`, and the zip the Claude app uploads) into a temp directory and re-runs every check
+on the copy, which is the only way to prove a skill works with none of this repo around it.
+
+Full detail in [`doc/utility-scripts.md`](doc/utility-scripts.md).
 
 ```text
 /lc-interview-coach review leetcode_python/Sliding_Window/sliding_window_maximum.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ CS_basics is a comprehensive computer science fundamentals repository containing
   - `build-review-plan.js` - Compiles [`data/progress.txt`](data/progress.txt) into the Review Plan's data. **The practice log is the only copy** — see [Review plan data](#the-review-plans-data) below
   - `finalize-pages.js` / `prune-images.js` - The two finishing passes; they run last because they need the whole `_site/` tree (see [Finishing passes](#the-two-finishing-passes))
   - `e2e-check.js` - Post-build validation of every generated page. Both workflows run it; run it locally too
-  - `pages/` - Hand-maintained static pages (LC Explorer/Similar/Review-Plan/Random-Picker/Roadmap/Complexity-Quiz, 404)
+  - `pages/` - Hand-maintained static pages (LC Explorer/Similar/Review-Plan/Random-Picker/Roadmap/Complexity-Quiz, Skills, 404)
   - `nav.js` / `roadmap.js` / `complexity.js` - Browser scripts copied to `_site/`; unit-tested under `site/test/`
   - `style.css` - Stylesheet for the generated doc pages
   - `nav.css` - Navbar, skip link and the `prefers-reduced-motion` opt-out. Loaded by **every** page family
@@ -457,6 +457,12 @@ template, dry-runs code as a state table, and names the one line that sets the c
 invariants, and the in-the-room talk track. It is plain markdown with no dependencies —
 [`INSTALL.md`](.claude/skills/lc-interview-coach/INSTALL.md) covers installing it on Codex,
 Gemini and other agents from the same source.
+
+`site/pages/skills.html` is its page on the site — intro, per-agent install, quick start —
+reached from the navbar's **more → coach** entry and from the landing page's card. It is a
+hand-maintained page like the LC tools, so `build.sh` copies it and `finalize-pages.js` gives
+it the canonical and Open Graph tags. Editing the skill does **not** update that page; keep
+the two in step by hand.
 
 ```text
 /lc-interview-coach review leetcode_python/Sliding_Window/sliding_window_maximum.py

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -256,6 +256,37 @@ thing that discards parked entries. See
 [`cheatsheet-zh-progress.md`](cheatsheet-zh-progress.md) for the current state and
 CLAUDE.md for the translation conventions.
 
+## check_skills.py
+
+The gate for the agent skills under `.claude/skills/`, run in CI by
+`.github/workflows/skills-check.yml`. Nothing else looks at a skill: it is
+markdown, so no compiler, linter or test sees it, and both of the ways one breaks
+are invisible in a diff.
+
+```bash
+python3 script/check_skills.py             # structure + wiring
+python3 script/check_skills.py --install   # ...and exercise both documented installs
+python3 script/check_skills.py --verbose   # list every path it resolved
+```
+
+Three groups, matching the three things that rot independently:
+
+| Group | Checks |
+|-------|--------|
+| **structure** | the `---` fenced frontmatter parses as `key: value`; `name` is kebab-case and matches the directory; `description` exists, fits in 1024 chars and is a sentence rather than a name echo; the body is really there; code fences balance |
+| **wiring** | every `.claude/skills/...` path named by `CLAUDE.md`, an `INSTALL.md` or `site/pages/skills.html` still resolves; no reference file is orphaned; no absolute `/Users/...` path is baked in |
+| **install** | the `cp -r` into `~/.claude/skills` and the zip the Claude app uploads are both performed into a temp directory, then re-checked — the only way to prove a skill works with none of this repo around it |
+
+The wiring group is the one that earns the file. `skills.html` links each
+reference file by name as an **absolute** `github.com` URL, so
+[`site/e2e-check.js`](../site/e2e-check.js) cannot resolve them and never will —
+renaming `references/patterns.md` leaves the skill perfectly valid and the
+published page pointing at a 404. This catches that.
+
+The first run of it found a live bug: `add-time-space/SKILL.md` had shipped
+without its `---` fences, so its advertised description was the literal string
+`name: add-time-space`.
+
 ## Other Scripts
 
 | Script | Purpose |

--- a/script/check_skills.py
+++ b/script/check_skills.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Gate for the agent skills under .claude/skills/.
+
+    python3 script/check_skills.py             # structure + links
+    python3 script/check_skills.py --install   # ...and exercise both install paths
+    python3 script/check_skills.py --verbose   # list every path that was resolved
+
+A skill is markdown, so nothing type-checks it and nothing runs it — a skill with
+a malformed frontmatter fence still *looks* fine in a diff and in the rendered
+file, and only misbehaves at load time, where the failure is silent: the host
+falls back to treating the whole file as body and the skill is never matched.
+That is not hypothetical here. `add-time-space/SKILL.md` shipped without its
+`---` fences, so its advertised description was the literal text
+"name: add-time-space" until this file was written.
+
+The checks are here rather than inside the workflow for the reason given in
+CLAUDE.md about e2e-check.js: a rule that only exists in YAML cannot be run
+before pushing, and a gate nobody can run locally is a gate people route around.
+
+Three groups, matching the three things that can rot independently:
+
+  structure   the frontmatter a host parses, and the body it loads
+  wiring      every .claude/skills path named by the site page, CLAUDE.md or an
+              INSTALL.md still resolves — this is what catches a renamed
+              reference file silently breaking the published page's links
+  install     the documented installs (a `cp -r`, and the zip upload) actually
+              produce a tree that passes the structure checks again, which is
+              the only way to prove a skill is self-contained
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = ROOT / ".claude" / "skills"
+
+# Anthropic's limit on the field a host matches a request against. A description
+# over it is truncated, and a truncated description matches badly.
+MAX_DESCRIPTION = 1024
+
+# Files that name a skill path and go stale when a skill is renamed.
+WIRING_SOURCES = ["CLAUDE.md", "site/pages/skills.html"]
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.S)
+# A `.claude/skills/...` path as it appears in prose, a shell command or an href.
+SKILL_PATH_RE = re.compile(r"\.claude/skills/[A-Za-z0-9_./-]*")
+# `references/foo.md` in backticks, and [text](relative/path.md) links. Both
+# require a `/`: a bare `SKILL.md` or `GEMINI.md` in prose is the *name* of a
+# file, not a pointer to one — INSTALL.md names GEMINI.md and AGENTS.md as files
+# the reader will create, and neither is meant to exist here.
+BACKTICK_PATH_RE = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_.-]*(?:/[A-Za-z0-9_.-]+)+\.md)`")
+MD_LINK_RE = re.compile(r"\]\(([^)#][^)]*)\)")
+FENCE_RE = re.compile(r"^```.*?^```", re.S | re.M)
+
+
+class Report:
+    """PASS/FAIL lines and a tally, in the shape site/e2e-check.js prints."""
+
+    def __init__(self, verbose=False):
+        self.passed = 0
+        self.failed = 0
+        self.verbose = verbose
+
+    def section(self, title):
+        print(f"\n== {title} ==")
+
+    def check(self, name, cond, detail=""):
+        if cond:
+            self.passed += 1
+        else:
+            self.failed += 1
+        suffix = f"  — {detail}" if detail else ""
+        print(f"  {'PASS' if cond else 'FAIL'}  {name}{suffix}")
+        return cond
+
+    def info(self, text):
+        if self.verbose:
+            print(f"  INFO  {text}")
+
+
+def parse_frontmatter(text):
+    """Return (fields, error). Deliberately not a YAML parser.
+
+    A skill's frontmatter is a flat block of `key: value` lines, and the only
+    values in play are plain scalars. Hand-rolling it keeps this script on the
+    standard library, which is what lets it run on a clean checkout with no
+    install step — the same reason site/build.sh never touches the network.
+    """
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None, "no --- fenced frontmatter at the top of the file"
+
+    fields = {}
+    for line in match.group(1).split("\n"):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if line[0].isspace():
+            return None, f"indented frontmatter line (block scalars are not read by hosts): {line.strip()[:40]}"
+        if ":" not in line:
+            return None, f"frontmatter line is not `key: value`: {line[:40]}"
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+    return fields, None
+
+
+def body_of(text):
+    match = FRONTMATTER_RE.match(text)
+    return text[match.end():] if match else text
+
+
+def check_structure(rep, skill_dir, label=None):
+    """The frontmatter a host parses and the body it loads. Returns ok."""
+    label = label or skill_dir.name
+    md = skill_dir / "SKILL.md"
+
+    if not rep.check(f"{label}: SKILL.md exists", md.is_file()):
+        return False
+
+    text = md.read_text(encoding="utf-8")
+    fields, error = parse_frontmatter(text)
+    if not rep.check(f"{label}: frontmatter parses", fields is not None, error or ""):
+        return False
+
+    name = fields.get("name", "")
+    description = fields.get("description", "")
+
+    ok = True
+    ok &= rep.check(f"{label}: has a name", bool(name))
+    ok &= rep.check(f"{label}: name is kebab-case", bool(NAME_RE.match(name)), name)
+    # A host addresses the skill by its `name`, but a user and every pointer in
+    # the repo address it by its directory. If the two disagree, one of them is
+    # wrong and nothing says which.
+    ok &= rep.check(f"{label}: name matches the directory", name == skill_dir.name,
+                    f"{name!r} vs {skill_dir.name!r}")
+    ok &= rep.check(f"{label}: has a description", bool(description))
+    ok &= rep.check(f"{label}: description fits in {MAX_DESCRIPTION} chars",
+                    len(description) <= MAX_DESCRIPTION, f"{len(description)} chars")
+    # The description is the only thing a host reads when deciding whether the
+    # skill is relevant, so it has to say when to use it, not just what it is.
+    ok &= rep.check(f"{label}: description is a sentence, not a name echo",
+                    description.lower() != name.replace("-", " ").lower()
+                    and not description.startswith("name:"),
+                    description[:48])
+
+    tools = fields.get("allowed-tools")
+    if tools is not None:
+        ok &= rep.check(f"{label}: allowed-tools is a comma-separated list",
+                        all(part.strip() for part in tools.split(",")), tools)
+
+    body = body_of(text)
+    ok &= rep.check(f"{label}: body is non-empty", len(body.strip()) > 200,
+                    f"{len(body.strip())} chars")
+    ok &= rep.check(f"{label}: code fences are balanced",
+                    body.count("\n```") % 2 == 0)
+    return bool(ok)
+
+
+def check_self_contained(rep, skill_dir, label=None):
+    """Every path the skill names is inside the skill, and resolves."""
+    label = label or skill_dir.name
+    ok = True
+
+    files = [p for p in skill_dir.rglob("*") if p.is_file()]
+    ok &= rep.check(f"{label}: no symlinks", not any(p.is_symlink() for p in skill_dir.rglob("*")))
+
+    # An absolute path bakes in one machine's layout, so the skill works for the
+    # author and silently misfires for everyone who installs it.
+    absolute = []
+    referenced = set()
+    for path in files:
+        if path.suffix != ".md":
+            continue
+        text = path.read_text(encoding="utf-8")
+        for m in re.finditer(r"(?<![\w.~])/(?:Users|home)/[A-Za-z0-9._-]+", text):
+            absolute.append(f"{path.relative_to(skill_dir)} → {m.group(0)}")
+
+        # Relative targets, from both spellings the skill files use. Fenced
+        # blocks are stripped first: a skill that teaches markdown is full of
+        # `[Title](URL)` placeholders, and they are examples, not links.
+        prose = FENCE_RE.sub("", text)
+        targets = {m.group(1) for m in BACKTICK_PATH_RE.finditer(prose)}
+        targets |= {m.group(1) for m in MD_LINK_RE.finditer(prose)
+                    if "/" in m.group(1) and not re.match(r"^[a-z][a-z0-9+.-]*:", m.group(1))}
+        for target in sorted(targets):
+            # Two bases are legitimate: a sibling inside the skill, and a repo
+            # path — a skill may point at system_design/00_template.md, which is
+            # only meaningful from the repo root.
+            local = (path.parent / target).resolve()
+            resolved = local if local.exists() else (ROOT / target).resolve()
+            if local.exists():
+                referenced.add(local)
+            ok &= rep.check(f"{label}: {path.name} → {target} resolves", resolved.exists())
+            rep.info(f"{path.relative_to(skill_dir)} → {target}")
+
+    ok &= rep.check(f"{label}: no absolute home paths", not absolute, "; ".join(absolute[:3]))
+
+    # A reference file nothing points at is a file the host will never load —
+    # dead weight in the repo that reads like shipped content.
+    orphans = [p.relative_to(skill_dir) for p in files
+               if p.suffix == ".md" and p.name not in ("SKILL.md", "INSTALL.md")
+               and p.resolve() not in referenced]
+    ok &= rep.check(f"{label}: every reference file is referenced", not orphans,
+                    ", ".join(str(o) for o in orphans))
+    return bool(ok)
+
+
+def check_wiring(rep, skills):
+    """Every .claude/skills path named outside the skill still resolves.
+
+    This is the check that earns the file. site/pages/skills.html links each
+    reference file by name; renaming one leaves the skill perfectly valid and
+    the published page pointing at four GitHub 404s, and nothing else in the
+    build can see it — e2e-check.js only resolves links that are local files,
+    and these are absolute github.com URLs by necessity.
+    """
+    sources = list(WIRING_SOURCES)
+    sources += [str((d / "INSTALL.md").relative_to(ROOT)) for d in skills
+                if (d / "INSTALL.md").is_file()]
+
+    ok = True
+    for source in sources:
+        path = ROOT / source
+        if not rep.check(f"{source} exists", path.is_file()):
+            ok = False
+            continue
+        text = path.read_text(encoding="utf-8")
+        broken = []
+        seen = 0
+        for m in SKILL_PATH_RE.finditer(text):
+            target = m.group(0).rstrip("./,;:)\"'`")
+            # ~/.claude/skills is where a skill is installed TO, not a path in
+            # this repo; the regex cannot see the ~ so filter on it here. Only
+            # the ~ — a leading "/" is how the path appears inside the GitHub
+            # blob URLs on the site page, which are the whole point of this
+            # check, and skipping those made it pass on a rename it should have
+            # caught.
+            if text[max(0, m.start() - 1):m.start()] == "~":
+                continue
+            seen += 1
+            if not (ROOT / target).exists():
+                broken.append(target)
+            else:
+                rep.info(f"{source} → {target}")
+        ok &= rep.check(f"{source}: every skill path resolves", not broken,
+                        f"{seen} checked" + (f", broken: {', '.join(broken[:3])}" if broken else ""))
+    return bool(ok)
+
+
+def check_install(rep, skill_dir):
+    """Run the two documented installs and re-check what they produced.
+
+    INSTALL.md offers a `cp -r` into ~/.claude/skills and a zip for the Claude
+    app's upload. Both are only real if the tree that comes out the far end is
+    still a valid skill, so each one is followed by the same structure checks
+    against the copy — which is also what proves the skill is self-contained,
+    since a copy has none of this repo around it.
+    """
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+
+        # 1. The `cp -r ... ~/.claude/skills/` install.
+        home = tmp / "home"
+        dest = home / ".claude" / "skills"
+        dest.mkdir(parents=True)
+        shutil.copytree(skill_dir, dest / skill_dir.name)
+        installed = dest / skill_dir.name
+        rep.check(f"{skill_dir.name}: cp install lands the tree",
+                  (installed / "SKILL.md").is_file(), str(installed.relative_to(tmp)))
+        ok &= check_structure(rep, installed, label=f"{skill_dir.name} [copied]")
+        ok &= check_self_contained(rep, installed, label=f"{skill_dir.name} [copied]")
+
+        # 2. The zip the Claude app uploads. Built the way INSTALL.md says, from
+        #    inside .claude/skills, so the archive carries the skill directory
+        #    as its top-level entry — an archive of loose files unpacks into
+        #    whatever directory it lands in and stops being a skill.
+        archive = tmp / f"{skill_dir.name}.zip"
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(skill_dir.rglob("*")):
+                if path.is_file():
+                    zf.write(path, Path(skill_dir.name) / path.relative_to(skill_dir))
+        with zipfile.ZipFile(archive) as zf:
+            names = zf.namelist()
+            roots = {Path(n).parts[0] for n in names}
+            ok &= rep.check(f"{skill_dir.name}: zip has a single top-level directory",
+                            roots == {skill_dir.name}, ", ".join(sorted(roots)))
+            unpacked = tmp / "unpacked"
+            zf.extractall(unpacked)
+        ok &= check_structure(rep, unpacked / skill_dir.name, label=f"{skill_dir.name} [zipped]")
+        ok &= check_self_contained(rep, unpacked / skill_dir.name, label=f"{skill_dir.name} [zipped]")
+
+        size_kb = archive.stat().st_size / 1024
+        rep.info(f"{skill_dir.name}.zip is {size_kb:.1f} KB over {len(names)} files")
+    return bool(ok)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--install", action="store_true",
+                        help="also exercise the copy and zip installs")
+    parser.add_argument("--verbose", action="store_true",
+                        help="list every path that was resolved")
+    args = parser.parse_args()
+
+    rep = Report(verbose=args.verbose)
+
+    if not SKILLS_DIR.is_dir():
+        print(f"no skills directory at {SKILLS_DIR}", file=sys.stderr)
+        return 1
+    skills = sorted(d for d in SKILLS_DIR.iterdir() if d.is_dir())
+
+    rep.section("skills found")
+    rep.check("at least one skill", bool(skills), ", ".join(d.name for d in skills))
+
+    rep.section("structure")
+    for skill in skills:
+        check_structure(rep, skill)
+
+    rep.section("self-contained")
+    for skill in skills:
+        check_self_contained(rep, skill)
+
+    rep.section("wiring")
+    check_wiring(rep, skills)
+
+    if args.install:
+        rep.section("install")
+        for skill in skills:
+            check_install(rep, skill)
+
+    print(f"\n{rep.passed} passed, {rep.failed} failed\n")
+    return 1 if rep.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/build-site.js
+++ b/site/build-site.js
@@ -835,6 +835,8 @@ const ENTRY_POINTS = [
    `Read a snippet, name its time and space.${quizQuestions ? ` ${quizQuestions} questions,` : ''} each with the trap it sets.`],
   ['algo_demo/index.html', 'Visualizers',
    `Step through Dijkstra, KMP, knapsack and ${visualizerCount - 3} more, one frame at a time.`],
+  ['skills.html', 'Interview coach',
+   'An agent skill that scores your solution the way an interviewer does — the failing input, the line that sets the complexity, one drill.'],
   ['problems.html', 'Problem index',
    'The full README table — every problem, its solutions, its tags and its status.']
 ];

--- a/site/e2e-check.js
+++ b/site/e2e-check.js
@@ -49,7 +49,7 @@ const rel = p => path.relative(SITE, p);
 console.log('\n== required artefacts ==');
 const REQUIRED = [
   'index.html', 'problems.html', 'resources.html', 'cheatsheets.html', 'faqs.html',
-  'patterns.html', 'search.html', 'lc-roadmap.html', '404.html',
+  'patterns.html', 'search.html', 'lc-roadmap.html', 'skills.html', '404.html',
   'style.css', 'nav.css', 'nav.js', 'lc-page.css', 'site.js', 'roadmap.js', 'complexity.js',
   'vendor/d3.min.js', 'vendor/highlight/atom-one-dark.min.css',
   'data/roadmap.json', 'data/complexity-quiz.json', 'data/lc-problems.json',
@@ -316,7 +316,7 @@ ok('nav.css honours prefers-reduced-motion',
 // One shared palette for the hand-written tool pages, rather than five copies
 // that had already drifted apart.
 console.log('\n== tool pages ==');
-const TOOL_PAGES = ['lc-explorer', 'lc-similar', 'lc-review-plan', 'lc-random-picker', 'lc-complexity-quiz'];
+const TOOL_PAGES = ['lc-explorer', 'lc-similar', 'lc-review-plan', 'lc-random-picker', 'lc-complexity-quiz', 'skills'];
 for (const name of TOOL_PAGES) {
   const html = sources.get(path.join(SITE, `${name}.html`));
   ok(`${name} uses the shared palette`,

--- a/site/nav.js
+++ b/site/nav.js
@@ -64,6 +64,7 @@
     { id: 'lc-review-plan',     label: 'review',     href: 'lc-review-plan.html' },
     { id: 'lc-random-picker',   label: 'random',     href: 'lc-random-picker.html' },
     { id: 'lc-complexity-quiz', label: 'complexity', href: 'lc-complexity-quiz.html' },
+    { id: 'skills',             label: 'coach',      href: 'skills.html' },
     { id: 'resources',          label: 'resources',  href: 'resources.html' },
     { id: 'github',             label: 'github',     href: 'https://github.com/yennanliu/CS_basics', external: true }
   ];

--- a/site/pages/skills.html
+++ b/site/pages/skills.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#000000">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <title>LC Interview Coach — CS_basics</title>
+  <meta name="description" content="An agent skill that reviews your LeetCode solution the way a FAANG interviewer scores it: a hire verdict, the failing input, the line that sets the complexity, and one drill. Installs on Claude Code, Codex, Gemini and anything else that takes a system prompt.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎓</text></svg>">
+  <link rel="stylesheet" href="nav.css">
+  <link rel="stylesheet" href="lc-page.css">
+  <!-- Blocking on purpose: nav.js restores the stored theme before first paint. -->
+  <script src="nav.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    /* Palette and footer: lc-page.css. Page-specific tokens only below. */
+    body {
+      margin: 0; padding: 0;
+      font-family: 'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,'Menlo',monospace;
+      background: var(--bg); color: var(--text);
+      transition: background 0.2s, color 0.2s; font-size: 13px;
+      line-height: 1.65;
+    }
+    a { color: var(--text); }
+
+    .container { max-width: 900px; margin: 0 auto; padding: 0 1.5rem; }
+
+    /* ── Hero ── */
+    .hero { padding: 3.5rem 0 2.5rem; border-bottom: 1px solid var(--border); }
+    .kicker {
+      font-size: 0.7rem; letter-spacing: 0.14em; text-transform: uppercase;
+      color: var(--text-light); margin: 0 0 0.9rem;
+    }
+    .hero h1 { margin: 0 0 0.75rem; font-size: 2.1rem; line-height: 1.15; letter-spacing: -0.02em; }
+    .hero .lede { color: var(--text-light); font-size: 0.95rem; max-width: 62ch; margin: 0 0 1.6rem; }
+    .hero-actions { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .btn {
+      display: inline-block; padding: 0.55rem 1.1rem; font-size: 0.85rem;
+      text-decoration: none; border: 1px solid var(--border);
+      color: var(--text); background: var(--surface); font-family: inherit;
+    }
+    .btn:hover { border-color: var(--text); }
+    .btn.primary { background: var(--text); color: var(--bg); border-color: var(--text); }
+
+    /* ── Sections ── */
+    section { padding: 2.75rem 0; border-bottom: 1px solid var(--border); }
+    section:last-of-type { border-bottom: none; }
+    h2 { font-size: 1.15rem; margin: 0 0 0.4rem; letter-spacing: -0.01em; }
+    .sub { color: var(--text-light); margin: 0 0 1.6rem; max-width: 70ch; }
+    h3 { font-size: 0.9rem; margin: 1.8rem 0 0.5rem; }
+
+    /* ── Tables ── */
+    .table-wrap { overflow-x: auto; border: 1px solid var(--border); }
+    table { border-collapse: collapse; width: 100%; min-width: 520px; font-size: 0.82rem; }
+    th, td { text-align: left; padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    th {
+      font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em;
+      color: var(--text-light); background: var(--surface); font-weight: 600;
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    td strong { font-weight: 700; }
+    td code, p code, li code {
+      background: var(--surface); border: 1px solid var(--border);
+      padding: 0.05rem 0.3rem; font-size: 0.92em; font-family: inherit;
+    }
+
+    /* ── Ladder ── */
+    ol.ladder { margin: 0; padding-left: 1.4rem; }
+    ol.ladder li { margin-bottom: 0.5rem; }
+    ol.ladder li::marker { color: var(--text-light); }
+
+    /* ── Code blocks ── */
+    .code {
+      position: relative; background: var(--surface); border: 1px solid var(--border);
+      margin: 0.75rem 0;
+    }
+    .code pre {
+      margin: 0; padding: 0.9rem 1rem; overflow-x: auto;
+      font-size: 0.78rem; line-height: 1.6; font-family: inherit;
+    }
+    .code code { font-family: inherit; }
+    .copy {
+      position: absolute; top: 0.4rem; right: 0.4rem;
+      background: var(--bg); color: var(--text-light); border: 1px solid var(--border);
+      font-family: inherit; font-size: 0.68rem; padding: 0.2rem 0.5rem; cursor: pointer;
+    }
+    .copy:hover { color: var(--text); border-color: var(--text); }
+
+    /* ── Install tabs ── */
+    .tabs { display: flex; gap: 0; flex-wrap: wrap; border-bottom: 1px solid var(--border); margin-bottom: 1.1rem; }
+    .tab {
+      background: none; border: none; border-bottom: 2px solid transparent;
+      color: var(--text-light); font-family: inherit; font-size: 0.82rem;
+      padding: 0.55rem 0.9rem; cursor: pointer; margin-bottom: -1px;
+    }
+    .tab:hover { color: var(--text); }
+    .tab[aria-selected="true"] { color: var(--text); border-bottom-color: var(--text); }
+    .panel p:first-child { margin-top: 0; }
+
+    /* ── File list ── */
+    ul.files { list-style: none; margin: 0; padding: 0; }
+    ul.files li { border-bottom: 1px solid var(--border); padding: 0.7rem 0; }
+    ul.files li:last-child { border-bottom: none; }
+    ul.files a { font-weight: 700; text-decoration: none; border-bottom: 1px solid var(--border); }
+    ul.files a:hover { border-bottom-color: var(--text); }
+    ul.files span { display: block; color: var(--text-light); font-size: 0.82rem; }
+
+    .note { color: var(--text-light); font-size: 0.82rem; }
+
+    @media (max-width: 600px) {
+      .hero { padding-top: 2.25rem; }
+      .hero h1 { font-size: 1.6rem; }
+    }
+  </style>
+</head>
+<body>
+
+<div id="site-nav" data-page="skills" data-base=""></div>
+<script>CSNav.mount();</script>
+
+<main id="main">
+
+  <div class="container">
+    <div class="hero">
+      <p class="kicker">Agent skill</p>
+      <h1>LC Interview Coach</h1>
+      <p class="lede">
+        A FAANG interviewer that also coaches. Show it a solution and it gives back a hire
+        verdict, the input that breaks the code, the single line that sets the complexity, a
+        score on the four signals a real round grades — and exactly one drill. It teaches the
+        pattern by derivation rather than handing over a template, dry-runs code as a state
+        table, and rehearses what to say out loud in the room.
+      </p>
+      <div class="hero-actions">
+        <a class="btn primary" href="#install">Install it</a>
+        <a class="btn" href="#quickstart">Quick start</a>
+        <a class="btn" href="https://github.com/yennanliu/CS_basics/blob/master/.claude/skills/lc-interview-coach/SKILL.md">Read the source</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
+
+    <!-- ── What it does ─────────────────────────────────────────────────── -->
+    <section id="what">
+      <h2>What it grades</h2>
+      <p class="sub">
+        Every FAANG coding round scores the same four signals. The coach uses them verbatim,
+        with evidence rather than adjectives, so you learn to self-score before the real one.
+        One signal at <em>No Hire</em> caps the whole round at <em>Lean Hire</em> — it says so
+        when that happens.
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Signal</th><th>Scored on</th><th>Fails when</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Communication</strong></td>
+              <td>Clarifying questions, stating the approach before coding, narrating while coding</td>
+              <td>Silent coding; typing starts at second 30</td>
+            </tr>
+            <tr>
+              <td><strong>Problem solving</strong></td>
+              <td>Brute force → bottleneck → optimal, and why that structure fits</td>
+              <td>Pattern-matches to a memorised template that does not fit</td>
+            </tr>
+            <tr>
+              <td><strong>Coding</strong></td>
+              <td>Compiles in the head, named variables, right at the boundaries</td>
+              <td>Off-by-one, mutation during iteration, unhandled empty input</td>
+            </tr>
+            <tr>
+              <td><strong>Verification</strong></td>
+              <td>Self-driven dry run, edge cases named before being asked, complexity stated</td>
+              <td>“It works”, with no trace; complexity guessed</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Six modes, one loop</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Ask</th><th>Mode</th><th>You get</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>“review this”, “would this pass?”</td><td><strong>Review</strong></td><td>Verdict, correctness, complexity, bottleneck, four signals, one drill</td></tr>
+            <tr><td>“why is this slow?”</td><td><strong>Bottleneck</strong></td><td>The dominant cost, and the structure that removes the repeated work</td></tr>
+            <tr><td>“walk me through it”</td><td><strong>Dry run</strong></td><td>A state table, one row per iteration, stopping at the row that breaks the invariant</td></tr>
+            <tr><td>“teach me monotonic stacks”</td><td><strong>Teach</strong></td><td>Brute force → what repeats → what structure kills it → invariant → template</td></tr>
+            <tr><td>“mock interview me on LC 239”</td><td><strong>Mock</strong></td><td>35 minutes in character: it asks, it does not tell, then it debriefs</td></tr>
+            <tr><td>“clean this up”</td><td><strong>Polish</strong></td><td>An interview-grade rewrite, plus what changed and why</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Why it does not just hand you the answer</h3>
+      <p class="sub">
+        A solution you did not derive shows up in the real loop as a “No Hire — memorised”. So
+        hints climb a ladder, one rung at a time, and stop the moment you move:
+      </p>
+      <ol class="ladder">
+        <li><strong>L1</strong> — a question about your own code: “what does <code>lo</code> hold when the loop exits?”</li>
+        <li><strong>L2</strong> — a failing input, no diagnosis: “try <code>[3,3], target = 6</code>.”</li>
+        <li><strong>L3</strong> — the category of the fix: “you recompute a max you have already seen.”</li>
+        <li><strong>L4</strong> — the invariant, or the template’s name.</li>
+        <li><strong>L5</strong> — code, and only after L4 was tried or you asked outright.</li>
+      </ol>
+    </section>
+
+    <!-- ── Install ──────────────────────────────────────────────────────── -->
+    <section id="install">
+      <h2>Install</h2>
+      <p class="sub">
+        Four plain markdown files, no dependencies, no network calls — so the same source runs
+        on any agent that takes a system prompt. Pick yours.
+      </p>
+
+      <div class="tabs" role="tablist" aria-label="Install target">
+        <button class="tab" role="tab" id="tab-cc"     aria-controls="p-cc"     aria-selected="true">Claude Code</button>
+        <button class="tab" role="tab" id="tab-claude" aria-controls="p-claude" aria-selected="false">Claude app</button>
+        <button class="tab" role="tab" id="tab-codex"  aria-controls="p-codex"  aria-selected="false">Codex</button>
+        <button class="tab" role="tab" id="tab-gemini" aria-controls="p-gemini" aria-selected="false">Gemini</button>
+        <button class="tab" role="tab" id="tab-other"  aria-controls="p-other"  aria-selected="false">Anything else</button>
+      </div>
+
+      <div class="panel" role="tabpanel" id="p-cc" aria-labelledby="tab-cc">
+        <p>Drop the skill directory into your user-level skills folder and it loads in every repo:</p>
+        <div class="code">
+          <button class="copy" type="button">copy</button>
+          <pre><code>git clone --depth 1 https://github.com/yennanliu/CS_basics.git /tmp/cs_basics
+mkdir -p ~/.claude/skills
+cp -r /tmp/cs_basics/.claude/skills/lc-interview-coach ~/.claude/skills/</code></pre>
+        </div>
+        <p class="note">
+          Already installed inside this repo at <code>.claude/skills/lc-interview-coach/</code>,
+          so a clone of CS_basics needs no setup at all. Claude Code matches it on the
+          description, or you can call it by name.
+        </p>
+      </div>
+
+      <div class="panel" role="tabpanel" id="p-claude" aria-labelledby="tab-claude" hidden>
+        <p>Zip the directory, then upload it under <em>Settings → Capabilities → Skills</em>:</p>
+        <div class="code">
+          <button class="copy" type="button">copy</button>
+          <pre><code>cd .claude/skills && zip -r lc-interview-coach.zip lc-interview-coach</code></pre>
+        </div>
+        <p class="note">
+          Leave the YAML frontmatter in <code>SKILL.md</code> intact — the <code>name</code> and
+          <code>description</code> fields are what the model matches your request against.
+        </p>
+      </div>
+
+      <div class="panel" role="tabpanel" id="p-codex" aria-labelledby="tab-codex" hidden>
+        <p>Codex reads <code>AGENTS.md</code> at the repo root automatically. Point it at the skill:</p>
+        <div class="code">
+          <button class="copy" type="button">copy</button>
+          <pre><code>## Interview coaching
+
+When asked to review a solution, run a mock interview, teach a pattern, or
+analyse a bottleneck, follow `.claude/skills/lc-interview-coach/SKILL.md`
+and the files under its `references/`.</code></pre>
+        </div>
+        <p class="note">A pointer, not a copy — one source of truth means a fix reaches every agent at once.</p>
+      </div>
+
+      <div class="panel" role="tabpanel" id="p-gemini" aria-labelledby="tab-gemini" hidden>
+        <p>Same shape in <code>GEMINI.md</code>, or point at it for a single session:</p>
+        <div class="code">
+          <button class="copy" type="button">copy</button>
+          <pre><code>gemini -p "Act as the coach defined in \
+.claude/skills/lc-interview-coach/SKILL.md. Review @solution.py"</code></pre>
+        </div>
+      </div>
+
+      <div class="panel" role="tabpanel" id="p-other" aria-labelledby="tab-other" hidden>
+        <p>
+          Paste <code>SKILL.md</code> in as the system prompt. It is self-contained; the
+          <code>references/</code> files are optional depth, and the coach works without them
+          with shallower pattern recall. For Cursor or Windsurf, put the Codex pointer above
+          into a rule file (<code>.cursor/rules/interview-coach.mdc</code> or the editor’s
+          equivalent).
+        </p>
+        <div class="code">
+          <button class="copy" type="button">copy</button>
+          <pre><code>curl -sL https://raw.githubusercontent.com/yennanliu/CS_basics/master/.claude/skills/lc-interview-coach/SKILL.md</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Quick start ──────────────────────────────────────────────────── -->
+    <section id="quickstart">
+      <h2>Quick start</h2>
+      <p class="sub">Show it code, or ask it to interview you. Both work from a cold start.</p>
+      <div class="code">
+        <button class="copy" type="button">copy</button>
+        <pre><code>/lc-interview-coach review leetcode_python/Sliding_Window/sliding_window_maximum.py
+
+/lc-interview-coach mock interview me on LC 239, 35 minutes
+
+/lc-interview-coach why is my solution O(n*k)? here is the code: ...
+
+/lc-interview-coach teach me monotonic deques — I keep memorising the template
+
+/lc-interview-coach dry run this on the smallest input that pops the deque</code></pre>
+      </div>
+
+      <h3>What a review looks like</h3>
+      <p class="sub">
+        Fixed shape, every time: verdict first, then evidence, then one thing to do next. Any
+        section with nothing to say is dropped rather than padded.
+      </p>
+      <div class="code">
+        <button class="copy" type="button">copy</button>
+        <pre><code>VERDICT — Lean Hire. O(n*k) vs O(n) optimal. Correct, but the window
+          max is recomputed from scratch every step.
+
+CORRECTNESS
+  ❌ k > len(nums) — fails on [1], k=2 → IndexError, want []
+
+COMPLEXITY
+  time    O(n*k)  because max(nums[i:i+k]) rescans the whole window
+  space   O(1)    besides the output
+  optimal O(n)    via a monotonic deque of indices
+
+BOTTLENECK
+  line 6 — consecutive windows overlap in k-1 elements, so almost the
+  same range is rescanned every step → a deque holding indices in the
+  window with decreasing values keeps the max at the front.
+
+SIGNALS
+  Communication   Hire      — approach stated before coding
+  Problem solving Lean Hire — brute force reached, bottleneck not named
+  Coding          Hire      — clean, one boundary bug
+  Verification    No Hire   — no trace, complexity given as "about O(n)"
+
+DRILL
+  Redo it with a deque, and before coding write the one-sentence
+  invariant that makes the front the maximum.</code></pre>
+      </div>
+    </section>
+
+    <!-- ── What's inside ────────────────────────────────────────────────── -->
+    <section id="inside">
+      <h2>What is inside</h2>
+      <p class="sub">
+        <code>SKILL.md</code> is the whole coach. The three reference files are loaded on
+        demand, so the prompt stays small until depth is actually needed.
+      </p>
+      <ul class="files">
+        <li>
+          <a href="https://github.com/yennanliu/CS_basics/blob/master/.claude/skills/lc-interview-coach/SKILL.md">SKILL.md</a>
+          <span>The coach — six modes over one review loop, the hint ladder, the output contract, and what it must never do.</span>
+        </li>
+        <li>
+          <a href="https://github.com/yennanliu/CS_basics/blob/master/.claude/skills/lc-interview-coach/references/rubric.md">references/rubric.md</a>
+          <span>The four signals with level-by-level anchors, how they combine into a round, and a 90-second self-score card to fill in after every practice problem.</span>
+        </li>
+        <li>
+          <a href="https://github.com/yennanliu/CS_basics/blob/master/.claude/skills/lc-interview-coach/references/patterns.md">references/patterns.md</a>
+          <span>Every core pattern as recognition cue, invariant, target complexity and the classic off-by-one — plus the three questions that resolve most mediums when the pattern will not come.</span>
+        </li>
+        <li>
+          <a href="https://github.com/yennanliu/CS_basics/blob/master/.claude/skills/lc-interview-coach/references/talk-track.md">references/talk-track.md</a>
+          <span>The sentences to actually say, phase by phase, and the phrases that cost you the signal.</span>
+        </li>
+        <li>
+          <a href="https://github.com/yennanliu/CS_basics/blob/master/.claude/skills/lc-interview-coach/INSTALL.md">INSTALL.md</a>
+          <span>The install notes above, kept next to the skill so they travel with it.</span>
+        </li>
+      </ul>
+    </section>
+
+    <!-- ── Where it fits ────────────────────────────────────────────────── -->
+    <section id="fits">
+      <h2>Where it fits</h2>
+      <p class="sub">
+        The coach is the interviewer side of the loop. The rest of this site is the study side:
+        the <a href="lc-roadmap.html">roadmap</a> says what to learn next and what it needs
+        first, the <a href="cheatsheets.html">cheatsheets</a> hold the templates, the
+        <a href="lc-complexity-quiz.html">complexity quiz</a> drills the analysis, and the
+        <a href="lc-review-plan.html">review plan</a> schedules what keeps coming back. This
+        page is for the part none of those cover — whether the thing you just wrote would
+        actually pass.
+      </p>
+    </section>
+
+  </div>
+</main>
+
+<footer>
+  <div class="container">
+    <p>CS_basics — computer science fundamentals &amp; interview preparation</p>
+    <p>
+      <a href="https://github.com/yennanliu/CS_basics">github</a> |
+      <a href="https://github.com/yennanliu/CS_basics/tree/master/doc">docs</a> |
+      <a href="https://github.com/yennanliu/CS_basics/issues">issues</a>
+    </p>
+  </div>
+</footer>
+
+<script>
+(function () {
+  'use strict';
+
+  // ── Install tabs ──────────────────────────────────────────────────────
+  // Panels are toggled with the `hidden` attribute rather than a class, so a
+  // hidden panel is out of the accessibility tree and out of find-in-page too.
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+
+  function select(tab) {
+    tabs.forEach(function (t) {
+      var on = t === tab;
+      t.setAttribute('aria-selected', on ? 'true' : 'false');
+      document.getElementById(t.getAttribute('aria-controls')).hidden = !on;
+    });
+  }
+
+  tabs.forEach(function (tab, i) {
+    tab.addEventListener('click', function () { select(tab); });
+    // Arrow keys move between tabs, which is what a tablist is expected to do
+    // once it announces itself as one.
+    tab.addEventListener('keydown', function (e) {
+      var step = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+      if (!step) return;
+      e.preventDefault();
+      var next = tabs[(i + step + tabs.length) % tabs.length];
+      select(next);
+      next.focus();
+    });
+  });
+
+  // ── Copy buttons ──────────────────────────────────────────────────────
+  // clipboard.writeText needs a secure context; on plain http it rejects, so
+  // the button says so instead of silently doing nothing.
+  document.querySelectorAll('.copy').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var code = btn.parentElement.querySelector('code').innerText;
+      var done = function (label) {
+        btn.textContent = label;
+        setTimeout(function () { btn.textContent = 'copy'; }, 1400);
+      };
+      if (!navigator.clipboard) return done('select it');
+      navigator.clipboard.writeText(code).then(function () { done('copied'); },
+                                               function () { done('select it'); });
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/site/pages/skills.html
+++ b/site/pages/skills.html
@@ -245,14 +245,16 @@ cp -r /tmp/cs_basics/.claude/skills/lc-interview-coach ~/.claude/skills/</code><
       </div>
 
       <div class="panel" role="tabpanel" id="p-claude" aria-labelledby="tab-claude" hidden>
-        <p>Zip the directory, then upload it under <em>Settings → Capabilities → Skills</em>:</p>
+        <p>Zip the directory, then <em>Customize → Skills → + → + Create skill → Upload a skill</em>:</p>
         <div class="code">
           <button class="copy" type="button">copy</button>
           <pre><code>cd .claude/skills && zip -r lc-interview-coach.zip lc-interview-coach</code></pre>
         </div>
         <p class="note">
-          Leave the YAML frontmatter in <code>SKILL.md</code> intact — the <code>name</code> and
-          <code>description</code> fields are what the model matches your request against.
+          Leave the YAML frontmatter in <code>SKILL.md</code> intact.
+          <code>description</code> is what Claude matches your request against when deciding to
+          load the skill on its own; <code>name</code> is the display label, and the directory
+          name is what supplies the slash command.
         </p>
       </div>
 


### PR DESCRIPTION
An interviewer-side counterpart to `script/eval_lc_readiness.py`: the script says which problems are weak, this says why a solution would not pass the room.

`SKILL.md` is the whole coach — six modes over one review loop that reports a hire verdict first, then the traced failing input, then the single line that sets the complexity, then a score on the four signals a FAANG round actually grades (communication, problem solving, coding, verification), then exactly one drill. Two rules keep it a coach rather than a solver: a five-rung hint ladder where code is the last rung, and a teaching ladder that derives the structure from the repeated work instead of naming a template.

`references/` carries the depth the loop pulls in on demand — level anchors and a 90-second self-score card, per-pattern invariant / target / classic off-by-one, and the sentences to say in each interview phase.

Plain markdown, no dependencies, so the same source runs on Codex, Gemini and other agents; INSTALL.md covers each, pointing at this file rather than copying it so one fix reaches them all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AI coding-interview coach that evaluates solutions across communication, problem-solving, coding, and verification.
  - Provides graduated hints, pattern-based guidance, complexity feedback, dry-run tracing, and timed mock-interview support.
  - Includes practical coaching scripts for clarifying problems, explaining approaches, coding, verifying solutions, and handling follow-up questions.
  - Added a dedicated Interview Coach page with quick-start examples, sample feedback, installation tabs, and copy-to-clipboard support.
  - Added links to the coach from the landing page and site navigation.

- **Documentation**
  - Added setup guidance for supported AI assistants and IDE agents.
  - Added reference materials covering scoring, interview patterns, and communication techniques.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->