### PR TITLE
Enhance the algorithm visualizers: readable step trace, crisp canvases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,40 @@ visualizers, roadmap topics, quiz questions, OK vs AGAIN — is read from the so
 files at build time. **Do not hardcode one**; a typed number is one that goes stale
 the first week nobody re-checks it.
 
+### The algorithm visualizers
+
+`algo_demo/` is 36 hand-written visualizer pages plus `common.js` and `style.css`.
+`build.sh` copies the directory wholesale — there is no generator — so anything
+that should look or behave the same on all 36 belongs in those two shared files,
+never copy-pasted into a page's inline `<script>`. `site/test/algo-demo.test.js`
+evaluates the shipped `common.js` in jsdom and asserts against it.
+
+Three things every page gets for free, and must not reimplement:
+
+- **The palette.** Canvases read colours from `VIZ` (the `--viz-*` tokens), never
+  a literal, so both themes and any repaint stay in one place.
+- **Canvas quality.** `getContext('2d')` is wrapped once: the backing store is
+  scaled to `devicePixelRatio` behind `width`/`height` accessors (a page still
+  writes and reads CSS pixels), and the `font` setter rewrites the generic
+  families to the site's face. Both fixes therefore reach pages that were written
+  before either existed.
+- **The step trace.** `createLogger(id)` still takes `clear()` and
+  `log(html, cls)`, but it reads the three shapes the pages already write and
+  renders them as structure — a numbered step, an indented line as *the reason*
+  tucked under the step above it, and `--- x ---` as a phase heading. A message
+  that is **entirely** one `<span class="highlight">` is the run's outcome; the
+  same span used mid-sentence is just emphasis, because pages use it both ways.
+
+The trace lives in its own full-width `.viz-trace` panel below the canvas. It was
+in the 300px control column, where `L=4 R=24 sum=28` wrapped three times and four
+steps filled the box — put it back there and the trace stops being readable.
+
+A page whose `draw()` takes arguments must wrap it: `draw = VIZ.repaintable(draw)`
+and `window.addEventListener('resize', draw.repaint)`. Handing `draw` straight to
+`addEventListener` passes it the resize Event as its first drawing argument, and
+calling it with reset arguments throws the highlight away — and a theme switch
+fires a resize, so either way the picture reverted mid-run.
+
 ## Build and Test Commands
 
 ### Java (leetcode_java/)

--- a/algo_demo/bellman-ford.html
+++ b/algo_demo/bellman-ford.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">New Graph</button>
         </div>
         <div class="complexity">Time: O(V&middot;E) | Space: O(V)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -89,8 +101,13 @@
       var ax=b.x*sx-22*Math.cos(angle),ay=b.y*sy-22*Math.sin(angle);
       ctx.beginPath();ctx.moveTo(ax,ay);ctx.lineTo(ax-8*Math.cos(angle-0.4),ay-8*Math.sin(angle-0.4));ctx.lineTo(ax-8*Math.cos(angle+0.4),ay-8*Math.sin(angle+0.4));ctx.closePath();ctx.fillStyle=ctx.strokeStyle;ctx.fill();
       // Weight
+      // Offset the weight to the left of the edge's own direction. A fixed
+      // offset put u->v and v->u on the same pixel, so the two weights
+      // overprinted into an unreadable smudge.
       var mx=(a.x+b.x)/2*sx,my=(a.y+b.y)/2*sy;
