### PR TITLE
add script/suggest_review.py — a bias-aware LC review planner

### DIFF
--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -304,7 +304,7 @@ python3 script/suggest_review.py --only top100liked
 python3 script/suggest_review.py --section "Binary Search" --top 10
 python3 script/suggest_review.py --no-balance         # plain importance rank
 python3 script/suggest_review.py --markdown doc/review_suggestions.md
-python3 script/suggest_review.py --self-test          # check the parsers
+python3 script/suggest_review.py --self-test          # run the unit tests
 ```
 
 ### What it reads
@@ -375,23 +375,40 @@ where the practice has been pooling.
   `Newly Added (kamyu104 gap)` drafts are left out of the balance maths so they
   cannot distort a category's share. `--all-sections` puts them back.
 
-### `--self-test`
+### Tests
 
 ```bash
-python3 script/suggest_review.py --self-test
+python3 script/test_suggest_review.py           # 88 tests, stdlib unittest, no deps
+python3 script/test_suggest_review.py -v
+python3 script/test_suggest_review.py ParseProgress   # one class
+python3 script/suggest_review.py --self-test    # the same suite, quietly
 ```
 
 Three of the four inputs are hand-written files whose shape nobody controls, so
 the failure mode is not a crash — it is a parser that quietly reads fewer rows
-than there are and returns a plausible but shrunken plan. The self-test pins the
-shapes that are really in those files (a `MUST` in the status cell vs. the word
-"must" in prose; a duplicate README row for one LC; an annotation containing a
-comma, a wrapped line, a `DP:` label, a stray period between entries) and
-cross-checks the live README against `extract_must_lc.py`.
+than there are and returns a plausible but shrunken plan. Every fixture in
+[`test_suggest_review.py`](../script/test_suggest_review.py) is therefore a line
+that is really in those files: a `MUST` in the status cell vs. the word "must" in
+prose, a duplicate README row for one LC, an annotation containing a comma, a
+line wrapped mid-annotation, a `DP:` label, a stray period between entries, a
+`git log` whose commit adds twenty files at once.
 
-It found one live difference worth knowing: `site/build-review-plan.js` does not
-strip a run's label, so `| DP: 44(todo), 10(todo)` loses LC 44. Eight entries in
-the current log — always the first problem after a label.
+The split mirrors `site/test/*.test.js`: the unit tests run against those
+fixtures so they do not move whenever a row does, and a `LiveFiles` class holds
+the real `README.md` and `data/progress.txt` — including the cross-check that
+`suggest_review.py` and `extract_must_lc.py` still agree on what a `MUST` row is,
+and that `EXCLUDED_SECTIONS` still names sections that exist (a renamed one would
+silently start competing for review slots).
+
+`--self-test` loads and runs that same module, so there is one copy of the
+assertions; it exists because the planner is most often run as a lone script and
+"does it still read the files correctly" should be one command away.
+
+Writing them turned up one live difference worth knowing:
+`site/build-review-plan.js` does not strip a run's label, so
+`| DP: 44(todo), 10(todo)` loses LC 44 — 8 entries in the current log, always the
+first problem after a label. This script strips them; the site build is
+untouched.
 
 ## Other Scripts
 

--- a/doc/utility-scripts.md
+++ b/doc/utility-scripts.md
@@ -287,6 +287,112 @@ The first run of it found a live bug: `add-time-space/SKILL.md` had shipped
 without its `---` fences, so its advertised description was the literal string
 `name: add-time-space`.
 
+## suggest_review.py
+
+Suggests what to practise next, chosen to keep the practice **balanced** rather
+than merely important. The problem it solves is bias: a good week on DP turns
+into three weeks on DP while linked list, design and slide window quietly go a
+month untouched — and a flat "most important, least recently seen" ranking makes
+that worse, because the biggest sections hold the most important problems and
+would fill the whole list.
+
+```bash
+python3 script/suggest_review.py                      # the balanced plan
+python3 script/suggest_review.py --top 20 --per-category 3
+python3 script/suggest_review.py --only must          # MUST rows only
+python3 script/suggest_review.py --only top100liked
+python3 script/suggest_review.py --section "Binary Search" --top 10
+python3 script/suggest_review.py --no-balance         # plain importance rank
+python3 script/suggest_review.py --markdown doc/review_suggestions.md
+python3 script/suggest_review.py --self-test          # check the parsers
+```
+
+### What it reads
+
+Nothing is invented; all three signals are already in the repo.
+
+| Source | What it contributes |
+|--------|---------------------|
+| `README.md` | The problem universe **and** this repo's own judgement of what matters: the `MUST` marker, the curated-list tags (`blind75` / `neetcode150` / `neetcode250` / `top100liked`), the company tags, and the status column's `OK`/`AGAIN` plus its `*` run of review passes. |
+| git history | When each problem was last *worked on* — the commit that touched its solution file, or named its LC number in the subject. |
+| [`data/progress.txt`](../data/progress.txt) | When it was last *practised*, which is not the same thing: a re-read that produced no commit still counts. |
+
+[`doc/must_lc_list.md`](must_lc_list.md) is generated from the same README rows by
+`extract_must_lc.py`, so reading README covers it — and `--self-test` asserts the
+two scripts agree on which rows carry `MUST`, so the rule cannot drift apart.
+
+### How a problem is chosen
+
+**score = importance × staleness × category balance**
+
+- **Importance** — `MUST` +5.0, `top100liked` +2.5, `blind75` +2.5 (the NeetCode
+  lists nest, so only the narrowest one scores: 150 → +1.5, 250 → +0.7),
+  `google` +1.5 (the stated target is a Google loop), other company tags +0.2
+  each capped at +1.0, Medium +0.5 / Hard +0.3, and +0.2 per recorded pass on an
+  `AGAIN` row up to +2.4. That last one reads the pass count as *difficulty*,
+  not as progress — the `AGAIN` marker never graduates in this repo, see
+  [`lc-readiness-guide.md`](lc-readiness-guide.md).
+- **Staleness** — `1 − 0.5 ^ (days / half-life)`, half-life 21 days. Touched
+  today scores 0, never touched saturates near 1.
+- **Category balance** — each README section's share of total importance
+  compared against its share of *recent attention*. A section getting none of
+  the practice it is owed nearly doubles its problems' scores; one getting twice
+  its share is cut to 0.4.
+
+Picks are then spent **round-robin across categories in deficit order**, capped
+at `--per-category` (default 2), so no single hot topic can own the list. The
+cap and the score floor are a preference for breadth, not a quota: once every
+eligible category has had its share, the rest of `--top` is filled by score.
+
+### Reading the output
+
+Read the **balance table first** and the picks second — the table is the
+finding, the picks are one way to act on it.
+
+```text
+== Balance: attention vs importance ==
+
+  category                       n  importance     attention         ratio  last
+  Array                        139  ######...... #...........    0.19 UNDER  today
+  Linked list                   24  ##.......... ............    0.00 UNDER  36d
+  ...
+  Dynamic Programming           94  #####....... ############    2.20 over   today
+```
+
+`ratio` is the share of recent attention divided by the share of importance:
+`1.00` is a fair share, `UNDER` (< 0.5) is the bias to fix, `over` (> 1.8) is
+where the practice has been pooling.
+
+### Two things it deliberately ignores
+
+- **Bulk commits.** A commit touching more than `--bulk-limit` (default 6)
+  solution files is an import or a sweeping refactor, not a study session. This
+  repo has commits adding 393 generated Java files at once; counted naively they
+  made every one of those problems look practised on the same day and put 563
+  problems inside a 30-day window that actually saw 188. Their file paths are
+  dropped; an LC number written into the subject by hand still counts.
+- **Non-practice sections.** SQL, Shell Script, Concurrency and the unverified
+  `Newly Added (kamyu104 gap)` drafts are left out of the balance maths so they
+  cannot distort a category's share. `--all-sections` puts them back.
+
+### `--self-test`
+
+```bash
+python3 script/suggest_review.py --self-test
+```
+
+Three of the four inputs are hand-written files whose shape nobody controls, so
+the failure mode is not a crash — it is a parser that quietly reads fewer rows
+than there are and returns a plausible but shrunken plan. The self-test pins the
+shapes that are really in those files (a `MUST` in the status cell vs. the word
+"must" in prose; a duplicate README row for one LC; an annotation containing a
+comma, a wrapped line, a `DP:` label, a stray period between entries) and
+cross-checks the live README against `extract_must_lc.py`.
+
+It found one live difference worth knowing: `site/build-review-plan.js` does not
+strip a run's label, so `| DP: 44(todo), 10(todo)` loses LC 44. Eight entries in
+the current log — always the first problem after a label.
+
 ## Other Scripts
 
 | Script | Purpose |
@@ -295,5 +401,5 @@ without its `---` fences, so its advertised description was the literal string
 | `get_company_LC.sh` | Get company-specific LeetCode problems |
 | `get_lc_per_rating.py` | Filter problems by difficulty rating |
 | `get_must_problems.sh` | Extract must-do problems |
-| `get_review_list.py` | Generate review lists |
+| `get_review_list.py` | Fibonacci-interval spaced-repetition dates from `data/progress.txt` (see `suggest_review.py` above for the importance/balance view) |
 | `list_leetcode_solutions_by_type.sh` | List solutions by algorithm type |

--- a/script/suggest_review.py
+++ b/script/suggest_review.py
@@ -649,8 +649,10 @@ def truncate(text, width):
     return text if len(text) <= width else text[:width - 1] + "…"
 
 
-def render_text(picks, cats, recent, args, warnings, out=sys.stdout):
-    w = out.write
+def render_text(picks, cats, recent, args, warnings, out=None):
+    # Resolved at call time, not bound as a default: a default would capture the
+    # real stdout at import and write straight past a redirect_stdout.
+    w = (out or sys.stdout).write
 
     w("\n== Recent focus (last %d days) ==\n\n" % args.window)
     if recent["events"]:
@@ -747,205 +749,27 @@ def render_markdown(picks, cats, recent, args):
 
 
 # ── Self-test ───────────────────────────────────────────────────────────────
-# `python3 script/suggest_review.py --self-test`
-#
-# Three of the four inputs are hand-written files whose shape nobody controls —
-# README rows, the practice log, commit subjects — so the failure mode is not a
-# crash, it is a parser that quietly reads fewer rows than there are and hands
-# back a plausible-looking but shrunken plan. These pin the shapes that are
-# actually in the files, plus a live cross-check against the one other script
-# that reads the same `MUST` marker.
-SELF_TEST_README = """
-## Resource
-
-| 999 | ignored, above the first LC section | | | | Easy | | OK |
-
-## Array
-
-|  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
-|-----|-------|----------|------|-------|------------|------|--------|
-| 48 | [Rotate Image](https://leetcode.com/problems/rotate-image/) | [Python](./leetcode_python/Array/rotate-image.py) | _O(n^2)_ | _O(1)_ | Medium | **array**, `google`, `blind75` | AGAIN*** (5) (MUST) |
-| 118 | [Pascal's Triangle](https://leetcode.com/problems/pascals-triangle/) | [Python](./leetcode_python/Array/pascals-triangle.py) | _O(n^2)_ | _O(1)_ | Easy | **array**, the row must be built from the one above, `amazon` | OK** |
-| 547 | [Friend Circles](https://leetcode.com/problems/number-of-provinces/) | [Python](./leetcode_python/DFS/friend-circles.py) | _O(n^2)_ | _O(n)_ | Medium | union find, `google` | AGAIN* |
-
-## Graph
-
-|  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
-|-----|-------|----------|------|-------|------------|------|--------|
-| 547 | [Number of Provinces](https://leetcode.com/problems/number-of-provinces/) | [Java](./leetcode_java/x/NumberOfProvinces.java) | _O(n^2)_ | _O(n)_ | Medium | **graph**, MUST, `fb` | AGAIN***** (2) |
-"""
-
-SELF_TEST_PROGRESS = """20260909: 4(todo), 34(again!!) | DP: 44(todo)
-
-20260908: 70(ok*, o(1) space!!),198(
-ok*),139(again* 1d dp)
-
-20260907: top 100 (backtrack): 51(todo) | (LC must) 438(again), 2289(todo: mono stack + dp)
-20260906: 39(again*).79(again*), topo_sort, weekly_331
-,53(again)
-
------- review
-
-20260905  1740(ok)
-"""
-
-
-def _check(label, condition, detail=""):
-    if condition:
-        return 0
-    print("  FAIL  %s%s" % (label, (" — " + detail) if detail else ""))
-    return 1
-
-
 def self_test(args):
-    import tempfile
+    """`--self-test` — run script/test_suggest_review.py, quietly.
 
-    failures = 0
+    The assertions live in that file, not here, so there is one copy of them:
+    this flag exists because the planner is most often run as a lone script and
+    "does it still read the files correctly" should be one command away.
+    """
+    import unittest
 
-    # ── README shapes ────────────────────────────────────────────────────────
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False,
-                                     encoding="utf-8") as fh:
-        fh.write(SELF_TEST_README)
-        readme_path = fh.name
-    problems = parse_readme(readme_path)
-    os.unlink(readme_path)
-
-    failures += _check("README: rows above the first LC section are skipped",
-                       999 not in problems)
-    failures += _check("README: three distinct problems parsed",
-                       sorted(problems) == [48, 118, 547], sorted(problems))
-    failures += _check("README: MUST in the status cell is a marker",
-                       problems[48]["must"])
-    failures += _check("README: 'must' in note prose is NOT a marker",
-                       not problems[118]["must"])
-    failures += _check("README: an ALL-CAPS MUST token in the note IS a marker",
-                       problems[547]["must"])
-    failures += _check("README: a duplicate row folds into the first sighting",
-                       problems[547]["also_in"] == ["Graph"]
-                       and problems[547]["passes"] == 5
-                       and {"google", "fb"} <= problems[547]["tags"]
-                       and len(problems[547]["paths"]) == 2)
-    failures += _check("README: the `*` run counts review passes",
-                       problems[48]["passes"] == 3)
-    failures += _check("README: title and url come off the link",
-                       problems[48]["title"] == "Rotate Image"
-                       and problems[48]["url"].endswith("/rotate-image/"))
-    failures += _check("README: difficulty is read by value, not by position",
-                       problems[118]["difficulty"] == "Easy")
-
-    # ── Practice log shapes ──────────────────────────────────────────────────
-    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False,
-                                     encoding="utf-8") as fh:
-        fh.write(SELF_TEST_PROGRESS)
-        progress_path = fh.name
-    dates, notes, warnings = parse_progress(progress_path)
-    os.unlink(progress_path)
-
-    failures += _check("log: `|` session separators do not hide problems",
-                       44 in dates)
-    failures += _check("log: an annotation containing a comma stays one entry",
-                       70 in dates and 198 in dates and 1 not in dates,
-                       "'(ok*, o(1) space!!)' must not split into '70' and 'o(1) space'")
-    failures += _check("log: an annotation wrapped across a newline is rejoined",
-                       198 in dates and 139 in dates)
-    failures += _check("log: a period between entries splits them",
-                       39 in dates and 79 in dates)
-    failures += _check("log: a bare continuation line joins the day above",
-                       53 in dates)
-    failures += _check("log: a `DP:` style label does not swallow the entry",
-                       44 in dates, "labelled runs are where the DP practice hides")
-    failures += _check("log: a label with its own parens is stripped",
-                       51 in dates and 100 not in dates)
-    failures += _check("log: a parenthesised label with no colon is stripped",
-                       438 in dates)
-    failures += _check("log: a colon inside an annotation is not a label",
-                       2289 in dates and notes[2289]["todo"] == 1,
-                       "'2289(todo: mono stack + dp)' must stay LC 2289")
-    failures += _check("log: named drills are not LC numbers",
-                       331 not in dates and 3 not in dates)
-    failures += _check("log: a separator line ends the day",
-                       1740 in dates)
-    failures += _check("log: `again` beats `ok` when a note says both",
-                       notes[34]["again"] == 1 and notes[70]["ok"] == 1)
-    failures += _check("log: nothing unreadable in the fixture",
-                       not warnings, warnings)
-
-    # ── Commit subjects ──────────────────────────────────────────────────────
-    def named(subject):
-        return {int(a or b) for a, b in SUBJECT_LC.findall(subject)}
-
-    failures += _check("subject: 'update 131 py' names LC 131",
-                       named("update 131 py") == {131})
-    failures += _check("subject: 'expand LC 131 (Template 8)' names LC 131",
-                       named("update backtrack cheatsheet: expand LC 131 (Template 8)")
-                       == {131})
-    failures += _check("subject: an LC range is not a problem",
-                       named("add 291 solutions for LC 1118-2000 coverage gap") == set(),
-                       "a bulk-import range must not mark LC 1118 as practised")
-    failures += _check("subject: a bare count is not a problem",
-                       named("cover the 13 uncovered classics") == set())
-
-    # ── Scoring ──────────────────────────────────────────────────────────────
-    failures += _check("staleness: touched today is ~0",
-                       staleness(0, DEFAULT_HALF_LIFE) == 0.0)
-    failures += _check("staleness: rises with days and stays under 1",
-                       staleness(7, 21) < staleness(60, 21) < 1.0)
-    failures += _check("staleness: never touched saturates",
-                       staleness(None, 21) > 0.99)
-
-    hot = {"section": "Hot", "importance_share": 0.5, "attention_share": 0.9,
-           "ratio": 1.8, "deficit": -0.4, "multiplier": 0.4, "last_ts": None, "n": 2}
-    cold = {"section": "Cold", "importance_share": 0.5, "attention_share": 0.1,
-            "ratio": 0.2, "deficit": 0.4, "multiplier": 1.8, "last_ts": None, "n": 3}
-    rows = ([{"lc": i, "section": "Hot", "score": 100 - i} for i in range(4)]
-            + [{"lc": 10 + i, "section": "Cold", "score": 50 - i} for i in range(3)])
-    cats = {"Hot": hot, "Cold": cold}
-
-    picked = pick(rows, cats, top=4, per_category=2, balanced=True, min_score_frac=0.0)
-    failures += _check("pick: the neglected category goes first",
-                       picked[0]["section"] == "Cold")
-    failures += _check("pick: no category takes more than --per-category",
-                       Counter(r["section"] for r in picked)["Hot"] == 2)
-    picked = pick(rows, cats, top=6, per_category=2, balanced=True, min_score_frac=0.0)
-    failures += _check("pick: the cap is a preference, not a quota",
-                       len(picked) == 6, "%d returned" % len(picked))
-    picked = pick(rows, cats, top=3, per_category=2, balanced=True, min_score_frac=0.9)
-    failures += _check("pick: a weak category is passed over",
-                       all(r["section"] == "Hot" for r in picked))
-    picked = pick(rows, cats, top=3, per_category=1, balanced=False)
-    failures += _check("pick: --no-balance is straight score order",
-                       [r["lc"] for r in picked] == [0, 1, 2])
-
-    # ── Live cross-checks ────────────────────────────────────────────────────
-    # The one rule shared with another script: what counts as a `MUST` row.
-    # extract_must_lc.py owns it and generates doc/must_lc_list.md from it, so
-    # the two readings must agree exactly or one of the two docs is lying.
-    live = parse_readme(args.readme)
-    failures += _check("live: README still parses as a table of problems",
-                       len(live) > 1000, "%d rows" % len(live))
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     try:
-        import extract_must_lc
-    except ImportError as exc:
-        failures += _check("live: extract_must_lc.py importable", False, str(exc))
-    else:
-        theirs = {num for num, _, _, _, _ in extract_must_lc.parse(args.readme)}
-        mine = {num for num, row in live.items() if row["must"]}
-        failures += _check("live: MUST agrees with extract_must_lc.py",
-                           mine == theirs,
-                           "only here %s / only there %s"
-                           % (sorted(mine - theirs)[:5], sorted(theirs - mine)[:5]))
+        import test_suggest_review
+    except ImportError:
+        print("script/test_suggest_review.py is not next to this script — "
+              "run the tests from a full checkout.", file=sys.stderr)
+        return 1
 
-    live_dates, _, live_warnings = parse_progress(args.progress)
-    failures += _check("live: the practice log still yields problems",
-                       len(live_dates) > 400, "%d problems" % len(live_dates))
-    # One known bad date (20260229 — 2026 is not a leap year) is in the log.
-    failures += _check("live: the log parses almost cleanly",
-                       len(live_warnings) <= 2, live_warnings)
+    suite = unittest.defaultTestLoader.loadTestsFromModule(test_suggest_review)
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    return 0 if result.wasSuccessful() else 1
 
-    print("\n  %s — %d check(s) failed\n" % ("FAILED" if failures else "all checks pass",
-                                             failures))
-    return 1 if failures else 0
 
 
 # ── CLI ─────────────────────────────────────────────────────────────────────

--- a/script/suggest_review.py
+++ b/script/suggest_review.py
@@ -592,6 +592,7 @@ def pick(rows, cats, top, per_category, balanced, min_score_frac=MIN_SCORE_FRAC)
     # still not be worth a pick ahead of a big one that is half-neglected.
     order = sorted(by_cat, key=lambda s: -cats[s]["deficit"])
     picks, cursor, used = [], {s: 0 for s in order}, defaultdict(int)
+    chosen = set()
 
     def take(section, cap, bar):
         queue = by_cat[section]
@@ -600,9 +601,10 @@ def pick(rows, cats, top, per_category, balanced, min_score_frac=MIN_SCORE_FRAC)
         while cursor[section] < len(queue):
             cand = queue[cursor[section]]
             cursor[section] += 1
-            if cand["score"] <= 0 or cand["score"] < bar:
+            if id(cand) in chosen or cand["score"] <= 0 or cand["score"] < bar:
                 continue
             picks.append(cand)
+            chosen.add(id(cand))
             used[section] += 1
             return True
         return False
@@ -620,14 +622,22 @@ def pick(rows, cats, top, per_category, balanced, min_score_frac=MIN_SCORE_FRAC)
     # every eligible category has had its share, the rest of the request is
     # filled by score. Without this, `--section "Binary Search" --top 5` returns
     # two problems, which reads as a bug rather than as a policy.
-    while len(picks) < top:
-        progressed = False
-        for section in order:
-            if len(picks) >= top:
-                break
-            progressed |= take(section, top, 0.0)
-        if not progressed:
+    #
+    # The refill reads `ranked` rather than resuming the per-category cursors.
+    # Those cursors have already been walked past every candidate the floor
+    # rejected — a queue is sorted by descending score, so a category whose best
+    # is under the floor has all of it under the floor and one pass exhausts it
+    # — and resuming from there returns short while eligible problems are still
+    # sitting in the pool. Reading `ranked` also makes "filled by score" true:
+    # continuing round-robin would instead keep ordering the remainder by
+    # category deficit.
+    for cand in ranked:
+        if len(picks) >= top:
             break
+        if id(cand) in chosen or cand["score"] <= 0:
+            continue
+        picks.append(cand)
+        chosen.add(id(cand))
     return picks
 
 
@@ -814,6 +824,20 @@ def main(argv=None):
 
     if args.self_test:
         return self_test(args)
+
+    # Both of these are divisors — the half-life in `staleness`, half the window
+    # in `category_balance` — so a zero turns a mistyped flag into a traceback
+    # instead of a usage line, and a negative one silently inverts the curve:
+    # the freshest problems would come out looking the most stale.
+    for flag, value in (("--top", args.top),
+                        ("--per-category", args.per_category),
+                        ("--window", args.window),
+                        ("--half-life", args.half_life),
+                        ("--bulk-limit", args.bulk_limit)):
+        if value <= 0:
+            ap.error("%s must be greater than 0" % flag)
+    if not 0.0 <= args.min_score_frac <= 1.0:
+        ap.error("--min-score-frac must be between 0 and 1")
 
     now = time.time()
 

--- a/script/suggest_review.py
+++ b/script/suggest_review.py
@@ -1,0 +1,1095 @@
+#!/usr/bin/env python3
+"""
+suggest_review.py — what to practise next, chosen to keep the practice *balanced*.
+
+The problem this solves is not "what have I not done" — it is bias. Practice
+drifts: a good week on DP turns into three weeks on DP, and binary search,
+heap and linked list quietly go a month untouched while still being exactly
+what a coding round is made of. A flat "most important, least recently seen"
+ranking makes that worse, because the biggest sections have the most important
+problems and would fill the whole list.
+
+So the pick is made in two stages:
+
+  1. Score every problem:  importance x staleness
+  2. Spend the picks across *categories* in order of how under-practised each
+     one is, capped at --per-category, so one hot topic cannot own the list.
+
+Three signals feed it, all already in the repo — nothing is invented here:
+
+  README.md            the problem universe, and this repo's own judgement of
+                       what matters: the `MUST` marker, the curated-list tags
+                       (`blind75` / `neetcode150` / `neetcode250` / `top100liked`),
+                       the company tags, and the status column's `OK`/`AGAIN`
+                       plus its `*` run of review passes.
+                       `doc/must_lc_list.md` is generated from these same rows
+                       (script/extract_must_lc.py), so reading README covers it.
+  git history          when each problem was last *worked on* — the commit that
+                       touched its solution file, or named its LC number.
+  data/progress.txt    when it was last *practised*, which is not the same
+                       thing: a re-read that produced no commit still counts.
+
+Usage:
+    python3 script/suggest_review.py                     # the balanced plan
+    python3 script/suggest_review.py --top 20 --per-category 3
+    python3 script/suggest_review.py --only must         # MUST rows only
+    python3 script/suggest_review.py --only top100liked
+    python3 script/suggest_review.py --section "Binary Search" --top 10
+    python3 script/suggest_review.py --no-balance        # plain importance rank
+    python3 script/suggest_review.py --json out.json
+    python3 script/suggest_review.py --markdown doc/review_suggestions.md
+
+Read the balance table first and the picks second: the table is the finding
+(where the practice is lopsided), the picks are just one way to act on it.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import Counter, OrderedDict, defaultdict
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DAY = 86400.0
+
+# ── Sections ────────────────────────────────────────────────────────────────
+# The LC tables start at `## Array`; everything above it is intro prose.
+FIRST_LC_SECTION = "Array"
+# Not DSA practice, or not verified solutions — kept out of the balance maths so
+# they cannot distort a category's share. `--all-sections` puts them back.
+EXCLUDED_SECTIONS = {
+    "SQL",
+    "Shell Script",
+    "Concurrency",
+    "Newly Added (kamyu104 gap)",
+}
+
+# ── Importance weights ──────────────────────────────────────────────────────
+# Deliberately coarse. These are priorities, not measurements, and a tenth of a
+# point of tuning here is noise next to "this topic has not been touched in six
+# weeks", which is what the staleness and balance factors are for.
+W_MUST = 5.0            # the repo's own strongest marker
+W_TOP100 = 2.5          # LeetCode's Top 100 Liked
+W_BLIND75 = 2.5         # the lists nest: only the narrowest one scores
+W_NEETCODE150 = 1.5
+W_NEETCODE250 = 0.7
+W_GOOGLE = 1.5          # the stated target is a Google SWE loop
+W_COMPANY_EACH = 0.2    # every other FAANG-ish tag
+W_COMPANY_CAP = 1.0
+W_PASS = 0.2            # per recorded review pass on an `AGAIN` row ...
+W_PASS_CAP = 2.4        # ... a problem that has fought back 12 times is a gap
+W_DIFFICULTY = {"Medium": 0.5, "Hard": 0.3, "Easy": 0.0}
+
+COMPANIES = ("fb", "amazon", "apple", "netflix", "microsoft",
+             "uber", "linkedin", "bloomberg")
+LIST_TAGS = ("blind75", "neetcode150", "neetcode250", "top100liked")
+
+# Staleness half-life: a problem untouched this many days is half-way to fully
+# stale. 21 days is roughly the point where a solved-once problem stops being
+# recallable without re-deriving it.
+DEFAULT_HALF_LIFE = 21.0
+COLD_DAYS = 400.0       # "never seen" — beyond any real gap, so it saturates
+
+# How hard the balance factor pushes. 1.0 means a category with no attention at
+# all doubles its problems' scores, and one with twice its fair share is halved.
+BALANCE_GAIN = 1.0
+BALANCE_FLOOR = 0.4
+# A category's best candidate must score at least this fraction of the whole
+# pool's best, or the category is passed over — breadth is the point, but not
+# at the price of filling a slot with a problem nothing recommends.
+MIN_SCORE_FRAC = 0.3
+
+DIFFS = ("Easy", "Medium", "Hard")
+MUST_ANY_CASE = re.compile(r"must", re.IGNORECASE)
+MUST_TAG_TOKEN = re.compile(r"(?<![A-Za-z])MUST(?![A-Za-z])")
+STATUS_WORD = re.compile(r"\b(OK|AGAIN|NOT_OK|TODO)\b")
+
+
+# ── README ──────────────────────────────────────────────────────────────────
+def parse_readme(path):
+    """README.md -> {lc: problem}.  Columns are
+    `# | Title | Solution | Time | Space | Difficulty | Note | Status`.
+
+    A handful of problems are filed under two sections (LC 200 under both DFS
+    and Graph, say). The first sighting owns the row — the balance maths needs
+    one home per problem or a shared problem inflates two categories at once —
+    and the other sections are kept in `also_in` so the row can still be found
+    by `--section`.
+    """
+    problems = OrderedDict()
+    section = None
+    seen_first = False
+
+    with open(path, encoding="utf-8") as f:
+        for raw in f:
+            line = raw.rstrip("\n")
+
+            head = re.match(r"^##\s+(.*)", line)
+            if head:
+                name = head.group(1).strip()
+                if name == FIRST_LC_SECTION:
+                    seen_first = True
+                if seen_first:
+                    section = name
+                continue
+
+            if not seen_first or "|" not in line:
+                continue
+
+            cols = [c.strip() for c in line.strip().strip("|").split("|")]
+            if len(cols) < 8 or not re.match(r"^\d+$", cols[0]):
+                continue
+
+            num = int(cols[0])
+            title_m = re.search(r"\[([^\]]+)\]\(([^)]+)\)", cols[1])
+            title = (title_m.group(1) if title_m else cols[1]).strip()
+            url = title_m.group(2).strip() if title_m else ""
+            difficulty = next((c for c in cols if c in DIFFS), "")
+            note, status = cols[-2], cols[-1]
+
+            # `MUST` is read the way script/extract_must_lc.py reads it: any
+            # casing in the status cell, but only a standalone ALL-CAPS token in
+            # the note cell, so prose ("the window must be non-decreasing")
+            # is not mistaken for the marker.
+            must = bool(MUST_ANY_CASE.search(status) or MUST_TAG_TOKEN.search(note))
+            sm = STATUS_WORD.search(status)
+            tags = set(re.findall(r"`([^`]+)`", note))
+
+            if num in problems:
+                # The duplicate row is the same problem filed a second time, and
+                # the two rows are rarely identical — LC 547 is `Friend Circles`
+                # with no marker under DFS and `Number of Provinces` with `MUST`
+                # under Graph. Keeping only the first sighting's flags loses the
+                # marker, so the rows are folded together: the strongest claim
+                # about a problem wins.
+                first = problems[num]
+                first["also_in"].append(section)
+                first["note"] += ", " + note
+                first["must"] = first["must"] or must
+                first["tags"] |= tags
+                first["passes"] = max(first["passes"], status.count("*"))
+                first["status"] = first["status"] or (sm.group(1) if sm else None)
+                first["paths"] += [q.split("#")[0].lstrip("./")
+                                   for q in re.findall(r"\]\(([^)]+)\)", cols[2])
+                                   if not q.startswith("http")]
+                continue
+
+            problems[num] = {
+                "lc": num,
+                "title": title,
+                "url": url,
+                "difficulty": difficulty,
+                "section": section,
+                "also_in": [],
+                "note": note,
+                "status": sm.group(1) if sm else None,
+                # The `*` run counts review passes; see doc/lc-readiness-guide.md.
+                "passes": status.count("*"),
+                "must": must,
+                "tags": tags,
+                "paths": [p.split("#")[0].lstrip("./")
+                          for p in re.findall(r"\]\(([^)]+)\)", cols[2])
+                          if not p.startswith("http")],
+            }
+
+    return problems
+
+
+def load_problem_lists(path):
+    """data/problem_lists.json -> {lc: {list names}}.
+
+    README only tags the narrowest list a row sits on, so this file is the
+    complete membership and is what the scoring reads.
+    """
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    out = {}
+    for p in data.get("problems", []):
+        try:
+            out[int(p["id"])] = set(p.get("lists", []))
+        except (KeyError, ValueError):
+            continue
+    return out
+
+
+# ── git ─────────────────────────────────────────────────────────────────────
+# Two independent readings of "when did I last work on this", because neither
+# alone is complete: most sessions edit the solution file, but plenty land in a
+# dev/ws scratch file whose name says nothing, and there the commit subject
+# ("update 1353 py") is the only record.
+SUBJECT_LC = re.compile(
+    r"\bLC[\s#]*(\d{1,4})\b(?![\s]*[-–]\s*\d)"        # "expand LC 131", not "LC 1118-2000"
+    r"|\b(\d{2,4})\s+(?:py|python|java|js|scala)\b",  # "update 131 py"
+    re.IGNORECASE,
+)
+
+# A commit touching more solution files than this is a bulk import or a
+# sweeping refactor, not a study session — the repo has commits adding 393
+# generated Java files at once. Counted naively they bury the real signal: they
+# made every one of those problems look practised on the same day, and put 563
+# problems inside a 30-day window that actually saw a few dozen. Their paths are
+# therefore ignored; an LC number written into the subject by hand still counts.
+BULK_FILE_LIMIT = 6
+# Same reasoning for a subject: more than a few numbers in one line is prose
+# ("add 148 solutions, completing the LC 1001-2000 gap"), not a work record.
+BULK_SUBJECT_LIMIT = 3
+
+
+def git_touch_history(repo, universe, bulk_limit=BULK_FILE_LIMIT):
+    """-> ({lc: [unix_ts, ...]} newest first, n_commits_skipped).
+
+    `universe` maps a repo-relative solution path to the LC numbers that claim
+    it, built from README, so a commit is attributed to a problem only when the
+    repo already says that file belongs to it.
+    """
+    cmd = ["git", "-C", repo, "log", "--no-merges",
+           "--name-only", "--pretty=format:\x01%ct\x01%s"]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True,
+                             check=True).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print("warning: could not read git history (%s); "
+              "falling back to the practice log alone" % exc, file=sys.stderr)
+        return {}, 0
+
+    touches = defaultdict(list)
+    ts = None
+    hits = set()
+    bulk = 0
+
+    def close_commit():
+        nonlocal bulk
+        if ts is None or not hits:
+            return
+        if len(hits) > bulk_limit:
+            bulk += 1
+            return
+        for lc in hits:
+            touches[lc].append(ts)
+
+    for line in out.split("\n"):
+        if line.startswith("\x01"):
+            close_commit()
+            hits = set()
+            _, stamp, subject = line.split("\x01", 2)
+            try:
+                ts = int(stamp)
+            except ValueError:
+                ts = None
+                continue
+            named = {int(a or b) for a, b in SUBJECT_LC.findall(subject)}
+            if len(named) <= BULK_SUBJECT_LIMIT:
+                for lc in named:
+                    touches[lc].append(ts)
+            continue
+        path = line.strip()
+        if not path or ts is None:
+            continue
+        hits.update(universe.get(path, ()))
+    close_commit()
+
+    for lc in touches:
+        touches[lc].sort(reverse=True)
+    return touches, bulk
+
+
+# ── data/progress.txt ───────────────────────────────────────────────────────
+# The practice log. Its shape is hand-written and loose; this mirrors the rules
+# site/build-review-plan.js already pins with tests, so the two agree on what a
+# line means. Anything it cannot place is counted and reported, never dropped
+# silently.
+STATUS_WORDS = ("again", "todo", "ok")
+
+
+def _split_top_level(payload):
+    """Split on commas outside parens — "(again, 2 pointers)" is one entry.
+    A period splits too: "39(again*).79(again*)" is a typo the log actually
+    contains, and without this LC 79 vanishes into LC 39's note.
+    """
+    parts, buf, depth = [], "", 0
+    for ch in payload:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        if depth == 0 and ch in ",.":
+            parts.append(buf)
+            buf = ""
+            continue
+        buf += ch
+    parts.append(buf)
+    return parts
+
+
+# A day is often written in labelled runs — "| DP: 44(todo), 10(todo)" or
+# "top 100 (backtrack): 51(todo)" or "| (LC must) 438(again)". The label is not
+# an entry, and the first problem after one does not start with a digit once the
+# label is glued to it, so without this it is dropped on the floor: 8 sessions'
+# worth in the current log, and always the first problem of a run.
+# site/build-review-plan.js does not strip labels and loses those same entries.
+#
+# The colon that ends a label is at paren depth 0. The one inside
+# "2289(todo: mono stack + dp)" is not, which is why the depth matters.
+def _strip_label(entry):
+    depth, cut = 0, -1
+    for i, ch in enumerate(entry):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif ch == ":" and depth == 0:
+            cut = i
+    if cut >= 0:
+        entry = entry[cut + 1:].lstrip()
+    # A parenthesised label with no colon: "(LC must) 438(again)".
+    m = re.match(r"^\([^)]*\)\s*(?=\d)", entry)
+    return entry[m.end():] if m else entry
+
+
+def _classify(note):
+    text = (note or "").lower()
+    for word in STATUS_WORDS:          # `again` before `ok`: "(ok, but again)"
+        if word in text:               # is a problem that still needs a pass
+            return word
+    return "other" if text else "none"
+
+
+def parse_progress(path):
+    """-> ({lc: [epoch_seconds, ...]} newest first, {lc: Counter(status)}, warnings)."""
+    if not os.path.exists(path):
+        return {}, {}, ["%s not found" % path]
+
+    dates = defaultdict(list)
+    notes = defaultdict(Counter)
+    warnings = []
+    current_ts = None
+    pending = None
+
+    def depth_of(text):
+        depth = 0
+        for ch in text:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth = max(0, depth - 1)
+        return depth
+
+    def flush():
+        if pending is None or current_ts is None:
+            return
+        for chunk in _split_top_level(pending.replace("|", ",")):
+            entry = chunk.strip()
+            if not entry:
+                continue
+            m = re.match(r"^(\d+)\s*(?:\((.*)\))?", _strip_label(entry))
+            if not m:      # named drills — topo_sort, weekly_331 — not LC rows
+                continue
+            lc = int(m.group(1))
+            dates[lc].append(current_ts)
+            notes[lc][_classify(m.group(2))] += 1
+
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().split("\n")
+
+    for i, raw in enumerate(lines):
+        trimmed = raw.strip()
+        mid_annotation = pending is not None and depth_of(pending) > 0
+
+        if not trimmed or re.match(r"^[-=]{2,}", trimmed):
+            flush()
+            pending = None
+            continue
+
+        header = re.match(r"^(\d{8})\s*[:.]?\s*(.*)$", trimmed)
+        # An 8-digit line is a date, never the tail of a wrapped annotation —
+        # an LC number is at most 4 digits. It therefore wins over a still-open
+        # paren, which would otherwise swallow every following day.
+        if header:
+            if mid_annotation:
+                warnings.append("line %d: previous entry left '(' unclosed" % (i + 1))
+            flush()
+            try:
+                current_ts = time.mktime(time.strptime(header.group(1), "%Y%m%d"))
+            except ValueError:
+                warnings.append("line %d: unreadable date %r" % (i + 1, header.group(1)))
+                current_ts = None
+            pending = header.group(2)
+            continue
+
+        if pending is None:
+            if current_ts is None:
+                warnings.append("line %d: content before any date" % (i + 1))
+                continue
+            pending = trimmed          # a bare continuation of the day above
+        else:
+            pending += ("" if mid_annotation else ",") + trimmed
+
+    flush()
+
+    for lc in dates:
+        dates[lc].sort(reverse=True)
+    return dict(dates), dict(notes), warnings
+
+
+# ── Scoring ─────────────────────────────────────────────────────────────────
+def importance(p, lists):
+    """Why this problem is worth a pass at all, in points. Returns (score, reasons)."""
+    score, reasons = 0.0, []
+
+    if p["must"]:
+        score += W_MUST
+        reasons.append("MUST")
+
+    on = lists.get(p["lc"], set()) | (p["tags"] & set(LIST_TAGS))
+    if "top100liked" in on:
+        score += W_TOP100
+        reasons.append("top100liked")
+    # The NeetCode lists nest, so only the narrowest one is credited.
+    if "blind75" in on:
+        score += W_BLIND75
+        reasons.append("blind75")
+    elif "neetcode150" in on:
+        score += W_NEETCODE150
+        reasons.append("neetcode150")
+    elif "neetcode250" in on:
+        score += W_NEETCODE250
+        reasons.append("neetcode250")
+
+    if "google" in p["tags"]:
+        score += W_GOOGLE
+        reasons.append("google")
+    others = [c for c in COMPANIES if c in p["tags"]]
+    if others:
+        score += min(len(others) * W_COMPANY_EACH, W_COMPANY_CAP)
+
+    # An `AGAIN` row that has already cost many passes is the opposite of
+    # settled — the marker never graduates in this repo (see the readiness
+    # guide), so the pass count is read as difficulty, not as progress.
+    if p["status"] == "AGAIN" and p["passes"]:
+        bump = min(p["passes"] * W_PASS, W_PASS_CAP)
+        score += bump
+        reasons.append("AGAIN x%d" % p["passes"])
+
+    score += W_DIFFICULTY.get(p["difficulty"], 0.0)
+    return score, reasons
+
+
+def staleness(days, half_life):
+    """0 (touched today) -> 1 (long gone). Halves the remaining freshness every
+    `half_life` days, so the curve is steep where it matters and flat after."""
+    if days is None:
+        days = COLD_DAYS
+    return 1.0 - 0.5 ** (max(0.0, days) / half_life)
+
+
+def build_rows(problems, lists, git_touch, prog_dates, prog_notes, now, half_life):
+    rows = []
+    for lc, p in problems.items():
+        imp, reasons = importance(p, lists)
+
+        git_last = git_touch.get(lc, [None])[0]
+        prog_last = prog_dates.get(lc, [None])[0]
+        last = max([t for t in (git_last, prog_last) if t], default=None)
+        days = None if last is None else (now - last) / DAY
+        stale = staleness(days, half_life)
+
+        rows.append(dict(
+            p,
+            importance=imp,
+            reasons=reasons,
+            last_ts=last,
+            days=days,
+            stale=stale,
+            git_touches=len(git_touch.get(lc, ())),
+            practices=len(prog_dates.get(lc, ())),
+            again_notes=prog_notes.get(lc, Counter()).get("again", 0),
+            base=imp * stale,
+        ))
+    return rows
+
+
+def category_balance(rows, now, window_days):
+    """Per category: the share of importance it holds vs the share of recent
+    attention it got. The gap between the two is the bias this script exists to
+    surface.
+
+    Attention is recency-weighted inside the window rather than a flat count,
+    so yesterday's session weighs more than one three weeks ago, and it counts
+    *touch events* (commits and practice-log entries), not distinct problems —
+    grinding one problem five times is five units of attention spent on that
+    category, which is exactly the behaviour being measured.
+    """
+    imp = defaultdict(float)
+    att = defaultdict(float)
+    last_seen = {}
+    cutoff = now - window_days * DAY
+
+    for r in rows:
+        imp[r["section"]] += r["importance"]
+        if r["last_ts"]:
+            prev = last_seen.get(r["section"])
+            if prev is None or r["last_ts"] > prev:
+                last_seen[r["section"]] = r["last_ts"]
+
+    for r in rows:
+        for ts in r["_events"]:
+            if ts >= cutoff:
+                att[r["section"]] += 0.5 ** ((now - ts) / DAY / (window_days / 2.0))
+
+    total_imp = sum(imp.values()) or 1.0
+    total_att = sum(att.values()) or 1.0
+
+    cats = {}
+    for section, weight in imp.items():
+        imp_share = weight / total_imp
+        att_share = att.get(section, 0.0) / total_att
+        # ratio 1.0 = getting exactly its fair share of practice.
+        ratio = att_share / imp_share if imp_share else 0.0
+        cats[section] = {
+            "section": section,
+            "importance_share": imp_share,
+            "attention_share": att_share,
+            "ratio": ratio,
+            "deficit": imp_share - att_share,
+            "multiplier": max(BALANCE_FLOOR,
+                              min(1.0 + BALANCE_GAIN,
+                                  1.0 + BALANCE_GAIN * (1.0 - ratio))),
+            "last_ts": last_seen.get(section),
+            "n": 0,
+        }
+    for r in rows:
+        cats[r["section"]]["n"] += 1
+    return cats
+
+
+def pick(rows, cats, top, per_category, balanced, min_score_frac=MIN_SCORE_FRAC):
+    """Spend `top` picks. Balanced: walk the categories in order of how much
+    absolute importance they are missing and take each one's best candidate in
+    turn, so the list cannot be swallowed by whichever topic is largest or
+    hottest. Unbalanced: straight score order.
+
+    Breadth has a floor. Ordering by deficit alone eventually reaches a
+    five-row section whose best candidate is a Hard problem carrying one
+    company tag — technically neglected, but not a topic worth a slot ahead of
+    a second pass at a `MUST`. A category is skipped when its best candidate
+    scores below `min_score_frac` of the strongest pick, and the slot goes back
+    to the categories that cleared the bar.
+    """
+    ranked = sorted(rows, key=lambda r: -r["score"])
+    if not balanced:
+        return ranked[:top]
+
+    by_cat = defaultdict(list)
+    for r in ranked:
+        by_cat[r["section"]].append(r)
+
+    floor = (ranked[0]["score"] * min_score_frac) if ranked else 0.0
+    # Absolute deficit, not the ratio: a tiny category can be 100% neglected and
+    # still not be worth a pick ahead of a big one that is half-neglected.
+    order = sorted(by_cat, key=lambda s: -cats[s]["deficit"])
+    picks, cursor, used = [], {s: 0 for s in order}, defaultdict(int)
+
+    def take(section, cap, bar):
+        queue = by_cat[section]
+        if used[section] >= cap:
+            return False
+        while cursor[section] < len(queue):
+            cand = queue[cursor[section]]
+            cursor[section] += 1
+            if cand["score"] <= 0 or cand["score"] < bar:
+                continue
+            picks.append(cand)
+            used[section] += 1
+            return True
+        return False
+
+    while len(picks) < top:
+        progressed = False
+        for section in order:
+            if len(picks) >= top:
+                break
+            progressed |= take(section, per_category, floor)
+        if not progressed:
+            break
+
+    # The cap and the floor are a preference for breadth, not a quota: once
+    # every eligible category has had its share, the rest of the request is
+    # filled by score. Without this, `--section "Binary Search" --top 5` returns
+    # two problems, which reads as a bug rather than as a policy.
+    while len(picks) < top:
+        progressed = False
+        for section in order:
+            if len(picks) >= top:
+                break
+            progressed |= take(section, top, 0.0)
+        if not progressed:
+            break
+    return picks
+
+
+# ── Rendering ───────────────────────────────────────────────────────────────
+def fmt_days(days):
+    if days is None:
+        return "never"
+    if days < 1:
+        return "today"
+    return "%dd" % round(days)
+
+
+def bar(fraction, width=14):
+    filled = int(round(max(0.0, min(1.0, fraction)) * width))
+    return "#" * filled + "." * (width - filled)
+
+
+def truncate(text, width):
+    return text if len(text) <= width else text[:width - 1] + "…"
+
+
+def render_text(picks, cats, recent, args, warnings, out=sys.stdout):
+    w = out.write
+
+    w("\n== Recent focus (last %d days) ==\n\n" % args.window)
+    if recent["events"]:
+        w("  %d touches on %d problems across %d categories.\n"
+          % (recent["events"], recent["problems"], len(recent["by_cat"])))
+        if recent["bulk_commits"]:
+            w("  (%d bulk commits ignored — a commit touching more than %d solution\n"
+              "   files is an import, not a session.)\n"
+              % (recent["bulk_commits"], args.bulk_limit))
+        for section, n in recent["by_cat"].most_common(8):
+            w("    %-26s %3d  %s\n"
+              % (truncate(section, 26), n, bar(n / recent["by_cat"].most_common(1)[0][1])))
+    else:
+        w("  nothing in the window — every category counts as neglected.\n")
+
+    w("\n== Balance: attention vs importance ==\n\n")
+    w("  %-26s %5s  %-14s %-14s %8s  %s\n"
+      % ("category", "n", "importance", "attention", "ratio", "last"))
+    ordered = sorted(cats.values(), key=lambda c: -c["deficit"])
+    scale = max(max((c["importance_share"] for c in ordered), default=0.01),
+                max((c["attention_share"] for c in ordered), default=0.01))
+    # A five-row section rounds to nothing on both axes and is noise in the
+    # table — unless it produced a pick, in which case hiding it would leave
+    # that pick unexplained.
+    picked_sections = {p["section"] for p in picks}
+    for c in ordered:
+        if (c["importance_share"] < 0.005 and c["attention_share"] < 0.005
+                and c["section"] not in picked_sections):
+            continue
+        flag = ("UNDER" if c["ratio"] < 0.5 else
+                "over " if c["ratio"] > 1.8 else "     ")
+        w("  %-26s %5d  %s %s %7.2f %s  %s\n"
+          % (truncate(c["section"], 26), c["n"],
+             bar(c["importance_share"] / scale, 12),
+             bar(c["attention_share"] / scale, 12),
+             c["ratio"], flag,
+             fmt_days(None if not c["last_ts"]
+                      else (recent["now"] - c["last_ts"]) / DAY)))
+    w("\n  ratio = share of recent attention / share of importance."
+      "  1.00 is a fair share; UNDER is the bias to fix.\n")
+
+    w("\n== Suggested review (%d problems, %d categories) ==\n\n" % (
+        len(picks), len({p["section"] for p in picks})))
+    if not args.no_balance:
+        w("  Ordered by how neglected the category is, not by score — that order\n"
+          "  is the recommendation.\n\n")
+    w("  %-3s %-5s %-34s %-7s %-20s %6s %6s  %s\n"
+      % ("#", "LC", "title", "diff", "category", "last", "score", "why"))
+    for i, p in enumerate(picks, 1):
+        w("  %-3d %-5d %-34s %-7s %-20s %6s %6.2f  %s\n"
+          % (i, p["lc"], truncate(p["title"], 34), p["difficulty"] or "?",
+             truncate(p["section"], 20), fmt_days(p["days"]), p["score"],
+             " · ".join(p["reasons"]) or "-"))
+
+    if warnings:
+        w("\n  %d parse warning(s) in data/progress.txt:\n" % len(warnings))
+        for warning in warnings[:5]:
+            w("    %s\n" % warning)
+    w("\n")
+
+
+def render_markdown(picks, cats, recent, args):
+    lines = [
+        "# Suggested LeetCode Review",
+        "",
+        "Generated by `script/suggest_review.py` — importance x staleness, "
+        "then balanced across categories so no one topic owns the list.",
+        "",
+        "## Balance: attention vs importance",
+        "",
+        "| Category | Problems | Importance share | Attention share (%dd) | Ratio | Last touched |"
+        % args.window,
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for c in sorted(cats.values(), key=lambda c: -c["deficit"]):
+        if c["importance_share"] < 0.005 and c["attention_share"] < 0.005:
+            continue
+        lines.append("| %s | %d | %.1f%% | %.1f%% | %.2f | %s |" % (
+            c["section"], c["n"], c["importance_share"] * 100,
+            c["attention_share"] * 100, c["ratio"],
+            fmt_days(None if not c["last_ts"]
+                     else (recent["now"] - c["last_ts"]) / DAY)))
+
+    lines += ["", "## Picks", "",
+              "| # | LC | Title | Difficulty | Category | Last touched | Score | Why |",
+              "|---:|---:|---|---|---|---|---:|---|"]
+    for i, p in enumerate(picks, 1):
+        title = "[%s](%s)" % (p["title"], p["url"]) if p["url"] else p["title"]
+        lines.append("| %d | %d | %s | %s | %s | %s | %.2f | %s |"
+                     % (i, p["lc"], title, p["difficulty"] or "?",
+                        p["section"], fmt_days(p["days"]), p["score"],
+                        ", ".join(p["reasons"]) or "-"))
+    return "\n".join(lines) + "\n"
+
+
+# ── Self-test ───────────────────────────────────────────────────────────────
+# `python3 script/suggest_review.py --self-test`
+#
+# Three of the four inputs are hand-written files whose shape nobody controls —
+# README rows, the practice log, commit subjects — so the failure mode is not a
+# crash, it is a parser that quietly reads fewer rows than there are and hands
+# back a plausible-looking but shrunken plan. These pin the shapes that are
+# actually in the files, plus a live cross-check against the one other script
+# that reads the same `MUST` marker.
+SELF_TEST_README = """
+## Resource
+
+| 999 | ignored, above the first LC section | | | | Easy | | OK |
+
+## Array
+
+|  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
+|-----|-------|----------|------|-------|------------|------|--------|
+| 48 | [Rotate Image](https://leetcode.com/problems/rotate-image/) | [Python](./leetcode_python/Array/rotate-image.py) | _O(n^2)_ | _O(1)_ | Medium | **array**, `google`, `blind75` | AGAIN*** (5) (MUST) |
+| 118 | [Pascal's Triangle](https://leetcode.com/problems/pascals-triangle/) | [Python](./leetcode_python/Array/pascals-triangle.py) | _O(n^2)_ | _O(1)_ | Easy | **array**, the row must be built from the one above, `amazon` | OK** |
+| 547 | [Friend Circles](https://leetcode.com/problems/number-of-provinces/) | [Python](./leetcode_python/DFS/friend-circles.py) | _O(n^2)_ | _O(n)_ | Medium | union find, `google` | AGAIN* |
+
+## Graph
+
+|  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
+|-----|-------|----------|------|-------|------------|------|--------|
+| 547 | [Number of Provinces](https://leetcode.com/problems/number-of-provinces/) | [Java](./leetcode_java/x/NumberOfProvinces.java) | _O(n^2)_ | _O(n)_ | Medium | **graph**, MUST, `fb` | AGAIN***** (2) |
+"""
+
+SELF_TEST_PROGRESS = """20260909: 4(todo), 34(again!!) | DP: 44(todo)
+
+20260908: 70(ok*, o(1) space!!),198(
+ok*),139(again* 1d dp)
+
+20260907: top 100 (backtrack): 51(todo) | (LC must) 438(again), 2289(todo: mono stack + dp)
+20260906: 39(again*).79(again*), topo_sort, weekly_331
+,53(again)
+
+------ review
+
+20260905  1740(ok)
+"""
+
+
+def _check(label, condition, detail=""):
+    if condition:
+        return 0
+    print("  FAIL  %s%s" % (label, (" — " + detail) if detail else ""))
+    return 1
+
+
+def self_test(args):
+    import tempfile
+
+    failures = 0
+
+    # ── README shapes ────────────────────────────────────────────────────────
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False,
+                                     encoding="utf-8") as fh:
+        fh.write(SELF_TEST_README)
+        readme_path = fh.name
+    problems = parse_readme(readme_path)
+    os.unlink(readme_path)
+
+    failures += _check("README: rows above the first LC section are skipped",
+                       999 not in problems)
+    failures += _check("README: three distinct problems parsed",
+                       sorted(problems) == [48, 118, 547], sorted(problems))
+    failures += _check("README: MUST in the status cell is a marker",
+                       problems[48]["must"])
+    failures += _check("README: 'must' in note prose is NOT a marker",
+                       not problems[118]["must"])
+    failures += _check("README: an ALL-CAPS MUST token in the note IS a marker",
+                       problems[547]["must"])
+    failures += _check("README: a duplicate row folds into the first sighting",
+                       problems[547]["also_in"] == ["Graph"]
+                       and problems[547]["passes"] == 5
+                       and {"google", "fb"} <= problems[547]["tags"]
+                       and len(problems[547]["paths"]) == 2)
+    failures += _check("README: the `*` run counts review passes",
+                       problems[48]["passes"] == 3)
+    failures += _check("README: title and url come off the link",
+                       problems[48]["title"] == "Rotate Image"
+                       and problems[48]["url"].endswith("/rotate-image/"))
+    failures += _check("README: difficulty is read by value, not by position",
+                       problems[118]["difficulty"] == "Easy")
+
+    # ── Practice log shapes ──────────────────────────────────────────────────
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False,
+                                     encoding="utf-8") as fh:
+        fh.write(SELF_TEST_PROGRESS)
+        progress_path = fh.name
+    dates, notes, warnings = parse_progress(progress_path)
+    os.unlink(progress_path)
+
+    failures += _check("log: `|` session separators do not hide problems",
+                       44 in dates)
+    failures += _check("log: an annotation containing a comma stays one entry",
+                       70 in dates and 198 in dates and 1 not in dates,
+                       "'(ok*, o(1) space!!)' must not split into '70' and 'o(1) space'")
+    failures += _check("log: an annotation wrapped across a newline is rejoined",
+                       198 in dates and 139 in dates)
+    failures += _check("log: a period between entries splits them",
+                       39 in dates and 79 in dates)
+    failures += _check("log: a bare continuation line joins the day above",
+                       53 in dates)
+    failures += _check("log: a `DP:` style label does not swallow the entry",
+                       44 in dates, "labelled runs are where the DP practice hides")
+    failures += _check("log: a label with its own parens is stripped",
+                       51 in dates and 100 not in dates)
+    failures += _check("log: a parenthesised label with no colon is stripped",
+                       438 in dates)
+    failures += _check("log: a colon inside an annotation is not a label",
+                       2289 in dates and notes[2289]["todo"] == 1,
+                       "'2289(todo: mono stack + dp)' must stay LC 2289")
+    failures += _check("log: named drills are not LC numbers",
+                       331 not in dates and 3 not in dates)
+    failures += _check("log: a separator line ends the day",
+                       1740 in dates)
+    failures += _check("log: `again` beats `ok` when a note says both",
+                       notes[34]["again"] == 1 and notes[70]["ok"] == 1)
+    failures += _check("log: nothing unreadable in the fixture",
+                       not warnings, warnings)
+
+    # ── Commit subjects ──────────────────────────────────────────────────────
+    def named(subject):
+        return {int(a or b) for a, b in SUBJECT_LC.findall(subject)}
+
+    failures += _check("subject: 'update 131 py' names LC 131",
+                       named("update 131 py") == {131})
+    failures += _check("subject: 'expand LC 131 (Template 8)' names LC 131",
+                       named("update backtrack cheatsheet: expand LC 131 (Template 8)")
+                       == {131})
+    failures += _check("subject: an LC range is not a problem",
+                       named("add 291 solutions for LC 1118-2000 coverage gap") == set(),
+                       "a bulk-import range must not mark LC 1118 as practised")
+    failures += _check("subject: a bare count is not a problem",
+                       named("cover the 13 uncovered classics") == set())
+
+    # ── Scoring ──────────────────────────────────────────────────────────────
+    failures += _check("staleness: touched today is ~0",
+                       staleness(0, DEFAULT_HALF_LIFE) == 0.0)
+    failures += _check("staleness: rises with days and stays under 1",
+                       staleness(7, 21) < staleness(60, 21) < 1.0)
+    failures += _check("staleness: never touched saturates",
+                       staleness(None, 21) > 0.99)
+
+    hot = {"section": "Hot", "importance_share": 0.5, "attention_share": 0.9,
+           "ratio": 1.8, "deficit": -0.4, "multiplier": 0.4, "last_ts": None, "n": 2}
+    cold = {"section": "Cold", "importance_share": 0.5, "attention_share": 0.1,
+            "ratio": 0.2, "deficit": 0.4, "multiplier": 1.8, "last_ts": None, "n": 3}
+    rows = ([{"lc": i, "section": "Hot", "score": 100 - i} for i in range(4)]
+            + [{"lc": 10 + i, "section": "Cold", "score": 50 - i} for i in range(3)])
+    cats = {"Hot": hot, "Cold": cold}
+
+    picked = pick(rows, cats, top=4, per_category=2, balanced=True, min_score_frac=0.0)
+    failures += _check("pick: the neglected category goes first",
+                       picked[0]["section"] == "Cold")
+    failures += _check("pick: no category takes more than --per-category",
+                       Counter(r["section"] for r in picked)["Hot"] == 2)
+    picked = pick(rows, cats, top=6, per_category=2, balanced=True, min_score_frac=0.0)
+    failures += _check("pick: the cap is a preference, not a quota",
+                       len(picked) == 6, "%d returned" % len(picked))
+    picked = pick(rows, cats, top=3, per_category=2, balanced=True, min_score_frac=0.9)
+    failures += _check("pick: a weak category is passed over",
+                       all(r["section"] == "Hot" for r in picked))
+    picked = pick(rows, cats, top=3, per_category=1, balanced=False)
+    failures += _check("pick: --no-balance is straight score order",
+                       [r["lc"] for r in picked] == [0, 1, 2])
+
+    # ── Live cross-checks ────────────────────────────────────────────────────
+    # The one rule shared with another script: what counts as a `MUST` row.
+    # extract_must_lc.py owns it and generates doc/must_lc_list.md from it, so
+    # the two readings must agree exactly or one of the two docs is lying.
+    live = parse_readme(args.readme)
+    failures += _check("live: README still parses as a table of problems",
+                       len(live) > 1000, "%d rows" % len(live))
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    try:
+        import extract_must_lc
+    except ImportError as exc:
+        failures += _check("live: extract_must_lc.py importable", False, str(exc))
+    else:
+        theirs = {num for num, _, _, _, _ in extract_must_lc.parse(args.readme)}
+        mine = {num for num, row in live.items() if row["must"]}
+        failures += _check("live: MUST agrees with extract_must_lc.py",
+                           mine == theirs,
+                           "only here %s / only there %s"
+                           % (sorted(mine - theirs)[:5], sorted(theirs - mine)[:5]))
+
+    live_dates, _, live_warnings = parse_progress(args.progress)
+    failures += _check("live: the practice log still yields problems",
+                       len(live_dates) > 400, "%d problems" % len(live_dates))
+    # One known bad date (20260229 — 2026 is not a leap year) is in the log.
+    failures += _check("live: the log parses almost cleanly",
+                       len(live_warnings) <= 2, live_warnings)
+
+    print("\n  %s — %d check(s) failed\n" % ("FAILED" if failures else "all checks pass",
+                                             failures))
+    return 1 if failures else 0
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Read the balance table first; the picks are one way to act on it.")
+    ap.add_argument("--readme", default=os.path.join(REPO, "README.md"))
+    ap.add_argument("--progress", default=os.path.join(REPO, "data", "progress.txt"))
+    ap.add_argument("--lists", default=os.path.join(REPO, "data", "problem_lists.json"))
+    ap.add_argument("--repo", default=REPO)
+    ap.add_argument("--top", type=int, default=15, help="how many problems to suggest (default 15)")
+    ap.add_argument("--per-category", type=int, default=2,
+                    help="most picks any one category may take (default 2)")
+    ap.add_argument("--window", type=int, default=30,
+                    help="days of history that count as 'recent attention' (default 30)")
+    ap.add_argument("--half-life", type=float, default=DEFAULT_HALF_LIFE,
+                    help="days for a problem to go half stale (default 21)")
+    ap.add_argument("--bulk-limit", type=int, default=BULK_FILE_LIMIT,
+                    help="a commit touching more solution files than this is a bulk "
+                         "import, not practice, and is ignored (default %d)" % BULK_FILE_LIMIT)
+    ap.add_argument("--min-score-frac", type=float, default=MIN_SCORE_FRAC,
+                    help="skip a category whose best candidate scores below this "
+                         "fraction of the top pick (default %.2f)" % MIN_SCORE_FRAC)
+    ap.add_argument("--no-balance", action="store_true",
+                    help="rank by score alone, without spreading across categories")
+    ap.add_argument("--only", choices=["must", "blind75", "neetcode150",
+                                       "neetcode250", "top100liked", "google", "again"],
+                    help="restrict the pool to one marker")
+    ap.add_argument("--section", action="append", default=[],
+                    help="restrict to a README section (repeatable, case-insensitive)")
+    ap.add_argument("--difficulty", action="append", default=[], choices=list(DIFFS),
+                    help="restrict to a difficulty (repeatable)")
+    ap.add_argument("--all-sections", action="store_true",
+                    help="include SQL / Shell / Concurrency / the kamyu104 drafts")
+    ap.add_argument("--json", metavar="PATH", help="also write the full result as JSON")
+    ap.add_argument("--markdown", metavar="PATH", help="also write a markdown report")
+    ap.add_argument("--self-test", action="store_true",
+                    help="check the parsers against known input shapes and exit")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test(args)
+
+    now = time.time()
+
+    problems = parse_readme(args.readme)
+    if not problems:
+        print("no problem rows found in %s" % args.readme, file=sys.stderr)
+        return 1
+    lists = load_problem_lists(args.lists)
+
+    path_owner = defaultdict(set)
+    for lc, p in problems.items():
+        for path in p["paths"]:
+            path_owner[path].add(lc)
+
+    git_touch, bulk_commits = git_touch_history(args.repo, path_owner,
+                                                args.bulk_limit)
+    prog_dates, prog_notes, warnings = parse_progress(args.progress)
+
+    rows = build_rows(problems, lists, git_touch, prog_dates, prog_notes,
+                      now, args.half_life)
+    for r in rows:
+        r["_events"] = git_touch.get(r["lc"], []) + prog_dates.get(r["lc"], [])
+
+    if not args.all_sections:
+        rows = [r for r in rows if r["section"] not in EXCLUDED_SECTIONS]
+
+    # The balance is measured over the whole pool, before --only / --section
+    # narrow it: the question "which topic am I neglecting" is not answerable
+    # from inside a filter.
+    cats = category_balance(rows, now, args.window)
+
+    recent = {
+        "now": now,
+        "by_cat": Counter(),
+        "events": 0,
+        "problems": 0,
+        "lcs": Counter(),
+        "bulk_commits": bulk_commits,
+    }
+    cutoff = now - args.window * DAY
+    for r in rows:
+        hits = [t for t in r["_events"] if t >= cutoff]
+        if hits:
+            recent["by_cat"][r["section"]] += len(hits)
+            recent["events"] += len(hits)
+            recent["problems"] += 1
+            recent["lcs"][r["lc"]] += len(hits)
+
+    for r in rows:
+        r["balance"] = cats[r["section"]]["multiplier"] if not args.no_balance else 1.0
+        r["score"] = r["base"] * r["balance"]
+
+    pool = rows
+    if args.only == "must":
+        pool = [r for r in pool if r["must"]]
+    elif args.only == "google":
+        pool = [r for r in pool if "google" in r["tags"]]
+    elif args.only == "again":
+        pool = [r for r in pool if r["status"] == "AGAIN"]
+    elif args.only:
+        pool = [r for r in pool
+                if args.only in (lists.get(r["lc"], set()) | r["tags"])]
+    if args.section:
+        wanted = {s.lower() for s in args.section}
+        pool = [r for r in pool
+                if r["section"].lower() in wanted
+                or any(s.lower() in wanted for s in r["also_in"])]
+    if args.difficulty:
+        pool = [r for r in pool if r["difficulty"] in set(args.difficulty)]
+
+    if not pool:
+        print("no problems match those filters", file=sys.stderr)
+        return 1
+
+    picks = pick(pool, cats, args.top, args.per_category,
+                 not args.no_balance, args.min_score_frac)
+    render_text(picks, cats, recent, args, warnings)
+
+    if args.json:
+        payload = {
+            "generated": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "window_days": args.window,
+            "half_life_days": args.half_life,
+            "categories": sorted(cats.values(), key=lambda c: -c["deficit"]),
+            "picks": [{k: v for k, v in p.items()
+                       if k not in ("_events", "tags", "paths", "note")}
+                      | {"tags": sorted(p["tags"])} for p in picks],
+            "warnings": warnings,
+        }
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=1, default=list)
+        print("wrote %s" % args.json)
+
+    if args.markdown:
+        with open(args.markdown, "w", encoding="utf-8") as f:
+            f.write(render_markdown(picks, cats, recent, args))
+        print("wrote %s" % args.markdown)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/test_suggest_review.py
+++ b/script/test_suggest_review.py
@@ -594,6 +594,44 @@ class Pick(unittest.TestCase):
         picks = self.pick(top=3, min_score_frac=0.9)
         self.assertTrue(all(p["section"] == "Hot" for p in picks))
 
+    def test_the_refill_can_reach_candidates_the_floor_rejected(self):
+        # Each queue is sorted by descending score, so a category whose best
+        # candidate is under the floor has every candidate under it, and one
+        # round-robin pass walks its cursor to the end. A refill that resumed
+        # those cursors would find nothing and return short while eligible
+        # problems are still sitting in the pool.
+        rows = ([{"lc": 1, "section": "Hot", "score": 100.0}]
+                + [{"lc": 10 + i, "section": "Cold", "score": 10.0 - i}
+                   for i in range(3)])
+        cats = {"Hot": cat("Hot", -0.1), "Cold": cat("Cold", 0.4)}
+        picks = sr.pick(rows, cats, top=4, per_category=2,
+                        balanced=True, min_score_frac=0.3)
+        self.assertEqual(len(picks), 4)
+        self.assertEqual([p["lc"] for p in picks], [1, 10, 11, 12])
+
+    def test_the_floor_still_orders_the_first_pass(self):
+        # The rewind must not turn the floor into a no-op: the above-floor
+        # category is still served before any below-floor one.
+        rows = ([{"lc": 1, "section": "Hot", "score": 100.0}]
+                + [{"lc": 10 + i, "section": "Cold", "score": 10.0 - i}
+                   for i in range(3)])
+        cats = {"Hot": cat("Hot", -0.1), "Cold": cat("Cold", 0.4)}
+        picks = sr.pick(rows, cats, top=2, per_category=2,
+                        balanced=True, min_score_frac=0.3)
+        self.assertEqual([p["lc"] for p in picks], [1, 10])
+
+    def test_the_refill_does_not_hand_back_a_problem_twice(self):
+        picks = self.pick(top=99, min_score_frac=0.9)
+        self.assertEqual(len({p["lc"] for p in picks}), len(picks))
+        self.assertEqual(len(picks), len(self.rows))
+
+    def test_the_refill_is_ordered_by_score_not_by_deficit(self):
+        # Breadth is spent in the round-robin; what is left over is simply the
+        # best of the rest, which is what --per-category being a preference
+        # rather than a quota means.
+        picks = self.pick(top=5, per_category=2)
+        self.assertEqual([p["lc"] for p in picks[4:]], [2])
+
     def test_a_zero_score_is_never_picked(self):
         rows = [{"lc": 1, "section": "Hot", "score": 0.0}]
         self.assertEqual(sr.pick(rows, self.cats, 5, 2, True, 0.0), [])
@@ -689,6 +727,24 @@ class LiveFiles(unittest.TestCase):
         text = out.getvalue()
         self.assertIn("Balance: attention vs importance", text)
         self.assertIn("Suggested review", text)
+
+    def test_a_non_positive_divisor_is_a_usage_error_not_a_traceback(self):
+        # --half-life divides in staleness(), --window in category_balance();
+        # a zero used to abort with a ZeroDivisionError traceback, and a
+        # negative silently inverted the curve.
+        import io
+        import contextlib
+
+        for argv in (["--half-life", "0"], ["--window", "0"], ["--top", "0"],
+                     ["--per-category", "0"], ["--bulk-limit", "0"],
+                     ["--half-life", "-3"], ["--min-score-frac", "1.5"]):
+            with self.subTest(argv=argv):
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    with self.assertRaises(SystemExit) as raised:
+                        sr.main(argv + ["--top", "2"] if argv[0] != "--top" else argv)
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn("must be", err.getvalue())
 
     def test_an_impossible_filter_exits_nonzero_rather_than_printing_nothing(self):
         import io

--- a/script/test_suggest_review.py
+++ b/script/test_suggest_review.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""
+Unit tests for script/suggest_review.py.
+
+    python3 script/test_suggest_review.py           # all of it
+    python3 script/test_suggest_review.py -v
+    python3 script/test_suggest_review.py ParseProgress
+    python3 script/suggest_review.py --self-test    # the same suite, quietly
+
+Three of the planner's four inputs are hand-written files whose shape nobody
+controls — README rows, the practice log, commit subjects. The failure mode
+there is not a crash, it is a parser that quietly reads fewer rows than there
+are and hands back a plausible but shrunken plan. So the fixtures below are not
+invented shapes: every one of them is a line that is really in those files, kept
+here so a format drift fails a test instead of silently shrinking the plan.
+
+The unit tests run against those fixtures rather than the real files, so they do
+not move whenever a row does. `LiveFiles` at the bottom is what holds the real
+ones — including the cross-check that this script and `extract_must_lc.py` still
+agree on what a `MUST` row is. That mirrors how site/test/*.test.js is split.
+"""
+import os
+import sys
+import textwrap
+import unittest
+from collections import Counter
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import suggest_review as sr  # noqa: E402
+
+REPO = sr.REPO
+
+
+def write(tmpdir, name, text):
+    path = os.path.join(tmpdir, name)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    return path
+
+
+class TempFileCase(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+
+
+# ── README ──────────────────────────────────────────────────────────────────
+README = """
+## Resource
+
+| 999 | above the first LC section | | | | Easy | | OK |
+
+## Array
+
+|  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
+|-----|-------|----------|------|-------|------------|------|--------|
+| 48 | [Rotate Image](https://leetcode.com/problems/rotate-image/) | \
+[Python](./leetcode_python/Array/rotate-image.py) | _O(n^2)_ | _O(1)_ | Medium | \
+**array**, `google`, `blind75` | AGAIN*** (5) (MUST) |
+| 118 | [Pascal's Triangle](https://leetcode.com/problems/pascals-triangle/) | \
+[Python](./leetcode_python/Array/pascals-triangle.py) | _O(n^2)_ | _O(1)_ | Easy | \
+**array**, the row must be built from the one above, `amazon` | OK** |
+| 547 | [Friend Circles](https://leetcode.com/problems/number-of-provinces/) | \
+[Python](./leetcode_python/DFS/friend-circles.py) | _O(n^2)_ | _O(n)_ | Medium | \
+union find, `google` | AGAIN* |
+| 254 | Plain Title With No Link | | _O(n)_ | _O(1)_ | Hard | `fb` | |
+
+## Graph
+
+|  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
+|-----|-------|----------|------|-------|------------|------|--------|
+| 547 | [Number of Provinces](https://leetcode.com/problems/number-of-provinces/) | \
+[Java](./leetcode_java/x/NumberOfProvinces.java) | _O(n^2)_ | _O(n)_ | Medium | \
+**graph**, MUST, `fb` | AGAIN***** (2) |
+"""
+
+
+class ParseReadme(TempFileCase):
+    def setUp(self):
+        super().setUp()
+        self.rows = sr.parse_readme(write(self.tmpdir, "README.md", README))
+
+    def test_rows_above_the_first_lc_section_are_not_problems(self):
+        # Everything above `## Array` is intro prose — the Note tags table in
+        # the real README is pipe-delimited too.
+        self.assertNotIn(999, self.rows)
+
+    def test_each_lc_number_appears_once(self):
+        self.assertEqual(sorted(self.rows), [48, 118, 254, 547])
+
+    def test_must_in_the_status_cell_is_a_marker(self):
+        self.assertTrue(self.rows[48]["must"])
+
+    def test_must_as_prose_in_the_note_is_not_a_marker(self):
+        # "the row must be built from the one above" is not a priority flag.
+        self.assertFalse(self.rows[118]["must"])
+
+    def test_an_all_caps_must_token_in_the_note_is_a_marker(self):
+        self.assertTrue(self.rows[547]["must"])
+
+    def test_a_duplicate_row_folds_into_the_first_sighting(self):
+        # LC 547 is `Friend Circles` with no marker under DFS and `Number of
+        # Provinces` with MUST under Graph. Keeping only the first row's flags
+        # loses the marker, so the strongest claim about a problem wins.
+        row = self.rows[547]
+        self.assertEqual(row["section"], "Array")
+        self.assertEqual(row["also_in"], ["Graph"])
+        self.assertTrue(row["must"])
+        self.assertEqual(row["passes"], 5)
+        self.assertLessEqual({"google", "fb"}, row["tags"])
+        self.assertEqual(len(row["paths"]), 2)
+
+    def test_the_star_run_counts_review_passes(self):
+        self.assertEqual(self.rows[48]["passes"], 3)
+
+    def test_title_and_url_come_off_the_markdown_link(self):
+        self.assertEqual(self.rows[48]["title"], "Rotate Image")
+        self.assertTrue(self.rows[48]["url"].endswith("/rotate-image/"))
+
+    def test_a_row_with_no_link_keeps_its_plain_title(self):
+        self.assertEqual(self.rows[254]["title"], "Plain Title With No Link")
+        self.assertEqual(self.rows[254]["url"], "")
+
+    def test_difficulty_is_read_by_value_not_by_position(self):
+        # The real table has ragged complexity cells ("ctor: O(1), next: O(1)
+        # amortized"), so the column index is not dependable.
+        self.assertEqual(self.rows[118]["difficulty"], "Easy")
+        self.assertEqual(self.rows[254]["difficulty"], "Hard")
+
+    def test_status_word_and_an_empty_status_cell(self):
+        self.assertEqual(self.rows[48]["status"], "AGAIN")
+        self.assertEqual(self.rows[118]["status"], "OK")
+        self.assertIsNone(self.rows[254]["status"])
+
+    def test_only_repo_relative_solution_paths_are_kept(self):
+        # The problem's own leetcode.com link lives in the title cell, but a
+        # row occasionally carries an external link in the solution cell too.
+        self.assertEqual(self.rows[48]["paths"],
+                         ["leetcode_python/Array/rotate-image.py"])
+
+    def test_separator_and_prose_rows_are_skipped(self):
+        rows = sr.parse_readme(write(self.tmpdir, "sep.md", textwrap.dedent("""
+            ## Array
+
+            |  #  | Title | Solution | Time | Space | Difficulty | Note | Status |
+            |-----|-------|----------|------|-------|------------|------|--------|
+            ||`Linear`| | | | | | |
+            | 1 | [Two Sum](https://leetcode.com/problems/two-sum/) | x | _O(n)_ | _O(n)_ | Easy | `blind75` | OK |
+        """)))
+        self.assertEqual(sorted(rows), [1])
+
+
+# ── data/progress.txt ───────────────────────────────────────────────────────
+# Every shape here is one the real log contains.
+PROGRESS = """20260909: 4(todo), 34(again!!) | DP: 44(todo)
+
+20260908: 70(ok*, o(1) space!!),198(
+ok*),139(again* 1d dp)
+
+20260907: top 100 (backtrack): 51(todo) | (LC must) 438(again), 2289(todo: mono stack + dp)
+20260906: 39(again*).79(again*), topo_sort, weekly_331
+,53(again)
+
+------ review
+
+20260905  1740(ok)
+"""
+
+
+class ParseProgress(TempFileCase):
+    def setUp(self):
+        super().setUp()
+        self.dates, self.notes, self.warnings = sr.parse_progress(
+            write(self.tmpdir, "progress.txt", PROGRESS))
+
+    def test_session_separators_do_not_hide_problems(self):
+        # "a | b | c" groups a day into sessions and carries no meaning here.
+        self.assertIn(44, self.dates)
+
+    def test_an_annotation_containing_a_comma_stays_one_entry(self):
+        # Splitting naively turns "70(ok*, o(1) space!!)" into an entry for
+        # LC 70 and one for "o(1) space", and the latter reads as LC 1.
+        self.assertIn(70, self.dates)
+        self.assertNotIn(1, self.dates)
+
+    def test_an_annotation_wrapped_across_a_newline_is_rejoined(self):
+        # "...,198(\nok*),139(again* 1d dp)" — a line ending inside an
+        # annotation is held back until its parens balance.
+        self.assertIn(198, self.dates)
+        self.assertIn(139, self.dates)
+
+    def test_a_period_between_entries_splits_them(self):
+        # "39(again*).79(again*)" is a typo for a comma, but it is the log's
+        # only period outside an annotation; without the rule LC 79 disappears.
+        self.assertIn(39, self.dates)
+        self.assertIn(79, self.dates)
+
+    def test_a_bare_continuation_line_joins_the_day_above(self):
+        self.assertIn(53, self.dates)
+
+    def test_a_labelled_run_does_not_swallow_its_first_problem(self):
+        self.assertIn(44, self.dates)     # "| DP: 44(todo)"
+        self.assertIn(51, self.dates)     # "top 100 (backtrack): 51(todo)"
+        self.assertIn(438, self.dates)    # "(LC must) 438(again)"
+
+    def test_a_label_of_its_own_is_never_read_as_a_problem(self):
+        self.assertNotIn(100, self.dates)  # from "top 100 (backtrack)"
+
+    def test_a_colon_inside_an_annotation_is_not_a_label(self):
+        self.assertIn(2289, self.dates)
+        self.assertEqual(self.notes[2289]["todo"], 1)
+
+    def test_named_drills_are_not_lc_numbers(self):
+        # topo_sort, weekly_331, lazy_bst_in_order are practice but not
+        # LeetCode numbers, so they cannot join a per-problem schedule.
+        self.assertNotIn(331, self.dates)
+        self.assertNotIn(3, self.dates)
+
+    def test_a_separator_line_ends_the_day(self):
+        self.assertIn(1740, self.dates)
+
+    def test_again_beats_ok_when_a_note_says_both(self):
+        self.assertEqual(self.notes[34]["again"], 1)
+        self.assertEqual(self.notes[70]["ok"], 1)
+
+    def test_dates_are_newest_first(self):
+        multi = sr.parse_progress(write(self.tmpdir, "two.txt",
+                                        "20260901: 1\n\n20260909: 1\n"))[0]
+        self.assertEqual(multi[1], sorted(multi[1], reverse=True))
+
+    def test_the_fixture_parses_without_warnings(self):
+        self.assertEqual(self.warnings, [])
+
+    def test_an_impossible_date_is_reported_not_dropped_silently(self):
+        # 2026 is not a leap year; the real log has a 20260229.
+        _, _, warnings = sr.parse_progress(
+            write(self.tmpdir, "bad.txt", "20260229: 1(ok)\n"))
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("20260229", warnings[0])
+
+    def test_a_dated_line_wins_over_an_unclosed_annotation(self):
+        # One missing ")" used to swallow every following day into the note.
+        # An LC number is at most four digits, so an eight-digit line is a date.
+        dates, _, warnings = sr.parse_progress(write(self.tmpdir, "open.txt",
+                                                     "20260908: 1(ok\n20260909: 2(ok)\n"))
+        self.assertIn(2, dates)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("unclosed", warnings[0])
+
+    def test_content_before_any_date_is_reported(self):
+        _, _, warnings = sr.parse_progress(
+            write(self.tmpdir, "orphan.txt", "12(ok)\n"))
+        self.assertTrue(any("before any date" in w for w in warnings))
+
+    def test_a_missing_log_is_a_warning_not_a_crash(self):
+        dates, notes, warnings = sr.parse_progress(
+            os.path.join(self.tmpdir, "nope.txt"))
+        self.assertEqual((dates, notes), ({}, {}))
+        self.assertEqual(len(warnings), 1)
+
+
+class StripLabel(unittest.TestCase):
+    def test_shapes(self):
+        cases = [
+            ("DP: 44(todo)", "44(todo)"),
+            ("top 100 (backtrack): 51(todo)", "51(todo)"),
+            ("(LC must) 438(again)", "438(again)"),
+            ("2289(todo: mono stack + dp)", "2289(todo: mono stack + dp)"),
+            ("139(again!!)", "139(again!!)"),
+        ]
+        for raw, want in cases:
+            with self.subTest(raw=raw):
+                self.assertEqual(sr._strip_label(raw), want)
+
+
+class SplitTopLevel(unittest.TestCase):
+    def test_commas_inside_parens_do_not_split(self):
+        self.assertEqual([c.strip() for c in sr._split_top_level("70(ok*, o(1) space!!),139")],
+                         ["70(ok*, o(1) space!!)", "139"])
+
+    def test_a_period_at_depth_zero_splits(self):
+        self.assertEqual([c.strip() for c in sr._split_top_level("39(again*).79(ok)")],
+                         ["39(again*)", "79(ok)"])
+
+
+class Classify(unittest.TestCase):
+    def test_again_is_checked_before_ok(self):
+        self.assertEqual(sr._classify("ok, but again"), "again")
+        self.assertEqual(sr._classify("ok*"), "ok")
+        self.assertEqual(sr._classify("todo: mono stack"), "todo")
+        self.assertEqual(sr._classify(""), "none")
+        self.assertEqual(sr._classify("with univeral algo"), "other")
+
+
+# ── git ─────────────────────────────────────────────────────────────────────
+class SubjectLc(unittest.TestCase):
+    @staticmethod
+    def named(subject):
+        return {int(a or b) for a, b in sr.SUBJECT_LC.findall(subject)}
+
+    def test_a_language_suffix_names_a_problem(self):
+        self.assertEqual(self.named("update 131 py"), {131})
+        self.assertEqual(self.named("update 1353 py, progress"), {1353})
+
+    def test_an_explicit_lc_prefix_names_a_problem(self):
+        self.assertEqual(
+            self.named("update backtrack cheatsheet: expand LC 131 (Template 8)"),
+            {131})
+
+    def test_an_lc_range_is_a_bulk_import_not_a_problem(self):
+        self.assertEqual(
+            self.named("add 291 solutions for LC 1118-2000 coverage gap"), set())
+
+    def test_a_bare_count_is_not_a_problem(self):
+        self.assertEqual(self.named("cover the 13 uncovered classics"), set())
+        self.assertEqual(self.named("update PQ cheatsheet"), set())
+
+
+class GitTouchHistory(unittest.TestCase):
+    """The bulk-commit rule, against a canned `git log` rather than the repo's."""
+
+    UNIVERSE = {
+        "leetcode_python/Array/rotate-image.py": {48},
+        "leetcode_python/Stack/daily-temperatures.py": {739},
+    }
+
+    def fake_log(self, text):
+        """Stand in for `git log --name-only --pretty=format:'\\x01%ct\\x01%s'`."""
+        import subprocess
+        from unittest import mock
+
+        completed = subprocess.CompletedProcess([], 0, stdout=text, stderr="")
+        return mock.patch.object(subprocess, "run", return_value=completed)
+
+    def test_a_normal_commit_attributes_its_files(self):
+        log = "\x01100\x01update 48 py\nleetcode_python/Array/rotate-image.py\n"
+        with self.fake_log(log):
+            touches, bulk = sr.git_touch_history("/repo", self.UNIVERSE)
+        self.assertEqual(sorted(touches), [48])
+        self.assertEqual(bulk, 0)
+
+    def test_a_file_the_readme_does_not_claim_is_ignored(self):
+        log = "\x01100\x01update ws\nleetcode_java/src/main/java/dev/Workspace18.java\n"
+        with self.fake_log(log):
+            touches, _ = sr.git_touch_history("/repo", self.UNIVERSE)
+        self.assertEqual(touches, {})
+
+    def test_a_bulk_commit_is_skipped(self):
+        # 393 generated Java files in one commit made every one of those
+        # problems look practised on the same day.
+        universe = {"f%d.py" % i: {i} for i in range(20)}
+        log = "\x01100\x01feat: add 20 solutions\n" + "".join(
+            "f%d.py\n" % i for i in range(20))
+        with self.fake_log(log):
+            touches, bulk = sr.git_touch_history("/repo", universe)
+        self.assertEqual(touches, {})
+        self.assertEqual(bulk, 1)
+
+    def test_the_bulk_limit_is_a_boundary_not_a_cliff(self):
+        universe = {"f%d.py" % i: {i} for i in range(20)}
+        log_of = lambda n: ("\x01100\x01batch\n"
+                            + "".join("f%d.py\n" % i for i in range(n)))
+        with self.fake_log(log_of(6)):
+            self.assertEqual(len(sr.git_touch_history("/repo", universe)[0]), 6)
+        with self.fake_log(log_of(7)):
+            self.assertEqual(sr.git_touch_history("/repo", universe)[0], {})
+
+    def test_a_hand_written_lc_number_survives_a_bulk_commit(self):
+        universe = {"f%d.py" % i: {i} for i in range(20)}
+        log = "\x01100\x01update 131 py plus a sweep\n" + "".join(
+            "f%d.py\n" % i for i in range(20))
+        with self.fake_log(log):
+            touches, bulk = sr.git_touch_history("/repo", universe)
+        self.assertEqual(sorted(touches), [131])
+        self.assertEqual(bulk, 1)
+
+    def test_touches_come_back_newest_first(self):
+        log = ("\x01300\x01update 48 py\nleetcode_python/Array/rotate-image.py\n"
+               "\x01100\x01update 48 py\nleetcode_python/Array/rotate-image.py\n")
+        with self.fake_log(log):
+            touches, _ = sr.git_touch_history("/repo", self.UNIVERSE)
+        self.assertEqual(touches[48], [300, 300, 100, 100])
+
+    def test_a_git_failure_degrades_to_the_practice_log(self):
+        import subprocess
+        from unittest import mock
+
+        with mock.patch.object(subprocess, "run",
+                               side_effect=OSError("git not found")):
+            with mock.patch.object(sys, "stderr", open(os.devnull, "w")):
+                self.assertEqual(sr.git_touch_history("/repo", self.UNIVERSE), ({}, 0))
+
+
+# ── Scoring ─────────────────────────────────────────────────────────────────
+def problem(**overrides):
+    base = {
+        "lc": 1, "title": "T", "url": "", "difficulty": "Medium",
+        "section": "Array", "also_in": [], "note": "", "status": None,
+        "passes": 0, "must": False, "tags": set(), "paths": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class Importance(unittest.TestCase):
+    def score(self, **kw):
+        return sr.importance(problem(**kw), kw.pop("_lists", {}))
+
+    def test_must_is_the_strongest_single_marker(self):
+        must, _ = sr.importance(problem(must=True, difficulty=""), {})
+        top100, _ = sr.importance(problem(difficulty=""), {1: {"top100liked"}})
+        self.assertEqual(must, sr.W_MUST)
+        self.assertGreater(must, top100)
+
+    def test_the_neetcode_lists_nest_so_only_the_narrowest_scores(self):
+        both, reasons = sr.importance(
+            problem(difficulty=""), {1: {"blind75", "neetcode150", "neetcode250"}})
+        self.assertEqual(both, sr.W_BLIND75)
+        self.assertEqual(reasons, ["blind75"])
+
+    def test_top100liked_stands_on_its_own(self):
+        # It is LeetCode's list and cuts across all three NeetCode lists.
+        score, reasons = sr.importance(
+            problem(difficulty=""), {1: {"blind75", "top100liked"}})
+        self.assertEqual(score, sr.W_BLIND75 + sr.W_TOP100)
+        self.assertIn("top100liked", reasons)
+
+    def test_a_readme_list_tag_counts_when_problem_lists_json_is_missing(self):
+        score, _ = sr.importance(problem(difficulty="", tags={"neetcode150"}), {})
+        self.assertEqual(score, sr.W_NEETCODE150)
+
+    def test_company_tags_are_capped(self):
+        score, _ = sr.importance(
+            problem(difficulty="", tags=set(sr.COMPANIES)), {})
+        self.assertEqual(score, sr.W_COMPANY_CAP)
+
+    def test_google_scores_on_its_own(self):
+        score, reasons = sr.importance(problem(difficulty="", tags={"google"}), {})
+        self.assertEqual(score, sr.W_GOOGLE)
+        self.assertIn("google", reasons)
+
+    def test_review_passes_count_only_against_an_again_row(self):
+        # The AGAIN marker never graduates in this repo, so the pass count is
+        # read as difficulty rather than as progress — but an OK row's passes
+        # really are progress and must not be scored as a gap.
+        again, _ = sr.importance(
+            problem(difficulty="", status="AGAIN", passes=5), {})
+        ok, _ = sr.importance(problem(difficulty="", status="OK", passes=5), {})
+        self.assertEqual(again, 5 * sr.W_PASS)
+        self.assertEqual(ok, 0.0)
+
+    def test_the_pass_bump_is_capped(self):
+        score, _ = sr.importance(
+            problem(difficulty="", status="AGAIN", passes=40), {})
+        self.assertEqual(score, sr.W_PASS_CAP)
+
+    def test_medium_outweighs_hard(self):
+        # A coding round is made of mediums.
+        medium, _ = sr.importance(problem(difficulty="Medium"), {})
+        hard, _ = sr.importance(problem(difficulty="Hard"), {})
+        easy, _ = sr.importance(problem(difficulty="Easy"), {})
+        self.assertGreater(medium, hard)
+        self.assertGreater(hard, easy)
+
+    def test_an_unmarked_easy_problem_scores_nothing(self):
+        self.assertEqual(sr.importance(problem(difficulty="Easy"), {})[0], 0.0)
+
+
+class Staleness(unittest.TestCase):
+    def test_touched_today_is_zero(self):
+        self.assertEqual(sr.staleness(0, sr.DEFAULT_HALF_LIFE), 0.0)
+
+    def test_one_half_life_is_half_stale(self):
+        self.assertAlmostEqual(sr.staleness(21, 21), 0.5)
+
+    def test_it_rises_with_days_and_is_bounded_by_one(self):
+        self.assertLess(sr.staleness(7, 21), sr.staleness(60, 21))
+        self.assertLess(sr.staleness(365, 21), 1.0)
+        # Far enough out the remaining freshness underflows to zero, so the
+        # curve saturates at exactly 1.0 rather than merely approaching it.
+        self.assertEqual(sr.staleness(10000, 21), 1.0)
+
+    def test_never_touched_saturates(self):
+        self.assertGreater(sr.staleness(None, 21), 0.99)
+
+    def test_a_future_timestamp_does_not_go_negative(self):
+        self.assertEqual(sr.staleness(-5, 21), 0.0)
+
+
+class CategoryBalance(unittest.TestCase):
+    def rows(self, now):
+        return [
+            {"section": "Hot", "importance": 10.0, "last_ts": now,
+             "_events": [now, now - sr.DAY]},
+            {"section": "Cold", "importance": 10.0, "last_ts": now - 90 * sr.DAY,
+             "_events": [now - 90 * sr.DAY]},
+        ]
+
+    def test_equal_importance_unequal_attention(self):
+        now = 1_700_000_000.0
+        cats = sr.category_balance(self.rows(now), now, window_days=30)
+        self.assertAlmostEqual(cats["Hot"]["importance_share"], 0.5)
+        self.assertAlmostEqual(cats["Cold"]["importance_share"], 0.5)
+        # The cold category's only event is outside the window.
+        self.assertEqual(cats["Cold"]["attention_share"], 0.0)
+        self.assertEqual(cats["Hot"]["attention_share"], 1.0)
+
+    def test_the_multiplier_rewards_neglect_and_penalises_pooling(self):
+        now = 1_700_000_000.0
+        cats = sr.category_balance(self.rows(now), now, window_days=30)
+        self.assertEqual(cats["Cold"]["multiplier"], 1.0 + sr.BALANCE_GAIN)
+        self.assertEqual(cats["Hot"]["multiplier"], sr.BALANCE_FLOOR)
+
+    def test_the_multiplier_stays_within_its_bounds(self):
+        now = 1_700_000_000.0
+        rows = [{"section": "S%d" % i, "importance": float(i + 1),
+                 "last_ts": now, "_events": [now] * (i * 7)} for i in range(6)]
+        for cat in sr.category_balance(rows, now, 30).values():
+            self.assertGreaterEqual(cat["multiplier"], sr.BALANCE_FLOOR)
+            self.assertLessEqual(cat["multiplier"], 1.0 + sr.BALANCE_GAIN)
+
+    def test_attention_is_recency_weighted_inside_the_window(self):
+        now = 1_700_000_000.0
+        rows = [
+            {"section": "Yesterday", "importance": 1.0, "last_ts": now,
+             "_events": [now - sr.DAY]},
+            {"section": "ThreeWeeksAgo", "importance": 1.0, "last_ts": now,
+             "_events": [now - 21 * sr.DAY]},
+        ]
+        cats = sr.category_balance(rows, now, window_days=30)
+        self.assertGreater(cats["Yesterday"]["attention_share"],
+                           cats["ThreeWeeksAgo"]["attention_share"])
+
+    def test_a_quiet_repo_does_not_divide_by_zero(self):
+        now = 1_700_000_000.0
+        rows = [{"section": "A", "importance": 0.0, "last_ts": None, "_events": []}]
+        cats = sr.category_balance(rows, now, 30)
+        self.assertEqual(cats["A"]["ratio"], 0.0)
+
+
+# ── Picking ─────────────────────────────────────────────────────────────────
+def cat(section, deficit, n=3):
+    return {"section": section, "importance_share": 0.5, "attention_share": 0.5,
+            "ratio": 1.0, "deficit": deficit, "multiplier": 1.0,
+            "last_ts": None, "n": n}
+
+
+class Pick(unittest.TestCase):
+    def setUp(self):
+        self.rows = ([{"lc": i, "section": "Hot", "score": 100 - i} for i in range(4)]
+                     + [{"lc": 10 + i, "section": "Cold", "score": 50 - i}
+                        for i in range(3)])
+        self.cats = {"Hot": cat("Hot", -0.4), "Cold": cat("Cold", 0.4)}
+
+    def pick(self, **kw):
+        kw.setdefault("min_score_frac", 0.0)
+        kw.setdefault("balanced", True)
+        kw.setdefault("per_category", 2)
+        return sr.pick(self.rows, self.cats, **kw)
+
+    def test_the_most_neglected_category_goes_first(self):
+        picks = self.pick(top=4)
+        self.assertEqual(picks[0]["section"], "Cold")
+
+    def test_it_alternates_rather_than_draining_one_category(self):
+        picks = self.pick(top=4)
+        self.assertEqual([p["section"] for p in picks],
+                         ["Cold", "Hot", "Cold", "Hot"])
+
+    def test_within_a_category_the_best_score_goes_first(self):
+        picks = self.pick(top=4)
+        cold = [p["lc"] for p in picks if p["section"] == "Cold"]
+        self.assertEqual(cold, sorted(cold))   # ids ascend as scores descend
+
+    def test_no_category_exceeds_per_category_while_others_are_waiting(self):
+        picks = self.pick(top=4, per_category=2)
+        self.assertEqual(Counter(p["section"] for p in picks)["Hot"], 2)
+
+    def test_the_cap_is_a_preference_not_a_quota(self):
+        # Returning two problems for `--section X --top 5` reads as a bug.
+        self.assertEqual(len(self.pick(top=6, per_category=2)), 6)
+
+    def test_it_never_returns_more_than_asked(self):
+        self.assertEqual(len(self.pick(top=3)), 3)
+
+    def test_it_stops_when_the_pool_runs_out(self):
+        self.assertEqual(len(self.pick(top=99)), len(self.rows))
+
+    def test_a_weak_category_is_passed_over(self):
+        # Breadth is the point, but not at the price of a slot spent on a
+        # problem nothing recommends.
+        picks = self.pick(top=3, min_score_frac=0.9)
+        self.assertTrue(all(p["section"] == "Hot" for p in picks))
+
+    def test_a_zero_score_is_never_picked(self):
+        rows = [{"lc": 1, "section": "Hot", "score": 0.0}]
+        self.assertEqual(sr.pick(rows, self.cats, 5, 2, True, 0.0), [])
+
+    def test_no_balance_is_straight_score_order(self):
+        picks = sr.pick(self.rows, self.cats, 3, 1, False)
+        self.assertEqual([p["lc"] for p in picks], [0, 1, 2])
+
+    def test_a_problem_is_never_picked_twice(self):
+        picks = self.pick(top=99)
+        self.assertEqual(len({id(p) for p in picks}), len(picks))
+
+
+# ── Rendering ───────────────────────────────────────────────────────────────
+class Formatting(unittest.TestCase):
+    def test_fmt_days(self):
+        self.assertEqual(sr.fmt_days(None), "never")
+        self.assertEqual(sr.fmt_days(0.4), "today")
+        self.assertEqual(sr.fmt_days(1.6), "2d")
+
+    def test_bar_is_clamped_to_its_width(self):
+        self.assertEqual(sr.bar(0.0, 4), "....")
+        self.assertEqual(sr.bar(1.0, 4), "####")
+        self.assertEqual(len(sr.bar(9.0, 4)), 4)
+        self.assertEqual(len(sr.bar(-1.0, 4)), 4)
+
+    def test_truncate_keeps_the_width(self):
+        self.assertEqual(sr.truncate("abc", 5), "abc")
+        self.assertEqual(len(sr.truncate("abcdefgh", 5)), 5)
+
+
+# ── The real files ──────────────────────────────────────────────────────────
+class LiveFiles(unittest.TestCase):
+    """Held against the repo's own README and practice log, the way
+    site/test/i18n.corpus.test.js is held against the real cheatsheets."""
+
+    README = os.path.join(REPO, "README.md")
+    PROGRESS = os.path.join(REPO, "data", "progress.txt")
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rows = sr.parse_readme(cls.README)
+
+    def test_readme_still_parses_as_a_table_of_problems(self):
+        self.assertGreater(len(self.rows), 1000)
+
+    def test_every_row_has_a_section_and_a_difficulty(self):
+        self.assertFalse([lc for lc, r in self.rows.items() if not r["section"]])
+        missing = [lc for lc, r in self.rows.items() if not r["difficulty"]]
+        self.assertLess(len(missing), 10, "unparsed difficulty in %s" % missing[:10])
+
+    def test_must_agrees_with_extract_must_lc(self):
+        # The one rule shared with another script. extract_must_lc.py owns it
+        # and generates doc/must_lc_list.md from it, so the two readings must
+        # agree exactly or one of the two docs is lying.
+        import extract_must_lc
+
+        theirs = {num for num, _, _, _, _ in extract_must_lc.parse(self.README)}
+        mine = {lc for lc, r in self.rows.items() if r["must"]}
+        self.assertEqual(mine, theirs)
+
+    def test_the_sections_the_planner_excludes_still_exist(self):
+        # A renamed section would silently stop being excluded, and SQL rows
+        # would start competing for review slots.
+        sections = {r["section"] for r in self.rows.values()}
+        self.assertLessEqual(sr.EXCLUDED_SECTIONS, sections)
+
+    def test_the_practice_log_still_yields_problems(self):
+        dates, _, _ = sr.parse_progress(self.PROGRESS)
+        self.assertGreater(len(dates), 400)
+
+    def test_the_practice_log_parses_almost_cleanly(self):
+        # One known bad date (20260229 — 2026 is not a leap year) is in the log.
+        _, _, warnings = sr.parse_progress(self.PROGRESS)
+        self.assertLessEqual(len(warnings), 2, warnings)
+
+    def test_solution_paths_resolve_to_files_on_disk(self):
+        # These paths are how a commit is attributed to a problem; a stale one
+        # is a problem whose git history silently reads as empty.
+        missing = [p for r in self.rows.values() for p in r["paths"]
+                   if not os.path.exists(os.path.join(REPO, p))]
+        self.assertLess(len(missing), len(self.rows) * 0.05,
+                        "%d dead solution links, e.g. %s" % (len(missing), missing[:5]))
+
+    def test_the_planner_runs_end_to_end(self):
+        import io
+        import contextlib
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            code = sr.main(["--top", "5"])
+        self.assertEqual(code, 0)
+        text = out.getvalue()
+        self.assertIn("Balance: attention vs importance", text)
+        self.assertIn("Suggested review", text)
+
+    def test_an_impossible_filter_exits_nonzero_rather_than_printing_nothing(self):
+        import io
+        import contextlib
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err), contextlib.redirect_stdout(io.StringIO()):
+            code = sr.main(["--section", "No Such Section"])
+        self.assertEqual(code, 1)
+        self.assertIn("no problems match", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Suggests what to practise next, chosen to keep the practice *balanced* rather than merely important. The problem it solves is drift: a good week on DP turns into three weeks on DP while linked list, design and slide window quietly go a month untouched — and a flat "most important, least recently seen" ranking makes that worse, because the biggest sections hold the most important problems and would fill the whole list.

So the pick is made in two stages:

  1. score every problem:  importance x staleness
  2. spend the picks round-robin across categories in deficit order, capped at --per-category, so one hot topic cannot own the list

Nothing is invented; all three signals are already in the repo:

  README.md          the problem universe and this repo's own judgement of what
                     matters — the `MUST` marker, the curated-list tags
                     (blind75 / neetcode150 / neetcode250 / top100liked), the
                     company tags, and the status column's OK/AGAIN plus its `*`
                     run of review passes. doc/must_lc_list.md is generated from
                     the same rows, so reading README covers it.
  git history        when each problem was last worked on — the commit that
                     touched its solution file, or named its LC number.
  data/progress.txt  when it was last practised, which is not the same thing: a
                     re-read that produced no commit still counts.

Read the balance table first and the picks second: the table is the finding, the picks are one way to act on it.

    == Balance: attention vs importance ==

      Array        139  importance ######  attention #             0.19 UNDER  today
      Linked list   24             ##                              0.00 UNDER  36d
      Design        45             #                               0.24 UNDER  23d
      ...
      Recursion     29             ##                 ####         1.95 over   1d
      Dynamic Prog. 94             #####              ############ 2.20 over   today

Two measurement decisions that change the answer materially:

- Bulk commits are ignored. A commit touching more than --bulk-limit (default 6) solution files is an import or a sweeping refactor, not a study session. This repo has commits adding 393 generated Java files at once; counted naively they put 563 problems inside a 30-day window that actually saw 188, and made LC 48 look reviewed 61 days ago when the real gap is 220.
- SQL, Shell Script, Concurrency and the unverified `Newly Added (kamyu104 gap)` drafts are left out of the balance maths so they cannot distort a category's share. --all-sections puts them back.

`--self-test` pins the shapes that are really in the hand-written inputs — a MUST in the status cell vs. the word "must" in prose, a duplicate README row for one LC, an annotation containing a comma, a wrapped line, a `DP:` label, a stray period between entries — because the failure mode here is not a crash but a parser that quietly reads fewer rows than there are and returns a plausible but shrunken plan. It also cross-checks the live README against extract_must_lc.py, so the two readings of `MUST` cannot drift apart.

Two things that cross-check turned up, both handled here only:

- A duplicate README row is folded into the first sighting, strongest claim winning. LC 547 is `Friend Circles` with no marker under DFS and `Number of Provinces` with MUST under Graph; keeping only the first row loses the marker. With that fixed the script and extract_must_lc.py both count 169 MUST rows — the committed doc/must_lc_list.md is stale at 165.
- site/build-review-plan.js does not strip a run's label, so `| DP: 44(todo), 10(todo)` loses LC 44 — 8 entries in the current log, always the first problem after a label. This script strips them; the site build is left alone.

Usage and the full scoring table are in doc/utility-scripts.md.

    python3 script/suggest_review.py
    python3 script/suggest_review.py --only must --top 20
    python3 script/suggest_review.py --section "Binary Search"
    python3 script/suggest_review.py --self-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a practice recommendation tool that suggests LeetCode problems using importance, staleness, recent practice, and category balance.
  - Supports text, JSON, and Markdown output, with filters for sections, difficulty, and categories.
  - Added validation for numeric limits and score ranges.

- **Bug Fixes**
  - Improved candidate selection so eligible problems can be reconsidered without duplicates.

- **Documentation**
  - Added usage guidance and test coverage details for the recommendation tool.
  - Clarified Fibonacci-interval spaced-repetition dates from the practice log.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->