### PR TITLE
rename /add-lc skill to /lc-add

### DIFF
--- a/.claude/skills/lc-add/SKILL.md
+++ b/.claude/skills/lc-add/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: add-lc
-description: File a LeetCode solution into this repo the way the existing ones are filed — find the problem's real slug, write the Python file in the house layout (problem docstring, V0 with an IDEA block and a time/space line), smoke-test it against the examples, and insert the README row. Use when asked to "add LC <number>", to file a problem just solved in a weekly contest, to turn a pasted draft into a committed solution, or to wire an existing solution file into README. Triggers - "add LC 4038 to Hash_table", "/add-lc 239 Sliding_Window", "add this solution and update the README", "file yesterday's contest Q1".
+name: lc-add
+description: File a LeetCode solution into this repo the way the existing ones are filed — find the problem's real slug, write the Python file in the house layout (problem docstring, V0 with an IDEA block and a time/space line), smoke-test it against the examples, and insert the README row. Use when asked to "add LC <number>", to file a problem just solved in a weekly contest, to turn a pasted draft into a committed solution, or to wire an existing solution file into README. Triggers - "add LC 4038 to Hash_table", "/lc-add 239 Sliding_Window", "add this solution and update the README", "file yesterday's contest Q1".
 allowed-tools: Read, Glob, Grep, Bash, Write, Edit
 ---
 
@@ -9,7 +9,7 @@ allowed-tools: Read, Glob, Grep, Bash, Write, Edit
 Turn an LC number (plus, usually, a draft the user already wrote) into a committed-quality
 solution file **and** its README row, in the shape the other ~826 Python files already use.
 
-**Invocation**: `/add-lc <LC number> <pattern dir>` — e.g. `/add-lc 4038 Hash_table`.
+**Invocation**: `/lc-add <LC number> <pattern dir>` — e.g. `/lc-add 4038 Hash_table`.
 A reference or draft solution pasted under the command is used as `V0`; with no draft, the
 draft is usually already in the contest scratch file (step 1).
 
@@ -189,7 +189,7 @@ the statement, a Java link deliberately omitted.
 
 ## Worked example
 
-`add-lc 4038 Hash_table`, with the user's draft pasted:
+`lc-add 4038 Hash_table`, with the user's draft pasted:
 
 | Step | What it produced |
 |---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,17 +230,17 @@ See [`doc/utility-scripts.md`](doc/utility-scripts.md) for full usage of all scr
 
 ---
 
-## Adding a LeetCode solution — `/add-lc`
+## Adding a LeetCode solution — `/lc-add`
 
-`.claude/skills/add-lc/` is the recipe for filing a solved problem into the repo:
+`.claude/skills/lc-add/` is the recipe for filing a solved problem into the repo:
 find the problem's real slug, write `leetcode_python/<Pattern_Dir>/<slug>.py` in the
 house layout (problem docstring → `# V0` → `# IDEA` → `# time = O(...), space = O(...)`
 → `class Solution(object)`), smoke-test it against the docstring's own examples, and
 insert the README row in LC-number order.
 
 ```text
-/add-lc 4038 Hash_table          # + paste the draft solution under it
-/add-lc 239 Sliding_Window
+/lc-add 4038 Hash_table          # + paste the draft solution under it
+/lc-add 239 Sliding_Window
 add LC 4038 to leetcode_python/Hash_table/    # the plain-English form works too
 ```
 


### PR DESCRIPTION
Give the LC skills a common `lc-` prefix, matching /lc-coach.

The skill directory name is the command, so this is a `git mv` plus the frontmatter `name`, the invocation lines in SKILL.md, and the section in CLAUDE.md. check_skills.py pins name-to-directory, so all three stay in step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the LeetCode solution skill from `/add-lc` to `/lc-add`.
  * Updated related documentation, directory references, and command examples to use `/lc-add`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->