-      ctx.fillStyle=e[2]<0?VIZ.danger:VIZ.muted;ctx.font='bold 11px sans-serif';ctx.textAlign='center';ctx.fillText(e[2],mx+10,my-6);
+      ctx.fillStyle=e[2]<0?VIZ.danger:VIZ.muted;ctx.font='bold 11px sans-serif';
+      ctx.textAlign='center';ctx.textBaseline='middle';
+      ctx.fillText(e[2],mx+Math.sin(angle)*13,my-Math.cos(angle)*13);
     });
     nodes.forEach(function(n,i){
       ctx.beginPath();ctx.arc(n.x*sx,n.y*sy,18,0,Math.PI*2);

--- a/algo_demo/bfs.html
+++ b/algo_demo/bfs.html
@@ -48,10 +48,22 @@
         </div>
         <p style="font-size:.75rem;color:var(--text-secondary)">Click cells to toggle walls. Click start/end to reposition.</p>
         <div class="complexity">Time: O(V+E) | Space: O(V)</div>
-        <h3>Queue</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Queue</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run BFS</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/bidirectional-bfs.html
+++ b/algo_demo/bidirectional-bfs.html
@@ -48,10 +48,22 @@
         </div>
         <p style="font-size:.75rem;color:var(--text-secondary)">Click cells to toggle walls.</p>
         <div class="complexity">Time: O(b^(d/2)) vs O(b^d) for normal BFS</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function(){

--- a/algo_demo/binary-search.html
+++ b/algo_demo/binary-search.html
@@ -46,10 +46,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(log n) | Space: O(1)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -57,6 +69,9 @@
   var ctx = canvas.getContext('2d');
   var arr = [], running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
 
   function resize() {
     var rect = canvas.parentElement.getBoundingClientRect();
@@ -168,7 +183,7 @@
   });
 
   genArray(); draw(0, arr.length - 1);
-  window.addEventListener('resize', function(){ draw(0, arr.length-1); });
+  window.addEventListener('resize', draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/binary-tree-traversal.html
+++ b/algo_demo/binary-tree-traversal.html
@@ -47,10 +47,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(h) DFS / O(n) BFS</div>
-        <h3>Visit order</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Visit order</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function(){

--- a/algo_demo/bubble-sort.html
+++ b/algo_demo/bubble-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n&sup2;) | Space: O(1)</div>
-        <h3>Stats</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Stats</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -53,6 +65,9 @@
   var ctx = canvas.getContext('2d');
   var arr = [], running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
   var comparisons = 0, swaps = 0;
 
   function resize() {
@@ -132,7 +147,7 @@
   });
 
   genArray(); draw();
-  window.addEventListener('resize', function(){ draw(); });
+  window.addEventListener('resize', draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/bucket-sort.html
+++ b/algo_demo/bucket-sort.html
@@ -43,10 +43,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Avg: O(n+k) | Worst: O(n&sup2;) | Space: O(n+k)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/common.js
+++ b/algo_demo/common.js
@@ -1,8 +1,16 @@
 // Shared helpers for the Algorithm Visualizer pages.
 //
 // The navbar and the theme switch live in the shared site/nav.js, which every
-// page loads before this file. All this module has to do is repaint the
-// canvases when nav.js announces a theme change.
+// page loads before this file. Beyond repainting on a theme change, this file
+// owns three things every visualization gets for free, without a line of
+// per-page code:
+//
+//   1. the --viz-* palette (VIZ)                — see "Visualization palette"
+//   2. crisp canvas rendering + canvas type     — see "Canvas quality"
+//   3. the structured step trace (createLogger) — see "Step trace"
+//
+// Rule of thumb: anything that should look the same on all 36 pages belongs
+// here or in style.css, never copy-pasted into a page's inline <script>.
 
 // ── Visualization palette ────────────────────────────────────────────────
 // Canvases must never hardcode a colour: read it from VIZ so both themes and
@@ -79,6 +87,245 @@ function parseColor(c) {
   return m ? [+m[1], +m[2], +m[3]] : null;
 }
 
+// ── Canvas quality ───────────────────────────────────────────────────────
+// Every page sizes its canvas the same way — `canvas.width = <css pixels>` in a
+// resize()/draw() function — which on a Retina display paints a 1x bitmap into
+// a 2x box: every label and every 1px rule ships blurred. Every page also asks
+// for `11px sans-serif`, which renders in whatever Helvetica-alike the platform
+// picks rather than in the site's own face.
+//
+// Both are fixed here rather than in 36 inline scripts, by wrapping the one call
+// all of them make first: getContext('2d').
+//
+//   * HiDPI — `width`/`height` become accessors on that one element. A page
+//     still writes and reads CSS pixels; behind them the backing store is
+//     devicePixelRatio times bigger and the context is pre-scaled, so existing
+//     draw code and existing mouse-coordinate maths are unchanged.
+//   * Type — the `font` setter rewrites the generic families to the site's
+//     stack and lifts the smallest sizes one step. Digits become tabular, which
+//     is what a column of array values wants.
+//
+// A page that genuinely needs the raw backing store can read canvas.deviceScale.
+
+var VIZ_FONT_STACK = "'SF Mono','JetBrains Mono','IBM Plex Mono',ui-monospace," +
+                     "'Cascadia Mono','Fira Code','Menlo','Courier New',monospace";
+
+// Canvas font shorthand in the visualizer's face. `VIZ.font(12, 'bold')`.
+VIZ.font = function(px, weight) {
+  return (weight ? weight + ' ' : '') + px + 'px ' + VIZ_FONT_STACK;
+};
+
+// Bar/cell labels are drawn at 9-11px so they fit; on a sharp canvas one step up
+// is still comfortably inside the same box and much easier to read.
+function bumpFontSize(px) { return px <= 11 ? px + 1 : px; }
+
+function normalizeCanvasFont(value) {
+  var s = String(value);
+  // <style?> <weight?> <size>px <family...> — only the trailing generic family
+  // is replaced, so a page that names a real face keeps it.
+  return s.replace(/(\d+(?:\.\d+)?)px/, function(_, n) {
+    return bumpFontSize(parseFloat(n)) + 'px';
+  }).replace(/\b(sans-serif|serif|monospace|system-ui)\s*$/, VIZ_FONT_STACK);
+}
+
+function upgradeCanvas(canvas, ctx) {
+  if (canvas.__vizUpgraded) return;
+  canvas.__vizUpgraded = true;
+
+  // --- type ---
+  var fontDesc = Object.getOwnPropertyDescriptor(CanvasRenderingContext2D.prototype, 'font');
+  if (fontDesc && fontDesc.set) {
+    Object.defineProperty(ctx, 'font', {
+      configurable: true,
+      get: function() { return fontDesc.get.call(ctx); },
+      set: function(v) { fontDesc.set.call(ctx, normalizeCanvasFont(v)); }
+    });
+  }
+
+  // --- resolution ---
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  canvas.deviceScale = dpr;
+  if (dpr === 1) return;
+
+  var wDesc = Object.getOwnPropertyDescriptor(HTMLCanvasElement.prototype, 'width');
+  var hDesc = Object.getOwnPropertyDescriptor(HTMLCanvasElement.prototype, 'height');
+  if (!wDesc || !hDesc) return;
+
+  var cssW = wDesc.get.call(canvas), cssH = hDesc.get.call(canvas);
+
+  function apply() {
+    // Writing either attribute resets the bitmap *and* the transform, so the
+    // scale has to be re-applied every time — which is also why both are set
+    // together instead of one per accessor.
+    wDesc.set.call(canvas, Math.round(cssW * dpr));
+    hDesc.set.call(canvas, Math.round(cssH * dpr));
+    canvas.style.width = cssW + 'px';
+    canvas.style.height = cssH + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  Object.defineProperty(canvas, 'width', {
+    configurable: true,
+    get: function() { return cssW; },
+    set: function(v) { cssW = v; apply(); }
+  });
+  Object.defineProperty(canvas, 'height', {
+    configurable: true,
+    get: function() { return cssH; },
+    set: function(v) { cssH = v; apply(); }
+  });
+}
+
+(function patchGetContext() {
+  var native = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function(type) {
+    var ctx = native.apply(this, arguments);
+    if (ctx && (type === '2d' || type === undefined)) {
+      try { upgradeCanvas(this, ctx); } catch (e) { /* never block a drawing */ }
+    }
+    return ctx;
+  };
+})();
+
+// ── Canvas drawing kit ───────────────────────────────────────────────────
+// The array-shaped visualizations each drew their own bars, their own value
+// labels and their own pointer letters, which is why no two of them framed the
+// same idea the same way. These are the shared parts — used by two-pointers and
+// sliding-window, and where the rest are reworked they should use them too.
+//
+// Everything here draws in CSS pixels and takes colours from VIZ, so a page
+// using them inherits both the HiDPI scaling and the palette.
+
+// A bar with its value above it. `state` picks the treatment:
+//   'normal'  solid fill
+//   'muted'   the eliminated / out-of-window half — visibly out of play
+VIZ.bar = function(ctx, x, y, w, h, color, value, state) {
+  var muted = state === 'muted';
+  ctx.save();
+  if (muted) ctx.globalAlpha = 0.28;
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.roundRect(x, y, w, Math.max(h, 2), 3);
+  ctx.fill();
+  ctx.restore();
+
+  if (value === undefined || value === null) return;
+  ctx.fillStyle = muted ? VIZ.dim : VIZ.label;
+  ctx.font = VIZ.font(Math.max(9, Math.min(12, w - 2)), muted ? '' : 'bold');
+  ctx.textAlign = 'center';
+  ctx.fillText(value, x + w / 2, y - 6);
+};
+
+// The rule the bars stand on, plus the index under each one. An array
+// visualization without indices asks the reader to count columns.
+VIZ.axis = function(ctx, x0, x1, y, n, startX, barW, gap, marks) {
+  ctx.strokeStyle = VIZ.line;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(x0, y + 0.5);
+  ctx.lineTo(x1, y + 0.5);
+  ctx.stroke();
+
+  ctx.textAlign = 'center';
+  for (var i = 0; i < n; i++) {
+    var cx = startX + i * (barW + gap) + barW / 2;
+    var mark = marks && marks[i];
+    ctx.fillStyle = mark ? mark.color : VIZ.dim;
+    ctx.font = VIZ.font(11, mark ? 'bold' : '');
+    ctx.fillText(i, cx, y + 15);
+  }
+};
+
+// A pointer sitting under the axis: a caret at the column and its name beside
+// it. Two pointers on the same column are stacked rather than overprinted.
+VIZ.pointer = function(ctx, cx, y, label, color, slot) {
+  var dy = (slot || 0) * 15;
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(cx, y + dy);
+  ctx.lineTo(cx - 5, y + 7 + dy);
+  ctx.lineTo(cx + 5, y + 7 + dy);
+  ctx.closePath();
+  ctx.fill();
+  ctx.font = VIZ.font(12, 'bold');
+  ctx.textAlign = 'center';
+  ctx.fillText(label, cx, y + 19 + dy);
+};
+
+// A washed band behind a range of columns, with its own caption. This is what
+// carries "the answer is somewhere in here" — the idea every one of these
+// algorithms turns on.
+VIZ.region = function(ctx, x0, x1, yTop, yBot, color, label, align) {
+  ctx.save();
+  ctx.fillStyle = VIZ.alpha(color, 0.10);
+  ctx.fillRect(x0, yTop, x1 - x0, yBot - yTop);
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([4, 3]);
+  ctx.strokeRect(x0 + 0.5, yTop + 0.5, x1 - x0 - 1, yBot - yTop - 1);
+  ctx.restore();
+  if (!label) return;
+  ctx.fillStyle = color;
+  ctx.font = VIZ.font(11, 'bold');
+  // Two regions that start on the same column would print their captions on
+  // top of each other, so a caller can push one to the far end instead.
+  ctx.textAlign = align === 'right' ? 'right' : 'left';
+  ctx.fillText(label, align === 'right' ? x1 - 5 : x0 + 5, yTop - 5);
+};
+
+// The readout across the top: the two or three numbers the run is actually
+// about, each in its own box so a changing value has a fixed place to change in.
+VIZ.readout = function(ctx, x, y, items) {
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  var h = 26, pad = 8, cx = x;
+  for (var i = 0; i < items.length; i++) {
+    var it = items[i];
+    if (!it) continue;
+    ctx.font = VIZ.font(11);
+    var lw = ctx.measureText(it.label).width;
+    ctx.font = VIZ.font(13, 'bold');
+    var vw = ctx.measureText(String(it.value)).width;
+    var w = pad + lw + 6 + vw + pad;
+
+    ctx.fillStyle = it.color ? VIZ.alpha(it.color, 0.12) : VIZ.surface;
+    ctx.fillRect(cx, y, w, h);
+    ctx.strokeStyle = it.color || VIZ.line;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(cx + 0.5, y + 0.5, w - 1, h - 1);
+
+    ctx.fillStyle = VIZ.muted;
+    ctx.font = VIZ.font(11);
+    ctx.fillText(it.label, cx + pad, y + h / 2 + 1);
+    ctx.fillStyle = it.color || VIZ.label;
+    ctx.font = VIZ.font(13, 'bold');
+    ctx.fillText(it.value, cx + pad + lw + 6, y + h / 2 + 1);
+
+    cx += w + 8;
+  }
+  ctx.textBaseline = 'alphabetic';
+};
+
+// Wrap a page's draw(...) so the frame the run is on survives a repaint.
+//
+// Two spellings of the same bug were in the pages: passing `draw` straight to
+// addEventListener hands it the resize Event as its first drawing argument,
+// and the handlers that avoided that called draw() with reset arguments. Both
+// silently threw the highlight away — and a theme switch fires a resize, so
+// changing theme mid-run wiped the picture.
+//
+//   draw = VIZ.repaintable(draw);                       // after the function
+//   window.addEventListener('resize', draw.repaint);    // replays the last call
+VIZ.repaintable = function(draw) {
+  var last = [];
+  function wrapped() {
+    last = Array.prototype.slice.call(arguments);
+    return draw.apply(this, last);
+  }
+  wrapped.repaint = function() { return draw.apply(null, last); };
+  return wrapped;
+};
+
 // ── Repaint on theme change ──────────────────────────────────────────────
 // Canvases draw with the --viz-* tokens, which change with the theme. Every
 // visualization already redraws on resize, so re-reading the palette and
@@ -90,19 +337,203 @@ function initThemeRepaint() {
   });
 }
 
-// Logging helper
+// ── Step trace ───────────────────────────────────────────────────────────
+// createLogger's contract with the pages is two calls, `clear()` and
+// `log(html, className)`, and they are kept exactly as they were. What changed
+// is what comes out the other end: instead of one flat run of <div>s, the three
+// shapes the pages have always written are recognised and rendered as
+// structure, so the trace can be skimmed rather than read.
+//
+//   logger.log('L=4 R=24 sum=28')                   → a numbered step
+//   logger.log('&nbsp;&nbsp;sum > target → move R')  → the reason, tucked under
+//                                                      the step it explains
+//   logger.log('<span class="highlight">Found!</span>') → the outcome, called out
+//   logger.log('--- Iteration 2 ---')                → a phase heading
+//   logger.log('')                                   → ignored (rows are spaced)
+//
+// Recognising the leading &nbsp; is what does most of the work: a step and the
+// decision it led to stop being two equal-weight lines and become one row.
+//
+// The outcome test is deliberately the *whole* message being one highlight
+// span. Pages also use that span inline to pick out a value mid-sentence
+// ("Process node <span class=highlight>1</span> dist=7"), and treating those as
+// outcomes flags nine rows in ten — which marks nothing at all.
+
+var LOG_INDENT = /^(?:&nbsp;|&#160;| |\s)+/;
+var LOG_PHASE = /^-{2,}\s*(.+?)\s*-{2,}$/;
+// The outcome test is deliberately the *whole* message being one highlight
+// span. Pages also use that span inline to pick out a value mid-sentence
+// ("Process node <span class=highlight>1</span> dist=7"), and counting those as
+// outcomes flags nine rows in ten — which marks nothing at all.
+var LOG_OUTCOME = /^<span class="highlight">(?:(?!<\/span>)[\s\S])*<\/span>$/;
+
 function createLogger(containerId) {
   var el = document.getElementById(containerId);
+  var count = 0;
+  var lastStep = null;
+  var countEl = null, emptyEl = null;
+
+  function chrome() {
+    // The panel's counter and its empty-state live next to the log; both are
+    // optional so a page that has not been re-laid-out still works.
+    var panel = el.closest ? el.closest('.viz-trace') : null;
+    countEl = panel ? panel.querySelector('[data-trace-count]') : null;
+    emptyEl = panel ? panel.querySelector('[data-trace-empty]') : null;
+  }
+
+  function sync() {
+    if (!countEl) chrome();
+    if (countEl) countEl.textContent = count === 1 ? '1 step' : count + ' steps';
+    if (emptyEl) emptyEl.hidden = count > 0 || el.children.length > 0;
+  }
+
+  // Follow the tail only while the reader is already at the tail. Scrolling up
+  // to re-read step 3 while a sort runs should not yank you back down.
+  function atBottom() {
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }
+  function follow(wasAtBottom) {
+    if (wasAtBottom) el.scrollTop = el.scrollHeight;
+  }
+
+  // Decorate `name=value` and the arrows so the eye can lock onto the changing
+  // numbers. Only text nodes are touched, so a message that already carries
+  // markup (every `<span class="highlight">` the pages write) is left intact.
+  function decorate(node) {
+    var walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, null);
+    var texts = [];
+    while (walker.nextNode()) texts.push(walker.currentNode);
+    for (var i = 0; i < texts.length; i++) {
+      var t = texts[i];
+      if (!/[A-Za-z_\]]\s*=|→|←|⇒/.test(t.nodeValue)) continue;
+      var frag = document.createElement('span');
+      frag.innerHTML = t.nodeValue
+        .replace(/[&<>]/g, function(c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]; })
+        .replace(/([A-Za-z_][A-Za-z0-9_]*(?:\[[^\]]*\])*)\s*=\s*(-?[\w.]+)/g,
+                 '<b class="k">$1</b>=<b class="v">$2</b>')
+        .replace(/(→|←|⇒|&rarr;)/g, '<i class="arrow">$1</i>');
+      t.parentNode.replaceChild(frag, t);
+    }
+  }
+
+  function row(cls) {
+    var div = document.createElement('div');
+    div.className = 'step ' + cls;
+    return div;
+  }
+
   return {
-    clear: function() { el.innerHTML = ''; },
+    clear: function() {
+      el.innerHTML = '';
+      count = 0;
+      lastStep = null;
+      sync();
+    },
+
     log: function(msg, cls) {
-      var div = document.createElement('div');
-      div.className = 'step' + (cls ? ' ' + cls : '');
-      div.innerHTML = msg;
-      el.appendChild(div);
-      el.scrollTop = el.scrollHeight;
+      var html = msg == null ? '' : String(msg);
+      if (!html.replace(LOG_INDENT, '').trim()) return;   // spacer — rows are spaced already
+      var wasAtBottom = atBottom();
+
+      var phase = html.replace(LOG_INDENT, '').match(LOG_PHASE);
+      if (phase) {
+        var head = row('step-phase');
+        head.innerHTML = '<span>' + phase[1] + '</span>';
+        el.appendChild(head);
+        lastStep = null;
+        follow(wasAtBottom);
+        return;
+      }
+
+      // An indented line explains the step above it: attach it there rather
+      // than spending a step number on it.
+      if (LOG_INDENT.test(html) && lastStep) {
+        var note = document.createElement('div');
+        note.className = 'step-note';
+        var noteHtml = html.replace(LOG_INDENT, '').trim();
+        note.innerHTML = noteHtml;
+        decorate(note);
+        if (LOG_OUTCOME.test(noteHtml)) note.classList.add('is-key');
+        lastStep.querySelector('.step-body').appendChild(note);
+        follow(wasAtBottom);
+        return;
+      }
+
+      count++;
+      var step = row('step-item' + (cls ? ' ' + cls : ''));
+      var num = document.createElement('span');
+      num.className = 'step-n';
+      num.textContent = count;
+      var body = document.createElement('div');
+      body.className = 'step-body';
+      var main = document.createElement('div');
+      main.className = 'step-main';
+      var mainHtml = html.replace(LOG_INDENT, '').trim();
+      main.innerHTML = mainHtml;
+      decorate(main);
+      body.appendChild(main);
+      step.appendChild(num);
+      step.appendChild(body);
+
+      if (LOG_OUTCOME.test(mainHtml)) step.classList.add('is-key');
+
+      // The newest row carries the marker; the previous one gives it up.
+      var prev = el.querySelector('.is-latest');
+      if (prev) prev.classList.remove('is-latest');
+      step.classList.add('is-latest');
+
+      el.appendChild(step);
+      lastStep = step;
+      sync();
+      follow(wasAtBottom);
     }
   };
+}
+
+// Wire the trace panel's own buttons. Pure chrome — nothing here is required
+// for a page to run, so a panel without them (or a page without a panel) is
+// simply skipped.
+function initTracePanel() {
+  var panel = document.querySelector('.viz-trace');
+  if (!panel) return;
+  var log = panel.querySelector('.viz-log');
+  if (!log) return;
+
+  var copy = panel.querySelector('[data-trace-copy]');
+  if (copy) {
+    copy.addEventListener('click', function() {
+      var lines = [];
+      log.querySelectorAll('.step').forEach(function(s) {
+        var n = s.querySelector('.step-n');
+        var main = s.querySelector('.step-main');
+        if (s.classList.contains('step-phase')) { lines.push('\n== ' + s.textContent.trim() + ' =='); return; }
+        lines.push((n ? n.textContent.padStart(3, ' ') + '. ' : '     ') + (main ? main.textContent.trim() : ''));
+        s.querySelectorAll('.step-note').forEach(function(nt) {
+          lines.push('       ' + nt.textContent.trim());
+        });
+      });
+      navigator.clipboard.writeText(lines.join('\n')).then(function() {
+        var was = copy.textContent;
+        copy.textContent = 'Copied';
+        setTimeout(function() { copy.textContent = was; }, 1200);
+      }, function() { /* clipboard blocked — nothing useful to say */ });
+    });
+  }
+
+  // "Jump to latest" only earns its place once the reader has scrolled away
+  // from the tail, so it shows itself.
+  var jump = panel.querySelector('[data-trace-jump]');
+  if (jump) {
+    var update = function() {
+      jump.hidden = log.scrollHeight - log.scrollTop - log.clientHeight < 40;
+    };
+    log.addEventListener('scroll', update);
+    new MutationObserver(update).observe(log, { childList: true, subtree: true });
+    jump.addEventListener('click', function() {
+      log.scrollTo({ top: log.scrollHeight, behavior: 'smooth' });
+    });
+    update();
+  }
 }
 
 // Sleep for animation
@@ -127,4 +558,5 @@ function randomArray(n, max) {
 document.addEventListener('DOMContentLoaded', function() {
   refreshViz();
   initThemeRepaint();
+  initTracePanel();
 });

--- a/algo_demo/common.js
+++ b/algo_demo/common.js
@@ -441,6 +441,10 @@ function createLogger(containerId) {
         head.innerHTML = '<span>' + phase[1] + '</span>';
         el.appendChild(head);
         lastStep = null;
+        // A phase spends no step number, but it is still a row on screen:
+        // sync() is what takes the empty-state prompt down, and bellman-ford
+        // and floyd-warshall both open their run with one of these.
+        sync();
         follow(wasAtBottom);
         return;
       }
@@ -512,6 +516,9 @@ function initTracePanel() {
           lines.push('       ' + nt.textContent.trim());
         });
       });
+      // navigator.clipboard exists only in a secure context, so this is absent
+      // when the built site is previewed over http from another machine.
+      if (!navigator.clipboard) return;
       navigator.clipboard.writeText(lines.join('\n')).then(function() {
         var was = copy.textContent;
         copy.textContent = 'Copied';

--- a/algo_demo/dfs.html
+++ b/algo_demo/dfs.html
@@ -47,10 +47,22 @@
         </div>
         <p style="font-size:.75rem;color:var(--text-secondary)">Click cells to toggle walls.</p>
         <div class="complexity">Time: O(V+E) | Space: O(V)</div>
-        <h3>Stack</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Stack</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run DFS</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/difference-array.html
+++ b/algo_demo/difference-array.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Range update: O(1) | Build result: O(n)</div>
-        <h3>Operations</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Operations</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run Demo</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/dijkstra.html
+++ b/algo_demo/dijkstra.html
@@ -34,9 +34,8 @@
       </div>
       <div class="viz-controls">
         <h3>Controls</h3>
-        <label>Nodes</label>
+        <label>Nodes: <span id="nodes-val">8</span></label>
         <input type="range" id="nodes" min="6" max="15" value="8">
-        <span id="nodes-val">8</span>
         <label>Speed</label>
         <input type="range" id="speed" min="1" max="10" value="5">
         <div class="btn-row">
@@ -44,10 +43,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O((V+E) log V) | Space: O(V)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/dp-1d.html
+++ b/algo_demo/dp-1d.html
@@ -62,16 +62,31 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
   var canvas = document.getElementById('canvas'), ctx = canvas.getContext('2d');
   var running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
   var dp = [], houses = [], n = 10, problem = 'stairs';
 
   function getN() { return +document.getElementById('n-range').value; }
@@ -206,7 +221,7 @@
   document.getElementById('n-range').addEventListener('input', function() { document.getElementById('n-val').textContent = this.value; init(); });
   document.getElementById('problem-select').addEventListener('change', init);
   init();
-  window.addEventListener('resize', function() { draw(-1, -1, -1); });
+  window.addEventListener('resize', draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/dp-2d.html
+++ b/algo_demo/dp-2d.html
@@ -60,16 +60,31 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(m·n) | Space: O(m·n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
   var canvas = document.getElementById('canvas'), ctx = canvas.getContext('2d');
   var running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
   var dp = [], grid = [], strA = [], strB = [], m = 5, n = 5, problem = 'paths';
 
   var ALPHA = 'ABCDE FGHIJ'.split('').filter(function(c) { return c !== ' '; });
@@ -221,7 +236,7 @@
   });
   document.getElementById('problem-select').addEventListener('change', function() { stopped = true; running = false; init(); });
   init();
-  window.addEventListener('resize', function() { draw(-1, -1, [], null); });
+  window.addEventListener('resize', draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/dp-knapsack.html
+++ b/algo_demo/dp-knapsack.html
@@ -57,16 +57,31 @@
           <button class="btn btn-secondary" id="reset-btn">New Items</button>
         </div>
         <div class="complexity">Time: O(n·W) | Space: O(n·W)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
   var canvas = document.getElementById('canvas'), ctx = canvas.getContext('2d');
   var running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
   var items = [], W = 8, dp = [], n;
 
   function getW() { return +document.getElementById('cap-range').value; }
@@ -105,8 +120,10 @@
     var startY = 40;
 
     // Column headers (capacity 0..W)
-    ctx.fillStyle = textColor; ctx.font = 'bold 11px sans-serif'; ctx.textAlign = 'center';
-    ctx.fillText('item \\ cap', startX - 28, startY + cellH / 2 + 4);
+    // The corner label belongs on the header line: beside row 0 it printed on
+    // top of that row's own "none".
+    ctx.fillStyle = textColor; ctx.font = 'bold 11px sans-serif'; ctx.textAlign = 'right';
+    ctx.fillText('item \\ cap', startX - 4, startY - 6);
     for (var c = 0; c <= W; c++) {
       ctx.fillStyle = textColor;
       ctx.fillText(c, startX + c * cellW + cellW / 2, startY - 6);
@@ -186,7 +203,7 @@
     stopped = true; running = false; genItems();
   });
   genItems();
-  window.addEventListener('resize', function() { draw(-1, -1, null); });
+  window.addEventListener('resize', draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/dp-string.html
+++ b/algo_demo/dp-string.html
@@ -69,16 +69,31 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(m·n) | Space: O(m·n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
   var canvas = document.getElementById('canvas'), ctx = canvas.getContext('2d');
   var running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
   var dp = [], strA = 'horse', strB = 'ros', problem = 'edit';
 
   function getProblem() { return document.getElementById('problem-select').value; }
@@ -274,7 +289,7 @@
     document.getElementById(id).addEventListener('input', function() { stopped = true; running = false; init(); });
   });
   init();
-  window.addEventListener('resize', function() { draw(-1, -1, [], false); });
+  window.addEventListener('resize', draw.repaint);
 
   function draw(a, b, c, d) {
     if (problem === 'edit') drawEdit(a, b, c, d);

--- a/algo_demo/dp-tree.html
+++ b/algo_demo/dp-tree.html
@@ -60,16 +60,31 @@
           <button class="btn btn-secondary" id="reset-btn">New Tree</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(h)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
   var canvas = document.getElementById('canvas'), ctx = canvas.getContext('2d');
   var running = false, stopped = false;
   var logger = createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
   var nodes = [], problem = 'robber', globalAns = 0;
 
   // Tree node: {id, val, left, right, x, y, state, rob, skip, depth, diam}
@@ -295,7 +310,7 @@
   document.getElementById('reset-btn').addEventListener('click', reset);
   document.getElementById('problem-select').addEventListener('change', function() { stopped = true; running = false; logger.clear(); draw(null, null); });
   reset();
-  window.addEventListener('resize', function() { draw(null, null); });
+  window.addEventListener('resize', draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/floyd-warshall.html
+++ b/algo_demo/floyd-warshall.html
@@ -41,10 +41,22 @@
           <button class="btn btn-secondary" id="reset-btn">New Graph</button>
         </div>
         <div class="complexity">Time: O(V&sup3;) | Space: O(V&sup2;)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/graph-backtracking.html
+++ b/algo_demo/graph-backtracking.html
@@ -48,10 +48,22 @@
         </div>
         <p style="font-size:.75rem;color:var(--text-secondary)">Click cells to toggle walls.</p>
         <div class="complexity">Time: O(4^(V)) worst | Prune with visited set</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Find Paths</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function(){

--- a/algo_demo/heap-sort.html
+++ b/algo_demo/heap-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n log n) always | Space: O(1) | Not stable</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/index.html
+++ b/algo_demo/index.html
@@ -16,8 +16,17 @@
   <main class="container">
     <div class="page-header">
       <h1>Algorithm Visualizations</h1>
-      <p>Interactive visualizations of common algorithms used in LeetCode problems.</p>
+      <p>Interactive visualizations of common algorithms used in LeetCode problems.
+         Each one runs step by step and prints the trace underneath.</p>
     </div>
+
+    <div class="viz-filter">
+      <label class="visually-hidden" for="filter">Filter visualizations</label>
+      <input type="search" id="filter" autocomplete="off" spellcheck="false"
+             placeholder="Filter — name, technique, or LC number">
+      <span class="viz-filter-count" id="filter-count"></span>
+    </div>
+    <p class="viz-filter-empty" id="filter-empty" hidden>Nothing matches that.</p>
 
     <h3 class="section-label">Sorting</h3>
     <div class="algo-grid">
@@ -235,6 +244,43 @@
       </a>
     </div>
   </main>
+<script>
+// Live filter over the cards. Everything the cards already say is searchable —
+// title, blurb and tags — so "log n", "LC 347" and "heap" all find something.
+(function() {
+  var input = document.getElementById('filter');
+  var count = document.getElementById('filter-count');
+  var empty = document.getElementById('filter-empty');
+  var cards = [].slice.call(document.querySelectorAll('.algo-card'));
+  var sections = [].slice.call(document.querySelectorAll('.section-label'));
+  cards.forEach(function(c) { c.dataset.hay = c.textContent.toLowerCase().replace(/\s+/g, ' '); });
+
+  function apply() {
+    var q = input.value.trim().toLowerCase();
+    var shown = 0;
+    cards.forEach(function(c) {
+      var hit = !q || c.dataset.hay.indexOf(q) >= 0;
+      c.hidden = !hit;
+      if (hit) shown++;
+    });
+    // A section heading with nothing under it is just a dangling rule.
+    sections.forEach(function(h) {
+      var grid = h.nextElementSibling;
+      var any = [].slice.call(grid.children).some(function(c) { return !c.hidden; });
+      h.hidden = !any;
+      grid.hidden = !any;
+    });
+    count.textContent = q ? shown + ' of ' + cards.length : cards.length + ' visualizations';
+    empty.hidden = shown > 0;
+  }
+
+  input.addEventListener('input', apply);
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') { input.value = ''; apply(); }
+  });
+  apply();
+})();
+</script>
   <footer>
     <div class="container">
       <p>CS_basics &mdash; computer science fundamentals &amp; interview preparation</p>

--- a/algo_demo/index.html
+++ b/algo_demo/index.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="viz-filter">
-      <label class="visually-hidden" for="filter">Filter visualizations</label>
+      <label class="sr-only" for="filter">Filter visualizations</label>
       <input type="search" id="filter" autocomplete="off" spellcheck="false"
              placeholder="Filter — name, technique, or LC number">
       <span class="viz-filter-count" id="filter-count"></span>

--- a/algo_demo/insertion-sort.html
+++ b/algo_demo/insertion-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Best: O(n) | Avg: O(n&sup2;) | Worst: O(n&sup2;) | Stable</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/kadane.html
+++ b/algo_demo/kadane.html
@@ -42,15 +42,30 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(1)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
   var canvas=document.getElementById('canvas'),ctx=canvas.getContext('2d');
   var arr=[],running=false,stopped=false,logger=createLogger('log');
+  // Keep the current frame across a resize or a theme switch — see
+  // VIZ.repaintable in common.js.
+  draw = VIZ.repaintable(draw);
 
   function resize(){var r=canvas.parentElement.getBoundingClientRect();canvas.width=r.width-32;canvas.height=Math.max(r.height-32,300);}
   function genArray(){
@@ -124,7 +139,7 @@
   document.getElementById('run-btn').addEventListener('click',run);
   document.getElementById('reset-btn').addEventListener('click',function(){stopped=true;running=false;genArray();logger.clear();draw();});
   document.getElementById('size').addEventListener('input',function(){document.getElementById('size-val').textContent=this.value;genArray();logger.clear();draw();});
-  genArray();draw();window.addEventListener('resize',draw);
+  genArray();draw();window.addEventListener('resize',draw.repaint);
 })();
 </script>
   <footer>

--- a/algo_demo/kmp.html
+++ b/algo_demo/kmp.html
@@ -46,10 +46,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n+m) | Space: O(m)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -107,14 +119,14 @@
       // index label
       ctx.fillStyle = VIZ.muted;
       ctx.font = '9px sans-serif';
-      ctx.fillText(k, fx + (cellSize - 2) / 2, failY + cellSize - 1);
+      ctx.fillText(k, fx + (cellSize - 2) / 2, failY + cellSize + 9);
     }
     // label for fail row
     ctx.fillStyle = VIZ.muted; ctx.font = '10px sans-serif'; ctx.textAlign = 'left';
     ctx.fillText('Failure function (lps)', pad, failY - 4);
 
     // --- draw text row ---
-    var textY = failY + cellSize + 20;
+    var textY = failY + cellSize + 26;
     ctx.fillStyle = fg; ctx.font = '11px sans-serif'; ctx.textAlign = 'left';
     ctx.fillText('text:', 4, textY + cellSize * 0.65);
     for (var k = 0; k < text.length; k++) {
@@ -138,11 +150,11 @@
       ctx.fillText(text[k], tx + (cellSize - 2) / 2, textY + cellSize * 0.67);
       // index
       ctx.fillStyle = VIZ.muted; ctx.font = '9px sans-serif';
-      ctx.fillText(k, tx + (cellSize - 2) / 2, textY + cellSize - 1);
+      ctx.fillText(k, tx + (cellSize - 2) / 2, textY + cellSize + 9);
     }
 
     // --- draw pattern row (aligned under text[i-j]) ---
-    var patY = textY + cellSize + 6;
+    var patY = textY + cellSize + 20;
     ctx.fillStyle = fg; ctx.font = '11px sans-serif'; ctx.textAlign = 'left';
     ctx.fillText('pat:', 4, patY + cellSize * 0.65);
     var patOffset = state.i >= 0 && state.j >= 0 ? state.i - state.j : 0;
@@ -168,7 +180,7 @@
     if (state.i >= 0) {
       var ix = pad + state.i * cellSize + (cellSize - 2) / 2;
       ctx.fillStyle = VIZ.swap; ctx.font = 'bold 11px sans-serif'; ctx.textAlign = 'center';
-      ctx.fillText('i', ix, textY + cellSize + 3);
+      ctx.fillText('i', ix, textY - 4);
     }
 
     // --- status line ---

--- a/algo_demo/lca.html
+++ b/algo_demo/lca.html
@@ -45,10 +45,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Post-order DFS</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Find LCA</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function(){

--- a/algo_demo/lfu-cache.html
+++ b/algo_demo/lfu-cache.html
@@ -53,10 +53,22 @@
           <button class="btn btn-primary" id="get-btn">Get</button>
         </div>
         <div class="complexity">get: O(1) | put: O(1) | HashMap + freq buckets</div>
-        <h3>Operations</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Operations</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run Demo</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function(){

--- a/algo_demo/linear-search.html
+++ b/algo_demo/linear-search.html
@@ -44,10 +44,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Best: O(1) | Avg: O(n) | Worst: O(n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/lru-cache.html
+++ b/algo_demo/lru-cache.html
@@ -53,10 +53,22 @@
           <button class="btn btn-primary" id="get-btn">Get</button>
         </div>
         <div class="complexity">get: O(1) | put: O(1)</div>
-        <h3>Operations</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Operations</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run Demo</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/merge-sort.html
+++ b/algo_demo/merge-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n log n) | Space: O(n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/monotonic-stack.html
+++ b/algo_demo/monotonic-stack.html
@@ -43,10 +43,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/multi-source-bfs.html
+++ b/algo_demo/multi-source-bfs.html
@@ -49,10 +49,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(V+E) | All sources enqueued at t=0</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function(){

--- a/algo_demo/prefix-sum.html
+++ b/algo_demo/prefix-sum.html
@@ -44,10 +44,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Build: O(n) | Query: O(1)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Build &amp; Query</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/quick-sort.html
+++ b/algo_demo/quick-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n log n) avg | Space: O(log n)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/rolling-hash.html
+++ b/algo_demo/rolling-hash.html
@@ -46,10 +46,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n+m) avg | Space: O(1)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -117,14 +129,14 @@
       ctx.fillText(text[k], tx + (cellSize - 2) / 2, textY + cellSize * 0.67);
       // index
       ctx.fillStyle = VIZ.muted; ctx.font = '9px sans-serif';
-      ctx.fillText(k, tx + (cellSize - 2) / 2, textY + cellSize - 1);
+      ctx.fillText(k, tx + (cellSize - 2) / 2, textY + cellSize + 9);
     }
 
     // bracket under current window
     if (state.winStart >= 0 && state.winStart + pat.length <= text.length) {
       var bx1 = pad + state.winStart * cellSize;
       var bx2 = pad + (state.winStart + pat.length) * cellSize - 2;
-      var bracketY = textY + cellSize + 2;
+      var bracketY = textY + cellSize + 15;
       ctx.strokeStyle = state.phase === 'match' ? VIZ.done : (state.phase === 'collision' ? VIZ.alt : VIZ.swap);
       ctx.lineWidth = 2; ctx.setLineDash([]);
       ctx.beginPath(); ctx.moveTo(bx1, bracketY); ctx.lineTo(bx1, bracketY + 6);
@@ -134,7 +146,7 @@
     }
 
     // --- pattern row ---
-    var patY = textY + cellSize + 24;
+    var patY = textY + cellSize + 34;
     ctx.fillStyle = fg; ctx.font = '11px sans-serif'; ctx.textAlign = 'left';
     ctx.fillText('pat:', 4, patY + cellSize * 0.65);
     for (var k = 0; k < pat.length; k++) {

--- a/algo_demo/selection-sort.html
+++ b/algo_demo/selection-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n&sup2;) always | Space: O(1) | Not stable</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/sliding-window.html
+++ b/algo_demo/sliding-window.html
@@ -28,6 +28,7 @@
           <div class="legend-item"><div class="legend-dot" style="background:var(--viz-base)"></div> Array element</div>
           <div class="legend-item"><div class="legend-dot" style="background:var(--viz-swap)"></div> Current window</div>
           <div class="legend-item"><div class="legend-dot" style="background:var(--viz-done)"></div> Best window</div>
+          <div class="legend-item"><div class="legend-dot" style="background:var(--viz-idle);opacity:.35"></div> Outside window</div>
         </div>
       </div>
       <div class="viz-controls">
@@ -43,10 +44,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(1)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -60,38 +73,61 @@
     state={wStart:-1,wEnd:-1,bestStart:-1,bestEnd:-1};
   }
 
+  // Layout bands, top to bottom: readout | bars | axis + indices | pointers.
+  var TOP = 52, AXIS_PAD = 64;
+
   function draw(){
     var r=canvas.parentElement.getBoundingClientRect();
-    canvas.width=r.width-32; canvas.height=Math.max(r.height-32,260);
+    canvas.width=r.width-32; canvas.height=Math.max(r.height-32,300);
     var w=canvas.width,h=canvas.height,n=arr.length;
     ctx.clearRect(0,0,w,h);
-    var barW=Math.min(44,(w-40)/n-4),gap=4,totalW=n*(barW+gap)-gap,startX=(w-totalW)/2;
+    var barW=Math.min(44,(w-40)/n-6),gap=6,totalW=n*(barW+gap)-gap,startX=(w-totalW)/2;
     var max=Math.max.apply(null,arr)||1;
-    var barAreaH=h-100;
+    var baseY=h-AXIS_PAD, barAreaH=baseY-TOP-24;
+    var live=state.wStart>=0;
+    var colX=function(i){ return startX+i*(barW+gap); };
+
+    // Best-so-far first, so the live window draws over it where they overlap.
+    // While the two are the same window there is only one thing to say, and
+    // saying it twice puts two captions on the same pixel.
+    var bestIsWindow=live&&state.bestStart===state.wStart&&state.bestEnd===state.wEnd;
+    if(state.bestStart>=0&&!bestIsWindow){
+      VIZ.region(ctx,colX(state.bestStart)-3,colX(state.bestEnd)+barW+3,
+                 TOP+16,baseY+4,VIZ.done,'best so far','right');
+    }
+    if(live){
+      VIZ.region(ctx,colX(state.wStart)-3,colX(state.wEnd)+barW+3,
+                 TOP+16,baseY+4,VIZ.swap,'window');
+    }
 
     for(var i=0;i<n;i++){
-      var x=startX+i*(barW+gap);
-      var bh=(arr[i]/max)*barAreaH*0.72;
-      var y=h-60-bh;
-      var color=VIZ.base;
-      if(state.bestStart>=0&&i>=state.bestStart&&i<=state.bestEnd) color=VIZ.done;
-      if(state.wStart>=0&&i>=state.wStart&&i<=state.wEnd) color=VIZ.swap;
-      ctx.fillStyle=color;
-      ctx.beginPath();ctx.roundRect(x,y,barW,bh||2,3);ctx.fill();
-      ctx.fillStyle=VIZ.label;
-      ctx.font='11px sans-serif';ctx.textAlign='center';
-      ctx.fillText(arr[i],x+barW/2,y-5);
+      var bh=(arr[i]/max)*barAreaH, y=baseY-bh;
+      var inWin=live&&i>=state.wStart&&i<=state.wEnd;
+      var inBest=state.bestStart>=0&&i>=state.bestStart&&i<=state.bestEnd;
+      var color=VIZ.base, mode='';
+      if(inWin) color=VIZ.swap;
+      else if(inBest) color=VIZ.done;
+      else if(live) { color=VIZ.idle; mode='muted'; }
+      VIZ.bar(ctx,colX(i),y,barW,bh,color,arr[i],mode);
     }
-    // draw window bracket
-    if(state.wStart>=0){
-      var wx=startX+state.wStart*(barW+gap)-2;
-      var wx2=startX+state.wEnd*(barW+gap)+barW+2;
-      ctx.strokeStyle=VIZ.swap;ctx.lineWidth=2;ctx.setLineDash([]);
-      ctx.strokeRect(wx,20,wx2-wx,h-80);
+
+    var marks={};
+    if(live) for(var j=state.wStart;j<=state.wEnd;j++) marks[j]={color:VIZ.swap};
+    VIZ.axis(ctx,startX-8,startX+totalW+8,baseY,n,startX,barW,gap,marks);
+
+    if(live){
+      // The two ends of the window are what a slide actually moves: the one
+      // that leaves and the one that joins.
+      VIZ.pointer(ctx,colX(state.wStart)+barW/2,baseY+22,'out',VIZ.idle,0);
+      VIZ.pointer(ctx,colX(state.wEnd)+barW/2,baseY+22,'in',VIZ.swap,
+                  state.wStart===state.wEnd?1:0);
     }
-    ctx.fillStyle=VIZ.label;
-    ctx.font='13px sans-serif';ctx.textAlign='left';
-    if(state.curSum!==undefined) ctx.fillText('curSum: '+state.curSum+'  maxSum: '+state.maxSum,10,18);
+
+    VIZ.readout(ctx,10,12,[
+      {label:'k',value:state.k===undefined?+document.getElementById('k-slider').value:state.k},
+      state.curSum===undefined?null:{label:'sum',value:state.curSum,color:VIZ.swap},
+      state.maxSum===undefined?null:{label:'best',value:state.maxSum,color:VIZ.done}
+    ]);
   }
 
   async function run(){

--- a/algo_demo/style.css
+++ b/algo_demo/style.css
@@ -46,6 +46,12 @@ a, button, [role="button"] { touch-action: manipulation; }
   --viz-surface:     #e6e6e6;  /* empty cell / panel fill             */
   --viz-surface-alt: #d2d2d2;  /* faint state fill                    */
   --viz-on-fill:     #ffffff;  /* text sitting on an accent fill      */
+  --viz-grid:        #e9e9e9;  /* plotting grid behind the canvas     */
+
+  /* Step-trace row states. Deliberately washes rather than accents: 30 rows
+     with a saturated background is a stripe pattern, not a highlight. */
+  --viz-trace-latest: #fff6e0;
+  --viz-trace-key:    #eaf7ee;
 
   /* Categorical ramp — only for "N distinct groups" (e.g. union-find) */
   --viz-cat-1: #000000; --viz-cat-2: #1a7f37; --viz-cat-3: #9a6700;
@@ -83,6 +89,10 @@ a, button, [role="button"] { touch-action: manipulation; }
   --viz-surface:     #262626;
   --viz-surface-alt: #363636;
   --viz-on-fill:     #000000;
+  --viz-grid:        #191919;
+
+  --viz-trace-latest: #1c1704;
+  --viz-trace-key:    #06180c;
 
   --viz-cat-1: #ffffff; --viz-cat-2: #3fb950; --viz-cat-3: #d29922;
   --viz-cat-4: #db61a2; --viz-cat-5: #39c5cf; --viz-cat-6: #a371f7;
@@ -156,19 +166,59 @@ main { padding: 32px 0; min-height: calc(100vh - 200px); }
   text-transform: uppercase; letter-spacing: 0.05em;
 }
 
-/* ── Visualization layout ─── */
-.viz-wrapper { display: grid; grid-template-columns: 1fr 300px; gap: 24px; margin-top: 8px; }
+/* ── Index filter ─── */
+.viz-filter { display: flex; align-items: center; gap: 12px; margin: 24px 0 4px; }
+.viz-filter input {
+  flex: 1 1 auto; min-width: 0;
+  padding: 9px 12px; font-family: inherit; font-size: 16px;
+  border: 1px solid var(--border-strong); border-radius: 0;
+  background: var(--bg); color: var(--text);
+}
+.viz-filter input:focus { outline: 1px solid var(--text); outline-offset: -2px; }
+.viz-filter input::placeholder { color: var(--text-dim); }
+.viz-filter-count {
+  font-size: 14px; color: var(--text-muted); white-space: nowrap;
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+.viz-filter-empty { color: var(--text-muted); margin: 24px 0; }
+.algo-card[hidden], .algo-grid[hidden], .section-label[hidden],
+.viz-filter-empty[hidden] { display: none; }
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px; overflow: hidden;
+  clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
+}
+
+/* ── Visualization layout ─────────────────────────────────────────────
+   Three bands, top to bottom: the canvas + its legend, the controls beside
+   them, and the step trace across the full width underneath.
+
+   The trace used to sit in the 300px control column, where a line like
+   "L=4 R=24 sum=28" wrapped three times and 220px of height showed four
+   steps. It is the thing a reader actually follows, so it gets the width.
+   ────────────────────────────────────────────────────────────────────── */
+.viz-wrapper { display: grid; grid-template-columns: 1fr 320px; gap: 24px; margin-top: 8px; align-items: start; }
+/* A grid item's default min-width is min-content, and the canvas carries an
+   explicit pixel width (set from the box it measured last). Without this the
+   two ratchet each other wider and the column can never shrink back — the page
+   ends up overflowing on a phone after a rotate. */
+.viz-wrapper > * { min-width: 0; }
 
 .viz-canvas-area {
-  background: var(--bg); border: 1px solid var(--border-strong);
-  padding: 16px; min-height: 400px; position: relative;
+  background-color: var(--bg);
+  /* A faint plotting grid: it gives bar heights and node positions something
+     to be read against, and marks the canvas as a figure rather than a gap. */
+  background-image: radial-gradient(var(--viz-grid) 1px, transparent 1px);
+  background-size: 24px 24px;
+  background-position: 12px 12px;
+  border: 1px solid var(--border-strong);
+  padding: 16px; min-height: 420px; position: relative;
 }
-canvas { width: 100%; height: 100%; display: block; }
+canvas { width: 100%; height: 100%; display: block; position: relative; }
 
 .viz-controls {
   background: var(--surface); border: 1px solid var(--border);
   padding: 16px; display: flex; flex-direction: column; gap: 12px;
-  align-self: start;
+  position: sticky; top: 76px;
 }
 .viz-controls h3 {
   font-size: 15px; margin: 0; color: var(--text);
@@ -179,8 +229,26 @@ canvas { width: 100%; height: 100%; display: block; }
   font-size: 15px; color: var(--text-muted);
   text-transform: uppercase; letter-spacing: 0.05em;
 }
+/* A label whose last child is its live value puts the two on one row. One that
+   wraps a <select> keeps the control on its own full-width line, where its
+   option text is not truncated. Browsers without :has() get the second layout
+   for both, which is what the page did before. */
+.viz-controls label:has(> span:last-child) {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+}
+/* The live value beside a slider is the number the reader is actually setting,
+   so it is typeset as data rather than as more label. */
+.viz-controls label > span:last-child {
+  color: var(--text); font-weight: 600; letter-spacing: 0;
+  background: var(--bg); border: 1px solid var(--border);
+  padding: 0 6px; min-width: 34px; text-align: center;
+}
 
-.viz-controls input[type="range"] { width: 100%; accent-color: var(--text); }
+.viz-controls input[type="range"] {
+  width: 100%; accent-color: var(--text);
+  height: 22px; margin: -4px 0 0;
+}
+
 .viz-controls select,
 .viz-controls input[type="number"],
 .viz-controls input[type="text"] {
@@ -208,24 +276,140 @@ canvas { width: 100%; height: 100%; display: block; }
 .btn-danger { background: var(--bg); color: var(--viz-danger); border-color: var(--viz-danger); }
 .btn-danger:hover { background: var(--viz-danger); color: var(--bg); }
 .btn-row { display: flex; gap: 8px; flex-wrap: wrap; }
-
-/* ── Log / info panel ─── */
-.viz-log {
-  max-height: 220px; overflow-y: auto; -webkit-overflow-scrolling: touch;
-  font-family: inherit; font-size: 14px; line-height: 1.6;
-  background: var(--bg); border: 1px solid var(--border);
-  padding: 10px; border-radius: 0;
+.btn-row .btn-primary { flex: 2 1 120px; }
+.btn-mini {
+  min-height: 28px; padding: 2px 10px; font-size: 13px; font-weight: 600;
+  border: 1px solid var(--border-strong); background: var(--bg); color: var(--text-muted);
+  font-family: inherit; text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer;
 }
-.viz-log .step { padding: 1px 0; color: var(--text-muted); }
-.viz-log .highlight { color: var(--text); font-weight: 600; }
+.btn-mini:hover { color: var(--text); border-color: var(--text); }
+
+/* ── Step trace ───────────────────────────────────────────────────────
+   createLogger emits three row kinds; each is styled to say what it is at a
+   glance, so the trace can be skimmed instead of read line by line:
+
+     .step-item   a numbered step        — gutter number + one unwrapped line
+     .step-note   the reason for it      — indented under its step
+     .step-phase  a phase heading        — "--- Iteration 2 ---"
+
+   Plus two states: .is-latest (where the run is right now) and .is-key (the
+   outcome the page marked with <span class="highlight">).
+   ────────────────────────────────────────────────────────────────────── */
+.viz-trace {
+  margin-top: 24px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
+}
+.viz-trace-head {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding: 10px 14px; background: var(--surface);
+  border-bottom: 1px solid var(--border-strong);
+}
+.viz-trace-head h3 {
+  margin: 0; font-size: 15px; color: var(--text);
+  text-transform: uppercase; letter-spacing: 0.08em;
+}
+.viz-trace-count {
+  font-size: 14px; color: var(--text-muted);
+  border: 1px solid var(--border); background: var(--bg); padding: 0 8px;
+}
+.viz-trace-tools { margin-left: auto; display: flex; gap: 8px; }
+
+.viz-trace-body { position: relative; }
+
+.viz-log {
+  /* Grows with the trace between these bounds, so a three-step run is not a
+     mostly-empty box and a fifty-step one does not push the page around.
+     Horizontal scroll rather than wrapping: a wrapped step line is the thing
+     that made the old panel unreadable. */
+  min-height: 260px; max-height: 420px;
+  overflow: auto; -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  font-family: inherit; font-size: 15px; line-height: 1.5;
+  padding: 6px 0;
+}
+
+.viz-log .step { padding: 0; color: var(--text-muted); }
+
+.viz-log .step-item {
+  display: grid; grid-template-columns: 40px minmax(0, 1fr);
+  gap: 12px; align-items: baseline;
+  padding: 4px 14px 4px 0;
+  border-left: 3px solid transparent;
+  border-top: 1px solid var(--border);
+}
+.viz-log .step-item:first-child { border-top: 0; }
+.viz-log .step-n {
+  font-size: 13px; color: var(--text-dim); text-align: right;
+  font-variant-numeric: tabular-nums; user-select: none;
+}
+.viz-log .step-body { min-width: 0; }
+.viz-log .step-main { color: var(--text); white-space: pre; }
+.viz-log .step-note {
+  color: var(--text-muted); font-size: 14px; white-space: pre;
+  margin-top: 1px; padding-left: 14px;
+  border-left: 1px dashed var(--border-strong);
+}
+
+/* name=value: the value is what changes between steps, so it is the part that
+   gets the colour. The arrows mark the decision the step took. */
+.viz-log .k { font-weight: 400; color: var(--text-muted); }
+.viz-log .v { font-weight: 700; color: var(--viz-alt); }
+.viz-log .arrow { font-style: normal; font-weight: 700; color: var(--viz-active); padding: 0 2px; }
+.viz-log .highlight { color: var(--text); font-weight: 700; }
+
+.viz-log .step-item.is-latest {
+  background: var(--viz-trace-latest);
+  border-left-color: var(--viz-active);
+}
+.viz-log .step-item.is-key,
+.viz-log .step-note.is-key { color: var(--text); }
+.viz-log .step-item.is-key {
+  border-left-color: var(--viz-done);
+  background: var(--viz-trace-key);
+}
+
+.viz-log .step-phase {
+  margin: 10px 14px 6px; padding: 0;
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13px; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: 0.08em;
+}
+.viz-log .step-phase::after {
+  content: ''; flex: 1; height: 1px; background: var(--border-strong);
+}
+.viz-log .step-phase:first-child { margin-top: 2px; }
+
+.viz-trace-empty {
+  position: absolute; inset: 0; margin: 0;
+  /* grid, not flex: a flex container makes each inline child a flex item and
+     eats the spaces around <b>Run</b>. */
+  display: grid; place-items: center; text-align: center;
+  padding: 0 24px; pointer-events: none;
+  font-size: 16px; color: var(--text-dim);
+}
+/* [hidden] is a UA rule on the element; a class selector outranks it. */
+.viz-trace-empty[hidden], .viz-trace-jump[hidden] { display: none; }
+.viz-trace-jump {
+  position: absolute; right: 18px; bottom: 14px;
+  font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer;
+  padding: 4px 10px; min-height: 28px;
+  background: var(--inverse-bg); color: var(--inverse-text);
+  border: 1px solid var(--inverse-bg);
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
 
 /* ── Legend ─── */
 .legend {
-  display: flex; gap: 16px; flex-wrap: wrap; font-size: 15px;
+  display: flex; gap: 8px; flex-wrap: wrap; font-size: 14px;
   margin-top: 12px; color: var(--text-muted);
   text-transform: uppercase; letter-spacing: 0.04em;
 }
-.legend-item { display: flex; align-items: center; gap: 6px; }
+.legend-item {
+  display: flex; align-items: center; gap: 7px;
+  border: 1px solid var(--border); background: var(--bg);
+  padding: 2px 9px 2px 7px;
+}
 .legend-dot {
   width: 12px; height: 12px; border-radius: 0; flex-shrink: 0;
   border: 1px solid var(--border-strong);
@@ -251,7 +435,8 @@ footer a:hover { color: var(--text); opacity: 1; }
 /* ── Responsive — tablet <=1024px ─── */
 @media (max-width: 1024px) {
   .container { padding: 0 24px; }
-  .viz-wrapper { grid-template-columns: 1fr 260px; gap: 16px; }
+  .viz-wrapper { grid-template-columns: 1fr 270px; gap: 16px; }
+  .viz-log { max-height: 360px; }
 }
 
 /* ── Responsive — mobile <=768px ─── */
@@ -265,13 +450,21 @@ footer a:hover { color: var(--text); opacity: 1; }
   .viz-canvas-area { min-height: 320px; padding: 10px; }
   .algo-grid { grid-template-columns: 1fr; }
   .btn { flex: 1 1 auto; }
+
+  /* Stacked, the controls are above the canvas, so sticking them would pin
+     the controls over the thing they control. */
+  .viz-controls { position: static; }
+  .viz-trace { margin-top: 20px; }
+  .viz-log { min-height: 220px; max-height: 320px; font-size: 14px; }
+  .viz-log .step-item { grid-template-columns: 30px minmax(0, 1fr); gap: 8px; padding-right: 10px; }
 }
 
 @media (max-width: 480px) {
   .container { padding: 0 12px; }
   h1 { font-size: 22px; }
   .page-header h1 { font-size: 20px; }
-  .legend { font-size: 14px; gap: 12px; }
+  .legend { font-size: 13px; gap: 6px; }
+  .viz-log { min-height: 200px; max-height: 280px; font-size: 13px; }
   footer p { font-size: 14px; }
 }
 
@@ -293,7 +486,8 @@ footer a:hover { color: var(--text); opacity: 1; }
 /* ── Print ─── */
 @media print {
   /* .navbar / .nav-toggle are hidden by nav.css */
-  footer, .viz-controls { display: none !important; }
+  footer, .viz-controls, .viz-trace-tools, .viz-trace-jump { display: none !important; }
+  .viz-log { min-height: 0; max-height: none; overflow: visible; }
   body { font-size: 11pt; color: #000; background: #fff; }
   main { padding: 0; }
   .viz-wrapper { grid-template-columns: 1fr; }

--- a/algo_demo/style.css
+++ b/algo_demo/style.css
@@ -183,9 +183,12 @@ main { padding: 32px 0; min-height: calc(100vh - 200px); }
 .viz-filter-empty { color: var(--text-muted); margin: 24px 0; }
 .algo-card[hidden], .algo-grid[hidden], .section-label[hidden],
 .viz-filter-empty[hidden] { display: none; }
-.visually-hidden {
-  position: absolute; width: 1px; height: 1px; overflow: hidden;
-  clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
+/* Named to match .sr-only in site/style.css. No `clip` fallback beside the
+   clip-path: the only engine that needs one is IE11, and this sheet is 88
+   var(--x) references deep, so it renders nothing there either way. */
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  overflow: hidden; clip-path: inset(50%); white-space: nowrap;
 }
 
 /* ── Visualization layout ─────────────────────────────────────────────

--- a/algo_demo/topological-sort.html
+++ b/algo_demo/topological-sort.html
@@ -42,10 +42,22 @@
           <button class="btn btn-secondary" id="reset-btn">New Graph</button>
         </div>
         <div class="complexity">Time: O(V+E) | Space: O(V+E)</div>
-        <h3>Order</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Order</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/algo_demo/two-pointers.html
+++ b/algo_demo/two-pointers.html
@@ -29,6 +29,7 @@
           <div class="legend-item"><div class="legend-dot" style="background:var(--viz-active)"></div> Left pointer</div>
           <div class="legend-item"><div class="legend-dot" style="background:var(--viz-swap)"></div> Right pointer</div>
           <div class="legend-item"><div class="legend-dot" style="background:var(--viz-done)"></div> Found pair</div>
+          <div class="legend-item"><div class="legend-dot" style="background:var(--viz-idle);opacity:.35"></div> Ruled out</div>
         </div>
       </div>
       <div class="viz-controls">
@@ -43,10 +44,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Time: O(n) | Space: O(1)</div>
-        <h3>Steps</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Steps</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {
@@ -67,45 +80,61 @@
     state={lo:-1,hi:-1,found:-1,foundHi:-1};
   }
 
+  // Layout bands, top to bottom: readout | bars | axis + indices | pointers.
+  var TOP = 52, AXIS_PAD = 64;
+
   function draw(){
     var r=canvas.parentElement.getBoundingClientRect();
-    canvas.width=r.width-32; canvas.height=Math.max(r.height-32,260);
+    canvas.width=r.width-32; canvas.height=Math.max(r.height-32,300);
     var w=canvas.width,h=canvas.height,n=arr.length;
     ctx.clearRect(0,0,w,h);
-    var barW=Math.min(50,(w-40)/n-4),gap=4,totalW=n*(barW+gap)-gap,startX=(w-totalW)/2;
-    var max=Math.max.apply(null,arr);
-    var barAreaH=h-100;
+    var barW=Math.min(50,(w-40)/n-6),gap=6,totalW=n*(barW+gap)-gap,startX=(w-totalW)/2;
+    var max=Math.max.apply(null,arr)||1;
+    var baseY=h-AXIS_PAD, barAreaH=baseY-TOP-24;
+    var live=state.lo>=0&&state.found<0;
+    var sum=live?arr[state.lo]+arr[state.hi]:null;
+
+    // The band still in play. Everything outside it has been ruled out by the
+    // sorted order — the one idea the whole technique rests on.
+    if(state.lo>=0&&state.found<0&&state.lo<state.hi){
+      VIZ.region(ctx,
+        startX+state.lo*(barW+gap)-3, startX+state.hi*(barW+gap)+barW+3,
+        TOP+16, baseY+4, VIZ.alt, 'still in play');
+    }
 
     for(var i=0;i<n;i++){
       var x=startX+i*(barW+gap);
-      var bh=(arr[i]/max)*barAreaH*0.7;
-      var y=h-60-bh;
-      var color=VIZ.base;
+      var bh=(arr[i]/max)*barAreaH;
+      var y=baseY-bh;
+      var color=VIZ.base, mode='';
       if(state.found>=0&&(i===state.found||i===state.foundHi)) color=VIZ.done;
       else if(i===state.lo) color=VIZ.active;
       else if(i===state.hi) color=VIZ.swap;
-      ctx.fillStyle=color;
-      ctx.beginPath();ctx.roundRect(x,y,barW,bh||2,3);ctx.fill();
-      // value
-      ctx.fillStyle=VIZ.label;
-      ctx.font='11px sans-serif';ctx.textAlign='center';
-      ctx.fillText(arr[i],x+barW/2,y-5);
-      // pointer labels
-      if(i===state.lo&&state.found<0){
-        ctx.fillStyle=VIZ.active;ctx.font='bold 11px sans-serif';
-        ctx.fillText('L',x+barW/2,h-42);
-      }
-      if(i===state.hi&&state.found<0){
-        ctx.fillStyle=VIZ.swap;ctx.font='bold 11px sans-serif';
-        ctx.fillText('R',x+barW/2,h-42);
-      }
+      else if(live&&(i<state.lo||i>state.hi)) { color=VIZ.idle; mode='muted'; }
+      VIZ.bar(ctx,x,y,barW,bh,color,arr[i],mode);
     }
-    // target info
-    ctx.fillStyle=VIZ.label;
-    ctx.font='13px sans-serif';ctx.textAlign='left';
-    ctx.fillText('Target: '+target,10,25);
-    if(state.lo>=0&&state.found<0)
-      ctx.fillText('sum: '+(arr[state.lo]||0)+' + '+(arr[state.hi]||0)+' = '+(arr[state.lo]+arr[state.hi]),10,45);
+
+    var marks={};
+    if(state.found>=0){ marks[state.found]={color:VIZ.done}; marks[state.foundHi]={color:VIZ.done}; }
+    else if(live){ marks[state.lo]={color:VIZ.active}; marks[state.hi]={color:VIZ.swap}; }
+    VIZ.axis(ctx,startX-8,startX+totalW+8,baseY,n,startX,barW,gap,marks);
+
+    if(live){
+      // Same column when the pointers meet: stack rather than overprint.
+      var same=state.lo===state.hi;
+      VIZ.pointer(ctx,startX+state.lo*(barW+gap)+barW/2,baseY+22,'L',VIZ.active,0);
+      VIZ.pointer(ctx,startX+state.hi*(barW+gap)+barW/2,baseY+22,'R',VIZ.swap,same?1:0);
+    }
+
+    var verdict=null;
+    if(sum!==null) verdict=sum===target?{label:'sum = target',value:'take it',color:VIZ.done}
+                   :sum<target?{label:'sum < target',value:'L \u2192',color:VIZ.active}
+                              :{label:'sum > target',value:'\u2190 R',color:VIZ.swap};
+    VIZ.readout(ctx,10,12,[
+      {label:'target',value:target},
+      sum!==null?{label:arr[state.lo]+' + '+arr[state.hi]+' =',value:sum,color:VIZ.alt}:null,
+      state.found>=0?{label:'found',value:arr[state.found]+' + '+arr[state.foundHi],color:VIZ.done}:verdict
+    ]);
   }
 
   async function run(){

--- a/algo_demo/union-find.html
+++ b/algo_demo/union-find.html
@@ -41,10 +41,22 @@
           <button class="btn btn-secondary" id="reset-btn">Reset</button>
         </div>
         <div class="complexity">Find: O(&alpha;(n)) &asymp; O(1) | Union: O(&alpha;(n)) &asymp; O(1)</div>
-        <h3>Operations</h3>
-        <div class="viz-log" id="log"></div>
       </div>
     </div>
+    <section class="viz-trace">
+      <div class="viz-trace-head">
+        <h3>Operations</h3>
+        <span class="viz-trace-count" data-trace-count>0 steps</span>
+        <div class="viz-trace-tools">
+          <button type="button" class="btn-mini" data-trace-copy>Copy</button>
+        </div>
+      </div>
+      <div class="viz-trace-body">
+        <div class="viz-log" id="log"></div>
+        <p class="viz-trace-empty" data-trace-empty><span>Press <b>Run Random Unions</b> to trace the algorithm one step at a time.</span></p>
+        <button type="button" class="viz-trace-jump" data-trace-jump hidden>&darr; latest</button>
+      </div>
+    </section>
   </main>
 <script>
 (function() {

--- a/site/test/algo-demo.test.js
+++ b/site/test/algo-demo.test.js
@@ -1,0 +1,279 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+// algo_demo/common.js is a plain browser script with no module wrapper, so it
+// is tested the way e2e-check.js tests search's score(): the shipped file is
+// evaluated as-is, and the assertions run against what the pages actually load.
+// Nothing here reimplements the logger.
+const COMMON = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'algo_demo', 'common.js'), 'utf8');
+const STYLE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'algo_demo', 'style.css'), 'utf8');
+
+// The markup every page carries around its log, so the panel chrome the logger
+// drives (the counter, the empty state) is exercised too.
+const PANEL = `
+  <section class="viz-trace">
+    <div class="viz-trace-head">
+      <h3>Steps</h3>
+      <span class="viz-trace-count" data-trace-count>0 steps</span>
+    </div>
+    <div class="viz-trace-body">
+      <div class="viz-log" id="log"></div>
+      <p class="viz-trace-empty" data-trace-empty><span>Press Run</span></p>
+    </div>
+  </section>`;
+
+function boot() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${PANEL}</body></html>`,
+                        { url: 'https://example.test/', runScripts: 'dangerously' });
+  dom.window.eval(COMMON);
+  return dom;
+}
+
+const rows = (dom) => [...dom.window.document.querySelectorAll('#log > .step')];
+const text = (el) => el.textContent.replace(/\s+/g, ' ').trim();
+const body = (el) => text(el.querySelector('.step-main') || el);
+
+// ── Step trace: the three shapes the pages write ──────────────────────────
+
+test('a plain message becomes a numbered step', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('L=4 R=24 sum=28');
+  log.log('L=4 R=22 sum=26');
+
+  const r = rows(dom);
+  assert.equal(r.length, 2);
+  assert.ok(r[0].classList.contains('step-item'));
+  assert.deepEqual(r.map((s) => s.querySelector('.step-n').textContent), ['1', '2']);
+});
+
+test('an indented message is the reason for the step above, not a step of its own', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('L=4 R=24 sum=28');
+  log.log('&nbsp;&nbsp;sum &gt; target, move R left');
+
+  const r = rows(dom);
+  assert.equal(r.length, 1, 'the note must not open a second row');
+  const note = r[0].querySelector('.step-note');
+  assert.ok(note);
+  assert.equal(text(note), 'sum > target, move R left');
+  // ...and it must not consume a step number.
+  assert.equal(r[0].querySelector('.step-n').textContent, '1');
+});
+
+test('an indented message with nothing above it still gets a row', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('&nbsp;&nbsp;orphaned detail');
+
+  const r = rows(dom);
+  assert.equal(r.length, 1);
+  assert.equal(body(r[0]), 'orphaned detail');
+});
+
+test('--- x --- is a phase heading and is not numbered', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('--- Iteration 2 ---');
+  log.log('relax 1->2');
+
+  const r = rows(dom);
+  assert.ok(r[0].classList.contains('step-phase'));
+  assert.equal(body(r[0]), 'Iteration 2');
+  assert.equal(r[1].querySelector('.step-n').textContent, '1',
+               'a phase heading must not spend a step number');
+});
+
+test('a note after a phase heading starts a step rather than attaching to nothing', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('first');
+  log.log('--- Iteration 2 ---');
+  log.log('&nbsp;&nbsp;detail');
+
+  const r = rows(dom);
+  assert.equal(r.length, 3);
+  assert.ok(r[2].classList.contains('step-item'));
+  assert.equal(r[0].querySelectorAll('.step-note').length, 0,
+               'the note belongs to the new phase, not to the step before it');
+});
+
+test('an empty message is dropped', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('');
+  log.log('   ');
+  log.log(null);
+  assert.equal(rows(dom).length, 0);
+});
+
+// ── Outcomes vs. inline emphasis ──────────────────────────────────────────
+
+test('a message that is entirely one highlight span is the outcome', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('<span class="highlight">Found! 4 + 24 = 28</span>');
+  assert.ok(rows(dom)[0].classList.contains('is-key'));
+});
+
+test('a highlight span used inline is emphasis, not an outcome', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  // Dijkstra writes every processed node this way; marking them all "key"
+  // would flag nine rows in ten.
+  log.log('Process node <span class="highlight">1</span> dist=7');
+
+  const row = rows(dom)[0];
+  assert.ok(!row.classList.contains('is-key'));
+  assert.ok(row.querySelector('.highlight'), 'the inline emphasis still renders');
+});
+
+test('an indented outcome marks the note, not a new step', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('slide to [2..5]');
+  log.log('&nbsp;&nbsp;<span class="highlight">New max=31</span>');
+
+  const note = rows(dom)[0].querySelector('.step-note');
+  assert.ok(note.classList.contains('is-key'));
+});
+
+// ── Decoration ────────────────────────────────────────────────────────────
+
+test('name=value is split so the changing value can be picked out', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('dp[2][3] = 10');
+
+  const row = rows(dom)[0];
+  assert.equal(row.querySelector('.k').textContent, 'dp[2][3]');
+  assert.equal(row.querySelector('.v').textContent, '10');
+});
+
+test('decoration never disturbs markup the page wrote', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('get(<span class="highlight">7</span>) = 42');
+
+  const row = rows(dom)[0];
+  assert.equal(row.querySelectorAll('.highlight').length, 1);
+  assert.equal(body(row), 'get(7) = 42');
+});
+
+test('an angle bracket in a message stays text and does not become a tag', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('L=4 R=24 sum=28');
+  log.log('&nbsp;&nbsp;sum &gt; target &rarr; move R left');
+
+  const note = rows(dom)[0].querySelector('.step-note');
+  assert.equal(text(note), 'sum > target → move R left');
+  assert.equal(note.querySelectorAll('*').length, note.querySelectorAll('span, i, b').length);
+});
+
+// ── State ─────────────────────────────────────────────────────────────────
+
+test('only the newest step carries the latest marker', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('one');
+  log.log('two');
+  log.log('three');
+
+  const latest = dom.window.document.querySelectorAll('#log .is-latest');
+  assert.equal(latest.length, 1);
+  assert.equal(body(latest[0]), 'three');
+});
+
+test('the panel counter and empty state follow the trace', () => {
+  const dom = boot();
+  const doc = dom.window.document;
+  const count = doc.querySelector('[data-trace-count]');
+  const empty = doc.querySelector('[data-trace-empty]');
+  const log = dom.window.createLogger('log');
+
+  log.log('one');
+  assert.equal(count.textContent, '1 step');
+  assert.equal(empty.hidden, true);
+
+  log.log('two');
+  assert.equal(count.textContent, '2 steps');
+
+  log.clear();
+  assert.equal(count.textContent, '0 steps');
+  assert.equal(empty.hidden, false, 'the prompt comes back on reset');
+  assert.equal(rows(dom).length, 0);
+});
+
+test('clear() restarts the numbering', () => {
+  const dom = boot();
+  const log = dom.window.createLogger('log');
+  log.log('one');
+  log.clear();
+  log.log('one again');
+  assert.equal(rows(dom)[0].querySelector('.step-n').textContent, '1');
+});
+
+// The CSS is the other half of the contract: a row class the stylesheet does
+// not know about renders as an undifferentiated line.
+test('every row class the logger emits is styled', () => {
+  for (const cls of ['.step-item', '.step-note', '.step-phase', '.step-n',
+                     '.step-main', '.is-latest', '.is-key', '.viz-log .k', '.viz-log .v']) {
+    assert.ok(STYLE.includes(cls.replace('.viz-log ', '')), `${cls} is unstyled`);
+  }
+});
+
+// ── repaintable ───────────────────────────────────────────────────────────
+
+test('repaintable replays the last frame instead of resetting it', () => {
+  const dom = boot();
+  const seen = [];
+  let draw = dom.window.VIZ.repaintable((...args) => seen.push(args));
+
+  draw(0, 14);
+  draw(3, 9, 6);
+  draw.repaint();
+
+  assert.deepEqual(seen, [[0, 14], [3, 9, 6], [3, 9, 6]]);
+});
+
+test('repaint before any draw is a no-op call, not a crash', () => {
+  const dom = boot();
+  let calls = 0;
+  const draw = dom.window.VIZ.repaintable(() => { calls++; });
+  draw.repaint();
+  assert.equal(calls, 1);
+});
+
+test('repaint drops the resize Event a listener would otherwise pass in', () => {
+  const dom = boot();
+  const seen = [];
+  const draw = dom.window.VIZ.repaintable((...args) => seen.push(args));
+  draw(1, 2);
+  // This is the shape the pages register: addEventListener hands the handler an
+  // Event, and repaint must ignore it in favour of the recorded arguments.
+  dom.window.addEventListener('resize', draw.repaint);
+  dom.window.dispatchEvent(new dom.window.Event('resize'));
+  assert.deepEqual(seen[1], [1, 2]);
+});
+
+// ── Palette helpers ───────────────────────────────────────────────────────
+
+test('VIZ.on picks ink that stays readable on the fill under it', () => {
+  const dom = boot();
+  assert.equal(dom.window.VIZ.on('#ffffff'), '#000000');
+  assert.equal(dom.window.VIZ.on('#000000'), '#ffffff');
+  assert.equal(dom.window.VIZ.on('rgb(26, 127, 55)'), '#ffffff');
+});
+
+test('VIZ.font asks for the visualizer face, not the platform default', () => {
+  const dom = boot();
+  assert.match(dom.window.VIZ.font(12), /^12px .*monospace$/);
+  assert.match(dom.window.VIZ.font(12, 'bold'), /^bold 12px /);
+});

--- a/site/test/algo-demo.test.js
+++ b/site/test/algo-demo.test.js
@@ -211,6 +211,15 @@ test('the panel counter and empty state follow the trace', () => {
   assert.equal(rows(dom).length, 0);
 });
 
+test('a phase heading takes the empty-state prompt down', () => {
+  const dom = boot();
+  const empty = dom.window.document.querySelector('[data-trace-empty]');
+  const log = dom.window.createLogger('log');
+  // bellman-ford and floyd-warshall both open their run with one of these.
+  log.log('--- Iteration 1 ---');
+  assert.equal(empty.hidden, true, 'the prompt would print over the heading');
+});
+
 test('clear() restarts the numbering', () => {
   const dom = boot();
   const log = dom.window.createLogger('log');
@@ -223,9 +232,10 @@ test('clear() restarts the numbering', () => {
 // The CSS is the other half of the contract: a row class the stylesheet does
 // not know about renders as an undifferentiated line.
 test('every row class the logger emits is styled', () => {
-  for (const cls of ['.step-item', '.step-note', '.step-phase', '.step-n',
-                     '.step-main', '.is-latest', '.is-key', '.viz-log .k', '.viz-log .v']) {
-    assert.ok(STYLE.includes(cls.replace('.viz-log ', '')), `${cls} is unstyled`);
+  for (const sel of ['.viz-log .step-item', '.viz-log .step-note', '.viz-log .step-phase',
+                     '.viz-log .step-n', '.viz-log .step-main', '.viz-log .k', '.viz-log .v',
+                     '.step-item.is-latest', '.step-item.is-key']) {
+    assert.ok(STYLE.includes(sel), `${sel} is unstyled`);
   }
 });
 


### PR DESCRIPTION
The step log was the weak point. It sat in the 300px control column, where "L=4 R=24 sum=28" wrapped three times and 220px of height showed four steps, and every line carried the same weight — a state line and the decision it led to were two equal siblings.

Move it into a full-width panel below the canvas, and teach createLogger the three shapes the pages already write, so the trace becomes structure rather than a flat run of divs:

  - a plain message           -> a numbered step
  - a leading &nbsp;          -> the reason, tucked under the step it explains
  - --- x ---                 -> a phase heading
  - a whole-message highlight -> the run's outcome

That last test is deliberately the *whole* message. Pages also use the same span inline to pick out a value mid-sentence ("Process node <b>1</b> dist=7"), and counting those as outcomes flagged nine rows in ten. name=value pairs are split so the changing number is what the eye lands on. No page's logger.log calls changed; all 36 pages get this.

Two more things every page now gets from common.js, for the same reason — 36 inline scripts cannot each be fixed:

  - HiDPI. Every page painted a 1x bitmap into a 2x box, so every label and every 1px rule shipped blurred. getContext('2d') is wrapped once and the backing store scales behind width/height accessors; pages still read and write CSS pixels, so no draw code or mouse maths changed.
  - Canvas type. The font setter maps the generic families to the site's face.

Rework two-pointers and sliding-window on a shared drawing kit (VIZ.bar / axis / pointer / region / readout): the ruled-out region is dimmed, indices are labelled, pointers sit under the axis and the live sum reads out on the canvas. The search space shrinking is now visible rather than implied.

Bugs found on the way:

  - 8 pages lost their highlight on any resize, either by passing draw to addEventListener (the Event became the first drawing argument) or by calling draw() with reset arguments. A theme switch fires a resize, so changing theme mid-run wiped the picture. Fixed with VIZ.repaintable.
  - "dp[2][3] = 10" was never decorated: the trigger required = adjacent to the name. Caught by a test.
  - Label collisions in kmp, rolling-hash and dp-knapsack; anti-parallel edge weights overprinting in bellman-ford; dijkstra's stray slider value.

site/test/algo-demo.test.js evaluates the shipped common.js in jsdom rather than reimplementing it, the way e2e-check.js lifts search's score().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable algorithm visualizer index with result counts and clear filtering.
  * Standardized trace panels with step counts, copy controls, empty-state guidance, and jump-to-latest actions.
  * Improved trace readability with numbered steps, phases, notes, highlights, and formatted values.
  * Enhanced canvas visualizations with clearer layouts, legends, labels, pointers, regions, and readouts.
* **Bug Fixes**
  * Preserved the current visualization when resizing or switching themes.
  * Improved canvas clarity on high-density displays and prevented overlapping edge labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->